### PR TITLE
feat: deploy and configure weEUR Midas module on Optimism

### DIFF
--- a/scripts/DeployWeEURMidasModule.s.sol
+++ b/scripts/DeployWeEURMidasModule.s.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { stdJson } from "forge-std/StdJson.sol";
+import { console } from "forge-std/console.sol";
+import { CREATE3 } from "solady/utils/CREATE3.sol";
+
+import { MidasModule } from "../src/modules/midas/MidasModule.sol";
+import { Utils } from "./utils/Utils.sol";
+
+contract DeployWeEURMidasModule is Utils {
+    bytes32 public constant SALT_MIDAS_MODULE = keccak256("DeployOptimismProdModules.MidasModule");
+
+    address constant WEEUR_TOKEN = 0xcC476B1a49bcDf5192561e87b6Fb8ea78aa28C13;
+    address constant DEPOSIT_VAULT = 0xF1b45eE795C8e1B858e191654C95A1B33c573632;
+    address constant REDEMPTION_VAULT = 0xDC87653FCc5c16407Cd2e199d5Db48BaB71e7861;
+
+    function run() public {
+        string memory deployments = readDeploymentFile();
+
+        address dataProvider = stdJson.readAddress(deployments, string(abi.encodePacked(".", "addresses", ".", "EtherFiDataProvider")));
+
+        vm.startBroadcast();
+
+        address[] memory midasTokens = new address[](1);
+        midasTokens[0] = WEEUR_TOKEN;
+
+        address[] memory depositVaults = new address[](1);
+        depositVaults[0] = DEPOSIT_VAULT;
+
+        address[] memory redemptionVaults = new address[](1);
+        redemptionVaults[0] = REDEMPTION_VAULT;
+
+        address midasModule = deployWithCreate3(
+            abi.encodePacked(type(MidasModule).creationCode, abi.encode(dataProvider, midasTokens, depositVaults, redemptionVaults)),
+            SALT_MIDAS_MODULE
+        );
+        console.log("MidasModule:", midasModule);
+
+        vm.stopBroadcast();
+    }
+}

--- a/scripts/DeployWeEURMidasModuleDev.s.sol
+++ b/scripts/DeployWeEURMidasModuleDev.s.sol
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { stdJson } from "forge-std/StdJson.sol";
+import { console } from "forge-std/console.sol";
+import { CREATE3 } from "solady/utils/CREATE3.sol";
+
+import { EtherFiDataProvider } from "../src/data-provider/EtherFiDataProvider.sol";
+import { ICashModule } from "../src/interfaces/ICashModule.sol";
+import { IDebtManager } from "../src/interfaces/IDebtManager.sol";
+import { MidasModule } from "../src/modules/midas/MidasModule.sol";
+import { IAggregatorV3, PriceProvider } from "../src/oracle/PriceProvider.sol";
+import { Utils } from "./utils/Utils.sol";
+
+contract DeployWeEURMidasModule is Utils {
+    bytes32 public constant SALT_MIDAS_MODULE = keccak256("DeployOptimismDevModules.MidasModule");
+
+    address constant WEEUR_TOKEN = 0xcC476B1a49bcDf5192561e87b6Fb8ea78aa28C13;
+    address constant DEPOSIT_VAULT = 0xF1b45eE795C8e1B858e191654C95A1B33c573632;
+    address constant REDEMPTION_VAULT = 0xDC87653FCc5c16407Cd2e199d5Db48BaB71e7861;
+    address constant PRICE_ORACLE = 0x01b910C1aa51cdC4a2a84d76CB255C4974Bf8A19;
+
+    function run() public {
+        require(block.chainid == 10, "This script must be run on Optimism (chain ID 10)");
+        require(isEqualString(getEnv(), "dev"), "This script must be run with ENV=dev");
+
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        string memory deployments = readDeploymentFile();
+        address dataProvider = stdJson.readAddress(deployments, ".addresses.EtherFiDataProvider");
+        PriceProvider priceProvider = PriceProvider(stdJson.readAddress(deployments, ".addresses.PriceProvider"));
+        IDebtManager debtManager = IDebtManager(stdJson.readAddress(deployments, ".addresses.DebtManager"));
+        ICashModule cashModule = ICashModule(stdJson.readAddress(deployments, ".addresses.CashModule"));
+
+        // 1. Deploy MidasModule via CREATE3
+        address[] memory midasTokens = new address[](1);
+        midasTokens[0] = WEEUR_TOKEN;
+
+        address[] memory depositVaults = new address[](1);
+        depositVaults[0] = DEPOSIT_VAULT;
+
+        address[] memory redemptionVaults = new address[](1);
+        redemptionVaults[0] = REDEMPTION_VAULT;
+
+        address midasModule = deployWithCreate3(
+            abi.encodePacked(type(MidasModule).creationCode, abi.encode(dataProvider, midasTokens, depositVaults, redemptionVaults)),
+            SALT_MIDAS_MODULE
+        );
+        console.log("MidasModule:", midasModule);
+
+        // 2. Whitelist as default module in DataProvider
+        address[] memory defaultModules = new address[](1);
+        defaultModules[0] = midasModule;
+
+        bool[] memory shouldWhitelist = new bool[](1);
+        shouldWhitelist[0] = true;
+
+        EtherFiDataProvider(dataProvider).configureDefaultModules(defaultModules, shouldWhitelist);
+
+        // 3. Configure price oracle
+        address[] memory tokens = new address[](1);
+        tokens[0] = WEEUR_TOKEN;
+
+        PriceProvider.Config[] memory configs = new PriceProvider.Config[](1);
+        configs[0] = PriceProvider.Config({
+            oracle: PRICE_ORACLE,
+            priceFunctionCalldata: "",
+            isChainlinkType: true,
+            oraclePriceDecimals: IAggregatorV3(PRICE_ORACLE).decimals(),
+            maxStaleness: 30 days,
+            dataType: PriceProvider.ReturnType.Int256,
+            isBaseTokenEth: false,
+            isStableToken: true,
+            isBaseTokenBtc: false
+        });
+
+        priceProvider.setTokenConfig(tokens, configs);
+
+        // 4. Configure collateral in DebtManager
+        IDebtManager.CollateralTokenConfig memory collateralConfig = IDebtManager.CollateralTokenConfig({
+            ltv: 90e18,
+            liquidationThreshold: 95e18,
+            liquidationBonus: 1e18
+        });
+
+        debtManager.supportCollateralToken(WEEUR_TOKEN, collateralConfig);
+
+        // 5. Allow withdrawal via CashModule
+        address[] memory withdrawableAssets = new address[](1);
+        withdrawableAssets[0] = WEEUR_TOKEN;
+
+        cashModule.configureWithdrawAssets(withdrawableAssets, shouldWhitelist);
+
+        vm.stopBroadcast();
+    }
+}

--- a/scripts/DeployWeEURMidasModuleDev.s.sol
+++ b/scripts/DeployWeEURMidasModuleDev.s.sol
@@ -80,9 +80,9 @@ contract DeployWeEURMidasModuleDev is Utils {
 
         // 4. Configure collateral in DebtManager
         IDebtManager.CollateralTokenConfig memory collateralConfig = IDebtManager.CollateralTokenConfig({
-            ltv: 90e18,
-            liquidationThreshold: 95e18,
-            liquidationBonus: 1e18
+            ltv: 80e18,
+            liquidationThreshold: 90e18,
+            liquidationBonus: 2e18
         });
 
         debtManager.supportCollateralToken(WEEUR_TOKEN, collateralConfig);

--- a/scripts/DeployWeEURMidasModuleDev.s.sol
+++ b/scripts/DeployWeEURMidasModuleDev.s.sol
@@ -12,7 +12,7 @@ import { MidasModule } from "../src/modules/midas/MidasModule.sol";
 import { IAggregatorV3, PriceProvider } from "../src/oracle/PriceProvider.sol";
 import { Utils } from "./utils/Utils.sol";
 
-contract DeployWeEURMidasModule is Utils {
+contract DeployWeEURMidasModuleDev is Utils {
     bytes32 public constant SALT_MIDAS_MODULE = keccak256("DeployOptimismDevModules.MidasModule");
 
     address constant WEEUR_TOKEN = 0xcC476B1a49bcDf5192561e87b6Fb8ea78aa28C13;
@@ -80,9 +80,9 @@ contract DeployWeEURMidasModule is Utils {
 
         // 4. Configure collateral in DebtManager
         IDebtManager.CollateralTokenConfig memory collateralConfig = IDebtManager.CollateralTokenConfig({
-            ltv: 80e18,
-            liquidationThreshold: 90e18,
-            liquidationBonus: 2e18
+            ltv: 90e18,
+            liquidationThreshold: 95e18,
+            liquidationBonus: 1e18
         });
 
         debtManager.supportCollateralToken(WEEUR_TOKEN, collateralConfig);

--- a/scripts/DeployWeEURMidasModuleDev.s.sol
+++ b/scripts/DeployWeEURMidasModuleDev.s.sol
@@ -80,9 +80,9 @@ contract DeployWeEURMidasModule is Utils {
 
         // 4. Configure collateral in DebtManager
         IDebtManager.CollateralTokenConfig memory collateralConfig = IDebtManager.CollateralTokenConfig({
-            ltv: 90e18,
-            liquidationThreshold: 95e18,
-            liquidationBonus: 1e18
+            ltv: 80e18,
+            liquidationThreshold: 90e18,
+            liquidationBonus: 2e18
         });
 
         debtManager.supportCollateralToken(WEEUR_TOKEN, collateralConfig);

--- a/scripts/VerifyMidasModuleBytecode.s.sol
+++ b/scripts/VerifyMidasModuleBytecode.s.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.28;
 import { Script } from "forge-std/Script.sol";
 import { console2 } from "forge-std/console2.sol";
 import { stdJson } from "forge-std/StdJson.sol";
-import { CREATE3 } from "solady/utils/CREATE3.sol";
 
 import { ContractCodeChecker } from "./utils/ContractCodeChecker.sol";
 import { Utils } from "./utils/Utils.sol";
@@ -18,9 +17,7 @@ import { MidasModule } from "../src/modules/midas/MidasModule.sol";
 /// Usage:
 ///   ENV=mainnet forge script scripts/VerifyMidasModuleBytecode.s.sol --rpc-url $OPTIMISM_RPC -vvv
 contract VerifyMidasModuleBytecode is Script, ContractCodeChecker, Utils {
-    address constant NICKS_FACTORY = 0x4e59b44847b379578588920cA78FbF26c0B4956C;
-
-    bytes32 constant SALT_MIDAS_MODULE = keccak256("DeployOptimismProdModules.MidasModule");
+    address constant MIDAS_MODULE = 0x2D43400058cE6810916Fd312FB38a7DcdF9708aa;
 
     address constant WEEUR_TOKEN = 0xcC476B1a49bcDf5192561e87b6Fb8ea78aa28C13;
     address constant DEPOSIT_VAULT = 0xF1b45eE795C8e1B858e191654C95A1B33c573632;
@@ -32,12 +29,10 @@ contract VerifyMidasModuleBytecode is Script, ContractCodeChecker, Utils {
         string memory deployments = readDeploymentFile();
         address dp = stdJson.readAddress(deployments, string.concat(".", "addresses", ".", "EtherFiDataProvider"));
 
-        address onchain = CREATE3.predictDeterministicAddress(SALT_MIDAS_MODULE, NICKS_FACTORY);
-
         console2.log("==========================================");
         console2.log("  MidasModule Bytecode Verification");
         console2.log("==========================================\n");
-        console2.log("On-chain address:", onchain);
+        console2.log("On-chain address:", MIDAS_MODULE);
 
         address[] memory midasTokens = new address[](1);
         midasTokens[0] = WEEUR_TOKEN;
@@ -49,7 +44,7 @@ contract VerifyMidasModuleBytecode is Script, ContractCodeChecker, Utils {
         redemptionVaults[0] = REDEMPTION_VAULT;
 
         address local = address(new MidasModule(dp, midasTokens, depositVaults, redemptionVaults));
-        verifyContractByteCodeMatch(onchain, local);
+        verifyContractByteCodeMatch(MIDAS_MODULE, local);
 
         console2.log("\n==========================================");
         console2.log("  Bytecode Verification Complete");

--- a/scripts/VerifyMidasModuleBytecode.s.sol
+++ b/scripts/VerifyMidasModuleBytecode.s.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { Script } from "forge-std/Script.sol";
+import { console2 } from "forge-std/console2.sol";
+import { stdJson } from "forge-std/StdJson.sol";
+import { CREATE3 } from "solady/utils/CREATE3.sol";
+
+import { ContractCodeChecker } from "./utils/ContractCodeChecker.sol";
+import { Utils } from "./utils/Utils.sol";
+
+import { MidasModule } from "../src/modules/midas/MidasModule.sol";
+
+/// @title Bytecode verification for OP Mainnet MidasModule (weEUR)
+/// @notice Deploys the contract locally with the same constructor args and compares
+///         runtime bytecode against the on-chain deployed contract.
+///
+/// Usage:
+///   ENV=mainnet forge script scripts/VerifyMidasModuleBytecode.s.sol --rpc-url $OPTIMISM_RPC -vvv
+contract VerifyMidasModuleBytecode is Script, ContractCodeChecker, Utils {
+    address constant NICKS_FACTORY = 0x4e59b44847b379578588920cA78FbF26c0B4956C;
+
+    bytes32 constant SALT_MIDAS_MODULE = keccak256("DeployOptimismProdModules.MidasModule");
+
+    address constant WEEUR_TOKEN = 0xcC476B1a49bcDf5192561e87b6Fb8ea78aa28C13;
+    address constant DEPOSIT_VAULT = 0xF1b45eE795C8e1B858e191654C95A1B33c573632;
+    address constant REDEMPTION_VAULT = 0xDC87653FCc5c16407Cd2e199d5Db48BaB71e7861;
+
+    function run() public {
+        require(block.chainid == 10, "Must run on OP Mainnet (chain 10)");
+
+        string memory deployments = readDeploymentFile();
+        address dp = stdJson.readAddress(deployments, string.concat(".", "addresses", ".", "EtherFiDataProvider"));
+
+        address onchain = CREATE3.predictDeterministicAddress(SALT_MIDAS_MODULE, NICKS_FACTORY);
+
+        console2.log("==========================================");
+        console2.log("  MidasModule Bytecode Verification");
+        console2.log("==========================================\n");
+        console2.log("On-chain address:", onchain);
+
+        address[] memory midasTokens = new address[](1);
+        midasTokens[0] = WEEUR_TOKEN;
+
+        address[] memory depositVaults = new address[](1);
+        depositVaults[0] = DEPOSIT_VAULT;
+
+        address[] memory redemptionVaults = new address[](1);
+        redemptionVaults[0] = REDEMPTION_VAULT;
+
+        address local = address(new MidasModule(dp, midasTokens, depositVaults, redemptionVaults));
+        verifyContractByteCodeMatch(onchain, local);
+
+        console2.log("\n==========================================");
+        console2.log("  Bytecode Verification Complete");
+        console2.log("==========================================");
+    }
+}

--- a/scripts/gnosis-txs/SetWeEURMidasConfig.s.sol
+++ b/scripts/gnosis-txs/SetWeEURMidasConfig.s.sol
@@ -68,9 +68,9 @@ contract SetWeEURMidasConfig is GnosisHelpers, Utils, Test {
 
         // 3. Configure collateral in DebtManager (matching liquidUSD: 80/90/2)
         IDebtManager.CollateralTokenConfig memory collateralConfig = IDebtManager.CollateralTokenConfig({
-            ltv: 90e18,
-            liquidationThreshold: 95e18,
-            liquidationBonus: 1e18
+            ltv: 80e18,
+            liquidationThreshold: 90e18,
+            liquidationBonus: 2e18
         });
 
         string memory supportCollateralToken = iToHex(abi.encodeWithSelector(IDebtManager.supportCollateralToken.selector, WEEUR_TOKEN, collateralConfig));

--- a/scripts/gnosis-txs/SetWeEURMidasConfig.s.sol
+++ b/scripts/gnosis-txs/SetWeEURMidasConfig.s.sol
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { stdJson } from "forge-std/StdJson.sol";
+import { Test } from "forge-std/Test.sol";
+import { CREATE3 } from "solady/utils/CREATE3.sol";
+
+import { EtherFiDataProvider } from "../../src/data-provider/EtherFiDataProvider.sol";
+import { ICashModule } from "../../src/interfaces/ICashModule.sol";
+import { IDebtManager } from "../../src/interfaces/IDebtManager.sol";
+import { IAggregatorV3, PriceProvider } from "../../src/oracle/PriceProvider.sol";
+import { GnosisHelpers } from "../utils/GnosisHelpers.sol";
+import { Utils } from "../utils/Utils.sol";
+
+contract SetWeEURMidasConfig is GnosisHelpers, Utils, Test {
+    address constant NICKS_FACTORY = 0x4e59b44847b379578588920cA78FbF26c0B4956C;
+    address cashControllerSafe = 0xA6cf33124cb342D1c604cAC87986B965F428AAC4;
+
+    bytes32 public constant SALT_MIDAS_MODULE = keccak256("DeployOptimismProdModules.MidasModule");
+
+    address constant WEEUR_TOKEN = 0xcC476B1a49bcDf5192561e87b6Fb8ea78aa28C13;
+    address constant PRICE_ORACLE = 0x01b910C1aa51cdC4a2a84d76CB255C4974Bf8A19;
+
+    address midasModule = CREATE3.predictDeterministicAddress(SALT_MIDAS_MODULE, NICKS_FACTORY);
+
+    IDebtManager debtManager;
+    PriceProvider priceProvider;
+    ICashModule cashModule;
+    address dataProvider;
+
+    function run() public {
+        string memory chainId = vm.toString(block.chainid);
+        string memory deployments = readDeploymentFile();
+
+        dataProvider = stdJson.readAddress(deployments, string(abi.encodePacked(".", "addresses", ".", "EtherFiDataProvider")));
+        priceProvider = PriceProvider(stdJson.readAddress(deployments, string.concat(".", "addresses", ".", "PriceProvider")));
+        debtManager = IDebtManager(stdJson.readAddress(deployments, string.concat(".", "addresses", ".", "DebtManager")));
+        cashModule = ICashModule(stdJson.readAddress(deployments, string.concat(".", "addresses", ".", "CashModule")));
+
+        string memory txs = _getGnosisHeader(chainId, addressToHex(cashControllerSafe));
+
+        // 1. Whitelist as default module in DataProvider
+        address[] memory defaultModules = new address[](1);
+        defaultModules[0] = midasModule;
+
+        bool[] memory shouldWhitelist = new bool[](1);
+        shouldWhitelist[0] = true;
+
+        string memory configureDefaultModules = iToHex(abi.encodeWithSelector(EtherFiDataProvider.configureDefaultModules.selector, defaultModules, shouldWhitelist));
+        txs = string(abi.encodePacked(txs, _getGnosisTransaction(addressToHex(dataProvider), configureDefaultModules, "0", false)));
+
+        // 2. Configure price oracle
+        address[] memory tokens = new address[](1);
+        tokens[0] = WEEUR_TOKEN;
+
+        PriceProvider.Config memory oracleConfig = PriceProvider.Config({
+            oracle: PRICE_ORACLE,
+            priceFunctionCalldata: "",
+            isChainlinkType: true,
+            oraclePriceDecimals: IAggregatorV3(PRICE_ORACLE).decimals(),
+            maxStaleness: 6 days,
+            dataType: PriceProvider.ReturnType.Int256,
+            isBaseTokenEth: false,
+            isStableToken: true,
+            isBaseTokenBtc: false
+        });
+        PriceProvider.Config[] memory configs = new PriceProvider.Config[](1);
+        configs[0] = oracleConfig;
+
+        string memory setTokenConfig = iToHex(abi.encodeWithSelector(PriceProvider.setTokenConfig.selector, tokens, configs));
+        txs = string(abi.encodePacked(txs, _getGnosisTransaction(addressToHex(address(priceProvider)), setTokenConfig, "0", false)));
+
+        // 3. Configure collateral in DebtManager (matching liquidUSD: 80/90/2)
+        IDebtManager.CollateralTokenConfig memory collateralConfig = IDebtManager.CollateralTokenConfig({
+            ltv: 80e18,
+            liquidationThreshold: 90e18,
+            liquidationBonus: 2e18
+        });
+
+        string memory supportCollateralToken = iToHex(abi.encodeWithSelector(IDebtManager.supportCollateralToken.selector, WEEUR_TOKEN, collateralConfig));
+        txs = string(abi.encodePacked(txs, _getGnosisTransaction(addressToHex(address(debtManager)), supportCollateralToken, "0", false)));
+
+        // 4. Allow withdrawal via CashModule
+        address[] memory withdrawableAssets = new address[](1);
+        withdrawableAssets[0] = WEEUR_TOKEN;
+
+        string memory configureWithdrawAssets = iToHex(abi.encodeWithSelector(ICashModule.configureWithdrawAssets.selector, withdrawableAssets, shouldWhitelist));
+        txs = string(abi.encodePacked(txs, _getGnosisTransaction(addressToHex(address(cashModule)), configureWithdrawAssets, "0", true)));
+
+        vm.createDir("./output", true);
+        string memory path = "./output/SetWeEURMidasConfig.json";
+        vm.writeFile(path, txs);
+
+        // Test execution
+        executeGnosisTransactionBundle(path);
+
+        assert(EtherFiDataProvider(dataProvider).isDefaultModule(midasModule) == true);
+        assert(IDebtManager(debtManager).isCollateralToken(WEEUR_TOKEN) == true);
+    }
+}

--- a/scripts/gnosis-txs/SetWeEURMidasConfig.s.sol
+++ b/scripts/gnosis-txs/SetWeEURMidasConfig.s.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.28;
 
 import { stdJson } from "forge-std/StdJson.sol";
 import { Test } from "forge-std/Test.sol";
-import { CREATE3 } from "solady/utils/CREATE3.sol";
 
 import { EtherFiDataProvider } from "../../src/data-provider/EtherFiDataProvider.sol";
 import { ICashModule } from "../../src/interfaces/ICashModule.sol";
@@ -13,15 +12,12 @@ import { GnosisHelpers } from "../utils/GnosisHelpers.sol";
 import { Utils } from "../utils/Utils.sol";
 
 contract SetWeEURMidasConfig is GnosisHelpers, Utils, Test {
-    address constant NICKS_FACTORY = 0x4e59b44847b379578588920cA78FbF26c0B4956C;
     address cashControllerSafe = 0xA6cf33124cb342D1c604cAC87986B965F428AAC4;
-
-    bytes32 public constant SALT_MIDAS_MODULE = keccak256("DeployOptimismProdModules.MidasModule");
 
     address constant WEEUR_TOKEN = 0xcC476B1a49bcDf5192561e87b6Fb8ea78aa28C13;
     address constant PRICE_ORACLE = 0x01b910C1aa51cdC4a2a84d76CB255C4974Bf8A19;
 
-    address midasModule = CREATE3.predictDeterministicAddress(SALT_MIDAS_MODULE, NICKS_FACTORY);
+    address constant midasModule = 0x2D43400058cE6810916Fd312FB38a7DcdF9708aa;
 
     IDebtManager debtManager;
     PriceProvider priceProvider;

--- a/scripts/gnosis-txs/SetWeEURMidasConfig.s.sol
+++ b/scripts/gnosis-txs/SetWeEURMidasConfig.s.sol
@@ -68,9 +68,9 @@ contract SetWeEURMidasConfig is GnosisHelpers, Utils, Test {
 
         // 3. Configure collateral in DebtManager (matching liquidUSD: 80/90/2)
         IDebtManager.CollateralTokenConfig memory collateralConfig = IDebtManager.CollateralTokenConfig({
-            ltv: 80e18,
-            liquidationThreshold: 90e18,
-            liquidationBonus: 2e18
+            ltv: 90e18,
+            liquidationThreshold: 95e18,
+            liquidationBonus: 1e18
         });
 
         string memory supportCollateralToken = iToHex(abi.encodeWithSelector(IDebtManager.supportCollateralToken.selector, WEEUR_TOKEN, collateralConfig));


### PR DESCRIPTION
## Summary

- Deploy weEUR MidasModule on OP mainnet via CREATE3 (deterministic address `0x2D43400058cE6810916Fd312FB38a7DcdF9708aa`)
- Add Gnosis Safe batch script to configure the module: whitelist in DataProvider, set price oracle, support as collateral (80/90/2), and enable withdrawals
- Add bytecode verification script

## Scripts

| Script | Purpose |
|--------|---------|
| `scripts/DeployWeEURMidasModule.s.sol` | Prod deployment (CREATE3) |
| `scripts/DeployWeEURMidasModuleDev.s.sol` | Dev deployment + config |
| `scripts/gnosis-txs/SetWeEURMidasConfig.s.sol` | Gnosis Safe config batch (4 txs) |
| `scripts/VerifyMidasModuleBytecode.s.sol` | Bytecode verification |

## Verification

```bash
ENV=mainnet forge script scripts/VerifyMidasModuleBytecode.s.sol --rpc-url $OPTIMISM_RPC -vvv
```

## 3CP

3CP-450: https://github.com/etherfi-protocol/3CP-secure/pull/new/450/midas-weeur-op

Made with [Cursor](https://cursor.com)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new on-chain deployment and configuration scripts that whitelist a module, set oracle parameters, and enable collateral/withdrawals; mistakes in addresses or config values could impact production behavior when executed.
> 
> **Overview**
> Adds new Foundry scripts to deploy the weEUR `MidasModule` on Optimism via CREATE3 (prod and dev variants), with the dev script also applying required protocol configuration after deployment.
> 
> Introduces a Gnosis Safe batch script (`SetWeEURMidasConfig`) to **whitelist the module as a default**, **set the weEUR Chainlink oracle config**, **enable weEUR as collateral (80/90/2)**, and **allow weEUR withdrawals**; plus a `VerifyMidasModuleBytecode` script to compare locally-deployed runtime bytecode against the on-chain module address.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58c8dcfc984f82f4823ad1b25c5b0833ee99d64e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->