### PR TITLE
feat: on-chain pending holds + unified spend() settlement

### DIFF
--- a/scripts/CashbackUpgrade.s.sol
+++ b/scripts/CashbackUpgrade.s.sol
@@ -72,7 +72,7 @@ contract CashbackUpgrade is GnosisHelpers, Utils, Test {
         address cashModuleCoreImpl = address(new CashModuleCore(dataProvider));
         address cashModuleSettersImpl = address(new CashModuleSetters(dataProvider));
         address cashEventEmitterImpl = address(new CashEventEmitter(cashModule));
-        address cashLensImpl = address(new CashLens(cashModule, dataProvider));
+        address cashLensImpl = address(new CashLens(cashModule, dataProvider, address(0)));
         address settlementDispatcherReapImpl = payable(address(new SettlementDispatcher(BinSponsor.Reap, dataProvider)));
         address settlementDispatcherRainImpl = payable(address(new SettlementDispatcher(BinSponsor.Rain, dataProvider)));
         address debtManagerCoreImpl = address(new DebtManagerCore(dataProvider));

--- a/scripts/DeployCashModule.s.sol
+++ b/scripts/DeployCashModule.s.sol
@@ -77,7 +77,7 @@ contract DeployCashModule is Utils {
             cashModuleSettersImpl
         );
 
-        address cashLensImpl = address(new CashLens(address(cashModule), address(dataProvider)));
+        address cashLensImpl = address(new CashLens(address(cashModule), address(dataProvider), address(0)));
         cashLens = CashLens(address(new UUPSProxy(cashLensImpl, "")));
         cashLens.initialize(address(roleRegistry));
 

--- a/scripts/DeployPendingHoldsModule.s.sol
+++ b/scripts/DeployPendingHoldsModule.s.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { stdJson } from "forge-std/StdJson.sol";
+import { console } from "forge-std/console.sol";
+
+import { UUPSProxy } from "../src/UUPSProxy.sol";
+import { PendingHoldsModule } from "../src/modules/cash/PendingHoldsModule.sol";
+import { Utils } from "./utils/Utils.sol";
+
+/**
+ * @title DeployPendingHoldsModule
+ * @notice Deploys PendingHoldsModule implementation + UUPS proxy.
+ *
+ * @dev Run order:
+ *   1. Run this script (PRIVATE_KEY deployer wallet) to produce the proxy address.
+ *   2. Manually add `"PendingHoldsModule": "<proxy>"` to deployments.json.
+ *   3. Run UpgradeCashModuleWithPendingHolds (Gnosis Safe) to upgrade CashModule and wire PHM.
+ *   4. Run UpgradeCashLensWithPendingHolds (Gnosis Safe) to wire PHM into CashLens.
+ *
+ * @dev The CashModule address passed to initialize() is also the value stored in
+ *      PendingHoldsModuleStorage.cashModuleCore (used to gate removeHold()).
+ *      It can be updated later via setCashModuleCore() by CASH_MODULE_CONTROLLER_ROLE.
+ */
+contract DeployPendingHoldsModule is Utils {
+    function run() public {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        string memory deployments = readDeploymentFile();
+
+        address dataProvider = stdJson.readAddress(
+            deployments,
+            string.concat(".", "addresses", ".", "EtherFiDataProvider")
+        );
+        address roleRegistry = stdJson.readAddress(
+            deployments,
+            string.concat(".", "addresses", ".", "RoleRegistry")
+        );
+        address cashModule = stdJson.readAddress(
+            deployments,
+            string.concat(".", "addresses", ".", "CashModule")
+        );
+
+        // Deploy implementation
+        PendingHoldsModule phmImpl = new PendingHoldsModule(dataProvider);
+        console.log("PendingHoldsModule impl:", address(phmImpl));
+
+        // Deploy proxy — initialize wires in roleRegistry + cashModuleCore (= CashModule proxy)
+        bytes memory initData = abi.encodeCall(
+            PendingHoldsModule.initialize,
+            (roleRegistry, cashModule)
+        );
+        address phmProxy = address(new UUPSProxy(address(phmImpl), initData));
+        console.log("PendingHoldsModule proxy:", phmProxy);
+        console.log(">>> Add to deployments.json: \"PendingHoldsModule\": \"%s\"", phmProxy);
+
+        vm.stopBroadcast();
+    }
+}

--- a/scripts/MultiSpendUpgrade.s.sol
+++ b/scripts/MultiSpendUpgrade.s.sol
@@ -81,7 +81,7 @@ contract MultispendUpgrade is GnosisHelpers, Utils, Test {
         address cashModuleCoreImpl = address(new CashModuleCore(dataProvider));
         address cashModuleSettersImpl = address(new CashModuleSetters(dataProvider));
         address cashEventEmitterImpl = address(new CashEventEmitter(cashModule));
-        address cashLensImpl = address(new CashLens(cashModule, dataProvider));
+        address cashLensImpl = address(new CashLens(cashModule, dataProvider, address(0)));
         address settlementDispatcherReapImpl = address(new SettlementDispatcher(BinSponsor.Reap));
         address settlementDispatcherRainImpl = address(new SettlementDispatcher(BinSponsor.Rain));
         address debtManagerCoreImpl = address(new DebtManagerCore(dataProvider));

--- a/scripts/Setup.s.sol
+++ b/scripts/Setup.s.sol
@@ -114,7 +114,7 @@ contract Setup is Utils {
         _setupPriceProvider();
         _setupCashbackDispatcher();
 
-        address cashLensImpl = deployWithCreate3(abi.encodePacked(type(CashLens).creationCode, abi.encode(address(cashModule), address(dataProvider))), getSalt(CASH_LENS_IMPL));
+        address cashLensImpl = deployWithCreate3(abi.encodePacked(type(CashLens).creationCode, abi.encode(address(cashModule), address(dataProvider), address(0))), getSalt(CASH_LENS_IMPL));
         cashLens = CashLens(deployWithCreate3(abi.encodePacked(type(UUPSProxy).creationCode, abi.encode(cashLensImpl, "")), getSalt(CASH_LENS_PROXY)));
         cashLens.initialize(address(roleRegistry));
 

--- a/scripts/SetupOptimism.s.sol
+++ b/scripts/SetupOptimism.s.sol
@@ -234,7 +234,7 @@ contract SetupOptimism is Utils {
         _setupCashbackDispatcher(p.roleRegistry, p.cashModule, p.priceProvider);
 
         console.log("Deploying CashLens...");
-        address cashLensImpl = deployCreate3(abi.encodePacked(type(CashLens).creationCode, abi.encode(p.cashModule, p.dataProvider)), SALT_CASH_LENS_IMPL);
+        address cashLensImpl = deployCreate3(abi.encodePacked(type(CashLens).creationCode, abi.encode(p.cashModule, p.dataProvider, address(0))), SALT_CASH_LENS_IMPL);
         cashLens = CashLens(deployCreate3(
             abi.encodePacked(type(UUPSProxy).creationCode, abi.encode(cashLensImpl, abi.encodeCall(CashLens.initialize, (p.roleRegistry)))),
             SALT_CASH_LENS_PROXY

--- a/scripts/UpgradeCashLens.s.sol
+++ b/scripts/UpgradeCashLens.s.sol
@@ -29,7 +29,7 @@ contract UpgradeCashLens is Utils {
             string(abi.encodePacked(".", "addresses", ".", "EtherFiDataProvider"))
         );
 
-        address cashLensImpl = address(new CashLens(cashModule, dataProvider));
+        address cashLensImpl = address(new CashLens(cashModule, dataProvider, address(0)));
         cashLens.upgradeToAndCall(address(cashLensImpl), "");
 
         vm.stopBroadcast();

--- a/scripts/UpgradeDelays.s.sol
+++ b/scripts/UpgradeDelays.s.sol
@@ -157,7 +157,7 @@ contract UpgradeDelays is Utils {
 
         cashModuleCoreImpl = address(new CashModuleCore(dataProvider));
         cashModuleSettersImpl = address(new CashModuleSetters(dataProvider));
-        cashLensImpl = address(new CashLens(cashModule, dataProvider));
+        cashLensImpl = address(new CashLens(cashModule, dataProvider, address(0)));
         cashEventEmitterImpl = address(new CashEventEmitter(cashModule));
         stakeModule = address(new EtherFiStakeModule(dataProvider, syncPool, weth, weETH));
         liquidModule = address(new EtherFiLiquidModule(liquidAssets, liquidTellers, dataProvider, weth));
@@ -277,7 +277,7 @@ contract RollbackDelaysUpgrade is Utils {
 
         cashModuleCoreImpl = address(new CashModuleCore(dataProvider));
         cashModuleSettersImpl = address(new CashModuleSetters(dataProvider));
-        cashLensImpl = address(new CashLens(cashModule, dataProvider));
+        cashLensImpl = address(new CashLens(cashModule, dataProvider, address(0)));
         cashEventEmitterImpl = address(new CashEventEmitter(cashModule));
         stakeModule = address(new EtherFiStakeModule(dataProvider, syncPool, weth, weETH));
         liquidModule = address(new EtherFiLiquidModule(liquidAssets, liquidTellers, dataProvider, weth));

--- a/scripts/VerifyOptimismProdBytecode.s.sol
+++ b/scripts/VerifyOptimismProdBytecode.s.sol
@@ -111,7 +111,7 @@ contract VerifyOptimismProdBytecode is Script, ContractCodeChecker {
 
     function _verifyModules() internal {
         console2.log("7. CashLens");
-        verifyContractByteCodeMatch(_getImpl(_proxy(SALT_CASH_LENS_PROXY)), address(new CashLens(cm, dp)));
+        verifyContractByteCodeMatch(_getImpl(_proxy(SALT_CASH_LENS_PROXY)), address(new CashLens(cm, dp, address(0))));
 
         console2.log("8. EtherFiHook");
         verifyContractByteCodeMatch(_getImpl(_proxy(SALT_HOOK_PROXY)), address(new EtherFiHook(dp)));

--- a/scripts/gnosis-txs/CashbackUpgrade.s.sol
+++ b/scripts/gnosis-txs/CashbackUpgrade.s.sol
@@ -132,7 +132,7 @@ contract CashbackUpgrade is GnosisHelpers, Utils {
         cashModuleCoreImpl = address(new CashModuleCore(dataProvider));
         cashModuleSettersImpl = address(new CashModuleSetters(dataProvider));
         cashEventEmitterImpl = address(new CashEventEmitter(cashModule));
-        cashLensImpl = address(new CashLens(cashModule, dataProvider));
+        cashLensImpl = address(new CashLens(cashModule, dataProvider, address(0)));
         settlementDispatcherReapImpl = payable(address(new SettlementDispatcher(BinSponsor.Reap, dataProvider)));
         settlementDispatcherRainImpl = payable(address(new SettlementDispatcher(BinSponsor.Rain, dataProvider)));
         debtManagerCoreImpl = address(new DebtManagerCore(dataProvider));

--- a/scripts/gnosis-txs/UpgradeCashLens.s.sol
+++ b/scripts/gnosis-txs/UpgradeCashLens.s.sol
@@ -34,7 +34,7 @@ contract UpgradeCashLens is GnosisHelpers, Utils {
             string.concat(".", "addresses", ".", "CashLens")
         );
 
-        CashLens cashLensImpl = new CashLens(cashModule, dataProvider);
+        CashLens cashLensImpl = new CashLens(cashModule, dataProvider, address(0));
 
         string memory txs = _getGnosisHeader(chainId, addressToHex(cashControllerSafe));
 

--- a/scripts/gnosis-txs/UpgradeCashLensWithPendingHolds.s.sol
+++ b/scripts/gnosis-txs/UpgradeCashLensWithPendingHolds.s.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { stdJson } from "forge-std/StdJson.sol";
+import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+
+import { CashLens } from "../../src/modules/cash/CashLens.sol";
+import { GnosisHelpers } from "../utils/GnosisHelpers.sol";
+import { Utils } from "../utils/Utils.sol";
+
+/**
+ * @title UpgradeCashLensWithPendingHolds
+ * @notice Gnosis Safe batch that upgrades CashLens to an implementation that carries a live
+ *         PendingHoldsModule immutable, enabling spendable() / getBalances() to deduct pending holds.
+ *
+ * @dev Prerequisites:
+ *   - DeployPendingHoldsModule has been run and its proxy address is in deployments.json
+ *     as "PendingHoldsModule".
+ *   - UpgradeCashModuleWithPendingHolds has been executed (CashModule now recognises PHM).
+ *
+ * @dev Because pendingHoldsModule is an immutable on CashLens, a new implementation must be
+ *      deployed and the proxy upgraded — it cannot be set via a setter.
+ */
+contract UpgradeCashLensWithPendingHolds is GnosisHelpers, Utils {
+    address cashControllerSafe = 0xA6cf33124cb342D1c604cAC87986B965F428AAC4;
+
+    function run() public {
+        string memory deployments = readDeploymentFile();
+        string memory chainId = vm.toString(block.chainid);
+
+        vm.startBroadcast();
+
+        address cashModule = stdJson.readAddress(
+            deployments,
+            string.concat(".", "addresses", ".", "CashModule")
+        );
+        address dataProvider = stdJson.readAddress(
+            deployments,
+            string.concat(".", "addresses", ".", "EtherFiDataProvider")
+        );
+        address cashLens = stdJson.readAddress(
+            deployments,
+            string.concat(".", "addresses", ".", "CashLens")
+        );
+        address phmProxy = stdJson.readAddress(
+            deployments,
+            string.concat(".", "addresses", ".", "PendingHoldsModule")
+        );
+
+        // Deploy new CashLens implementation with live PendingHoldsModule address
+        address newCashLensImpl = address(new CashLens(cashModule, dataProvider, phmProxy));
+
+        // --- Build Gnosis Safe transaction batch ---
+        string memory txs = _getGnosisHeader(chainId, addressToHex(cashControllerSafe));
+
+        // Single tx: upgrade CashLens proxy to new implementation
+        string memory upgradeLensCalldata = iToHex(
+            abi.encodeWithSelector(UUPSUpgradeable.upgradeToAndCall.selector, newCashLensImpl, "")
+        );
+        txs = string(abi.encodePacked(txs, _getGnosisTransaction(addressToHex(cashLens), upgradeLensCalldata, "0", true)));
+
+        vm.createDir("./output", true);
+        string memory path = "./output/UpgradeCashLensWithPendingHolds.json";
+        vm.writeFile(path, txs);
+
+        vm.stopBroadcast();
+
+        executeGnosisTransactionBundle(path);
+    }
+}

--- a/scripts/gnosis-txs/UpgradeCashModuleWithPendingHolds.s.sol
+++ b/scripts/gnosis-txs/UpgradeCashModuleWithPendingHolds.s.sol
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { stdJson } from "forge-std/StdJson.sol";
+import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+
+import { CashModuleCore } from "../../src/modules/cash/CashModuleCore.sol";
+import { CashModuleSetters } from "../../src/modules/cash/CashModuleSetters.sol";
+import { ICashModule } from "../../src/interfaces/ICashModule.sol";
+import { GnosisHelpers } from "../utils/GnosisHelpers.sol";
+import { Utils } from "../utils/Utils.sol";
+
+/**
+ * @title UpgradeCashModuleWithPendingHolds
+ * @notice Gnosis Safe batch that:
+ *   1. Upgrades CashModule to new Core implementation (adds rawSpendable() and removeHold() call in spend()).
+ *   2. Wires in the new CashModuleSetters implementation (adds withdrawal guard + setPendingHoldsModule()).
+ *   3. Calls setPendingHoldsModule() to link the deployed PendingHoldsModule proxy.
+ *
+ * @dev Prerequisites:
+ *   - DeployPendingHoldsModule has been run and its proxy address is in deployments.json
+ *     as "PendingHoldsModule".
+ *   - cashControllerSafe has CASH_MODULE_CONTROLLER_ROLE on the RoleRegistry.
+ *
+ * @dev Atomic safety: steps 1-3 execute in a single Gnosis batch so there is no window where
+ *   CashModule points to the new Core but the pending-holds withdrawal guard is missing.
+ */
+contract UpgradeCashModuleWithPendingHolds is GnosisHelpers, Utils {
+    address cashControllerSafe = 0xA6cf33124cb342D1c604cAC87986B965F428AAC4;
+
+    function run() public {
+        string memory deployments = readDeploymentFile();
+        string memory chainId = vm.toString(block.chainid);
+
+        vm.startBroadcast();
+
+        address dataProvider = stdJson.readAddress(
+            deployments,
+            string.concat(".", "addresses", ".", "EtherFiDataProvider")
+        );
+        address cashModule = stdJson.readAddress(
+            deployments,
+            string.concat(".", "addresses", ".", "CashModule")
+        );
+        address phmProxy = stdJson.readAddress(
+            deployments,
+            string.concat(".", "addresses", ".", "PendingHoldsModule")
+        );
+
+        // Deploy new implementations (broadcast pays gas; Safe executes the upgrades)
+        address newCoreImpl = address(new CashModuleCore(dataProvider));
+        address newSettersImpl = address(new CashModuleSetters(dataProvider));
+
+        // --- Build Gnosis Safe transaction batch ---
+        string memory txs = _getGnosisHeader(chainId, addressToHex(cashControllerSafe));
+
+        // Tx 1: upgrade CashModule proxy to new Core implementation
+        string memory upgradeCoreCalldata = iToHex(
+            abi.encodeWithSelector(UUPSUpgradeable.upgradeToAndCall.selector, newCoreImpl, "")
+        );
+        txs = string(abi.encodePacked(txs, _getGnosisTransaction(addressToHex(cashModule), upgradeCoreCalldata, "0", false)));
+
+        // Tx 2: point CashModule at new Setters implementation
+        string memory setSettersCalldata = iToHex(
+            abi.encodeWithSelector(ICashModule.setCashModuleSettersAddress.selector, newSettersImpl)
+        );
+        txs = string(abi.encodePacked(txs, _getGnosisTransaction(addressToHex(cashModule), setSettersCalldata, "0", false)));
+
+        // Tx 3: wire PendingHoldsModule into CashModule (routed via fallback → CashModuleSetters)
+        string memory setPhmCalldata = iToHex(
+            abi.encodeWithSelector(ICashModule.setPendingHoldsModule.selector, phmProxy)
+        );
+        txs = string(abi.encodePacked(txs, _getGnosisTransaction(addressToHex(cashModule), setPhmCalldata, "0", true)));
+
+        vm.createDir("./output", true);
+        string memory path = "./output/UpgradeCashModuleWithPendingHolds.json";
+        vm.writeFile(path, txs);
+
+        vm.stopBroadcast();
+
+        executeGnosisTransactionBundle(path);
+    }
+}

--- a/scripts/gnosis-txs/UpgradeCashModuleWithPendingHolds.s.sol
+++ b/scripts/gnosis-txs/UpgradeCashModuleWithPendingHolds.s.sol
@@ -6,6 +6,7 @@ import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils
 
 import { CashModuleCore } from "../../src/modules/cash/CashModuleCore.sol";
 import { CashModuleSetters } from "../../src/modules/cash/CashModuleSetters.sol";
+import { CashModuleSettersExt } from "../../src/modules/cash/CashModuleSettersExt.sol";
 import { ICashModule } from "../../src/interfaces/ICashModule.sol";
 import { GnosisHelpers } from "../utils/GnosisHelpers.sol";
 import { Utils } from "../utils/Utils.sol";
@@ -50,6 +51,7 @@ contract UpgradeCashModuleWithPendingHolds is GnosisHelpers, Utils {
         // Deploy new implementations (broadcast pays gas; Safe executes the upgrades)
         address newCoreImpl = address(new CashModuleCore(dataProvider));
         address newSettersImpl = address(new CashModuleSetters(dataProvider));
+        address newSettersExtImpl = address(new CashModuleSettersExt(dataProvider));
 
         // --- Build Gnosis Safe transaction batch ---
         string memory txs = _getGnosisHeader(chainId, addressToHex(cashControllerSafe));
@@ -66,7 +68,14 @@ contract UpgradeCashModuleWithPendingHolds is GnosisHelpers, Utils {
         );
         txs = string(abi.encodePacked(txs, _getGnosisTransaction(addressToHex(cashModule), setSettersCalldata, "0", false)));
 
-        // Tx 3: wire PendingHoldsModule into CashModule (routed via fallback → CashModuleSetters)
+        // Tx 3: wire CashModuleSettersExt (second fallback hop: repay + collectRemaining live here).
+        // Must precede any repay/collectRemaining call, else CashModuleSetters.fallback() reverts.
+        string memory setSettersExtCalldata = iToHex(
+            abi.encodeWithSelector(ICashModule.setCashModuleSettersExt.selector, newSettersExtImpl)
+        );
+        txs = string(abi.encodePacked(txs, _getGnosisTransaction(addressToHex(cashModule), setSettersExtCalldata, "0", false)));
+
+        // Tx 4: wire PendingHoldsModule into CashModule (routed via fallback → CashModuleSetters)
         string memory setPhmCalldata = iToHex(
             abi.encodeWithSelector(ICashModule.setPendingHoldsModule.selector, phmProxy)
         );

--- a/scripts/gnosis-txs/UpgradeDelays.s.sol
+++ b/scripts/gnosis-txs/UpgradeDelays.s.sol
@@ -190,7 +190,7 @@ contract UpgradeDelays is Utils, Test, GnosisHelpers {
 
         cashModuleCoreImpl = address(new CashModuleCore(dataProvider));
         cashModuleSettersImpl = address(new CashModuleSetters(dataProvider));
-        cashLensImpl = address(new CashLens(cashModule, dataProvider));
+        cashLensImpl = address(new CashLens(cashModule, dataProvider, address(0)));
         cashEventEmitterImpl = address(new CashEventEmitter(cashModule));
         stakeModule = address(new EtherFiStakeModule(dataProvider, syncPool, weth, weETH));
         liquidModule = address(new EtherFiLiquidModule(liquidAssets, liquidTellers, dataProvider, weth));

--- a/scripts/gnosis-txs/UpgradeMultispend.s.sol
+++ b/scripts/gnosis-txs/UpgradeMultispend.s.sol
@@ -91,7 +91,7 @@ contract UpgradeMultispend is GnosisHelpers, Utils, Test {
         cashModuleCoreImpl = address(new CashModuleCore(dataProvider));
         cashModuleSettersImpl = address(new CashModuleSetters(dataProvider));
         cashEventEmitterImpl = address(new CashEventEmitter(cashModule));
-        cashLensImpl = address(new CashLens(cashModule, dataProvider));
+        cashLensImpl = address(new CashLens(cashModule, dataProvider, address(0)));
         settlementDispatcherReapImpl = address(new SettlementDispatcher(BinSponsor.Reap));
         settlementDispatcherRainImpl = address(new SettlementDispatcher(BinSponsor.Rain));
         debtManagerCoreImpl = address(new DebtManagerCore(dataProvider));

--- a/src/interfaces/ICashModule.sol
+++ b/src/interfaces/ICashModule.sol
@@ -331,6 +331,17 @@ interface ICashModule {
     function getDebtManager() external view returns (IDebtManager);
 
     /**
+     * @notice Returns the remaining spendable capacity for a safe based on its spending limits
+     * @dev Returns min(remainingDailyLimit, remainingMonthlyLimit) in USD (1e6).
+     *      When PendingHoldsModule is active, holds are charged to spentToday/spentThisMonth at
+     *      addHold() time, so this value already reflects in-flight hold consumption — callers
+     *      do NOT need to subtract totalPendingHolds() separately.
+     * @param safe Address of the EtherFi Safe
+     * @return Spendable amount in USD (1e6), reflecting in-flight hold consumption
+     */
+    function rawSpendable(address safe) external view returns (uint256);
+
+    /**
      * @notice Gets the settlement dispatcher address
      * @dev The settlement dispatcher receives the funds that are spent
      * @param binSponsor Bin sponsor for which the settlement dispatcher needs to be returned
@@ -535,7 +546,19 @@ interface ICashModule {
 
     /**
      * @notice Processes a spending transaction with multiple tokens
-     * @dev Only callable by EtherFi wallet for valid EtherFi Safe addresses
+     * @dev Unified settlement path — handles both normal holds and recovery (no-hold) cases.
+     *      Only callable by EtherFi wallet for valid EtherFi Safe addresses.
+     *
+     *      Limit accounting:
+     *        - Hold exists, non-forced: charge/release delta between settlement and hold amount.
+     *        - Hold exists, forced:     no limit adjustment (forced holds bypass limits).
+     *        - No hold:                 no limit charge (Settlement is KING — bypass).
+     *        - No PHM module set:       charge spendingLimit directly (legacy path).
+     *
+     *      Partial settlement: if the safe has insufficient balance, the Spend event reflects the
+     *      actually transferred amount. The remainder is tracked as a forced hold for later
+     *      clearance by a dedicated special function.
+     *
      * @param safe Address of the EtherFi Safe
      * @param txId Transaction identifier
      * @param binSponsor Bin sponsor used for spending
@@ -544,12 +567,11 @@ interface ICashModule {
      * @param cashbacks Struct of Cashback to be given
      * @custom:throws TransactionAlreadyCleared if the transaction was already processed
      * @custom:throws UnsupportedToken if any token is not supported
-     * @custom:throws AmountZero if any converted amount is zero
+     * @custom:throws AmountZero if total amounts are zero
      * @custom:throws ArrayLengthMismatch if token and amount arrays have different lengths
      * @custom:throws OnlyOneTokenAllowedInCreditMode if multiple tokens are used in credit mode
-     * @custom:throws If spending would exceed limits or balances
      */
-    function spend(address safe, bytes32 txId, BinSponsor binSponsor,  address[] calldata tokens,  uint256[] calldata amountsInUsd,  Cashback[] calldata cashbacks) external;
+    function spend(address safe, bytes32 txId, BinSponsor binSponsor, address[] calldata tokens, uint256[] calldata amountsInUsd, Cashback[] calldata cashbacks) external;
 
     /**
      * @notice Clears pending cashback for users
@@ -640,4 +662,11 @@ interface ICashModule {
      * @return SafeTiers Tier of the safe
      */
     function getSafeTier(address safe) external view returns (SafeTiers);
+
+    /**
+     * @notice Sets the PendingHoldsModule address
+     * @dev Only callable by accounts with CASH_MODULE_CONTROLLER_ROLE.
+     * @param _pendingHoldsModule Address of the deployed PendingHoldsModule proxy
+     */
+    function setPendingHoldsModule(address _pendingHoldsModule) external;
 }

--- a/src/interfaces/ICashModule.sol
+++ b/src/interfaces/ICashModule.sol
@@ -683,4 +683,18 @@ interface ICashModule {
      * @param _pendingHoldsModule Address of the deployed PendingHoldsModule proxy
      */
     function setPendingHoldsModule(address _pendingHoldsModule) external;
+
+    /**
+     * @notice Sets the CashModuleSettersExt address — the second fallback-hop overflow contract.
+     * @dev Only callable by accounts with CASH_MODULE_CONTROLLER_ROLE. Functions not present in Core
+     *      or Setters (e.g. repay, collectRemaining) are delegatecalled here. Must be wired before any
+     *      such function is invoked, or the call reverts in CashModuleSetters.fallback().
+     * @param _cashModuleSettersExt Address of the deployed CashModuleSettersExt
+     */
+    function setCashModuleSettersExt(address _cashModuleSettersExt) external;
+
+    /**
+     * @notice Returns the CashModuleSettersExt address.
+     */
+    function getCashModuleSettersExt() external view returns (address);
 }

--- a/src/interfaces/ICashModule.sol
+++ b/src/interfaces/ICashModule.sol
@@ -574,6 +574,20 @@ interface ICashModule {
     function spend(address safe, bytes32 txId, BinSponsor binSponsor, address[] calldata tokens, uint256[] calldata amountsInUsd, Cashback[] calldata cashbacks) external;
 
     /**
+     * @notice Collects the outstanding remainder of an under-funded settlement from the safe's balance.
+     * @dev When a debit spend() could not fully cover the settlement, the unpaid remainder is parked in
+     *      a forced hold that blocks withdrawals. Once the safe is funded, ops calls this to sweep the
+     *      remainder from `token` to the settlement dispatcher and clear the hold. The spending limit is
+     *      NOT charged again (already charged at the original settlement). Only valid for already-settled
+     *      transactions (transactionCleared == true). Routed to CashModuleSetters via Core's fallback().
+     * @param safe Address of the EtherFi Safe
+     * @param txId Transaction identifier
+     * @param binSponsor Bin sponsor the settlement was made under
+     * @param token Borrow token to collect the remainder from
+     */
+    function collectRemaining(address safe, bytes32 txId, BinSponsor binSponsor, address token) external;
+
+    /**
      * @notice Clears pending cashback for users
      * @param users Addresses of users to clear the pending cashback for
      * @param tokens Addresses of cashback tokens

--- a/src/interfaces/IPendingHoldsModule.sol
+++ b/src/interfaces/IPendingHoldsModule.sol
@@ -1,0 +1,312 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { BinSponsor } from "./ICashModule.sol";
+
+/**
+ * @title ReleaseReason
+ * @notice Reason for releasing a hold without a corresponding on-chain spend
+ */
+enum ReleaseReason {
+    /// @notice Network reversal — provider reversed the transaction before settlement
+    REVERSAL,
+    /// @notice Admin release — operator-initiated hold removal (e.g. force-capture recovery)
+    ADMIN
+}
+
+/**
+ * @title HoldRecord
+ * @notice Per-transaction hold entry stored in PendingHoldsModule
+ */
+struct HoldRecord {
+    /// @notice Hold amount in USD with 1e6 denomination (same as USDC)
+    uint256 amountUsd;
+    /// @notice Timestamp when the hold was created
+    uint40 createdAt;
+    /// @notice 4-byte provider code derived from BinSponsor (e.g. "RAIN", "REAP")
+    bytes4 providerCode;
+    /// @notice True when added via forceAddHold — exempt from automatic expiry jobs
+    bool forced;
+}
+
+/**
+ * @title IPendingHoldsModule
+ * @author ether.fi
+ * @notice Interface for the on-chain pending holds registry.
+ *
+ * @dev Holds are identified by a provider-namespaced key:
+ *      key = keccak256(abi.encode(safe, providerCode, txId))
+ *
+ *      Lifecycle:
+ *        addHold()      — at transaction:created (auth-ack), called by EtherFi wallet (backend)
+ *        removeHold()   — at settlement, called by CashModuleCore internally after spend()
+ *        releaseHold()  — reversals or operator-initiated releases, called by EtherFi wallet
+ *        forceAddHold() — force-capture / recovery path, operator-only, bypasses balance check
+ *        updateHold()   — incremental auth adjustment, called by EtherFi wallet (backend)
+ *
+ *      Spendable invariant enforced at hold-write time:
+ *        totalPendingHolds(safe) + newAmount <= rawSpendable(safe)
+ *
+ *      Provider-namespaced keys prevent txId collisions between Rain / Reap / PIX.
+ *      Use providerCodeFromBinSponsor() to convert BinSponsor enum values to bytes4.
+ */
+interface IPendingHoldsModule {
+
+    // -------------------------------------------------------------------------
+    // Events
+    // -------------------------------------------------------------------------
+
+    /**
+     * @notice Emitted when a hold is added for a safe
+     * @param safe Safe address the hold is placed on
+     * @param providerCode 4-byte provider code (e.g. "RAIN")
+     * @param txId Provider transaction identifier
+     * @param amountUsd Hold amount in USD (1e6)
+     * @param createdAt Block timestamp when the hold was created
+     * @param forced True when the hold was added via forceAddHold (bypasses balance check)
+     */
+    event HoldAdded(
+        address indexed safe,
+        bytes4 indexed providerCode,
+        bytes32 indexed txId,
+        uint256 amountUsd,
+        uint256 createdAt,
+        bool forced
+    );
+
+    /**
+     * @notice Emitted when a hold is removed following a successful on-chain spend
+     * @param safe Safe address
+     * @param providerCode 4-byte provider code
+     * @param txId Provider transaction identifier
+     * @param amountUsd Hold amount released in USD (1e6)
+     * @param settledAt Block timestamp of removal
+     */
+    event HoldRemoved(
+        address indexed safe,
+        bytes4 indexed providerCode,
+        bytes32 indexed txId,
+        uint256 amountUsd,
+        uint256 settledAt
+    );
+
+    /**
+     * @notice Emitted when a hold is released without a corresponding spend (reversal or admin)
+     * @param safe Safe address
+     * @param providerCode 4-byte provider code
+     * @param txId Provider transaction identifier
+     * @param amountUsd Hold amount released in USD (1e6)
+     * @param reason Why the hold was released
+     * @param releasedAt Block timestamp of release
+     */
+    event HoldReleased(
+        address indexed safe,
+        bytes4 indexed providerCode,
+        bytes32 indexed txId,
+        uint256 amountUsd,
+        ReleaseReason reason,
+        uint256 releasedAt
+    );
+
+    /**
+     * @notice Emitted when a hold amount is updated (incremental auth)
+     * @param safe Safe address
+     * @param providerCode 4-byte provider code
+     * @param txId Provider transaction identifier
+     * @param oldAmountUsd Previous hold amount in USD (1e6)
+     * @param newAmountUsd New hold amount in USD (1e6)
+     * @param updatedAt Block timestamp of the update
+     */
+    event HoldUpdated(
+        address indexed safe,
+        bytes4 indexed providerCode,
+        bytes32 indexed txId,
+        uint256 oldAmountUsd,
+        uint256 newAmountUsd,
+        uint256 updatedAt
+    );
+
+    /**
+     * @notice Emitted when the CashModuleCore address is updated
+     * @param oldCashModuleCore Previous CashModuleCore address
+     * @param newCashModuleCore New CashModuleCore address
+     */
+    event CashModuleCoreSet(address oldCashModuleCore, address newCashModuleCore);
+
+    // -------------------------------------------------------------------------
+    // Errors
+    // -------------------------------------------------------------------------
+
+    /// @notice Thrown when a hold lookup returns no record
+    error HoldNotFound();
+
+    /// @notice Thrown when attempting to add a hold that already exists for the same key
+    error DuplicateHold();
+
+    /// @notice Thrown when the caller is not the registered CashModuleCore
+    error OnlyCashModuleCore();
+
+    /// @notice Thrown when an amount argument is zero
+    error InvalidAmount();
+
+    /// @notice Thrown when address(0) is passed as cashModuleCore
+    error ZeroCashModuleCore();
+
+    // -------------------------------------------------------------------------
+    // Write functions — EtherFi wallet (backend) only
+    // -------------------------------------------------------------------------
+
+    /**
+     * @notice Adds a pending hold for a safe at auth-ack time
+     * @dev Immediately consumes amountUsd from the safe's daily/monthly spending limits
+     *      so the limit reflects the user's authorized spend from the moment of auth-ack.
+     *      Reverts with ExceededDailySpendingLimit or ExceededMonthlySpendingLimit if the
+     *      hold would breach the limit.
+     *      Only callable by EtherFi wallet (backend service wallet).
+     * @param safe Safe address
+     * @param providerCode 4-byte provider code (use providerCodeFromBinSponsor to convert)
+     * @param txId Provider transaction identifier
+     * @param amountUsd Amount to hold in USD (1e6)
+     */
+    function addHold(address safe, bytes4 providerCode, bytes32 txId, uint256 amountUsd) external;
+
+    /**
+     * @notice Adds a hold without checking the spendable balance (operator recovery path)
+     * @dev Marks the hold as forced=true. Forced holds are exempt from automatic expiry.
+     *      Emits HoldAdded with forced=true.
+     *      Only callable by EtherFi wallet.
+     * @param safe Safe address
+     * @param providerCode 4-byte provider code (use providerCodeFromBinSponsor to convert)
+     * @param txId Provider transaction identifier
+     * @param amountUsd Amount to hold in USD (1e6)
+     */
+    function forceAddHold(address safe, bytes4 providerCode, bytes32 txId, uint256 amountUsd) external;
+
+    /**
+     * @notice Updates an existing hold amount atomically (incremental auth adjustment)
+     * @dev If newAmountUsd > oldAmountUsd, consumes the delta from the spending limit immediately.
+     *      If newAmountUsd < oldAmountUsd, credits the delta back to the spending limit.
+     *      Only callable by EtherFi wallet (backend service wallet).
+     * @param safe Safe address
+     * @param providerCode 4-byte provider code
+     * @param txId Provider transaction identifier
+     * @param newAmountUsd New hold amount in USD (1e6)
+     */
+    function updateHold(address safe, bytes4 providerCode, bytes32 txId, uint256 newAmountUsd) external;
+
+    /**
+     * @notice Releases a hold without a corresponding spend (network reversal or admin action)
+     * @dev Does NOT call spend() — only decrements the hold accumulator.
+     *      Only callable by EtherFi wallet.
+     * @param safe Safe address
+     * @param providerCode 4-byte provider code
+     * @param txId Provider transaction identifier
+     * @param reason Why the hold is being released
+     */
+    function releaseHold(address safe, bytes4 providerCode, bytes32 txId, ReleaseReason reason) external;
+
+    // -------------------------------------------------------------------------
+    // Write functions — CashModuleCore only
+    // -------------------------------------------------------------------------
+
+    /**
+     * @notice Syncs (or creates) a hold to match the settlement amount at on-chain settlement time
+     * @dev Called by CashModuleCore inside spend() to align the hold with the actual settlement.
+     *      - If a hold exists: updates hold.amountUsd to settlementAmount, adjusts totalHolds.
+     *        Does NOT call back to CashModuleCore for limit accounting — Core handles limits
+     *        directly using the returned (existed, wasForced, oldAmount) values.
+     *      - If no hold: creates a forced hold (Settlement is KING — limit bypass).
+     *      Only callable by CashModuleCore.
+     * @param safe Safe address
+     * @param binSponsor Bin sponsor for the card transaction
+     * @param txId Provider transaction identifier
+     * @param settlementAmount Settlement amount in USD (1e6)
+     * @return existed True if a hold existed for this (safe, binSponsor, txId) before this call
+     * @return wasForced True if the existing hold was forced (only meaningful when existed=true)
+     * @return oldAmount The hold amount before this call (only meaningful when existed=true)
+     */
+    function settlementSyncHold(
+        address safe,
+        BinSponsor binSponsor,
+        bytes32 txId,
+        uint256 settlementAmount
+    ) external returns (bool existed, bool wasForced, uint256 oldAmount);
+
+    /**
+     * @notice Updates a hold's amount to reflect remaining un-settled debt after a partial spend
+     * @dev Called by CashModuleCore inside spend() when the safe had insufficient balance to
+     *      cover the full settlement amount. The hold is reduced to `remaining` and marked
+     *      forced so subsequent special-function calls do not double-charge the spending limit.
+     *      Does NOT adjust the spending limit — the limit was fully charged at settlementSyncHold.
+     *      Only callable by CashModuleCore.
+     * @param safe Safe address
+     * @param binSponsor Bin sponsor for the card transaction
+     * @param txId Provider transaction identifier
+     * @param remaining Remaining un-spent amount in USD (1e6); must be > 0
+     */
+    function settlementSetRemainingHold(
+        address safe,
+        BinSponsor binSponsor,
+        bytes32 txId,
+        uint256 remaining
+    ) external;
+
+    /**
+     * @notice Removes a hold after a successful on-chain spend at settlement
+     * @dev Must be called by CashModuleCore after spend() executes.
+     *      Decrements totalHolds by the stored hold.amountUsd (not by the settlement amount).
+     *      Accepts BinSponsor (not bytes4) because CashModuleCore already has binSponsor in
+     *      scope in spend() — avoiding a providerCode conversion in Core saves precious bytecode.
+     *      Only callable by CashModuleCore.
+     * @param safe Safe address
+     * @param binSponsor Bin sponsor for the card transaction
+     * @param txId Provider transaction identifier
+     */
+    function removeHold(address safe, BinSponsor binSponsor, bytes32 txId) external;
+
+    // -------------------------------------------------------------------------
+    // Write functions — controller role
+    // -------------------------------------------------------------------------
+
+    /**
+     * @notice Updates the CashModuleCore address
+     * @dev Only callable by CASH_MODULE_CONTROLLER_ROLE.
+     * @param cashModuleCore New CashModuleCore address
+     */
+    function setCashModuleCore(address cashModuleCore) external;
+
+    // -------------------------------------------------------------------------
+    // View functions
+    // -------------------------------------------------------------------------
+
+    /**
+     * @notice Returns the sum of all active hold amounts for a safe (USD, 1e6)
+     * @param safe Safe address
+     * @return Total pending hold amount in USD (1e6)
+     */
+    function totalPendingHolds(address safe) external view returns (uint256);
+
+    /**
+     * @notice Returns the hold record for a specific transaction
+     * @dev Returns a zero-struct (amountUsd=0, createdAt=0) if the hold does not exist.
+     * @param safe Safe address
+     * @param providerCode 4-byte provider code
+     * @param txId Provider transaction identifier
+     * @return hold The HoldRecord struct
+     */
+    function getHold(address safe, bytes4 providerCode, bytes32 txId) external view returns (HoldRecord memory hold);
+
+    /**
+     * @notice Returns the 4-byte provider code for a given BinSponsor
+     * @dev Pure utility — callers use this to convert BinSponsor to the bytes4 used in hold keys.
+     * @param binSponsor The bin sponsor enum value
+     * @return providerCode 4-byte provider code (e.g. bytes4("RAIN"))
+     */
+    function providerCodeFromBinSponsor(BinSponsor binSponsor) external pure returns (bytes4 providerCode);
+
+    /**
+     * @notice Returns the registered CashModuleCore address
+     * @return Address of the CashModuleCore contract
+     */
+    function cashModuleCore() external view returns (address);
+}

--- a/src/interfaces/IPendingHoldsModule.sol
+++ b/src/interfaces/IPendingHoldsModule.sol
@@ -297,6 +297,17 @@ interface IPendingHoldsModule {
     function getHold(address safe, bytes4 providerCode, bytes32 txId) external view returns (HoldRecord memory hold);
 
     /**
+     * @notice Returns the outstanding hold amount for a (safe, binSponsor, txId), in USD (1e6)
+     * @dev Convenience for the settlement / collection path which keys by BinSponsor. Returns 0 if
+     *      no hold exists. Used by collectRemaining() to size the outstanding under-funded debt.
+     * @param safe Safe address
+     * @param binSponsor The bin sponsor enum value
+     * @param txId Provider transaction identifier
+     * @return Outstanding hold amount in USD (1e6)
+     */
+    function remainingHold(address safe, BinSponsor binSponsor, bytes32 txId) external view returns (uint256);
+
+    /**
      * @notice Returns the 4-byte provider code for a given BinSponsor
      * @dev Pure utility — callers use this to convert BinSponsor to the bytes4 used in hold keys.
      * @param binSponsor The bin sponsor enum value

--- a/src/interfaces/IPendingHoldsModule.sol
+++ b/src/interfaces/IPendingHoldsModule.sol
@@ -44,8 +44,11 @@ struct HoldRecord {
  *        forceAddHold() — force-capture / recovery path, operator-only, bypasses balance check
  *        updateHold()   — incremental auth adjustment, called by EtherFi wallet (backend)
  *
- *      Spendable invariant enforced at hold-write time:
- *        totalPendingHolds(safe) + newAmount <= rawSpendable(safe)
+ *      Limit accounting at hold-write time:
+ *        addHold()/updateHold()-increase charge the daily/monthly spending limit (via
+ *        CashModuleCore.consumeSpendingLimit) and revert if the limit would be breached. Holds are
+ *        thus bounded by the spending limit, NOT separately re-checked against rawSpendable or token
+ *        balance. forceAddHold() bypasses this charge entirely (operator recovery).
  *
  *      Provider-namespaced keys prevent txId collisions between Rain / Reap / PIX.
  *      Use providerCodeFromBinSponsor() to convert BinSponsor enum values to bytes4.

--- a/src/interfaces/IPendingHoldsModule.sol
+++ b/src/interfaces/IPendingHoldsModule.sol
@@ -167,11 +167,12 @@ interface IPendingHoldsModule {
      *      hold would breach the limit.
      *      Only callable by EtherFi wallet (backend service wallet).
      * @param safe Safe address
-     * @param providerCode 4-byte provider code (use providerCodeFromBinSponsor to convert)
+     * @param binSponsor Bin sponsor; the provider code (hold-key namespace) is derived on-chain so
+     *        the auth-time key provably matches the settlement-time key
      * @param txId Provider transaction identifier
      * @param amountUsd Amount to hold in USD (1e6)
      */
-    function addHold(address safe, bytes4 providerCode, bytes32 txId, uint256 amountUsd) external;
+    function addHold(address safe, BinSponsor binSponsor, bytes32 txId, uint256 amountUsd) external;
 
     /**
      * @notice Adds a hold without checking the spendable balance (operator recovery path)
@@ -179,11 +180,11 @@ interface IPendingHoldsModule {
      *      Emits HoldAdded with forced=true.
      *      Only callable by EtherFi wallet.
      * @param safe Safe address
-     * @param providerCode 4-byte provider code (use providerCodeFromBinSponsor to convert)
+     * @param binSponsor Bin sponsor; provider code derived on-chain
      * @param txId Provider transaction identifier
      * @param amountUsd Amount to hold in USD (1e6)
      */
-    function forceAddHold(address safe, bytes4 providerCode, bytes32 txId, uint256 amountUsd) external;
+    function forceAddHold(address safe, BinSponsor binSponsor, bytes32 txId, uint256 amountUsd) external;
 
     /**
      * @notice Updates an existing hold amount atomically (incremental auth adjustment)
@@ -191,22 +192,22 @@ interface IPendingHoldsModule {
      *      If newAmountUsd < oldAmountUsd, credits the delta back to the spending limit.
      *      Only callable by EtherFi wallet (backend service wallet).
      * @param safe Safe address
-     * @param providerCode 4-byte provider code
+     * @param binSponsor Bin sponsor; provider code derived on-chain
      * @param txId Provider transaction identifier
      * @param newAmountUsd New hold amount in USD (1e6)
      */
-    function updateHold(address safe, bytes4 providerCode, bytes32 txId, uint256 newAmountUsd) external;
+    function updateHold(address safe, BinSponsor binSponsor, bytes32 txId, uint256 newAmountUsd) external;
 
     /**
      * @notice Releases a hold without a corresponding spend (network reversal or admin action)
      * @dev Does NOT call spend() — only decrements the hold accumulator.
      *      Only callable by EtherFi wallet.
      * @param safe Safe address
-     * @param providerCode 4-byte provider code
+     * @param binSponsor Bin sponsor; provider code derived on-chain
      * @param txId Provider transaction identifier
      * @param reason Why the hold is being released
      */
-    function releaseHold(address safe, bytes4 providerCode, bytes32 txId, ReleaseReason reason) external;
+    function releaseHold(address safe, BinSponsor binSponsor, bytes32 txId, ReleaseReason reason) external;
 
     // -------------------------------------------------------------------------
     // Write functions — CashModuleCore only

--- a/src/interfaces/IPendingHoldsModule.sol
+++ b/src/interfaces/IPendingHoldsModule.sol
@@ -155,6 +155,11 @@ interface IPendingHoldsModule {
     /// @notice Thrown when address(0) is passed as cashModuleCore
     error ZeroCashModuleCore();
 
+    /// @notice Thrown when a per-hold amount exceeds the running totalHolds sum — i.e. totalHolds has
+    ///         drifted from the sum of individual holds (an invariant break). Surfaced loudly rather
+    ///         than silently floored, because totalHolds drives the withdrawal guard.
+    error TotalHoldsUnderflow();
+
     // -------------------------------------------------------------------------
     // Write functions — EtherFi wallet (backend) only
     // -------------------------------------------------------------------------

--- a/src/libraries/SpendingLimitLib.sol
+++ b/src/libraries/SpendingLimitLib.sol
@@ -115,6 +115,19 @@ library SpendingLimitLib {
     }
 
     /**
+     * @notice Credits amount back to the daily and monthly spent counters
+     * @dev Applies day/month rollovers before crediting so we never decrement a counter
+     *      that already reset to 0. Floors each counter at 0.
+     * @param limit Storage reference to the SpendingLimit
+     * @param amount Amount to credit back in USD (1e6)
+     */
+    function release(SpendingLimit storage limit, uint256 amount) internal {
+        currentLimit(limit);
+        limit.spentToday = amount <= limit.spentToday ? limit.spentToday - amount : 0;
+        limit.spentThisMonth = amount <= limit.spentThisMonth ? limit.spentThisMonth - amount : 0;
+    }
+
+    /**
      * @notice Updates spending limits with optional delay for decreases
      * @dev Immediate increases, delayed decreases with activation timestamp
      * @param limit Storage reference to the SpendingLimit

--- a/src/libraries/SpendingLimitLib.sol
+++ b/src/libraries/SpendingLimitLib.sol
@@ -123,8 +123,31 @@ library SpendingLimitLib {
      */
     function release(SpendingLimit storage limit, uint256 amount) internal {
         currentLimit(limit);
-        limit.spentToday = amount <= limit.spentToday ? limit.spentToday - amount : 0;
-        limit.spentThisMonth = amount <= limit.spentThisMonth ? limit.spentThisMonth - amount : 0;
+        // Floor at 0 is legitimate here: currentLimit() may have reset the counters at a day/month
+        // rollover, after which crediting back a stale charge underflows by design.
+        limit.spentToday = _subFloor(limit.spentToday, amount);
+        limit.spentThisMonth = _subFloor(limit.spentThisMonth, amount);
+    }
+
+    /**
+     * @notice Reconciles the limit when the charged amount for an obligation changes from
+     *         oldCharged to newOwed (e.g. settlement amount differs from the authorized hold).
+     * @dev Single primitive for "the limit currently reflects oldCharged; make it reflect newOwed."
+     *      Charges the positive delta (subject to limit checks) or releases the negative delta.
+     *      Pass oldCharged = 0 to charge the full newOwed (forced / no-prior-hold settlement).
+     * @param limit Storage reference to the SpendingLimit
+     * @param oldCharged Amount already reflected in the limit for this obligation (USD 1e6)
+     * @param newOwed Amount that should now be reflected (USD 1e6)
+     */
+    function reconcileLimit(SpendingLimit storage limit, uint256 oldCharged, uint256 newOwed) internal {
+        if (newOwed > oldCharged) spend(limit, newOwed - oldCharged);
+        else if (newOwed < oldCharged) release(limit, oldCharged - newOwed);
+    }
+
+    /// @dev Saturating subtraction: max(a - b, 0). Use only where underflow is an expected,
+    ///      documented consequence (e.g. day/month limit rollover), never to mask an invariant break.
+    function _subFloor(uint256 a, uint256 b) private pure returns (uint256) {
+        unchecked { return a >= b ? a - b : 0; }
     }
 
     /**

--- a/src/modules/cash/CashLens.sol
+++ b/src/modules/cash/CashLens.sol
@@ -7,6 +7,7 @@ import { EnumerableSetLib } from "solady/utils/EnumerableSetLib.sol";
 import { ArrayDeDupLib } from "../../libraries/ArrayDeDupLib.sol";
 
 import { ICashModule, Mode, SafeCashData, SafeData, WithdrawalRequest, DebitModeMaxSpend } from "../../interfaces/ICashModule.sol";
+import { IPendingHoldsModule } from "../../interfaces/IPendingHoldsModule.sol";
 import { IDebtManager } from "../../interfaces/IDebtManager.sol";
 import { IEtherFiDataProvider } from "../../interfaces/IEtherFiDataProvider.sol";
 import { IEtherFiSafe } from "../../interfaces/IEtherFiSafe.sol";
@@ -32,6 +33,8 @@ contract CashLens is UpgradeableProxy {
     ICashModule public immutable cashModule;
     /// @notice Reference to the deployed EtherFiDataProvider contract
     IEtherFiDataProvider public immutable dataProvider;
+    /// @notice Reference to the deployed PendingHoldsModule contract
+    IPendingHoldsModule public immutable pendingHoldsModule;
 
     /// @notice Constant representing 100% with 18 decimal places
     uint256 public constant HUNDRED_PERCENT = 100e18;
@@ -42,13 +45,17 @@ contract CashLens is UpgradeableProxy {
     error NotABorrowToken();
 
     /**
-     * @notice Initializes the CashLens contract with a reference to the CashModule
-     * @param _cashModule Address of the deployed CashModule contract
+     * @notice Initializes the CashLens contract with references to the CashModule and PendingHoldsModule
+     * @dev Adding pendingHoldsModule as an immutable requires a new proxy deployment — existing proxies
+     *      cannot adopt new constructor immutables via upgrade.
+     * @param _cashModule Address of the deployed CashModule (Core) proxy
      * @param _dataProvider Address of the deployed EtherFiDataProvider contract
+     * @param _pendingHoldsModule Address of the deployed PendingHoldsModule proxy
      */
-    constructor(address _cashModule, address _dataProvider) {
+    constructor(address _cashModule, address _dataProvider, address _pendingHoldsModule) {
         cashModule = ICashModule(_cashModule);
         dataProvider = IEtherFiDataProvider(_dataProvider);
+        pendingHoldsModule = IPendingHoldsModule(_pendingHoldsModule);
 
         _disableInitializers();
     }
@@ -166,7 +173,9 @@ contract CashLens is UpgradeableProxy {
         // In Credit mode, only one token is allowed
         if (mode == Mode.Credit && tokens.length > 1) return (false, "Only one token allowed in Credit mode");
         
-        // Check spending limit
+        // Check spending limit. When PendingHoldsModule is active, holds are charged to
+        // spentToday/spentThisMonth at addHold() time, so the limit already reflects in-flight
+        // hold consumption — no manual deduction needed here.
         (bool withinLimit, string memory limitMessage) = safeData.spendingLimit.canSpend(totalSpendingInUsd);
         if (!withinLimit) return (false, limitMessage);
         
@@ -675,7 +684,48 @@ contract CashLens is UpgradeableProxy {
         assembly ("memory-safe") {
             mstore(tokenAmounts, m)
         }
-        
+
         return (tokenAmounts, "");
+    }
+
+    // -------------------------------------------------------------------------
+    // Pending holds views
+    // -------------------------------------------------------------------------
+
+    /**
+     * @notice Returns the spendable balance for a safe
+     * @dev Delegates to rawSpendable() which already reflects hold consumption — holds are
+     *      charged to spentToday/spentThisMonth at addHold() time, so no separate deduction
+     *      is needed here.
+     * @param safe Address of the EtherFi Safe
+     * @return Spendable amount in USD (1e6)
+     */
+    function spendable(address safe) external view returns (uint256) {
+        return cashModule.rawSpendable(safe);
+    }
+
+    /**
+     * @notice Convenience aggregator returning all pending-holds state for a safe in one call
+     * @dev Useful for debugging card declines and manual reconciliation.
+     *      Holds are charged to spentToday/spentThisMonth at addHold() time, so spendableAmt
+     *      already reflects all in-flight hold consumption.
+     *
+     *      IMPORTANT: totalHolds is already embedded in spendableAmt. Do NOT subtract
+     *      totalHolds from spendableAmt — that double-counts and understates available capacity.
+     *
+     *      rawSpendableAmt is provided alongside spendableAmt for convenience; both values are
+     *      always identical under the current design. Callers that need only the spendable balance
+     *      should prefer spendable() or rawSpendable() directly.
+     * @param safe Address of the EtherFi Safe
+     * @return totalHolds Sum of active hold amounts in USD (1e6) — for display/withdrawal guard only
+     * @return spendableAmt Remaining spendable capacity in USD (1e6), holds already reflected
+     * @return rawSpendableAmt Identical to spendableAmt; both equal cashModule.rawSpendable(safe)
+     */
+    function holdsSummary(address safe) external view returns (uint256 totalHolds, uint256 spendableAmt, uint256 rawSpendableAmt) {
+        rawSpendableAmt = cashModule.rawSpendable(safe);
+        spendableAmt = rawSpendableAmt;
+        if (address(pendingHoldsModule) != address(0)) {
+            totalHolds = pendingHoldsModule.totalPendingHolds(safe);
+        }
     }
 }

--- a/src/modules/cash/CashModuleCore.sol
+++ b/src/modules/cash/CashModuleCore.sol
@@ -18,6 +18,7 @@ import { SignatureUtils } from "../../libraries/SignatureUtils.sol";
 import { SpendingLimit, SpendingLimitLib } from "../../libraries/SpendingLimitLib.sol";
 import { UpgradeableProxy } from "../../utils/UpgradeableProxy.sol";
 import { ModuleBase } from "../ModuleBase.sol";
+import { IPendingHoldsModule } from "../../interfaces/IPendingHoldsModule.sol";
 import { CashModuleStorageContract } from "./CashModuleStorageContract.sol";
 
 /**
@@ -322,7 +323,26 @@ contract CashModuleCore is CashModuleStorageContract {
 
     /**
      * @notice Processes a spending transaction with multiple tokens
-     * @dev Only callable by EtherFi wallet for valid EtherFi Safe addresses
+     * @dev Unified settlement path — handles both normal (hold exists) and recovery (no hold) cases.
+     *
+     *      Hold-sync step (before token transfer):
+     *        - Hold exists, non-forced: update hold to settlement amount; charge/release limit delta.
+     *        - Hold exists, forced:     update hold to settlement amount; no limit adjustment.
+     *        - No hold:                 create forced hold; bypass limit ("Settlement is KING").
+     *        - No PHM:                  charge spendingLimit.spend() directly (legacy path).
+     *
+     *      Spend step:
+     *        - Credit mode: borrow full settlement amount; all-or-nothing.
+     *        - Debit mode:  transfer min(required, available) per token; partial spend supported.
+     *
+     *      Finalize step (after token transfer):
+     *        - Fully spent (remaining == 0): removeHold().
+     *        - Partially spent (remaining > 0): settlementSetRemainingHold(remaining) — hold
+     *          tracks outstanding debt; a separate special function handles clearance.
+     *
+     *      Emits Spend with the ACTUALLY spent amount, not the settlement amount if partial.
+     *
+     *      Only callable by EtherFi wallet for valid EtherFi Safe addresses.
      * @param safe Address of the EtherFi Safe
      * @param txId Transaction identifier
      * @param binSponsor Bin sponsor used for spending
@@ -331,22 +351,39 @@ contract CashModuleCore is CashModuleStorageContract {
      * @param cashbacks Struct of Cashback to be given
      * @custom:throws TransactionAlreadyCleared if the transaction was already processed
      * @custom:throws UnsupportedToken if any token is not supported
-     * @custom:throws AmountZero if any converted amount is zero
+     * @custom:throws AmountZero if total amounts are zero
      * @custom:throws ArrayLengthMismatch if token and amount arrays have different lengths
      * @custom:throws OnlyOneTokenAllowedInCreditMode if multiple tokens are used in credit mode
-     * @custom:throws If spending would exceed limits or balances
      */
-    function spend(address safe, bytes32 txId, BinSponsor binSponsor,  address[] calldata tokens,  uint256[] calldata amountsInUsd,  Cashback[] calldata cashbacks) external whenNotPaused nonReentrant onlyEtherFiWallet onlyEtherFiSafe(safe) {
+    function spend(address safe, bytes32 txId, BinSponsor binSponsor, address[] calldata tokens, uint256[] calldata amountsInUsd, Cashback[] calldata cashbacks) external whenNotPaused nonReentrant onlyEtherFiWallet onlyEtherFiSafe(safe) {
         CashModuleStorage storage $ = _getCashModuleStorage();
 
-        uint256 totalSpendingInUsd = _validateSpend($.safeCashConfig[safe], txId, tokens, amountsInUsd);        
-                
-        if ($.safeCashConfig[safe].mode == Mode.Credit)  _spendCredit($, safe, txId, binSponsor, tokens, amountsInUsd, totalSpendingInUsd);
-        else _spendDebit($, safe, txId, binSponsor, tokens, amountsInUsd, totalSpendingInUsd);
-        _cashback($, safe, totalSpendingInUsd, cashbacks);
+        uint256 totalSpendingInUsd = _validateSpend($.safeCashConfig[safe], txId, tokens, amountsInUsd);
+
+        // Sync hold to settlement amount (or create forced hold). Handle limit delta in Core to
+        // avoid a PHM→Core callback re-entering the nonReentrant spend() context.
+        _phmSettleHold($, safe, binSponsor, txId, totalSpendingInUsd);
+
+        uint256 actualSpendInUsd;
+        if ($.safeCashConfig[safe].mode == Mode.Credit) {
+            _spendCredit($, safe, txId, binSponsor, tokens, amountsInUsd, totalSpendingInUsd);
+            actualSpendInUsd = totalSpendingInUsd;
+        } else {
+            actualSpendInUsd = _spendDebitPartial($, safe, txId, binSponsor, tokens, amountsInUsd);
+            // When PHM is unset, partial settlement has nowhere to record the remainder —
+            // transactionCleared[txId] is already set and _phmFinalize is a no-op, so any
+            // untransferred amount would become silent debt. Require full settlement here
+            // to preserve strict debit semantics for legacy / pre-PHM deployments.
+            if ($.pendingHoldsModule == address(0) && actualSpendInUsd != totalSpendingInUsd) {
+                revert InsufficientBalance();
+            }
+        }
+
+        _phmFinalize($, safe, binSponsor, txId, totalSpendingInUsd, actualSpendInUsd);
+        _cashback($, safe, actualSpendInUsd, cashbacks);
     }
 
-    function _validateSpend(SafeCashConfig storage $$, bytes32 txId, address[] calldata tokens,  uint256[] calldata amountsInUsd) internal returns(uint256) {
+    function _validateSpend(SafeCashConfig storage $$, bytes32 txId, address[] calldata tokens, uint256[] calldata amountsInUsd) internal returns(uint256) {
         // Input validation
         if (tokens.length == 0) revert InvalidInput();
         if (tokens.length != amountsInUsd.length) revert ArrayLengthMismatch();
@@ -356,7 +393,7 @@ contract CashModuleCore is CashModuleStorageContract {
         // Set current mode and check transaction status
         _setCurrentMode($$);
         if ($$.transactionCleared[txId]) revert TransactionAlreadyCleared();
-        
+
         // In Credit mode, only one token is allowed
         if ($$.mode == Mode.Credit && tokens.length > 1) revert OnlyOneTokenAllowedInCreditMode();
 
@@ -367,12 +404,72 @@ contract CashModuleCore is CashModuleStorageContract {
         }
 
         if (totalSpendingInUsd == 0) revert AmountZero();
-        
-        // Update spending limit
+
         $$.transactionCleared[txId] = true;
-        $$.spendingLimit.spend(totalSpendingInUsd);
+        // NOTE: spendingLimit.spend() is NOT called here. Callers are responsible:
+        //   - spend():      skips if hold was non-forced (limit already consumed at addHold time)
+        //   - forceSpend(): skips if hold was non-forced; always charges otherwise
+        //   - No-PHM path: always calls spendingLimit.spend() at settlement
 
         return totalSpendingInUsd;
+    }
+
+    /**
+     * @dev Syncs/creates a hold via PHM and handles spending-limit accounting for spend().
+     *      Extracted to its own stack frame to avoid stack-too-deep in callers.
+     *
+     *      Limit accounting rules after settlementSyncHold() returns:
+     *        - No hold existed (Settlement is KING): bypass limit — no charge.
+     *        - Non-forced hold, settlement > old:   charge delta to limit.
+     *        - Non-forced hold, settlement < old:   release delta from limit.
+     *        - Non-forced hold, settlement == old:  no-op.
+     *        - Forced hold (forceAddHold path):     charge full settlement to limit now,
+     *                                               since limit was bypassed at forceAddHold.
+     *        - No PHM:                              charge spendingLimit.spend(amount) directly.
+     *
+     *      Limit adjustments are performed in Core — NOT via a PHM→Core callback — to avoid
+     *      re-entering the nonReentrant spend() context through CashModuleSetters.
+     */
+    function _phmSettleHold(CashModuleStorage storage $, address safe, BinSponsor binSponsor, bytes32 txId, uint256 amount) private {
+        address phm = $.pendingHoldsModule;
+        if (phm == address(0)) {
+            $.safeCashConfig[safe].spendingLimit.spend(amount);
+            return;
+        }
+        (bool existed, bool wasForced, uint256 oldAmount) =
+            IPendingHoldsModule(phm).settlementSyncHold(safe, binSponsor, txId, amount);
+        if (!existed) {
+            // Settlement is KING — no prior hold, bypass limit entirely.
+            return;
+        }
+        if (!wasForced) {
+            // Non-forced hold: limit was pre-charged at addHold for oldAmount; adjust for delta.
+            if (amount > oldAmount) {
+                $.safeCashConfig[safe].spendingLimit.spend(amount - oldAmount);
+            } else if (amount < oldAmount) {
+                $.safeCashConfig[safe].spendingLimit.release(oldAmount - amount);
+            }
+        } else {
+            // Forced hold (forceAddHold path): limit was bypassed at creation — charge now.
+            $.safeCashConfig[safe].spendingLimit.spend(amount);
+        }
+    }
+
+    /**
+     * @dev Finalizes the hold state after spend() executes the token transfer.
+     *      - remaining == 0: removeHold() — fully settled.
+     *      - remaining  > 0: settlementSetRemainingHold(remaining) — partial settlement; the
+     *        remaining hold tracks outstanding debt for the special-function clearance path.
+     */
+    function _phmFinalize(CashModuleStorage storage $, address safe, BinSponsor binSponsor, bytes32 txId, uint256 total, uint256 actual) private {
+        address phm = $.pendingHoldsModule;
+        if (phm == address(0)) return;
+        uint256 remaining = total - actual;
+        if (remaining == 0) {
+            IPendingHoldsModule(phm).removeHold(safe, binSponsor, txId);
+        } else {
+            IPendingHoldsModule(phm).settlementSetRemainingHold(safe, binSponsor, txId, remaining);
+        }
     }
 
     /**
@@ -410,31 +507,43 @@ contract CashModuleCore is CashModuleStorageContract {
     }
 
     /**
-     * @dev Internal function to execute debit mode spending transactions (multiple tokens)
-     * @param $ Storage reference to the CashModuleStorage
-     * @param safe Address of the EtherFi Safe
-     * @param txId Transaction identifier
-     * @param tokens Array of addresses of the tokens to spend
-     * @param amountsInUsd Array of amounts to spend in USD
+     * @dev Executes a debit-mode spend, capping each token at the safe's available balance.
+     *      Returns the total USD actually transferred (may be less than the requested total if
+     *      any token balance is insufficient — partial settlement).
+     *
+     *      For each token:
+     *        - Converts amountsInUsd[i] → required token amount via debtManager price oracle.
+     *        - If balance >= required: transfer required; actualUsd[i] = amountsInUsd[i].
+     *        - If balance  < required: transfer available; actualUsd[i] proportionally scaled.
+     *
+     *      Emits Spend with the actually transferred amounts and actualSpendInUsd total.
+     *      Caller (_phmFinalize) updates or removes the hold for any remaining USD.
      */
-    function _spendDebit(CashModuleStorage storage $, address safe, bytes32 txId, BinSponsor binSponsor, address[] calldata tokens, uint256[] calldata amountsInUsd, uint256 totalSpendingInUsd) internal {
+    function _spendDebitPartial(CashModuleStorage storage $, address safe, bytes32 txId, BinSponsor binSponsor, address[] calldata tokens, uint256[] calldata amountsInUsd) internal returns (uint256 actualSpendInUsd) {
         uint256[] memory amounts = new uint256[](tokens.length);
-        
-        // Convert USD amounts to token amounts and validate
+        uint256[] memory actualUsd = new uint256[](tokens.length);
+
         for (uint256 i = 0; i < tokens.length; i++) {
             if (!_isBorrowToken($.debtManager, tokens[i])) revert UnsupportedToken();
+            // Use amounts[i] as "required" first, then overwrite if partial.
             amounts[i] = $.debtManager.convertUsdToCollateralToken(tokens[i], amountsInUsd[i]);
-            if (IERC20(tokens[i]).balanceOf(safe) < amounts[i]) revert InsufficientBalance();
-            
+            uint256 available = IERC20(tokens[i]).balanceOf(safe);
+            if (available < amounts[i]) {
+                // Partial: scale USD proportionally; cap token transfer at available.
+                actualUsd[i] = amounts[i] > 0 ? amountsInUsd[i] * available / amounts[i] : 0;
+                amounts[i] = available;
+            } else {
+                actualUsd[i] = amountsInUsd[i];
+            }
+            actualSpendInUsd += actualUsd[i];
             _cancelWithdrawalRequestIfNecessary(safe, tokens[i], amounts[i]);
         }
 
         _spendDebit(safe, binSponsor, tokens, amounts);
 
-        $.cashEventEmitter.emitSpend(safe, txId, binSponsor, tokens, amounts, amountsInUsd, totalSpendingInUsd, Mode.Debit);
-        
-        // Ensuring the account is healthy
-        // If account is unhealthy after spend, cancel withdrawal and try again
+        $.cashEventEmitter.emitSpend(safe, txId, binSponsor, tokens, amounts, actualUsd, actualSpendInUsd, Mode.Debit);
+
+        // Ensuring the account is healthy; retry once after canceling any pending withdrawal.
         try $.debtManager.ensureHealth(safe) {}
         catch {
             _cancelOldWithdrawal(safe);
@@ -548,49 +657,6 @@ contract CashModuleCore is CashModuleStorageContract {
                 ++i;
             }
         }
-    }
-
-    /**
-     * @notice Repays borrowed tokens
-     * @dev Only callable by EtherFi wallet for valid EtherFi Safe addresses
-     * @param safe Address of the EtherFi Safe
-     * @param token Address of the token to repay
-     * @param amountInUsd Amount to repay in USD
-     * @custom:throws OnlyBorrowToken if token is not a valid borrow token
-     */
-    function repay(address safe, address token, uint256 amountInUsd) public whenNotPaused nonReentrant onlyEtherFiWallet onlyEtherFiSafe(safe) {
-        IDebtManager debtManager = getDebtManager();
-        if (!_isBorrowToken(debtManager, token)) revert OnlyBorrowToken();
-        _repay(safe, debtManager, token, amountInUsd);
-    }
-
-    /**
-     * @dev Internal function to execute the repayment transaction
-     * @param safe Address of the EtherFi Safe
-     * @param debtManager Reference to the debt manager contract
-     * @param token Address of the token to repay
-     * @param amountInUsd Amount to repay in USD
-     * @custom:throws AmountZero if the converted amount is zero
-     */
-    function _repay(address safe, IDebtManager debtManager, address token, uint256 amountInUsd) internal {
-        uint256 amount = IDebtManager(debtManager).convertUsdToCollateralToken(token, amountInUsd);
-        if (amount == 0) revert AmountZero();
-        _cancelWithdrawalRequestIfNecessary(safe, token, amount);
-
-        address[] memory to = new address[](3);
-        bytes[] memory data = new bytes[](3);
-        uint256[] memory values = new uint256[](3);
-
-        to[0] = token;
-        to[1] = address(debtManager);
-        to[2] = token;
-
-        data[0] = abi.encodeWithSelector(IERC20.approve.selector, address(debtManager), amount);
-        data[1] = abi.encodeWithSelector(IDebtManager.repay.selector, safe, token, amount);
-        data[2] = abi.encodeWithSelector(IERC20.approve.selector, address(debtManager), 0);
-
-        IEtherFiSafe(safe).execTransactionFromModule(to, values, data);
-        _getCashModuleStorage().cashEventEmitter.emitRepayDebtManager(safe, token, amount, amountInUsd);
     }
 
     /**

--- a/src/modules/cash/CashModuleCore.sol
+++ b/src/modules/cash/CashModuleCore.sol
@@ -419,12 +419,13 @@ contract CashModuleCore is CashModuleStorageContract {
      *      Extracted to its own stack frame to avoid stack-too-deep in callers.
      *
      *      Limit accounting rules after settlementSyncHold() returns:
-     *        - No hold existed (Settlement is KING): bypass limit — no charge.
+     *        - No hold existed (Settlement is KING): charge full settlement to limit now (the
+     *                                               forced hold created at sync bypassed it).
+     *        - Forced hold (forceAddHold path):     charge full settlement to limit now,
+     *                                               since limit was bypassed at forceAddHold.
      *        - Non-forced hold, settlement > old:   charge delta to limit.
      *        - Non-forced hold, settlement < old:   release delta from limit.
      *        - Non-forced hold, settlement == old:  no-op.
-     *        - Forced hold (forceAddHold path):     charge full settlement to limit now,
-     *                                               since limit was bypassed at forceAddHold.
      *        - No PHM:                              charge spendingLimit.spend(amount) directly.
      *
      *      Limit adjustments are performed in Core — NOT via a PHM→Core callback — to avoid
@@ -438,20 +439,19 @@ contract CashModuleCore is CashModuleStorageContract {
         }
         (bool existed, bool wasForced, uint256 oldAmount) =
             IPendingHoldsModule(phm).settlementSyncHold(safe, binSponsor, txId, amount);
-        if (!existed) {
-            // Settlement is KING — no prior hold, bypass limit entirely.
-            return;
-        }
-        if (!wasForced) {
-            // Non-forced hold: limit was pre-charged at addHold for oldAmount; adjust for delta.
+        if (!existed || wasForced) {
+            // No prior hold ("Settlement is KING", created as a forced hold inside settlementSyncHold)
+            // OR a forceAddHold hold: in both cases the spending limit was bypassed at creation, so
+            // charge the full settlement amount now. The limit is the primary risk control and must
+            // reflect funds leaving the safe even when settlement arrives without a matching auth hold.
+            $.safeCashConfig[safe].spendingLimit.spend(amount);
+        } else {
+            // Non-forced hold: limit was pre-charged at addHold for oldAmount; adjust for the delta.
             if (amount > oldAmount) {
                 $.safeCashConfig[safe].spendingLimit.spend(amount - oldAmount);
             } else if (amount < oldAmount) {
                 $.safeCashConfig[safe].spendingLimit.release(oldAmount - amount);
             }
-        } else {
-            // Forced hold (forceAddHold path): limit was bypassed at creation — charge now.
-            $.safeCashConfig[safe].spendingLimit.spend(amount);
         }
     }
 

--- a/src/modules/cash/CashModuleCore.sol
+++ b/src/modules/cash/CashModuleCore.sol
@@ -439,20 +439,12 @@ contract CashModuleCore is CashModuleStorageContract {
         }
         (bool existed, bool wasForced, uint256 oldAmount) =
             IPendingHoldsModule(phm).settlementSyncHold(safe, binSponsor, txId, amount);
-        if (!existed || wasForced) {
-            // No prior hold ("Settlement is KING", created as a forced hold inside settlementSyncHold)
-            // OR a forceAddHold hold: in both cases the spending limit was bypassed at creation, so
-            // charge the full settlement amount now. The limit is the primary risk control and must
-            // reflect funds leaving the safe even when settlement arrives without a matching auth hold.
-            $.safeCashConfig[safe].spendingLimit.spend(amount);
-        } else {
-            // Non-forced hold: limit was pre-charged at addHold for oldAmount; adjust for the delta.
-            if (amount > oldAmount) {
-                $.safeCashConfig[safe].spendingLimit.spend(amount - oldAmount);
-            } else if (amount < oldAmount) {
-                $.safeCashConfig[safe].spendingLimit.release(oldAmount - amount);
-            }
-        }
+        // The limit already reflects `oldCharged` for this obligation; make it reflect `amount`.
+        //   - non-forced hold: limit was pre-charged at addHold for oldAmount → reconcile the delta.
+        //   - forced hold / no prior hold ("Settlement is KING"): limit was bypassed at creation
+        //     (oldCharged = 0) → reconcileLimit charges the full settlement amount now.
+        uint256 oldCharged = (existed && !wasForced) ? oldAmount : 0;
+        $.safeCashConfig[safe].spendingLimit.reconcileLimit(oldCharged, amount);
     }
 
     /**

--- a/src/modules/cash/CashModuleSetters.sol
+++ b/src/modules/cash/CashModuleSetters.sol
@@ -18,6 +18,7 @@ import { UpgradeableProxy } from "../../utils/UpgradeableProxy.sol";
 import { ModuleBase } from "../ModuleBase.sol";
 import { CashModuleStorageContract } from "./CashModuleStorageContract.sol";
 import { EnumerableAddressWhitelistLib } from "../../libraries/EnumerableAddressWhitelistLib.sol";
+import { IPendingHoldsModule } from "../../interfaces/IPendingHoldsModule.sol";
 
 
 /**
@@ -332,7 +333,11 @@ function _requestWithdrawal(address safe, address[] memory tokens, uint256[] mem
 
         if (recipient == address(0)) revert RecipientCannotBeAddressZero();
         if (tokens.length > 1) tokens.checkDuplicates();
-        
+
+        // Block withdrawals while pending holds exist — the safe's balance is committed to unsettled card txns
+        address phm = $.pendingHoldsModule;
+        if (phm != address(0) && IPendingHoldsModule(phm).totalPendingHolds(safe) > 0) revert WithdrawalBlockedByPendingHolds();
+
         _areAssetsWithdrawable($, tokens);
         _cancelOldWithdrawal(safe);
 
@@ -346,5 +351,114 @@ function _requestWithdrawal(address safe, address[] memory tokens, uint256[] mem
         _getDebtManager().ensureHealth(safe);
 
         if ($.withdrawalDelay == 0) _processWithdrawal(safe);
+    }
+
+    // -------------------------------------------------------------------------
+    // Repayment — moved here from CashModuleCore to preserve Core's 24KB ceiling
+    // -------------------------------------------------------------------------
+
+    /**
+     * @notice Repays borrowed tokens
+     * @dev Only callable by EtherFi wallet for valid EtherFi Safe addresses.
+     *      Routed from Core via fallback() delegatecall.
+     * @param safe Address of the EtherFi Safe
+     * @param token Address of the token to repay
+     * @param amountInUsd Amount to repay in USD
+     * @custom:throws OnlyBorrowToken if token is not a valid borrow token
+     */
+    function repay(address safe, address token, uint256 amountInUsd) public whenNotPaused nonReentrant onlyEtherFiWallet onlyEtherFiSafe(safe) {
+        IDebtManager debtManager = _getDebtManager();
+        if (!_isBorrowToken(debtManager, token)) revert OnlyBorrowToken();
+        _repay(safe, debtManager, token, amountInUsd);
+    }
+
+    /**
+     * @dev Internal function to execute the repayment transaction
+     * @param safe Address of the EtherFi Safe
+     * @param debtManager Reference to the debt manager contract
+     * @param token Address of the token to repay
+     * @param amountInUsd Amount to repay in USD
+     * @custom:throws AmountZero if the converted amount is zero
+     */
+    function _repay(address safe, IDebtManager debtManager, address token, uint256 amountInUsd) internal {
+        uint256 amount = IDebtManager(debtManager).convertUsdToCollateralToken(token, amountInUsd);
+        if (amount == 0) revert AmountZero();
+        _cancelWithdrawalRequestIfNecessary(safe, token, amount);
+
+        address[] memory to = new address[](3);
+        bytes[] memory data = new bytes[](3);
+        uint256[] memory values = new uint256[](3);
+
+        to[0] = token;
+        to[1] = address(debtManager);
+        to[2] = token;
+
+        data[0] = abi.encodeWithSelector(IERC20.approve.selector, address(debtManager), amount);
+        data[1] = abi.encodeWithSelector(IDebtManager.repay.selector, safe, token, amount);
+        data[2] = abi.encodeWithSelector(IERC20.approve.selector, address(debtManager), 0);
+
+        IEtherFiSafe(safe).execTransactionFromModule(to, values, data);
+        _getCashModuleStorage().cashEventEmitter.emitRepayDebtManager(safe, token, amount, amountInUsd);
+    }
+
+    // -------------------------------------------------------------------------
+    // PendingHoldsModule integration
+    // -------------------------------------------------------------------------
+
+    /**
+     * @notice Returns the remaining spendable capacity for a safe based on its spending limits
+     * @dev Returns min(remainingDailyLimit, remainingMonthlyLimit) in USD (1e6).
+     *      When PendingHoldsModule is active, holds are charged to spentToday/spentThisMonth at
+     *      addHold() time, so this value already reflects in-flight hold consumption.
+     *      Lives here (not in Core) to preserve Core's EVM 24KB bytecode ceiling.
+     *      Routed transparently via Core's fallback() delegatecall.
+     * @param safe Address of the EtherFi Safe
+     * @return Spendable amount in USD (1e6)
+     */
+    function rawSpendable(address safe) external view returns (uint256) {
+        return _getCashModuleStorage().safeCashConfig[safe].spendingLimit.maxCanSpend();
+    }
+
+    /**
+     * @notice Consumes amountUsd from the safe's daily and monthly spending limits
+     * @dev Called by PendingHoldsModule at addHold() and updateHold() (increase) so that
+     *      the limit reflects the user's authorized spend immediately at auth-ack time.
+     *      Reverts with ExceededDailySpendingLimit or ExceededMonthlySpendingLimit if the
+     *      amount would breach the limit — identical validation to the settlement-time spend().
+     *      Only callable by the registered PendingHoldsModule.
+     *      Lives here (not in Core) to preserve Core's EVM 24KB bytecode ceiling.
+     * @param safe Address of the EtherFi Safe
+     * @param amountUsd Amount to consume from limits in USD (1e6)
+     */
+    function consumeSpendingLimit(address safe, uint256 amountUsd) external {
+        if (msg.sender != _getCashModuleStorage().pendingHoldsModule) revert InvalidInput();
+        _getCashModuleStorage().safeCashConfig[safe].spendingLimit.spend(amountUsd);
+    }
+
+    /**
+     * @notice Credits amountUsd back to the safe's daily and monthly spending limits
+     * @dev Called by PendingHoldsModule at releaseHold() and updateHold() (decrease) to
+     *      return limit headroom when an authorized transaction is reversed or downsized.
+     *      Applies a floor at 0 on each counter — safe for day/month-boundary crossings where
+     *      the counter already reset to 0 before the credit arrives.
+     *      Only callable by the registered PendingHoldsModule.
+     *      Lives here (not in Core) to preserve Core's EVM 24KB bytecode ceiling.
+     * @param safe Address of the EtherFi Safe
+     * @param amountUsd Amount to release from limits in USD (1e6)
+     */
+    function releaseSpendingLimit(address safe, uint256 amountUsd) external {
+        if (msg.sender != _getCashModuleStorage().pendingHoldsModule) revert InvalidInput();
+        _getCashModuleStorage().safeCashConfig[safe].spendingLimit.release(amountUsd);
+    }
+
+    /**
+     * @notice Sets the PendingHoldsModule address
+     * @dev Only callable by accounts with CASH_MODULE_CONTROLLER_ROLE.
+     * @param _pendingHoldsModule Address of the deployed PendingHoldsModule proxy
+     */
+    function setPendingHoldsModule(address _pendingHoldsModule) external {
+        if (!roleRegistry().hasRole(CASH_MODULE_CONTROLLER_ROLE, msg.sender)) revert OnlyCashModuleController();
+        if (_pendingHoldsModule == address(0)) revert InvalidInput();
+        _getCashModuleStorage().pendingHoldsModule = _pendingHoldsModule;
     }
 }

--- a/src/modules/cash/CashModuleSetters.sol
+++ b/src/modules/cash/CashModuleSetters.sol
@@ -354,54 +354,6 @@ function _requestWithdrawal(address safe, address[] memory tokens, uint256[] mem
     }
 
     // -------------------------------------------------------------------------
-    // Repayment — moved here from CashModuleCore to preserve Core's 24KB ceiling
-    // -------------------------------------------------------------------------
-
-    /**
-     * @notice Repays borrowed tokens
-     * @dev Only callable by EtherFi wallet for valid EtherFi Safe addresses.
-     *      Routed from Core via fallback() delegatecall.
-     * @param safe Address of the EtherFi Safe
-     * @param token Address of the token to repay
-     * @param amountInUsd Amount to repay in USD
-     * @custom:throws OnlyBorrowToken if token is not a valid borrow token
-     */
-    function repay(address safe, address token, uint256 amountInUsd) public whenNotPaused nonReentrant onlyEtherFiWallet onlyEtherFiSafe(safe) {
-        IDebtManager debtManager = _getDebtManager();
-        if (!_isBorrowToken(debtManager, token)) revert OnlyBorrowToken();
-        _repay(safe, debtManager, token, amountInUsd);
-    }
-
-    /**
-     * @dev Internal function to execute the repayment transaction
-     * @param safe Address of the EtherFi Safe
-     * @param debtManager Reference to the debt manager contract
-     * @param token Address of the token to repay
-     * @param amountInUsd Amount to repay in USD
-     * @custom:throws AmountZero if the converted amount is zero
-     */
-    function _repay(address safe, IDebtManager debtManager, address token, uint256 amountInUsd) internal {
-        uint256 amount = IDebtManager(debtManager).convertUsdToCollateralToken(token, amountInUsd);
-        if (amount == 0) revert AmountZero();
-        _cancelWithdrawalRequestIfNecessary(safe, token, amount);
-
-        address[] memory to = new address[](3);
-        bytes[] memory data = new bytes[](3);
-        uint256[] memory values = new uint256[](3);
-
-        to[0] = token;
-        to[1] = address(debtManager);
-        to[2] = token;
-
-        data[0] = abi.encodeWithSelector(IERC20.approve.selector, address(debtManager), amount);
-        data[1] = abi.encodeWithSelector(IDebtManager.repay.selector, safe, token, amount);
-        data[2] = abi.encodeWithSelector(IERC20.approve.selector, address(debtManager), 0);
-
-        IEtherFiSafe(safe).execTransactionFromModule(to, values, data);
-        _getCashModuleStorage().cashEventEmitter.emitRepayDebtManager(safe, token, amount, amountInUsd);
-    }
-
-    // -------------------------------------------------------------------------
     // PendingHoldsModule integration
     // -------------------------------------------------------------------------
 
@@ -462,105 +414,46 @@ function _requestWithdrawal(address safe, address[] memory tokens, uint256[] mem
         _getCashModuleStorage().pendingHoldsModule = _pendingHoldsModule;
     }
 
+    // -------------------------------------------------------------------------
+    // CashModuleSettersExt routing (second overflow hop)
+    // -------------------------------------------------------------------------
+
     /**
-     * @notice Collects the outstanding remainder of an under-funded settlement from the safe's balance.
-     * @dev When spend() settled a transaction the safe could not fully cover, the unpaid remainder is
-     *      parked in a forced "remaining" hold (see CashModuleCore._phmFinalize). This lets ops sweep
-     *      that remainder once the safe is funded: it pays up to the outstanding remainder from `token`,
-     *      reduces the hold, and removes it (unblocking withdrawals) once fully paid.
-     *
-     *      The spending limit is NOT charged again — the full settlement amount was already charged at
-     *      the original spend(). Only operates on already-settled transactions (transactionCleared == true),
-     *      which distinguishes a post-settlement debt from a pre-settlement forceAddHold hold.
-     *
-     *      Lives here (not in Core) to preserve Core's EVM 24KB bytecode ceiling; routed via fallback().
-     * @param safe Address of the EtherFi Safe
-     * @param txId Transaction identifier (the original authorization/settlement id)
-     * @param binSponsor Bin sponsor the settlement was made under
-     * @param token Borrow token to collect the remainder from
-     * @custom:throws InvalidInput if PHM unset, txId not yet settled, or no remainder outstanding
-     * @custom:throws UnsupportedToken if token is not a borrow token
-     * @custom:throws InsufficientBalance if the safe holds nothing collectable in token
+     * @notice Sets the CashModuleSettersExt address — the second fallback-hop overflow contract.
+     * @dev Only callable by accounts with CASH_MODULE_CONTROLLER_ROLE. Functions not found in Core
+     *      or Setters are delegatecalled here (e.g. repay, collectRemaining).
+     * @param _cashModuleSettersExt Address of the deployed CashModuleSettersExt
      */
-    function collectRemaining(address safe, bytes32 txId, BinSponsor binSponsor, address token)
-        external
-        whenNotPaused
-        nonReentrant
-        onlyEtherFiWallet
-        onlyEtherFiSafe(safe)
-    {
-        CashModuleStorage storage $ = _getCashModuleStorage();
-        address phm = $.pendingHoldsModule;
-        if (phm == address(0)) revert InvalidInput();
-        // Must be a post-settlement debt, not a pre-settlement forceAddHold hold awaiting spend().
-        if (!$.safeCashConfig[safe].transactionCleared[txId]) revert InvalidInput();
-        if (!_isBorrowToken($.debtManager, token)) revert UnsupportedToken();
-
-        uint256 remaining = IPendingHoldsModule(phm).remainingHold(safe, binSponsor, txId);
-        if (remaining == 0) revert InvalidInput();
-
-        (uint256 payToken, uint256 paidUsd) = _collectAmounts($, safe, token, remaining);
-
-        _cancelWithdrawalRequestIfNecessary(safe, token, payToken);
-        _collectTransferAndEmit($, safe, binSponsor, txId, token, payToken, paidUsd);
-
-        // Reduce or clear the hold. No limit charge — already charged at the original settlement.
-        if (remaining - paidUsd == 0) IPendingHoldsModule(phm).removeHold(safe, binSponsor, txId);
-        else IPendingHoldsModule(phm).settlementSetRemainingHold(safe, binSponsor, txId, remaining - paidUsd);
-
-        $.debtManager.ensureHealth(safe);
+    function setCashModuleSettersExt(address _cashModuleSettersExt) external {
+        if (!roleRegistry().hasRole(CASH_MODULE_CONTROLLER_ROLE, msg.sender)) revert OnlyCashModuleController();
+        if (_cashModuleSettersExt == address(0)) revert InvalidInput();
+        _getCashModuleStorage().cashModuleSettersExt = _cashModuleSettersExt;
     }
 
-    /// @dev Computes how much of `remaining` (USD 1e6) can be collected from the safe's `token` balance.
-    ///      Rounds USD down (favors the safe). Reverts if nothing meaningful is collectable.
-    function _collectAmounts(CashModuleStorage storage $, address safe, address token, uint256 remaining)
-        private
-        view
-        returns (uint256 payToken, uint256 paidUsd)
-    {
-        uint256 required = $.debtManager.convertUsdToCollateralToken(token, remaining);
-        if (required == 0) revert AmountZero();
-        uint256 available = IERC20(token).balanceOf(safe);
-        if (available < required) {
-            payToken = available;
-            paidUsd = remaining * available / required; // round down — never over-credits the debt
-        } else {
-            payToken = required;
-            paidUsd = remaining;
+    /**
+     * @notice Returns the CashModuleSettersExt address.
+     */
+    function getCashModuleSettersExt() public view returns (address) {
+        return _getCashModuleStorage().cashModuleSettersExt;
+    }
+
+    /**
+     * @dev Second fallback hop. Core delegatecalls Setters for any selector not in Core; if the
+     *      selector is not in Setters either, this forwards (still by delegatecall, so Core's storage
+     *      and the original msg.sender are preserved) to CashModuleSettersExt.
+     */
+    // solhint-disable-next-line no-complex-fallback
+    fallback() external {
+        address extImpl = _getCashModuleStorage().cashModuleSettersExt;
+        if (extImpl == address(0)) revert InvalidInput();
+        // solhint-disable-next-line no-inline-assembly
+        assembly ("memory-safe") {
+            calldatacopy(0, 0, calldatasize())
+            let result := delegatecall(gas(), extImpl, 0, calldatasize(), 0, 0)
+            returndatacopy(0, 0, returndatasize())
+            switch result
+            case 0 { revert(0, returndatasize()) }
+            default { return(0, returndatasize()) }
         }
-        // Refuse a transfer that would move tokens without reducing the recorded debt (dust guard).
-        if (paidUsd == 0) revert InsufficientBalance();
-    }
-
-    /// @dev Transfers the collected tokens to the settlement dispatcher and emits a Spend event.
-    function _collectTransferAndEmit(
-        CashModuleStorage storage $,
-        address safe,
-        BinSponsor binSponsor,
-        bytes32 txId,
-        address token,
-        uint256 payToken,
-        uint256 paidUsd
-    ) private {
-        address[] memory to = new address[](1);
-        bytes[] memory data = new bytes[](1);
-        to[0] = token;
-        data[0] = abi.encodeWithSelector(IERC20.transfer.selector, _settlementDispatcherFor($, binSponsor), payToken);
-        IEtherFiSafe(safe).execTransactionFromModule(to, new uint256[](1), data);
-
-        uint256[] memory tokenAmounts = new uint256[](1);
-        uint256[] memory usdAmounts = new uint256[](1);
-        tokenAmounts[0] = payToken;
-        usdAmounts[0] = paidUsd;
-        $.cashEventEmitter.emitSpend(safe, txId, binSponsor, to, tokenAmounts, usdAmounts, paidUsd, Mode.Debit);
-    }
-
-    /// @dev Resolves the settlement dispatcher for a bin sponsor (mirrors CashModuleCore.getSettlementDispatcher).
-    function _settlementDispatcherFor(CashModuleStorage storage $, BinSponsor binSponsor) private view returns (address dispatcher) {
-        if (binSponsor == BinSponsor.Rain) dispatcher = $.settlementDispatcherRain;
-        else if (binSponsor == BinSponsor.PIX) dispatcher = $.settlementDispatcherPix;
-        else if (binSponsor == BinSponsor.CardOrder) dispatcher = $.settlementDispatcherCardOrder;
-        else dispatcher = $.settlementDispatcherReap;
-        if (dispatcher == address(0)) revert SettlementDispatcherNotSetForBinSponsor();
     }
 }

--- a/src/modules/cash/CashModuleSetters.sol
+++ b/src/modules/cash/CashModuleSetters.sol
@@ -461,4 +461,106 @@ function _requestWithdrawal(address safe, address[] memory tokens, uint256[] mem
         if (_pendingHoldsModule == address(0)) revert InvalidInput();
         _getCashModuleStorage().pendingHoldsModule = _pendingHoldsModule;
     }
+
+    /**
+     * @notice Collects the outstanding remainder of an under-funded settlement from the safe's balance.
+     * @dev When spend() settled a transaction the safe could not fully cover, the unpaid remainder is
+     *      parked in a forced "remaining" hold (see CashModuleCore._phmFinalize). This lets ops sweep
+     *      that remainder once the safe is funded: it pays up to the outstanding remainder from `token`,
+     *      reduces the hold, and removes it (unblocking withdrawals) once fully paid.
+     *
+     *      The spending limit is NOT charged again — the full settlement amount was already charged at
+     *      the original spend(). Only operates on already-settled transactions (transactionCleared == true),
+     *      which distinguishes a post-settlement debt from a pre-settlement forceAddHold hold.
+     *
+     *      Lives here (not in Core) to preserve Core's EVM 24KB bytecode ceiling; routed via fallback().
+     * @param safe Address of the EtherFi Safe
+     * @param txId Transaction identifier (the original authorization/settlement id)
+     * @param binSponsor Bin sponsor the settlement was made under
+     * @param token Borrow token to collect the remainder from
+     * @custom:throws InvalidInput if PHM unset, txId not yet settled, or no remainder outstanding
+     * @custom:throws UnsupportedToken if token is not a borrow token
+     * @custom:throws InsufficientBalance if the safe holds nothing collectable in token
+     */
+    function collectRemaining(address safe, bytes32 txId, BinSponsor binSponsor, address token)
+        external
+        whenNotPaused
+        nonReentrant
+        onlyEtherFiWallet
+        onlyEtherFiSafe(safe)
+    {
+        CashModuleStorage storage $ = _getCashModuleStorage();
+        address phm = $.pendingHoldsModule;
+        if (phm == address(0)) revert InvalidInput();
+        // Must be a post-settlement debt, not a pre-settlement forceAddHold hold awaiting spend().
+        if (!$.safeCashConfig[safe].transactionCleared[txId]) revert InvalidInput();
+        if (!_isBorrowToken($.debtManager, token)) revert UnsupportedToken();
+
+        uint256 remaining = IPendingHoldsModule(phm).remainingHold(safe, binSponsor, txId);
+        if (remaining == 0) revert InvalidInput();
+
+        (uint256 payToken, uint256 paidUsd) = _collectAmounts($, safe, token, remaining);
+
+        _cancelWithdrawalRequestIfNecessary(safe, token, payToken);
+        _collectTransferAndEmit($, safe, binSponsor, txId, token, payToken, paidUsd);
+
+        // Reduce or clear the hold. No limit charge — already charged at the original settlement.
+        if (remaining - paidUsd == 0) IPendingHoldsModule(phm).removeHold(safe, binSponsor, txId);
+        else IPendingHoldsModule(phm).settlementSetRemainingHold(safe, binSponsor, txId, remaining - paidUsd);
+
+        $.debtManager.ensureHealth(safe);
+    }
+
+    /// @dev Computes how much of `remaining` (USD 1e6) can be collected from the safe's `token` balance.
+    ///      Rounds USD down (favors the safe). Reverts if nothing meaningful is collectable.
+    function _collectAmounts(CashModuleStorage storage $, address safe, address token, uint256 remaining)
+        private
+        view
+        returns (uint256 payToken, uint256 paidUsd)
+    {
+        uint256 required = $.debtManager.convertUsdToCollateralToken(token, remaining);
+        if (required == 0) revert AmountZero();
+        uint256 available = IERC20(token).balanceOf(safe);
+        if (available < required) {
+            payToken = available;
+            paidUsd = remaining * available / required; // round down — never over-credits the debt
+        } else {
+            payToken = required;
+            paidUsd = remaining;
+        }
+        // Refuse a transfer that would move tokens without reducing the recorded debt (dust guard).
+        if (paidUsd == 0) revert InsufficientBalance();
+    }
+
+    /// @dev Transfers the collected tokens to the settlement dispatcher and emits a Spend event.
+    function _collectTransferAndEmit(
+        CashModuleStorage storage $,
+        address safe,
+        BinSponsor binSponsor,
+        bytes32 txId,
+        address token,
+        uint256 payToken,
+        uint256 paidUsd
+    ) private {
+        address[] memory to = new address[](1);
+        bytes[] memory data = new bytes[](1);
+        to[0] = token;
+        data[0] = abi.encodeWithSelector(IERC20.transfer.selector, _settlementDispatcherFor($, binSponsor), payToken);
+        IEtherFiSafe(safe).execTransactionFromModule(to, new uint256[](1), data);
+
+        uint256[] memory tokenAmounts = new uint256[](1);
+        uint256[] memory usdAmounts = new uint256[](1);
+        tokenAmounts[0] = payToken;
+        usdAmounts[0] = paidUsd;
+        $.cashEventEmitter.emitSpend(safe, txId, binSponsor, to, tokenAmounts, usdAmounts, paidUsd, Mode.Debit);
+    }
+
+    /// @dev Resolves the settlement dispatcher for a bin sponsor (mirrors CashModuleCore.getSettlementDispatcher).
+    function _settlementDispatcherFor(CashModuleStorage storage $, BinSponsor binSponsor) private view returns (address dispatcher) {
+        if (binSponsor == BinSponsor.Rain) dispatcher = $.settlementDispatcherRain;
+        else if (binSponsor == BinSponsor.PIX) dispatcher = $.settlementDispatcherPix;
+        else if (binSponsor == BinSponsor.CardOrder) dispatcher = $.settlementDispatcherCardOrder;
+        else dispatcher = $.settlementDispatcherReap;
+        if (dispatcher == address(0)) revert SettlementDispatcherNotSetForBinSponsor();
+    }
 }

--- a/src/modules/cash/CashModuleSettersExt.sol
+++ b/src/modules/cash/CashModuleSettersExt.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.28;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-import { Mode, BinSponsor } from "../../interfaces/ICashModule.sol";
+import { ICashModule, Mode, BinSponsor } from "../../interfaces/ICashModule.sol";
 import { IDebtManager } from "../../interfaces/IDebtManager.sol";
 import { IEtherFiSafe } from "../../interfaces/IEtherFiSafe.sol";
 import { IPendingHoldsModule } from "../../interfaces/IPendingHoldsModule.sol";
@@ -152,10 +152,14 @@ contract CashModuleSettersExt is CashModuleStorageContract {
         uint256 payToken,
         uint256 paidUsd
     ) private {
+        // Single source of truth for the dispatcher mapping: CashModuleCore.getSettlementDispatcher.
+        // Ext runs in Core's storage via delegatecall, so address(this) is the Core proxy.
+        address dispatcher = ICashModule(address(this)).getSettlementDispatcher(binSponsor);
+
         address[] memory to = new address[](1);
         bytes[] memory data = new bytes[](1);
         to[0] = token;
-        data[0] = abi.encodeWithSelector(IERC20.transfer.selector, _settlementDispatcherFor($, binSponsor), payToken);
+        data[0] = abi.encodeWithSelector(IERC20.transfer.selector, dispatcher, payToken);
         IEtherFiSafe(safe).execTransactionFromModule(to, new uint256[](1), data);
 
         uint256[] memory tokenAmounts = new uint256[](1);
@@ -163,14 +167,5 @@ contract CashModuleSettersExt is CashModuleStorageContract {
         tokenAmounts[0] = payToken;
         usdAmounts[0] = paidUsd;
         $.cashEventEmitter.emitSpend(safe, txId, binSponsor, to, tokenAmounts, usdAmounts, paidUsd, Mode.Debit);
-    }
-
-    /// @dev Resolves the settlement dispatcher for a bin sponsor (mirrors CashModuleCore.getSettlementDispatcher).
-    function _settlementDispatcherFor(CashModuleStorage storage $, BinSponsor binSponsor) private view returns (address dispatcher) {
-        if (binSponsor == BinSponsor.Rain) dispatcher = $.settlementDispatcherRain;
-        else if (binSponsor == BinSponsor.PIX) dispatcher = $.settlementDispatcherPix;
-        else if (binSponsor == BinSponsor.CardOrder) dispatcher = $.settlementDispatcherCardOrder;
-        else dispatcher = $.settlementDispatcherReap;
-        if (dispatcher == address(0)) revert SettlementDispatcherNotSetForBinSponsor();
     }
 }

--- a/src/modules/cash/CashModuleSettersExt.sol
+++ b/src/modules/cash/CashModuleSettersExt.sol
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import { Mode, BinSponsor } from "../../interfaces/ICashModule.sol";
+import { IDebtManager } from "../../interfaces/IDebtManager.sol";
+import { IEtherFiSafe } from "../../interfaces/IEtherFiSafe.sol";
+import { IPendingHoldsModule } from "../../interfaces/IPendingHoldsModule.sol";
+import { CashModuleStorageContract } from "./CashModuleStorageContract.sol";
+
+/**
+ * @title CashModuleSettersExt
+ * @author ether.fi
+ * @notice Second overflow implementation for the Cash Module. Reached via a fallback hop:
+ *         CashModuleCore.fallback() → delegatecall CashModuleSetters → CashModuleSetters.fallback()
+ *         → delegatecall CashModuleSettersExt. Every hop is a delegatecall, so all functions here run
+ *         in Core's storage context with the original msg.sender preserved.
+ *
+ * @dev Exists purely to keep CashModuleCore and CashModuleSetters under the EIP-170 24KB bytecode
+ *      limit. Functions are placed here when neither Core nor Setters has room. This contract shares
+ *      the exact storage layout of Core/Setters via CashModuleStorageContract and must NEVER declare
+ *      its own state variables outside that layout.
+ */
+contract CashModuleSettersExt is CashModuleStorageContract {
+    constructor(address _etherFiDataProvider) CashModuleStorageContract(_etherFiDataProvider) {
+        _disableInitializers();
+    }
+
+    // -------------------------------------------------------------------------
+    // Repayment (relocated from CashModuleSetters to free bytecode room)
+    // -------------------------------------------------------------------------
+
+    /**
+     * @notice Repays borrowed tokens
+     * @dev Only callable by EtherFi wallet for valid EtherFi Safe addresses. Routed via fallback hops.
+     * @param safe Address of the EtherFi Safe
+     * @param token Address of the token to repay
+     * @param amountInUsd Amount to repay in USD
+     * @custom:throws OnlyBorrowToken if token is not a valid borrow token
+     */
+    function repay(address safe, address token, uint256 amountInUsd) public whenNotPaused nonReentrant onlyEtherFiWallet onlyEtherFiSafe(safe) {
+        IDebtManager debtManager = _getDebtManager();
+        if (!_isBorrowToken(debtManager, token)) revert OnlyBorrowToken();
+        _repay(safe, debtManager, token, amountInUsd);
+    }
+
+    /**
+     * @dev Internal function to execute the repayment transaction
+     * @custom:throws AmountZero if the converted amount is zero
+     */
+    function _repay(address safe, IDebtManager debtManager, address token, uint256 amountInUsd) internal {
+        uint256 amount = IDebtManager(debtManager).convertUsdToCollateralToken(token, amountInUsd);
+        if (amount == 0) revert AmountZero();
+        _cancelWithdrawalRequestIfNecessary(safe, token, amount);
+
+        address[] memory to = new address[](3);
+        bytes[] memory data = new bytes[](3);
+        uint256[] memory values = new uint256[](3);
+
+        to[0] = token;
+        to[1] = address(debtManager);
+        to[2] = token;
+
+        data[0] = abi.encodeWithSelector(IERC20.approve.selector, address(debtManager), amount);
+        data[1] = abi.encodeWithSelector(IDebtManager.repay.selector, safe, token, amount);
+        data[2] = abi.encodeWithSelector(IERC20.approve.selector, address(debtManager), 0);
+
+        IEtherFiSafe(safe).execTransactionFromModule(to, values, data);
+        _getCashModuleStorage().cashEventEmitter.emitRepayDebtManager(safe, token, amount, amountInUsd);
+    }
+
+    // -------------------------------------------------------------------------
+    // Under-funded settlement collection (C1)
+    // -------------------------------------------------------------------------
+
+    /**
+     * @notice Collects the outstanding remainder of an under-funded settlement from the safe's balance.
+     * @dev When spend() settled a transaction the safe could not fully cover, the unpaid remainder is
+     *      parked in a forced "remaining" hold (see CashModuleCore._phmFinalize). This lets ops sweep
+     *      that remainder once the safe is funded: it pays up to the outstanding remainder from `token`,
+     *      reduces the hold, and removes it (unblocking withdrawals) once fully paid.
+     *
+     *      The spending limit is NOT charged again — the full settlement amount was already charged at
+     *      the original spend(). Only operates on already-settled transactions (transactionCleared == true),
+     *      which distinguishes a post-settlement debt from a pre-settlement forceAddHold hold.
+     * @param safe Address of the EtherFi Safe
+     * @param txId Transaction identifier (the original authorization/settlement id)
+     * @param binSponsor Bin sponsor the settlement was made under
+     * @param token Borrow token to collect the remainder from
+     * @custom:throws InvalidInput if PHM unset, txId not yet settled, or no remainder outstanding
+     * @custom:throws UnsupportedToken if token is not a borrow token
+     * @custom:throws InsufficientBalance if the safe holds nothing collectable in token
+     */
+    function collectRemaining(address safe, bytes32 txId, BinSponsor binSponsor, address token)
+        external
+        whenNotPaused
+        nonReentrant
+        onlyEtherFiWallet
+        onlyEtherFiSafe(safe)
+    {
+        CashModuleStorage storage $ = _getCashModuleStorage();
+        address phm = $.pendingHoldsModule;
+        if (phm == address(0)) revert InvalidInput();
+        // Must be a post-settlement debt, not a pre-settlement forceAddHold hold awaiting spend().
+        if (!$.safeCashConfig[safe].transactionCleared[txId]) revert InvalidInput();
+        if (!_isBorrowToken($.debtManager, token)) revert UnsupportedToken();
+
+        uint256 remaining = IPendingHoldsModule(phm).remainingHold(safe, binSponsor, txId);
+        if (remaining == 0) revert InvalidInput();
+
+        (uint256 payToken, uint256 paidUsd) = _collectAmounts($, safe, token, remaining);
+
+        _cancelWithdrawalRequestIfNecessary(safe, token, payToken);
+        _collectTransferAndEmit($, safe, binSponsor, txId, token, payToken, paidUsd);
+
+        // Reduce or clear the hold. No limit charge — already charged at the original settlement.
+        if (remaining - paidUsd == 0) IPendingHoldsModule(phm).removeHold(safe, binSponsor, txId);
+        else IPendingHoldsModule(phm).settlementSetRemainingHold(safe, binSponsor, txId, remaining - paidUsd);
+
+        $.debtManager.ensureHealth(safe);
+    }
+
+    /// @dev Computes how much of `remaining` (USD 1e6) can be collected from the safe's `token` balance.
+    ///      Rounds USD down (favors the safe). Reverts if nothing meaningful is collectable.
+    function _collectAmounts(CashModuleStorage storage $, address safe, address token, uint256 remaining)
+        private
+        view
+        returns (uint256 payToken, uint256 paidUsd)
+    {
+        uint256 required = $.debtManager.convertUsdToCollateralToken(token, remaining);
+        if (required == 0) revert AmountZero();
+        uint256 available = IERC20(token).balanceOf(safe);
+        if (available < required) {
+            payToken = available;
+            paidUsd = remaining * available / required; // round down — never over-credits the debt
+        } else {
+            payToken = required;
+            paidUsd = remaining;
+        }
+        // Refuse a transfer that would move tokens without reducing the recorded debt (dust guard).
+        if (paidUsd == 0) revert InsufficientBalance();
+    }
+
+    /// @dev Transfers the collected tokens to the settlement dispatcher and emits a Spend event.
+    function _collectTransferAndEmit(
+        CashModuleStorage storage $,
+        address safe,
+        BinSponsor binSponsor,
+        bytes32 txId,
+        address token,
+        uint256 payToken,
+        uint256 paidUsd
+    ) private {
+        address[] memory to = new address[](1);
+        bytes[] memory data = new bytes[](1);
+        to[0] = token;
+        data[0] = abi.encodeWithSelector(IERC20.transfer.selector, _settlementDispatcherFor($, binSponsor), payToken);
+        IEtherFiSafe(safe).execTransactionFromModule(to, new uint256[](1), data);
+
+        uint256[] memory tokenAmounts = new uint256[](1);
+        uint256[] memory usdAmounts = new uint256[](1);
+        tokenAmounts[0] = payToken;
+        usdAmounts[0] = paidUsd;
+        $.cashEventEmitter.emitSpend(safe, txId, binSponsor, to, tokenAmounts, usdAmounts, paidUsd, Mode.Debit);
+    }
+
+    /// @dev Resolves the settlement dispatcher for a bin sponsor (mirrors CashModuleCore.getSettlementDispatcher).
+    function _settlementDispatcherFor(CashModuleStorage storage $, BinSponsor binSponsor) private view returns (address dispatcher) {
+        if (binSponsor == BinSponsor.Rain) dispatcher = $.settlementDispatcherRain;
+        else if (binSponsor == BinSponsor.PIX) dispatcher = $.settlementDispatcherPix;
+        else if (binSponsor == BinSponsor.CardOrder) dispatcher = $.settlementDispatcherCardOrder;
+        else dispatcher = $.settlementDispatcherReap;
+        if (dispatcher == address(0)) revert SettlementDispatcherNotSetForBinSponsor();
+    }
+}

--- a/src/modules/cash/CashModuleStorageContract.sol
+++ b/src/modules/cash/CashModuleStorageContract.sol
@@ -71,6 +71,8 @@ contract CashModuleStorageContract is UpgradeableProxy, ModuleBase {
         address settlementDispatcherPix;
         /// @notice Address of the SettlementDispatcher for CardOrder
         address settlementDispatcherCardOrder;
+        /// @notice Address of the PendingHoldsModule registry contract
+        address pendingHoldsModule;
     }
 
     // keccak256(abi.encode(uint256(keccak256("etherfi.storage.CashModuleStorage")) - 1)) & ~bytes32(uint256(0xff))
@@ -161,6 +163,9 @@ contract CashModuleStorageContract is UpgradeableProxy, ModuleBase {
 
     /// @notice Error thrown when a withdrawal request is made by an invalid address or to an invalid recipient
     error InvalidWithdrawRequest();
+
+    /// @notice Error thrown when a withdrawal would exceed spendable balance after pending holds are deducted
+    error WithdrawalBlockedByPendingHolds();
 
     constructor(address _etherFiDataProvider) ModuleBase(_etherFiDataProvider) { 
         _disableInitializers();

--- a/src/modules/cash/CashModuleStorageContract.sol
+++ b/src/modules/cash/CashModuleStorageContract.sol
@@ -74,6 +74,9 @@ contract CashModuleStorageContract is UpgradeableProxy, ModuleBase {
         address settlementDispatcherCardOrder;
         /// @notice Address of the PendingHoldsModule registry contract
         address pendingHoldsModule;
+        /// @notice Address of the CashModuleSettersExt overflow contract (second fallback hop).
+        ///         Holds functions that no longer fit in Core or Setters under the EIP-170 24KB cap.
+        address cashModuleSettersExt;
     }
 
     // keccak256(abi.encode(uint256(keccak256("etherfi.storage.CashModuleStorage")) - 1)) & ~bytes32(uint256(0xff))

--- a/src/modules/cash/CashModuleStorageContract.sol
+++ b/src/modules/cash/CashModuleStorageContract.sol
@@ -12,6 +12,7 @@ import { ICashbackDispatcher } from "../../interfaces/ICashbackDispatcher.sol";
 import { IDebtManager } from "../../interfaces/IDebtManager.sol";
 import { IEtherFiDataProvider } from "../../interfaces/IEtherFiDataProvider.sol";
 import { IEtherFiSafe } from "../../interfaces/IEtherFiSafe.sol";
+import { IPendingHoldsModule } from "../../interfaces/IPendingHoldsModule.sol";
 import { ArrayDeDupLib } from "../../libraries/ArrayDeDupLib.sol";
 import { CashVerificationLib } from "../../libraries/CashVerificationLib.sol";
 import { SignatureUtils } from "../../libraries/SignatureUtils.sol";
@@ -308,6 +309,12 @@ contract CashModuleStorageContract is UpgradeableProxy, ModuleBase {
         if ($$.pendingWithdrawalRequest.tokens.length == 0) revert WithdrawalDoesNotExist();
 
         if ($$.pendingWithdrawalRequest.finalizeTime > block.timestamp) revert CannotWithdrawYet();
+
+        // Re-check pending holds at finalize, not only at request time. A hold may have been added
+        // during the withdrawal delay window; processing anyway would drain funds the hold reserves.
+        address phm = $.pendingHoldsModule;
+        if (phm != address(0) && IPendingHoldsModule(phm).totalPendingHolds(safe) > 0) revert WithdrawalBlockedByPendingHolds();
+
         // Ensure that if the recipient of withdrawal is a whitelisted withdrawal module, only that module can process the withdrawal
         if ($.whitelistedModulesCanRequestWithdraw.contains($$.pendingWithdrawalRequest.recipient)) {
             if (msg.sender != $$.pendingWithdrawalRequest.recipient) revert OnlyModuleThatRequestedCanWithdraw();

--- a/src/modules/cash/PendingHoldsModule.sol
+++ b/src/modules/cash/PendingHoldsModule.sol
@@ -1,0 +1,432 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { BinSponsor } from "../../interfaces/ICashModule.sol";
+import { HoldRecord, IPendingHoldsModule, ReleaseReason } from "../../interfaces/IPendingHoldsModule.sol";
+import { ModuleBase } from "../ModuleBase.sol";
+import { UpgradeableProxy } from "../../utils/UpgradeableProxy.sol";
+
+/**
+ * @title PendingHoldsModule
+ * @author ether.fi
+ * @notice On-chain registry of pending card transaction holds for EtherFi Safes.
+ *
+ * @dev Architecture:
+ *   - Pure registry: stores holds, sums them per safe, emits rich indexed events.
+ *   - Zero spend() logic: CashModuleCore owns settlement; it calls removeHold() after spend().
+ *   - Spendable invariant: spendable(safe) = rawSpendable(safe) - totalPendingHolds(safe)
+ *   - Hold keys are provider-namespaced: keccak256(abi.encode(safe, providerCode, txId))
+ *     This prevents txId collisions across Rain / Reap / PIX namespaces.
+ *
+ * @dev Hold lifecycle:
+ *   transaction:created  → addHold(safe, providerCode, txId, amountUsd)  [EtherFi wallet]
+ *   settlement           → removeHold(safe, providerCode, txId)          [CashModuleCore only]
+ *   network reversal     → releaseHold(..., REVERSAL)                    [EtherFi wallet]
+ *   operator recovery    → releaseHold(..., ADMIN)                       [EtherFi wallet]
+ *   force-capture        → forceAddHold(...)                             [EtherFi wallet]
+ *   incremental auth     → updateHold(safe, providerCode, txId, newAmt)  [EtherFi wallet]
+ *
+ * @dev Two-removal-path invariant (R19):
+ *   removeHold()  — post-spend path, called only by CashModuleCore
+ *   releaseHold() — non-spend path (reversals / admin), called only by EtherFi wallet
+ *   These are structurally separate: no hold can be removed without one of these explicit calls.
+ */
+contract PendingHoldsModule is UpgradeableProxy, ModuleBase, IPendingHoldsModule {
+
+    // -------------------------------------------------------------------------
+    // ERC-7201 namespaced storage
+    // -------------------------------------------------------------------------
+
+    /**
+     * @dev Storage structure for PendingHoldsModule.
+     * @custom:storage-location erc7201:etherfi.storage.PendingHoldsModuleStorage
+     */
+    struct PendingHoldsModuleStorage {
+        /// @notice Per-hold records keyed by keccak256(abi.encode(safe, providerCode, txId))
+        mapping(bytes32 holdKey => HoldRecord record) holds;
+        /// @notice Running sum of active hold amounts per safe in USD (1e6)
+        mapping(address safe => uint256 totalHolds) totalHolds;
+        /// @notice Address of CashModuleCore — the only contract that can call removeHold()
+        address cashModuleCore;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("etherfi.storage.PendingHoldsModuleStorage")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant PendingHoldsModuleStorageLocation =
+        0x0042c358db30ed9f9b20b913b4f4622ef177b2464108d9b113967b28b46ada00;
+
+    // -------------------------------------------------------------------------
+    // Role constants
+    // -------------------------------------------------------------------------
+
+    /// @notice Role identifier for EtherFi wallet (backend service wallet)
+    bytes32 public constant ETHER_FI_WALLET_ROLE = keccak256("ETHER_FI_WALLET_ROLE");
+
+    /// @notice Role identifier for Cash Module controller (admin configuration)
+    bytes32 public constant CASH_MODULE_CONTROLLER_ROLE = keccak256("CASH_MODULE_CONTROLLER_ROLE");
+
+    // -------------------------------------------------------------------------
+    // Constructor
+    // -------------------------------------------------------------------------
+
+    constructor(address _etherFiDataProvider) ModuleBase(_etherFiDataProvider) {
+        _disableInitializers();
+    }
+
+    // -------------------------------------------------------------------------
+    // Initializer
+    // -------------------------------------------------------------------------
+
+    /**
+     * @notice Initializes the PendingHoldsModule proxy
+     * @param _roleRegistry Address of the role registry
+     * @param _cashModuleCore Address of CashModuleCore (used for onlyCashModuleCore gating)
+     */
+    function initialize(address _roleRegistry, address _cashModuleCore) external initializer {
+        if (_cashModuleCore == address(0)) revert ZeroCashModuleCore();
+        __UpgradeableProxy_init(_roleRegistry);
+        _getPendingHoldsModuleStorage().cashModuleCore = _cashModuleCore;
+        emit CashModuleCoreSet(address(0), _cashModuleCore);
+    }
+
+    // -------------------------------------------------------------------------
+    // Storage accessor
+    // -------------------------------------------------------------------------
+
+    function _getPendingHoldsModuleStorage() internal pure returns (PendingHoldsModuleStorage storage $) {
+        assembly {
+            $.slot := PendingHoldsModuleStorageLocation
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Modifiers
+    // -------------------------------------------------------------------------
+
+    /**
+     * @dev Restricts access to the registered CashModuleCore contract only.
+     *      Used by removeHold() — the only path Core can remove a hold.
+     */
+    modifier onlyCashModuleCore() {
+        if (_getPendingHoldsModuleStorage().cashModuleCore != msg.sender) revert OnlyCashModuleCore();
+        _;
+    }
+
+    /**
+     * @dev Restricts access to accounts holding the EtherFi wallet role.
+     *      Used by addHold(), forceAddHold(), updateHold(), releaseHold().
+     */
+    modifier onlyEtherFiWallet() {
+        if (!roleRegistry().hasRole(ETHER_FI_WALLET_ROLE, msg.sender)) revert Unauthorized();
+        _;
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * @dev Computes the provider-namespaced hold key for a (safe, providerCode, txId) tuple.
+     *      Namespacing prevents txId collisions between different bin providers (Rain/Reap/PIX).
+     */
+    function _holdKey(address safe, bytes4 providerCode, bytes32 txId) internal pure returns (bytes32) {
+        return keccak256(abi.encode(safe, providerCode, txId));
+    }
+
+    // -------------------------------------------------------------------------
+    // Write functions — EtherFi wallet only
+    // -------------------------------------------------------------------------
+
+    /// @inheritdoc IPendingHoldsModule
+    function addHold(address safe, bytes4 providerCode, bytes32 txId, uint256 amountUsd)
+        external
+        whenNotPaused
+        nonReentrant
+        onlyEtherFiWallet
+    {
+        if (amountUsd == 0) revert InvalidAmount();
+
+        bytes32 key = _holdKey(safe, providerCode, txId);
+        PendingHoldsModuleStorage storage $ = _getPendingHoldsModuleStorage();
+
+        if ($.holds[key].createdAt != 0) revert DuplicateHold();
+
+        // Consume from the spending limit at auth-ack time so the limit immediately reflects
+        // the user's authorized spend. Reverts with ExceededDailySpendingLimit or
+        // ExceededMonthlySpendingLimit if the hold would breach the limit.
+        ICashModuleForHolds($.cashModuleCore).consumeSpendingLimit(safe, amountUsd);
+
+        $.holds[key] = HoldRecord({
+            amountUsd: amountUsd,
+            createdAt: uint40(block.timestamp),
+            providerCode: providerCode,
+            forced: false
+        });
+        $.totalHolds[safe] += amountUsd;
+
+        emit HoldAdded(safe, providerCode, txId, amountUsd, block.timestamp, false);
+    }
+
+    /// @inheritdoc IPendingHoldsModule
+    function forceAddHold(address safe, bytes4 providerCode, bytes32 txId, uint256 amountUsd)
+        external
+        whenNotPaused
+        nonReentrant
+        onlyEtherFiWallet
+    {
+        if (amountUsd == 0) revert InvalidAmount();
+
+        bytes32 key = _holdKey(safe, providerCode, txId);
+        PendingHoldsModuleStorage storage $ = _getPendingHoldsModuleStorage();
+
+        if ($.holds[key].createdAt != 0) revert DuplicateHold();
+
+        // No balance check for forced holds (operator recovery path)
+        $.holds[key] = HoldRecord({
+            amountUsd: amountUsd,
+            createdAt: uint40(block.timestamp),
+            providerCode: providerCode,
+            forced: true
+        });
+        $.totalHolds[safe] += amountUsd;
+
+        emit HoldAdded(safe, providerCode, txId, amountUsd, block.timestamp, true);
+    }
+
+    /// @inheritdoc IPendingHoldsModule
+    function updateHold(address safe, bytes4 providerCode, bytes32 txId, uint256 newAmountUsd)
+        external
+        whenNotPaused
+        nonReentrant
+        onlyEtherFiWallet
+    {
+        if (newAmountUsd == 0) revert InvalidAmount();
+
+        bytes32 key = _holdKey(safe, providerCode, txId);
+        PendingHoldsModuleStorage storage $ = _getPendingHoldsModuleStorage();
+
+        HoldRecord storage record = $.holds[key];
+        if (record.createdAt == 0) revert HoldNotFound();
+
+        uint256 oldAmountUsd = record.amountUsd;
+
+        if (newAmountUsd > oldAmountUsd) {
+            // Increasing hold — consume delta from the spending limit immediately.
+            // Non-forced holds were originally charged at addHold; charge only the delta.
+            // Forced holds bypassed the limit at creation; charge the full delta now.
+            uint256 delta = newAmountUsd - oldAmountUsd;
+            if (!record.forced) ICashModuleForHolds($.cashModuleCore).consumeSpendingLimit(safe, delta);
+            $.totalHolds[safe] = $.totalHolds[safe] - oldAmountUsd + newAmountUsd;
+        } else {
+            // Decreasing hold — credit delta back to the spending limit for non-forced holds.
+            // Apply the same defensive floor as releaseHold/removeHold to guard against any
+            // totalHolds drift (e.g., caused by a prior forceAddHold + forceSpend sequence).
+            uint256 delta = oldAmountUsd - newAmountUsd;
+            if (!record.forced) ICashModuleForHolds($.cashModuleCore).releaseSpendingLimit(safe, delta);
+            uint256 current = $.totalHolds[safe];
+            $.totalHolds[safe] = (oldAmountUsd <= current ? current - oldAmountUsd : 0) + newAmountUsd;
+        }
+
+        record.amountUsd = newAmountUsd;
+
+        emit HoldUpdated(safe, providerCode, txId, oldAmountUsd, newAmountUsd, block.timestamp);
+    }
+
+    /// @inheritdoc IPendingHoldsModule
+    function releaseHold(address safe, bytes4 providerCode, bytes32 txId, ReleaseReason reason)
+        external
+        whenNotPaused
+        nonReentrant
+        onlyEtherFiWallet
+    {
+        bytes32 key = _holdKey(safe, providerCode, txId);
+        PendingHoldsModuleStorage storage $ = _getPendingHoldsModuleStorage();
+
+        HoldRecord storage record = $.holds[key];
+        if (record.createdAt == 0) revert HoldNotFound();
+
+        uint256 holdAmount = record.amountUsd;
+        bool wasForced = record.forced;
+        uint256 current = $.totalHolds[safe];
+        $.totalHolds[safe] = holdAmount <= current ? current - holdAmount : 0;
+
+        delete $.holds[key];
+
+        // Credit back the spending limit for non-forced holds (forced holds never consumed it).
+        if (!wasForced) ICashModuleForHolds($.cashModuleCore).releaseSpendingLimit(safe, holdAmount);
+
+        emit HoldReleased(safe, providerCode, txId, holdAmount, reason, block.timestamp);
+    }
+
+    // -------------------------------------------------------------------------
+    // Write functions — CashModuleCore only
+    // -------------------------------------------------------------------------
+
+    /// @inheritdoc IPendingHoldsModule
+    function settlementSyncHold(
+        address safe,
+        BinSponsor binSponsor,
+        bytes32 txId,
+        uint256 settlementAmount
+    ) external nonReentrant onlyCashModuleCore returns (bool existed, bool wasForced, uint256 oldAmount) {
+        if (settlementAmount == 0) revert InvalidAmount();
+
+        bytes4 providerCode = providerCodeFromBinSponsor(binSponsor);
+        bytes32 key = _holdKey(safe, providerCode, txId);
+        PendingHoldsModuleStorage storage $ = _getPendingHoldsModuleStorage();
+        HoldRecord storage record = $.holds[key];
+
+        if (record.createdAt != 0) {
+            // Hold exists — sync to settlement amount. Limit accounting is handled by Core
+            // using the returned (existed, wasForced, oldAmount) values; no callback needed.
+            oldAmount = record.amountUsd;
+            wasForced = record.forced;
+            existed = true;
+
+            if (settlementAmount != oldAmount) {
+                if (settlementAmount > oldAmount) {
+                    $.totalHolds[safe] = $.totalHolds[safe] - oldAmount + settlementAmount;
+                } else {
+                    uint256 current = $.totalHolds[safe];
+                    $.totalHolds[safe] = (oldAmount <= current ? current - oldAmount : 0) + settlementAmount;
+                }
+                record.amountUsd = settlementAmount;
+                emit HoldUpdated(safe, providerCode, txId, oldAmount, settlementAmount, block.timestamp);
+            }
+            // existed/wasForced/oldAmount already set above; Solidity returns them.
+        } else {
+            // No hold — create a forced hold. Settlement is KING: bypass spending limit.
+            $.holds[key] = HoldRecord({
+                amountUsd: settlementAmount,
+                createdAt: uint40(block.timestamp),
+                providerCode: providerCode,
+                forced: true
+            });
+            $.totalHolds[safe] += settlementAmount;
+            emit HoldAdded(safe, providerCode, txId, settlementAmount, block.timestamp, true);
+            // existed=false, wasForced=false, oldAmount=0 (Solidity zero-initialises returns)
+        }
+    }
+
+    /// @inheritdoc IPendingHoldsModule
+    function settlementSetRemainingHold(
+        address safe,
+        BinSponsor binSponsor,
+        bytes32 txId,
+        uint256 remaining
+    ) external nonReentrant onlyCashModuleCore {
+        bytes4 providerCode = providerCodeFromBinSponsor(binSponsor);
+        bytes32 key = _holdKey(safe, providerCode, txId);
+        PendingHoldsModuleStorage storage $ = _getPendingHoldsModuleStorage();
+
+        HoldRecord storage record = $.holds[key];
+        if (record.createdAt == 0) revert HoldNotFound();
+
+        uint256 oldAmount = record.amountUsd;
+        uint256 current = $.totalHolds[safe];
+        $.totalHolds[safe] = (oldAmount <= current ? current - oldAmount : 0) + remaining;
+        record.amountUsd = remaining;
+        // Mark forced so the special-function path does not double-charge the spending limit.
+        // The limit was already fully charged for the settlement amount at settlementSyncHold.
+        record.forced = true;
+
+        emit HoldUpdated(safe, providerCode, txId, oldAmount, remaining, block.timestamp);
+    }
+
+    /// @inheritdoc IPendingHoldsModule
+    function removeHold(address safe, BinSponsor binSponsor, bytes32 txId)
+        external
+        nonReentrant
+        onlyCashModuleCore
+    {
+        bytes4 providerCode = providerCodeFromBinSponsor(binSponsor);
+        bytes32 key = _holdKey(safe, providerCode, txId);
+        PendingHoldsModuleStorage storage $ = _getPendingHoldsModuleStorage();
+
+        HoldRecord storage record = $.holds[key];
+        if (record.createdAt == 0) revert HoldNotFound();
+
+        uint256 holdAmount = record.amountUsd;
+        uint256 current = $.totalHolds[safe];
+        $.totalHolds[safe] = holdAmount <= current ? current - holdAmount : 0;
+
+        delete $.holds[key];
+
+        emit HoldRemoved(safe, providerCode, txId, holdAmount, block.timestamp);
+    }
+
+    // -------------------------------------------------------------------------
+    // Write functions — controller role
+    // -------------------------------------------------------------------------
+
+    /// @inheritdoc IPendingHoldsModule
+    function setCashModuleCore(address _cashModuleCore) external {
+        if (!roleRegistry().hasRole(CASH_MODULE_CONTROLLER_ROLE, msg.sender)) revert Unauthorized();
+        if (_cashModuleCore == address(0)) revert ZeroCashModuleCore();
+
+        PendingHoldsModuleStorage storage $ = _getPendingHoldsModuleStorage();
+        address old = $.cashModuleCore;
+        $.cashModuleCore = _cashModuleCore;
+
+        emit CashModuleCoreSet(old, _cashModuleCore);
+    }
+
+    // -------------------------------------------------------------------------
+    // View functions
+    // -------------------------------------------------------------------------
+
+    /// @inheritdoc IPendingHoldsModule
+    function totalPendingHolds(address safe) external view returns (uint256) {
+        return _getPendingHoldsModuleStorage().totalHolds[safe];
+    }
+
+    /// @inheritdoc IPendingHoldsModule
+    function getHold(address safe, bytes4 providerCode, bytes32 txId)
+        external
+        view
+        returns (HoldRecord memory hold)
+    {
+        bytes32 key = _holdKey(safe, providerCode, txId);
+        return _getPendingHoldsModuleStorage().holds[key];
+    }
+
+    /// @inheritdoc IPendingHoldsModule
+    function cashModuleCore() external view returns (address) {
+        return _getPendingHoldsModuleStorage().cashModuleCore;
+    }
+
+    /// @inheritdoc IPendingHoldsModule
+    function providerCodeFromBinSponsor(BinSponsor binSponsor) public pure returns (bytes4) {
+        if (binSponsor == BinSponsor.Reap)      return bytes4("REAP");
+        if (binSponsor == BinSponsor.Rain)      return bytes4("RAIN");
+        if (binSponsor == BinSponsor.PIX)       return bytes4("PIX_");
+        if (binSponsor == BinSponsor.CardOrder) return bytes4("CORD");
+        revert InvalidInput();
+    }
+}
+
+// -------------------------------------------------------------------------
+// Minimal callback interface: PendingHoldsModule → CashModuleCore
+// -------------------------------------------------------------------------
+
+/**
+ * @dev Minimal slice of CashModule that PendingHoldsModule calls back on for
+ *      limit consumption and release at hold creation/release time.
+ *
+ *      consumeSpendingLimit() and releaseSpendingLimit() live in CashModuleSetters and are
+ *      routed transparently via CashModuleCore's fallback() delegatecall.
+ *      Defined here to avoid a circular import.
+ */
+interface ICashModuleForHolds {
+    /**
+     * @notice Validates and increments the safe's daily/monthly limits by amountUsd.
+     *         Reverts with ExceededDailySpendingLimit or ExceededMonthlySpendingLimit
+     *         if the amount would breach the limit.
+     */
+    function consumeSpendingLimit(address safe, uint256 amountUsd) external;
+
+    /**
+     * @notice Credits amountUsd back to the safe's daily/monthly limits.
+     *         Applies a floor at 0 to handle day/month-boundary crossings safely.
+     */
+    function releaseSpendingLimit(address safe, uint256 amountUsd) external;
+}

--- a/src/modules/cash/PendingHoldsModule.sol
+++ b/src/modules/cash/PendingHoldsModule.sol
@@ -141,7 +141,7 @@ contract PendingHoldsModule is UpgradeableProxy, ModuleBase, IPendingHoldsModule
     // -------------------------------------------------------------------------
 
     /// @inheritdoc IPendingHoldsModule
-    function addHold(address safe, bytes4 providerCode, bytes32 txId, uint256 amountUsd)
+    function addHold(address safe, BinSponsor binSponsor, bytes32 txId, uint256 amountUsd)
         external
         whenNotPaused
         nonReentrant
@@ -149,6 +149,7 @@ contract PendingHoldsModule is UpgradeableProxy, ModuleBase, IPendingHoldsModule
     {
         if (amountUsd == 0) revert InvalidAmount();
 
+        bytes4 providerCode = providerCodeFromBinSponsor(binSponsor);
         bytes32 key = _holdKey(safe, providerCode, txId);
         PendingHoldsModuleStorage storage $ = _getPendingHoldsModuleStorage();
 
@@ -171,7 +172,7 @@ contract PendingHoldsModule is UpgradeableProxy, ModuleBase, IPendingHoldsModule
     }
 
     /// @inheritdoc IPendingHoldsModule
-    function forceAddHold(address safe, bytes4 providerCode, bytes32 txId, uint256 amountUsd)
+    function forceAddHold(address safe, BinSponsor binSponsor, bytes32 txId, uint256 amountUsd)
         external
         whenNotPaused
         nonReentrant
@@ -179,6 +180,7 @@ contract PendingHoldsModule is UpgradeableProxy, ModuleBase, IPendingHoldsModule
     {
         if (amountUsd == 0) revert InvalidAmount();
 
+        bytes4 providerCode = providerCodeFromBinSponsor(binSponsor);
         bytes32 key = _holdKey(safe, providerCode, txId);
         PendingHoldsModuleStorage storage $ = _getPendingHoldsModuleStorage();
 
@@ -197,7 +199,7 @@ contract PendingHoldsModule is UpgradeableProxy, ModuleBase, IPendingHoldsModule
     }
 
     /// @inheritdoc IPendingHoldsModule
-    function updateHold(address safe, bytes4 providerCode, bytes32 txId, uint256 newAmountUsd)
+    function updateHold(address safe, BinSponsor binSponsor, bytes32 txId, uint256 newAmountUsd)
         external
         whenNotPaused
         nonReentrant
@@ -205,6 +207,7 @@ contract PendingHoldsModule is UpgradeableProxy, ModuleBase, IPendingHoldsModule
     {
         if (newAmountUsd == 0) revert InvalidAmount();
 
+        bytes4 providerCode = providerCodeFromBinSponsor(binSponsor);
         bytes32 key = _holdKey(safe, providerCode, txId);
         PendingHoldsModuleStorage storage $ = _getPendingHoldsModuleStorage();
 
@@ -236,12 +239,13 @@ contract PendingHoldsModule is UpgradeableProxy, ModuleBase, IPendingHoldsModule
     }
 
     /// @inheritdoc IPendingHoldsModule
-    function releaseHold(address safe, bytes4 providerCode, bytes32 txId, ReleaseReason reason)
+    function releaseHold(address safe, BinSponsor binSponsor, bytes32 txId, ReleaseReason reason)
         external
         whenNotPaused
         nonReentrant
         onlyEtherFiWallet
     {
+        bytes4 providerCode = providerCodeFromBinSponsor(binSponsor);
         bytes32 key = _holdKey(safe, providerCode, txId);
         PendingHoldsModuleStorage storage $ = _getPendingHoldsModuleStorage();
 

--- a/src/modules/cash/PendingHoldsModule.sol
+++ b/src/modules/cash/PendingHoldsModule.sol
@@ -390,6 +390,12 @@ contract PendingHoldsModule is UpgradeableProxy, ModuleBase, IPendingHoldsModule
     }
 
     /// @inheritdoc IPendingHoldsModule
+    function remainingHold(address safe, BinSponsor binSponsor, bytes32 txId) external view returns (uint256) {
+        bytes4 providerCode = providerCodeFromBinSponsor(binSponsor);
+        return _getPendingHoldsModuleStorage().holds[_holdKey(safe, providerCode, txId)].amountUsd;
+    }
+
+    /// @inheritdoc IPendingHoldsModule
     function cashModuleCore() external view returns (address) {
         return _getPendingHoldsModuleStorage().cashModuleCore;
     }

--- a/src/modules/cash/PendingHoldsModule.sol
+++ b/src/modules/cash/PendingHoldsModule.sol
@@ -14,7 +14,11 @@ import { UpgradeableProxy } from "../../utils/UpgradeableProxy.sol";
  * @dev Architecture:
  *   - Pure registry: stores holds, sums them per safe, emits rich indexed events.
  *   - Zero spend() logic: CashModuleCore owns settlement; it calls removeHold() after spend().
- *   - Spendable invariant: spendable(safe) = rawSpendable(safe) - totalPendingHolds(safe)
+ *   - Spendable accounting: non-forced holds are charged to spentToday/spentThisMonth at addHold()
+ *     time, so rawSpendable(safe) already reflects them. spendable(safe) == rawSpendable(safe);
+ *     do NOT subtract totalPendingHolds again (that double-counts). Forced holds (forceAddHold and
+ *     settlement-created "Settlement is KING" holds) deliberately bypass the limit until settlement,
+ *     so they are NOT reflected in rawSpendable; totalPendingHolds drives only the withdrawal guard.
  *   - Hold keys are provider-namespaced: keccak256(abi.encode(safe, providerCode, txId))
  *     This prevents txId collisions across Rain / Reap / PIX namespaces.
  *

--- a/src/modules/cash/PendingHoldsModule.sol
+++ b/src/modules/cash/PendingHoldsModule.sol
@@ -136,6 +136,19 @@ contract PendingHoldsModule is UpgradeableProxy, ModuleBase, IPendingHoldsModule
         return keccak256(abi.encode(safe, providerCode, txId));
     }
 
+    /**
+     * @dev Replaces `oldAmount` with `newAmount` in totalHolds[safe] (pass newAmount = 0 to remove).
+     *      Reverts with TotalHoldsUnderflow if oldAmount exceeds the running sum. oldAmount is always
+     *      read from the very HoldRecord being mutated, and every increment paired its stored amount,
+     *      so oldAmount <= totalHolds is an invariant. A silent floor here would corrupt the running
+     *      sum — and thus the withdrawal guard — so we fail loudly instead.
+     */
+    function _replaceTotalHolds(PendingHoldsModuleStorage storage $, address safe, uint256 oldAmount, uint256 newAmount) private {
+        uint256 current = $.totalHolds[safe];
+        if (oldAmount > current) revert TotalHoldsUnderflow();
+        $.totalHolds[safe] = current - oldAmount + newAmount;
+    }
+
     // -------------------------------------------------------------------------
     // Write functions — EtherFi wallet only
     // -------------------------------------------------------------------------
@@ -216,22 +229,16 @@ contract PendingHoldsModule is UpgradeableProxy, ModuleBase, IPendingHoldsModule
 
         uint256 oldAmountUsd = record.amountUsd;
 
-        if (newAmountUsd > oldAmountUsd) {
-            // Increasing hold — consume delta from the spending limit immediately.
-            // Non-forced holds were originally charged at addHold; charge only the delta.
-            // Forced holds bypassed the limit at creation; charge the full delta now.
-            uint256 delta = newAmountUsd - oldAmountUsd;
-            if (!record.forced) ICashModuleForHolds($.cashModuleCore).consumeSpendingLimit(safe, delta);
-            $.totalHolds[safe] = $.totalHolds[safe] - oldAmountUsd + newAmountUsd;
-        } else {
-            // Decreasing hold — credit delta back to the spending limit for non-forced holds.
-            // Apply the same defensive floor as releaseHold/removeHold to guard against any
-            // totalHolds drift (e.g., caused by a prior forceAddHold + forceSpend sequence).
-            uint256 delta = oldAmountUsd - newAmountUsd;
-            if (!record.forced) ICashModuleForHolds($.cashModuleCore).releaseSpendingLimit(safe, delta);
-            uint256 current = $.totalHolds[safe];
-            $.totalHolds[safe] = (oldAmountUsd <= current ? current - oldAmountUsd : 0) + newAmountUsd;
+        // Adjust the spending limit for non-forced holds (forced holds bypassed it at creation):
+        // charge the delta on an increase, credit it back on a decrease.
+        if (!record.forced) {
+            if (newAmountUsd > oldAmountUsd) {
+                ICashModuleForHolds($.cashModuleCore).consumeSpendingLimit(safe, newAmountUsd - oldAmountUsd);
+            } else if (newAmountUsd < oldAmountUsd) {
+                ICashModuleForHolds($.cashModuleCore).releaseSpendingLimit(safe, oldAmountUsd - newAmountUsd);
+            }
         }
+        _replaceTotalHolds($, safe, oldAmountUsd, newAmountUsd);
 
         record.amountUsd = newAmountUsd;
 
@@ -254,8 +261,7 @@ contract PendingHoldsModule is UpgradeableProxy, ModuleBase, IPendingHoldsModule
 
         uint256 holdAmount = record.amountUsd;
         bool wasForced = record.forced;
-        uint256 current = $.totalHolds[safe];
-        $.totalHolds[safe] = holdAmount <= current ? current - holdAmount : 0;
+        _replaceTotalHolds($, safe, holdAmount, 0);
 
         delete $.holds[key];
 
@@ -291,12 +297,7 @@ contract PendingHoldsModule is UpgradeableProxy, ModuleBase, IPendingHoldsModule
             existed = true;
 
             if (settlementAmount != oldAmount) {
-                if (settlementAmount > oldAmount) {
-                    $.totalHolds[safe] = $.totalHolds[safe] - oldAmount + settlementAmount;
-                } else {
-                    uint256 current = $.totalHolds[safe];
-                    $.totalHolds[safe] = (oldAmount <= current ? current - oldAmount : 0) + settlementAmount;
-                }
+                _replaceTotalHolds($, safe, oldAmount, settlementAmount);
                 record.amountUsd = settlementAmount;
                 emit HoldUpdated(safe, providerCode, txId, oldAmount, settlementAmount, block.timestamp);
             }
@@ -330,8 +331,7 @@ contract PendingHoldsModule is UpgradeableProxy, ModuleBase, IPendingHoldsModule
         if (record.createdAt == 0) revert HoldNotFound();
 
         uint256 oldAmount = record.amountUsd;
-        uint256 current = $.totalHolds[safe];
-        $.totalHolds[safe] = (oldAmount <= current ? current - oldAmount : 0) + remaining;
+        _replaceTotalHolds($, safe, oldAmount, remaining);
         record.amountUsd = remaining;
         // Mark forced so the special-function path does not double-charge the spending limit.
         // The limit was already fully charged for the settlement amount at settlementSyncHold.
@@ -354,8 +354,7 @@ contract PendingHoldsModule is UpgradeableProxy, ModuleBase, IPendingHoldsModule
         if (record.createdAt == 0) revert HoldNotFound();
 
         uint256 holdAmount = record.amountUsd;
-        uint256 current = $.totalHolds[safe];
-        $.totalHolds[safe] = holdAmount <= current ? current - holdAmount : 0;
+        _replaceTotalHolds($, safe, holdAmount, 0);
 
         delete $.holds[key];
 

--- a/test/safe/SafeTestSetup.t.sol
+++ b/test/safe/SafeTestSetup.t.sol
@@ -177,7 +177,7 @@ contract SafeTestSetup is Utils {
         address hookImpl = address(new EtherFiHook(address(dataProvider)));
         hook = EtherFiHook(address(new UUPSProxy(hookImpl, abi.encodeWithSelector(EtherFiHook.initialize.selector, address(roleRegistry)))));
 
-        address cashLensImpl = address(new CashLens(address(cashModule), address(dataProvider)));
+        address cashLensImpl = address(new CashLens(address(cashModule), address(dataProvider), address(0)));
         cashLens = CashLens(address(new UUPSProxy(cashLensImpl, abi.encodeWithSelector(CashLens.initialize.selector, address(roleRegistry)))));
 
         dataProvider.initialize(EtherFiDataProvider.InitParams(address(roleRegistry), address(cashModule), address(cashLens), modules, defaultModules, address(hook), address(safeFactory), address(priceProvider), etherFiRecoverySigner, thirdPartyRecoverySigner, refundWallet));

--- a/test/safe/SafeTestSetup.t.sol
+++ b/test/safe/SafeTestSetup.t.sol
@@ -22,6 +22,7 @@ import { CashLens } from "../../src/modules/cash/CashLens.sol";
 import { CashEventEmitter } from "../../src/modules/cash/CashEventEmitter.sol";
 import { CashModuleCore } from "../../src/modules/cash/CashModuleCore.sol";
 import { CashModuleSetters } from "../../src/modules/cash/CashModuleSetters.sol";
+import { CashModuleSettersExt } from "../../src/modules/cash/CashModuleSettersExt.sol";
 import { RoleRegistry } from "../../src/role-registry/RoleRegistry.sol";
 import { ArrayDeDupLib, EtherFiSafe, EtherFiSafeBase, EtherFiSafeErrors } from "../../src/safe/EtherFiSafe.sol";
 import { EtherFiSafeFactory } from "../../src/safe/EtherFiSafeFactory.sol";
@@ -199,6 +200,10 @@ contract SafeTestSetup is Utils {
 
         roleRegistry.grantRole(cashModule.ETHER_FI_WALLET_ROLE(), etherFiWallet);
         roleRegistry.grantRole(cashModule.CASH_MODULE_CONTROLLER_ROLE(), owner);
+
+        // Wire the second-hop overflow contract (repay, collectRemaining live here).
+        address cashModuleSettersExtImpl = address(new CashModuleSettersExt(address(dataProvider)));
+        CashModuleSetters(address(cashModule)).setCashModuleSettersExt(cashModuleSettersExtImpl);
 
         _setupWithdrawTokenWhitelist();
 

--- a/test/safe/modules/cash/MultiSpend.t.sol
+++ b/test/safe/modules/cash/MultiSpend.t.sol
@@ -167,87 +167,53 @@ contract CashModuleMultiSpendTest is CashModuleTestSetup {
     }
 
     function test_spend_failsWithInsufficientBalance_oneToken() public {
-        // Setup: Fund the safe with enough of one token but not enough of another
+        // In no-PHM mode, partial settlement has nowhere to track the remainder —
+        // spend() reverts on insufficient balance. Partial settlement is only valid
+        // when PHM is wired (covered by PendingHoldsModuleTest integration tests).
         uint256 usdcAmountInUsd = 50e6;
         uint256 weETHAmountInUsd = 50e6;
-        
+
         uint256 usdcAmount = debtManager.convertUsdToCollateralToken(address(usdc), usdcAmountInUsd);
-        
-        // Only fund with USDC, not with weETH
+
         deal(address(usdc), address(safe), usdcAmount);
         deal(address(weETH), address(safe), 0); // No weETH
-        
+
         address[] memory spendTokens = new address[](2);
         spendTokens[0] = address(usdc);
         spendTokens[1] = address(weETH);
-        
+
         uint256[] memory spendAmounts = new uint256[](2);
         spendAmounts[0] = usdcAmountInUsd;
         spendAmounts[1] = weETHAmountInUsd;
 
-        Cashback[] memory cashbacks = new Cashback[](1);
-        CashbackTokens[] memory cashbackTokens = new CashbackTokens[](1);
+        Cashback[] memory cashbacks = _makeScrCashback();
 
-        CashbackTokens memory scr = CashbackTokens({
-            token: address(cashbackToken),
-            amountInUsd: 1e6,
-            cashbackType: 0
-        });
-
-        cashbackTokens[0] = scr;
-
-        Cashback memory scrCashback = Cashback({
-            to: address(safe),
-            cashbackTokens: cashbackTokens
-        });
-
-        cashbacks[0] = scrCashback;
-        
-        // Should revert due to insufficient weETH balance
         vm.prank(etherFiWallet);
         vm.expectRevert(ICashModule.InsufficientBalance.selector);
         cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
     }
 
     function test_spend_failsWithInsufficientBalance_partialAmount() public {
-        // Setup: Fund the safe with enough of one token but only partial amount of another
+        // Same story as above: partial balance on one token → revert in no-PHM mode.
         uint256 usdcAmountInUsd = 50e6;
         uint256 weETHAmountInUsd = 50e6;
-        
+
         uint256 usdcAmount = debtManager.convertUsdToCollateralToken(address(usdc), usdcAmountInUsd);
         uint256 weETHAmount = debtManager.convertUsdToCollateralToken(address(weETH), weETHAmountInUsd);
-        
-        // Fund with full USDC amount, but only half of the weETH amount
+
         deal(address(usdc), address(safe), usdcAmount);
         deal(address(weETH), address(safe), weETHAmount / 2);
-        
+
         address[] memory spendTokens = new address[](2);
         spendTokens[0] = address(usdc);
         spendTokens[1] = address(weETH);
-        
+
         uint256[] memory spendAmounts = new uint256[](2);
         spendAmounts[0] = usdcAmountInUsd;
         spendAmounts[1] = weETHAmountInUsd;
 
-        Cashback[] memory cashbacks = new Cashback[](1);
-        CashbackTokens[] memory cashbackTokens = new CashbackTokens[](1);
+        Cashback[] memory cashbacks = _makeScrCashback();
 
-        CashbackTokens memory scr = CashbackTokens({
-            token: address(cashbackToken),
-            amountInUsd: 1e6,
-            cashbackType: 0
-        });
-
-        cashbackTokens[0] = scr;
-
-        Cashback memory scrCashback = Cashback({
-            to: address(safe),
-            cashbackTokens: cashbackTokens
-        });
-
-        cashbacks[0] = scrCashback;
-        
-        // Should revert due to insufficient weETH balance
         vm.prank(etherFiWallet);
         vm.expectRevert(ICashModule.InsufficientBalance.selector);
         cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
@@ -648,7 +614,7 @@ contract CashModuleMultiSpendTest is CashModuleTestSetup {
             initialBalances[1] + expectedIncreases[1]
         );
         assertEq(
-            cashbackToken.balanceOf(address(settlementDispatcherReap)),
+            cashbackToken.balanceOf(address(settlementDispatcherReap)), 
             initialBalances[2] + expectedIncreases[2]
         );
     }
@@ -679,5 +645,12 @@ contract CashModuleMultiSpendTest is CashModuleTestSetup {
         tokenAmounts[2] = debtManager.convertUsdToCollateralToken(address(cashbackToken), scrAmountInUsd);
         
         return (spendTokens, spendAmounts, tokenAmounts);
+    }
+
+    function _makeScrCashback() internal view returns (Cashback[] memory cashbacks) {
+        CashbackTokens[] memory cashbackTokens = new CashbackTokens[](1);
+        cashbackTokens[0] = CashbackTokens({ token: address(cashbackToken), amountInUsd: 1e6, cashbackType: 0 });
+        cashbacks = new Cashback[](1);
+        cashbacks[0] = Cashback({ to: address(safe), cashbackTokens: cashbackTokens });
     }
 }

--- a/test/safe/modules/cash/PendingHoldsFindings.t.sol
+++ b/test/safe/modules/cash/PendingHoldsFindings.t.sol
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
+import { ICashModule, BinSponsor, Cashback, Mode } from "../../../../src/interfaces/ICashModule.sol";
+import { HoldRecord, IPendingHoldsModule, ReleaseReason } from "../../../../src/interfaces/IPendingHoldsModule.sol";
+import { PendingHoldsModule } from "../../../../src/modules/cash/PendingHoldsModule.sol";
+import { PendingHoldsTestSetup } from "./PendingHoldsModuleTest.t.sol";
+
+/**
+ * @title PendingHoldsFindings
+ * @notice Proving tests for PR #120 review findings. Each asserts the *desired* (correct) behavior,
+ *         so it is RED against the original code (proving the bug) and GREEN after the fix.
+ *
+ *  C2  — no-hold "Settlement is KING" path must charge the spending limit.
+ *  C1  — under-funded settlement leftover must be collectable later via collectRemaining().
+ *  M1  — the pending-holds withdrawal block must be enforced at finalize, not only at request.
+ */
+contract PendingHoldsFindingsTest is PendingHoldsTestSetup {
+
+    // ---------------------------------------------------------------------
+    // C2: no-hold settlement must charge the spending limit
+    // ---------------------------------------------------------------------
+    function test_C2_noHoldSettlement_chargesLimit() public {
+        uint256 amount = 100e6;
+        deal(address(usdc), address(safe), amount);
+
+        uint256 rawBefore = cashModule.rawSpendable(address(safe));
+
+        _spendWithoutHold(txId, BinSponsor.Reap, amount);
+
+        // The limit is debited by the settled amount (no longer bypassed).
+        assertEq(cashModule.rawSpendable(address(safe)), rawBefore - amount, "C2: no-hold settlement must charge limit");
+    }
+
+    // ---------------------------------------------------------------------
+    // C1: under-funded settlement leaves a collectable remainder
+    // ---------------------------------------------------------------------
+    function test_C1_underfundedSettlement_remainderCollectable() public {
+        uint256 authAmount = 100e6;
+        uint256 funded = 40e6; // safe can only cover $40 of the $100 settlement
+        deal(address(usdc), address(safe), funded);
+
+        uint256 rawBefore = cashModule.rawSpendable(address(safe));
+
+        _addHold(PROVIDER_REAP, txId, authAmount);                 // limit charged $100
+        assertEq(cashModule.rawSpendable(address(safe)), rawBefore - authAmount);
+
+        // Settlement $100 against a $40 balance → partial: $40 moves, $60 remains as a forced hold.
+        _spendWithHold(txId, BinSponsor.Reap, authAmount);
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), 60e6, "C1: $60 remainder parked");
+        assertTrue(cashModule.transactionCleared(address(safe), txId));
+
+        // User later funds the safe; ops sweeps the remainder.
+        deal(address(usdc), address(safe), 60e6);
+        vm.prank(etherFiWallet);
+        cashModule.collectRemaining(address(safe), txId, BinSponsor.Reap, address(usdc));
+
+        // Remainder cleared → withdrawals unblock; limit reflects exactly $100 (no double charge).
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), 0, "C1: remainder must collect to 0");
+        assertEq(cashModule.rawSpendable(address(safe)), rawBefore - authAmount, "C1: no double charge to limit");
+    }
+
+    // ---------------------------------------------------------------------
+    // M1: withdrawal block must be enforced at finalize, not only at request
+    // ---------------------------------------------------------------------
+    function test_M1_withdrawalBlock_enforcedAtFinalize() public {
+        // Give withdrawals a delay so request and finalize are distinct steps.
+        (, uint64 spendLimitDelay, uint64 modeDelay) = cashModule.getDelays();
+        vm.prank(owner);
+        cashModule.setDelays(1 days, spendLimitDelay, modeDelay);
+
+        uint256 amount = 100e6;
+        deal(address(usdc), address(safe), amount);
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = amount;
+
+        // Request a withdrawal while there are NO holds (passes the request-time guard).
+        _requestWithdrawal(tokens, amounts, withdrawRecipient);
+
+        // A card hold appears during the delay window.
+        _addHold(PROVIDER_REAP, txId, 50e6);
+
+        // Delay elapses; finalize must be blocked because a hold now exists.
+        vm.warp(block.timestamp + 1 days + 1);
+        vm.expectRevert(abi.encodeWithSignature("WithdrawalBlockedByPendingHolds()"));
+        cashModule.processWithdrawal(address(safe));
+    }
+}

--- a/test/safe/modules/cash/PendingHoldsFindings.t.sol
+++ b/test/safe/modules/cash/PendingHoldsFindings.t.sol
@@ -89,4 +89,64 @@ contract PendingHoldsFindingsTest is PendingHoldsTestSetup {
         vm.expectRevert(abi.encodeWithSignature("WithdrawalBlockedByPendingHolds()"));
         cashModule.processWithdrawal(address(safe));
     }
+
+    // ---------------------------------------------------------------------
+    // Invariant: totalPendingHolds(safe) == Σ getHold(...).amountUsd, preserved across
+    // every mutation path. Validates the checked _replaceTotalHolds helper (Tier 1 #3).
+    // ---------------------------------------------------------------------
+    bytes32 constant INV_T1 = keccak256("inv-reap");
+    bytes32 constant INV_T2 = keccak256("inv-rain");
+
+    function _sumHolds() internal view returns (uint256) {
+        return pendingHoldsModule.getHold(address(safe), PROVIDER_REAP, INV_T1).amountUsd
+             + pendingHoldsModule.getHold(address(safe), PROVIDER_RAIN, INV_T2).amountUsd;
+    }
+
+    function _assertHoldsInvariant() internal view {
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), _sumHolds(), "totalHolds != sum of holds");
+    }
+
+    function test_invariant_totalHoldsEqualsSumOfHolds_acrossLifecycle() public {
+        deal(address(usdc), address(safe), 1_000e6);
+        _assertHoldsInvariant();                                    // empty
+
+        _addHold(BinSponsor.Reap, INV_T1, 300e6);
+        _assertHoldsInvariant();                                    // 300
+        _addHold(BinSponsor.Rain, INV_T2, 200e6);
+        _assertHoldsInvariant();                                    // 500
+
+        vm.prank(etherFiWallet);
+        pendingHoldsModule.updateHold(address(safe), BinSponsor.Reap, INV_T1, 400e6); // increase
+        _assertHoldsInvariant();                                    // 600
+
+        vm.prank(etherFiWallet);
+        pendingHoldsModule.updateHold(address(safe), BinSponsor.Reap, INV_T1, 150e6); // decrease
+        _assertHoldsInvariant();                                    // 350
+
+        vm.prank(etherFiWallet);
+        pendingHoldsModule.releaseHold(address(safe), BinSponsor.Rain, INV_T2, ReleaseReason.REVERSAL);
+        _assertHoldsInvariant();                                    // 150
+
+        // Full settlement of the remaining hold → totalHolds returns to 0.
+        _spendWithHold(INV_T1, BinSponsor.Reap, 150e6);
+        _assertHoldsInvariant();                                    // 0
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), 0);
+    }
+
+    function test_invariant_totalHoldsConsistent_partialSettleThenCollect() public {
+        // Under-funded settlement leaves a remainder hold; collectRemaining clears it.
+        deal(address(usdc), address(safe), 40e6);
+        _addHold(BinSponsor.Reap, INV_T1, 100e6);
+        _assertHoldsInvariant();                                    // 100
+
+        _spendWithHold(INV_T1, BinSponsor.Reap, 100e6);             // pays 40, 60 remains
+        _assertHoldsInvariant();                                    // 60
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), 60e6);
+
+        deal(address(usdc), address(safe), 60e6);
+        vm.prank(etherFiWallet);
+        cashModule.collectRemaining(address(safe), INV_T1, BinSponsor.Reap, address(usdc));
+        _assertHoldsInvariant();                                    // 0
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), 0);
+    }
 }

--- a/test/safe/modules/cash/PendingHoldsFindings.t.sol
+++ b/test/safe/modules/cash/PendingHoldsFindings.t.sol
@@ -43,7 +43,7 @@ contract PendingHoldsFindingsTest is PendingHoldsTestSetup {
 
         uint256 rawBefore = cashModule.rawSpendable(address(safe));
 
-        _addHold(PROVIDER_REAP, txId, authAmount);                 // limit charged $100
+        _addHold(BinSponsor.Reap, txId, authAmount);                 // limit charged $100
         assertEq(cashModule.rawSpendable(address(safe)), rawBefore - authAmount);
 
         // Settlement $100 against a $40 balance → partial: $40 moves, $60 remains as a forced hold.
@@ -82,7 +82,7 @@ contract PendingHoldsFindingsTest is PendingHoldsTestSetup {
         _requestWithdrawal(tokens, amounts, withdrawRecipient);
 
         // A card hold appears during the delay window.
-        _addHold(PROVIDER_REAP, txId, 50e6);
+        _addHold(BinSponsor.Reap, txId, 50e6);
 
         // Delay elapses; finalize must be blocked because a hold now exists.
         vm.warp(block.timestamp + 1 days + 1);

--- a/test/safe/modules/cash/PendingHoldsModuleTest.t.sol
+++ b/test/safe/modules/cash/PendingHoldsModuleTest.t.sol
@@ -1,0 +1,864 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
+import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+import { Test } from "forge-std/Test.sol";
+
+import { UUPSProxy } from "../../../../src/UUPSProxy.sol";
+import { ICashModule, BinSponsor, Cashback, Mode } from "../../../../src/interfaces/ICashModule.sol";
+import { HoldRecord, IPendingHoldsModule, ReleaseReason } from "../../../../src/interfaces/IPendingHoldsModule.sol";
+import { CashVerificationLib } from "../../../../src/libraries/CashVerificationLib.sol";
+import { SpendingLimitLib } from "../../../../src/libraries/SpendingLimitLib.sol";
+import { CashLens } from "../../../../src/modules/cash/CashLens.sol";
+import { CashEventEmitter } from "../../../../src/modules/cash/CashEventEmitter.sol";
+import { PendingHoldsModule } from "../../../../src/modules/cash/PendingHoldsModule.sol";
+import { CashModuleTestSetup } from "./CashModuleTestSetup.t.sol";
+
+/**
+ * @dev Common setup: deploys PendingHoldsModule, wires it to CashModule, and redeploys
+ *      CashLens with the correct pendingHoldsModule immutable (requires new deployment per the plan).
+ */
+contract PendingHoldsTestSetup is CashModuleTestSetup {
+    IPendingHoldsModule public pendingHoldsModule;
+
+    bytes4 internal constant PROVIDER_REAP = bytes4("REAP");
+    bytes4 internal constant PROVIDER_RAIN = bytes4("RAIN");
+
+    function setUp() public virtual override {
+        super.setUp();
+
+        vm.startPrank(owner);
+
+        // Deploy PendingHoldsModule proxy and wire to CashModule
+        address phImpl = address(new PendingHoldsModule(address(dataProvider)));
+        pendingHoldsModule = IPendingHoldsModule(address(new UUPSProxy(
+            phImpl,
+            abi.encodeWithSelector(PendingHoldsModule.initialize.selector, address(roleRegistry), address(cashModule))
+        )));
+        cashModule.setPendingHoldsModule(address(pendingHoldsModule));
+
+        // Redeploy CashLens with pendingHoldsModule so hold-aware lens functions work
+        address cashLensImpl = address(new CashLens(address(cashModule), address(dataProvider), address(pendingHoldsModule)));
+        cashLens = CashLens(address(new UUPSProxy(cashLensImpl, abi.encodeWithSelector(CashLens.initialize.selector, address(roleRegistry)))));
+
+        vm.stopPrank();
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    function _addHold(bytes4 providerCode, bytes32 _txId, uint256 amountUsd) internal {
+        vm.prank(etherFiWallet);
+        pendingHoldsModule.addHold(address(safe), providerCode, _txId, amountUsd);
+    }
+
+    function _spendWithHold(bytes32 _txId, BinSponsor binSponsor, uint256 amountUsd) internal {
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amountsInUsd = new uint256[](1);
+        amountsInUsd[0] = amountUsd;
+        Cashback[] memory cashbacks;
+
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), _txId, binSponsor, tokens, amountsInUsd, cashbacks);
+    }
+
+    /// @dev Calls spend() without a prior hold — tests the "Settlement is KING" (no-hold) path.
+    ///      In the unified design, spend() handles both hold-exists and no-hold settlement.
+    function _spendWithoutHold(bytes32 _txId, BinSponsor binSponsor, uint256 amountUsd) internal {
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amountsInUsd = new uint256[](1);
+        amountsInUsd[0] = amountUsd;
+        Cashback[] memory cashbacks;
+
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), _txId, binSponsor, tokens, amountsInUsd, cashbacks);
+    }
+
+    /// @dev Builds sigs and calls requestWithdrawal directly — no internal getDelays() or expectEmit,
+    ///      so vm.expectRevert placed before this call is correctly consumed by requestWithdrawal.
+    ///      The nonce MUST be pre-computed by the caller before any vm.expectRevert is set,
+    ///      because safe.nonce() is an external call that would otherwise consume the expectRevert.
+    function _requestWithdrawalRaw(uint256 nonce, address[] memory tokens, uint256[] memory amounts, address recipient) internal {
+        bytes32 digestHash = MessageHashUtils.toEthSignedMessageHash(
+            keccak256(abi.encodePacked(CashVerificationLib.REQUEST_WITHDRAWAL_METHOD, block.chainid, address(safe), nonce, abi.encode(tokens, amounts, recipient)))
+        );
+        (uint8 v1, bytes32 r1, bytes32 s1) = vm.sign(owner1Pk, digestHash);
+        (uint8 v2, bytes32 r2, bytes32 s2) = vm.sign(owner2Pk, digestHash);
+        address[] memory signers = new address[](2);
+        signers[0] = owner1;
+        signers[1] = owner2;
+        bytes[] memory signatures = new bytes[](2);
+        signatures[0] = abi.encodePacked(r1, s1, v1);
+        signatures[1] = abi.encodePacked(r2, s2, v2);
+        cashModule.requestWithdrawal(address(safe), tokens, amounts, recipient, signers, signatures);
+    }
+}
+
+// =============================================================================
+// Unit tests: hold lifecycle (addHold, forceAddHold, updateHold, releaseHold, removeHold)
+// =============================================================================
+
+contract PendingHoldsModuleUnitTest is PendingHoldsTestSetup {
+
+    // -------------------------------------------------------------------------
+    // Initialization
+    // -------------------------------------------------------------------------
+
+    function test_initialize_setCashModuleCore() public view {
+        assertEq(pendingHoldsModule.cashModuleCore(), address(cashModule));
+    }
+
+    function test_initialize_revertsOnReinit() public {
+        vm.expectRevert();
+        PendingHoldsModule(address(pendingHoldsModule)).initialize(address(roleRegistry), address(cashModule));
+    }
+
+    // -------------------------------------------------------------------------
+    // addHold
+    // -------------------------------------------------------------------------
+
+    function test_addHold_storesRecordAndIncrementsTotalHolds() public {
+        uint256 amount = 100e6;
+
+        vm.prank(etherFiWallet);
+        vm.expectEmit(true, true, true, true);
+        emit IPendingHoldsModule.HoldAdded(address(safe), PROVIDER_REAP, txId, amount, block.timestamp, false);
+        pendingHoldsModule.addHold(address(safe), PROVIDER_REAP, txId, amount);
+
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), amount);
+
+        HoldRecord memory hold = pendingHoldsModule.getHold(address(safe), PROVIDER_REAP, txId);
+        assertEq(hold.amountUsd, amount);
+        assertEq(hold.providerCode, PROVIDER_REAP);
+        assertFalse(hold.forced);
+        assertGt(hold.createdAt, 0);
+    }
+
+    function test_addHold_revertsOnDuplicate() public {
+        uint256 amount = 100e6;
+        _addHold(PROVIDER_REAP, txId, amount);
+
+        vm.prank(etherFiWallet);
+        vm.expectRevert(IPendingHoldsModule.DuplicateHold.selector);
+        pendingHoldsModule.addHold(address(safe), PROVIDER_REAP, txId, amount);
+    }
+
+    function test_addHold_revertsOnZeroAmount() public {
+        vm.prank(etherFiWallet);
+        vm.expectRevert(IPendingHoldsModule.InvalidAmount.selector);
+        pendingHoldsModule.addHold(address(safe), PROVIDER_REAP, txId, 0);
+    }
+
+    function test_addHold_revertsWhenExceedsDailyLimit() public {
+        // daily limit = 10_000e6 — hold exceeds it so consumeSpendingLimit reverts
+        uint256 exceedingAmount = 10_001e6;
+
+        vm.prank(etherFiWallet);
+        vm.expectRevert(SpendingLimitLib.ExceededDailySpendingLimit.selector);
+        pendingHoldsModule.addHold(address(safe), PROVIDER_REAP, txId, exceedingAmount);
+    }
+
+    function test_addHold_revertsWhenNotEtherFiWallet() public {
+        vm.prank(address(0xdead));
+        vm.expectRevert();
+        pendingHoldsModule.addHold(address(safe), PROVIDER_REAP, txId, 100e6);
+    }
+
+    function test_addHold_providerCodeNamespacing_noCollisionBetweenProviders() public {
+        uint256 amount = 100e6;
+        _addHold(PROVIDER_REAP, txId, amount);
+
+        // Same txId, different providerCode — should succeed (separate namespace)
+        vm.prank(etherFiWallet);
+        pendingHoldsModule.addHold(address(safe), PROVIDER_RAIN, txId, amount);
+
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), amount * 2);
+    }
+
+    // -------------------------------------------------------------------------
+    // forceAddHold
+    // -------------------------------------------------------------------------
+
+    function test_forceAddHold_bypassesSpendableCheck_setsForcedTrue() public {
+        uint256 exceedingAmount = 10_001e6; // beyond rawSpendable
+
+        vm.prank(etherFiWallet);
+        vm.expectEmit(true, true, true, true);
+        emit IPendingHoldsModule.HoldAdded(address(safe), PROVIDER_REAP, txId, exceedingAmount, block.timestamp, true);
+        pendingHoldsModule.forceAddHold(address(safe), PROVIDER_REAP, txId, exceedingAmount);
+
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), exceedingAmount);
+
+        HoldRecord memory hold = pendingHoldsModule.getHold(address(safe), PROVIDER_REAP, txId);
+        assertTrue(hold.forced);
+    }
+
+    function test_forceAddHold_revertsOnDuplicate() public {
+        _addHold(PROVIDER_REAP, txId, 100e6);
+
+        vm.prank(etherFiWallet);
+        vm.expectRevert(IPendingHoldsModule.DuplicateHold.selector);
+        pendingHoldsModule.forceAddHold(address(safe), PROVIDER_REAP, txId, 100e6);
+    }
+
+    // -------------------------------------------------------------------------
+    // updateHold
+    // -------------------------------------------------------------------------
+
+    function test_updateHold_increase_updatesTotalHolds() public {
+        uint256 initial = 100e6;
+        uint256 increased = 200e6;
+
+        _addHold(PROVIDER_REAP, txId, initial);
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), initial);
+
+        vm.prank(etherFiWallet);
+        vm.expectEmit(true, true, true, true);
+        emit IPendingHoldsModule.HoldUpdated(address(safe), PROVIDER_REAP, txId, initial, increased, block.timestamp);
+        pendingHoldsModule.updateHold(address(safe), PROVIDER_REAP, txId, increased);
+
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), increased);
+        assertEq(pendingHoldsModule.getHold(address(safe), PROVIDER_REAP, txId).amountUsd, increased);
+    }
+
+    function test_updateHold_decrease_updatesTotalHolds() public {
+        uint256 initial = 200e6;
+        uint256 decreased = 100e6;
+
+        _addHold(PROVIDER_REAP, txId, initial);
+
+        vm.prank(etherFiWallet);
+        pendingHoldsModule.updateHold(address(safe), PROVIDER_REAP, txId, decreased);
+
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), decreased);
+        assertEq(pendingHoldsModule.getHold(address(safe), PROVIDER_REAP, txId).amountUsd, decreased);
+    }
+
+    function test_updateHold_increase_revertsWhenExceedsDailyLimit() public {
+        uint256 initial = 9_900e6;
+        // After addHold(9_900), spentToday=9_900, remaining=100. Delta of 101 breaches limit.
+        uint256 exceedingIncrease = 10_001e6;
+
+        _addHold(PROVIDER_REAP, txId, initial);
+
+        vm.prank(etherFiWallet);
+        vm.expectRevert(SpendingLimitLib.ExceededDailySpendingLimit.selector);
+        pendingHoldsModule.updateHold(address(safe), PROVIDER_REAP, txId, exceedingIncrease);
+    }
+
+    function test_updateHold_revertsOnHoldNotFound() public {
+        vm.prank(etherFiWallet);
+        vm.expectRevert(IPendingHoldsModule.HoldNotFound.selector);
+        pendingHoldsModule.updateHold(address(safe), PROVIDER_REAP, txId, 100e6);
+    }
+
+    // -------------------------------------------------------------------------
+    // releaseHold
+    // -------------------------------------------------------------------------
+
+    function test_releaseHold_reversal_decrementsAndDeletes() public {
+        uint256 amount = 100e6;
+        _addHold(PROVIDER_REAP, txId, amount);
+
+        vm.prank(etherFiWallet);
+        vm.expectEmit(true, true, true, true);
+        emit IPendingHoldsModule.HoldReleased(address(safe), PROVIDER_REAP, txId, amount, ReleaseReason.REVERSAL, block.timestamp);
+        pendingHoldsModule.releaseHold(address(safe), PROVIDER_REAP, txId, ReleaseReason.REVERSAL);
+
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), 0);
+        assertEq(pendingHoldsModule.getHold(address(safe), PROVIDER_REAP, txId).createdAt, 0);
+    }
+
+    function test_releaseHold_admin_works() public {
+        uint256 amount = 100e6;
+        _addHold(PROVIDER_REAP, txId, amount);
+
+        vm.prank(etherFiWallet);
+        vm.expectEmit(true, true, true, true);
+        emit IPendingHoldsModule.HoldReleased(address(safe), PROVIDER_REAP, txId, amount, ReleaseReason.ADMIN, block.timestamp);
+        pendingHoldsModule.releaseHold(address(safe), PROVIDER_REAP, txId, ReleaseReason.ADMIN);
+
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), 0);
+    }
+
+    function test_releaseHold_revertsOnHoldNotFound() public {
+        vm.prank(etherFiWallet);
+        vm.expectRevert(IPendingHoldsModule.HoldNotFound.selector);
+        pendingHoldsModule.releaseHold(address(safe), PROVIDER_REAP, txId, ReleaseReason.REVERSAL);
+    }
+
+    // -------------------------------------------------------------------------
+    // removeHold (onlyCashModuleCore)
+    // -------------------------------------------------------------------------
+
+    function test_removeHold_revertsWhenCalledByNonCore() public {
+        _addHold(PROVIDER_REAP, txId, 100e6);
+
+        vm.prank(etherFiWallet);
+        vm.expectRevert(IPendingHoldsModule.OnlyCashModuleCore.selector);
+        pendingHoldsModule.removeHold(address(safe), BinSponsor.Reap, txId);
+    }
+
+    function test_removeHold_succeedsWhenModulePaused() public {
+        // removeHold must not be blocked by pause — pausing PHM should halt new hold creation
+        // but must not freeze in-flight settlements that CashModuleCore drives via spend().
+        _addHold(PROVIDER_REAP, txId, 100e6);
+
+        vm.prank(pauser);
+        PendingHoldsModule(address(pendingHoldsModule)).pause();
+
+        // spend() → removeHold() must still succeed under pause
+        deal(address(usdc), address(safe), 100e6);
+        _spendWithHold(txId, BinSponsor.Reap, 100e6);
+
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), 0);
+    }
+
+    function test_updateHold_decrease_defensiveFloor_noUnderflow() public {
+        // Simulate a corrupted totalHolds where the running sum is less than oldAmountUsd.
+        // After fix, the decreasing branch uses the same floor pattern as releaseHold/removeHold
+        // rather than a bare subtraction that would revert with underflow.
+
+        uint256 amount = 200e6;
+        bytes32 txId2 = keccak256("txId2");
+
+        _addHold(PROVIDER_REAP, txId, amount);
+        _addHold(PROVIDER_RAIN, txId2, amount);
+        // totalHolds = 400e6
+
+        // Release txId2 via releaseHold — totalHolds drops to 200e6
+        vm.prank(etherFiWallet);
+        pendingHoldsModule.releaseHold(address(safe), PROVIDER_RAIN, txId2, ReleaseReason.ADMIN);
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), amount);
+
+        // Decreasing update on txId (200e6 → 50e6) — floor kicks in if drift exists; normal path here
+        vm.prank(etherFiWallet);
+        pendingHoldsModule.updateHold(address(safe), PROVIDER_REAP, txId, 50e6);
+
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), 50e6);
+        assertEq(pendingHoldsModule.getHold(address(safe), PROVIDER_REAP, txId).amountUsd, 50e6);
+    }
+
+    // -------------------------------------------------------------------------
+    // providerCodeFromBinSponsor
+    // -------------------------------------------------------------------------
+
+    function test_providerCodeFromBinSponsor_mappings() public view {
+        assertEq(pendingHoldsModule.providerCodeFromBinSponsor(BinSponsor.Reap), bytes4("REAP"));
+        assertEq(pendingHoldsModule.providerCodeFromBinSponsor(BinSponsor.Rain), bytes4("RAIN"));
+        assertEq(pendingHoldsModule.providerCodeFromBinSponsor(BinSponsor.PIX), bytes4("PIX_"));
+        assertEq(pendingHoldsModule.providerCodeFromBinSponsor(BinSponsor.CardOrder), bytes4("CORD"));
+    }
+
+    // -------------------------------------------------------------------------
+    // CashModuleSetters auth guards
+    // -------------------------------------------------------------------------
+
+    function test_setPendingHoldsModule_revertsIfNotController() public {
+        vm.prank(address(0xdead));
+        vm.expectRevert();
+        cashModule.setPendingHoldsModule(address(pendingHoldsModule));
+    }
+
+    function test_consumeSpendingLimit_revertsIfNotPHM() public {
+        // Any caller that is not the registered pendingHoldsModule must be rejected.
+        // cashModule is ICashModule so we low-level call to avoid interface type constraint.
+        vm.prank(address(0xdead));
+        (bool ok,) = address(cashModule).call(
+            abi.encodeWithSignature("consumeSpendingLimit(address,uint256)", address(safe), 100e6)
+        );
+        assertFalse(ok, "consumeSpendingLimit should revert for non-PHM caller");
+    }
+
+    function test_releaseSpendingLimit_revertsIfNotPHM() public {
+        vm.prank(address(0xdead));
+        (bool ok,) = address(cashModule).call(
+            abi.encodeWithSignature("releaseSpendingLimit(address,uint256)", address(safe), 100e6)
+        );
+        assertFalse(ok, "releaseSpendingLimit should revert for non-PHM caller");
+    }
+}
+
+// =============================================================================
+// Integration tests: CashModule + PendingHoldsModule
+// =============================================================================
+
+contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
+
+    // -------------------------------------------------------------------------
+    // spend() integration
+    // -------------------------------------------------------------------------
+
+    function test_spend_withMatchingHold_removesHoldAndSettles() public {
+        uint256 amount = 100e6;
+        deal(address(usdc), address(safe), amount);
+
+        _addHold(PROVIDER_REAP, txId, amount);
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), amount);
+
+        vm.expectEmit(true, true, true, true);
+        emit IPendingHoldsModule.HoldRemoved(address(safe), PROVIDER_REAP, txId, amount, block.timestamp);
+        _spendWithHold(txId, BinSponsor.Reap, amount);
+
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), 0);
+        assertEq(pendingHoldsModule.getHold(address(safe), PROVIDER_REAP, txId).createdAt, 0);
+        assertTrue(cashModule.transactionCleared(address(safe), txId));
+    }
+
+    function test_spend_withNoMatchingHold_settlementIsKing_succeedsAndBypassesLimit() public {
+        // "Settlement is KING": spend() with no prior hold creates a forced hold and settles.
+        // The spending limit is NOT charged (bypass), and the transaction is cleared.
+        uint256 amount = 100e6;
+        deal(address(usdc), address(safe), amount);
+
+        uint256 rawBefore = cashModule.rawSpendable(address(safe));
+
+        // No hold added — spend() creates a forced hold internally and settles it
+        vm.expectEmit(true, true, true, true);
+        emit IPendingHoldsModule.HoldAdded(address(safe), PROVIDER_REAP, txId, amount, block.timestamp, true);
+        vm.expectEmit(true, true, true, true);
+        emit IPendingHoldsModule.HoldRemoved(address(safe), PROVIDER_REAP, txId, amount, block.timestamp);
+        _spendWithoutHold(txId, BinSponsor.Reap, amount);
+
+        // Limit is bypassed (Settlement is KING)
+        assertEq(cashModule.rawSpendable(address(safe)), rawBefore);
+        // Hold is gone after settlement
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), 0);
+        assertTrue(cashModule.transactionCleared(address(safe), txId));
+    }
+
+    function test_spend_settlementLessThanHold_creditsLimitDeltaBack() public {
+        // Settlement < hold: the $50 over-auth is credited back to the spending limit.
+        // settlementSyncHold updates hold 150→100, releasing $50 delta from spentToday/spentThisMonth.
+        uint256 holdAmount = 150e6;  // hold was for $150
+        uint256 settleAmount = 100e6; // settlement comes in at $100
+
+        deal(address(usdc), address(safe), holdAmount);
+        uint256 rawBefore = cashModule.rawSpendable(address(safe));
+
+        _addHold(PROVIDER_REAP, txId, holdAmount);
+        // addHold consumed $150 from limit
+        assertEq(cashModule.rawSpendable(address(safe)), rawBefore - holdAmount);
+
+        _spendWithHold(txId, BinSponsor.Reap, settleAmount);
+
+        // $50 delta credited back: limit now reflects only $100 consumed
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), 0);
+        assertEq(cashModule.rawSpendable(address(safe)), rawBefore - settleAmount);
+    }
+
+    function test_spend_settlementExceedsHold_chargesOnlyDelta() public {
+        // Tip / gratuity scenario: settlement > hold amount.
+        // The hold pre-charged $100 at addHold. The extra $20 tip must be charged at settlement.
+        uint256 holdAmount = 100e6;
+        uint256 settleAmount = 120e6;
+
+        deal(address(usdc), address(safe), settleAmount);
+        uint256 rawBefore = cashModule.rawSpendable(address(safe));
+
+        _addHold(PROVIDER_REAP, txId, holdAmount);
+        assertEq(cashModule.rawSpendable(address(safe)), rawBefore - holdAmount);
+
+        _spendWithHold(txId, BinSponsor.Reap, settleAmount);
+
+        // The $20 delta must be charged: total limit consumed = $100 (hold) + $20 (delta) = $120
+        assertEq(cashModule.rawSpendable(address(safe)), rawBefore - settleAmount);
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), 0);
+    }
+
+    function test_spend_withForceAddHold_chargesFullLimitAtSettlement() public {
+        // forceAddHold bypasses consumeSpendingLimit — limit is NOT charged at addHold time.
+        // When spend() settles it, limitConsumed=false (hold.forced=true) so the full amount is charged.
+        uint256 amount = 100e6;
+        deal(address(usdc), address(safe), amount);
+
+        uint256 rawBefore = cashModule.rawSpendable(address(safe));
+
+        // Force-add: no limit consumption
+        vm.prank(etherFiWallet);
+        pendingHoldsModule.forceAddHold(address(safe), PROVIDER_REAP, txId, amount);
+        assertEq(cashModule.rawSpendable(address(safe)), rawBefore); // limit unchanged
+
+        // Normal spend() clears the forced hold and NOW charges the limit
+        _spendWithHold(txId, BinSponsor.Reap, amount);
+
+        assertEq(cashModule.rawSpendable(address(safe)), rawBefore - amount);
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), 0);
+        assertTrue(cashModule.transactionCleared(address(safe), txId));
+    }
+
+    // -------------------------------------------------------------------------
+    // requestWithdrawal() guard
+    // -------------------------------------------------------------------------
+
+    function test_requestWithdrawal_blockedWhenHoldsExist() public {
+        uint256 amount = 100e6;
+        deal(address(usdc), address(safe), amount);
+        _addHold(PROVIDER_REAP, txId, amount);
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = amount;
+
+        // Pre-compute nonce BEFORE vm.expectRevert — safe.nonce() is an external call that would
+        // otherwise consume the expectRevert before requestWithdrawal is reached.
+        uint256 nonce = safe.nonce();
+        vm.expectRevert(abi.encodeWithSignature("WithdrawalBlockedByPendingHolds()"));
+        _requestWithdrawalRaw(nonce, tokens, amounts, withdrawRecipient);
+    }
+
+    function test_requestWithdrawal_allowedWhenNoHolds() public {
+        uint256 amount = 100e6;
+        deal(address(usdc), address(safe), amount);
+
+        // No holds — withdrawal should proceed normally
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = amount;
+
+        _requestWithdrawal(tokens, amounts, withdrawRecipient);
+    }
+
+    function test_requestWithdrawal_allowedAfterHoldReleased() public {
+        uint256 amount = 100e6;
+        deal(address(usdc), address(safe), amount);
+        _addHold(PROVIDER_REAP, txId, amount);
+
+        // Release hold first
+        vm.prank(etherFiWallet);
+        pendingHoldsModule.releaseHold(address(safe), PROVIDER_REAP, txId, ReleaseReason.REVERSAL);
+
+        // Now withdrawal should succeed
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = amount;
+
+        _requestWithdrawal(tokens, amounts, withdrawRecipient);
+    }
+
+    // -------------------------------------------------------------------------
+    // spend() — no-hold path (formerly "forceSpend")
+    // -------------------------------------------------------------------------
+    // In the unified design, spend() handles both hold-exists and no-hold settlement paths.
+    // The no-hold path is "Settlement is KING": a forced hold is created and immediately removed,
+    // and the spending limit is NOT charged (bypass).
+
+    function test_spend_withNoHold_deductsBalanceAndBypassesLimit() public {
+        uint256 amount = 100e6;
+        deal(address(usdc), address(safe), amount);
+
+        uint256 safeBalBefore = usdc.balanceOf(address(safe));
+        uint256 dispatcherBalBefore = usdc.balanceOf(address(settlementDispatcherReap));
+        uint256 rawBefore = cashModule.rawSpendable(address(safe));
+
+        _spendWithoutHold(txId, BinSponsor.Reap, amount);
+
+        assertEq(usdc.balanceOf(address(safe)), safeBalBefore - debtManager.convertUsdToCollateralToken(address(usdc), amount));
+        assertGt(usdc.balanceOf(address(settlementDispatcherReap)), dispatcherBalBefore);
+        assertTrue(cashModule.transactionCleared(address(safe), txId));
+        // Limit is bypassed (Settlement is KING)
+        assertEq(cashModule.rawSpendable(address(safe)), rawBefore);
+    }
+
+    function test_spend_withNoHold_emitsCorrectSpendEvent() public {
+        uint256 amount = 100e6;
+        deal(address(usdc), address(safe), amount);
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amountsInUsd = new uint256[](1);
+        amountsInUsd[0] = amount;
+        uint256 tokenAmount = debtManager.convertUsdToCollateralToken(address(usdc), amount);
+        uint256[] memory tokenAmounts = new uint256[](1);
+        tokenAmounts[0] = tokenAmount;
+        Cashback[] memory cashbacks;
+        Mode currentMode = cashModule.getMode(address(safe));
+
+        vm.prank(etherFiWallet);
+        vm.expectEmit(true, true, true, true);
+        emit CashEventEmitter.Spend(address(safe), txId, BinSponsor.Reap, tokens, tokenAmounts, amountsInUsd, amount, currentMode);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, tokens, amountsInUsd, cashbacks);
+    }
+
+    function test_spend_withNoHold_doesNotAffectUnrelatedHold() public {
+        // spend() on a different txId with no hold creates a forced hold for that txId and settles it.
+        // The existing hold on the original txId must be unaffected.
+        uint256 holdAmount = 100e6;
+        uint256 spendAmount = 50e6;
+        deal(address(usdc), address(safe), holdAmount + spendAmount);
+
+        _addHold(PROVIDER_REAP, txId, holdAmount);
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), holdAmount);
+
+        // spend() on a different txId (no-hold path) — creates and immediately removes a forced hold
+        bytes32 noHoldTxId = keccak256("noHoldTxId");
+        _spendWithoutHold(noHoldTxId, BinSponsor.Reap, spendAmount);
+
+        // Original hold for txId is unaffected
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), holdAmount);
+        assertTrue(cashModule.transactionCleared(address(safe), noHoldTxId));
+    }
+
+    function test_spend_afterForceAddHold_sameTxId_clearsHoldAndChargesLimit() public {
+        // forceAddHold followed by spend() on the same txId clears the hold.
+        // Unlike the no-hold path, the forced hold (forceAddHold) bypassed the limit at creation,
+        // so spend() charges the full settlement amount to the spending limit.
+        uint256 amount = 100e6;
+        deal(address(usdc), address(safe), amount);
+
+        uint256 rawBefore = cashModule.rawSpendable(address(safe));
+
+        // Force-capture: place a hold without a balance check (no limit consumption)
+        vm.prank(etherFiWallet);
+        pendingHoldsModule.forceAddHold(address(safe), PROVIDER_REAP, txId, amount);
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), amount);
+        assertEq(cashModule.rawSpendable(address(safe)), rawBefore); // limit unchanged
+
+        // Settlement via spend() — clears the forced hold and charges limit
+        _spendWithHold(txId, BinSponsor.Reap, amount);
+
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), 0);
+        assertEq(pendingHoldsModule.getHold(address(safe), PROVIDER_REAP, txId).createdAt, 0);
+        assertTrue(cashModule.transactionCleared(address(safe), txId));
+        // Forced hold: limit was NOT charged at forceAddHold, IS charged at settlement
+        assertEq(cashModule.rawSpendable(address(safe)), rawBefore - amount);
+    }
+
+    function test_releaseHoldThenSpend_settlementIsKing_consistentState() public {
+        // After a hold is released (e.g. reversal), the settlement might still arrive.
+        // spend() with no existing hold (Settlement is KING): creates a forced hold and settles.
+        // Limit is NOT charged since the no-hold path bypasses it.
+        uint256 amount = 100e6;
+        deal(address(usdc), address(safe), amount);
+
+        uint256 rawBefore = cashModule.rawSpendable(address(safe));
+        _addHold(PROVIDER_REAP, txId, amount);
+
+        // Admin releases the hold (e.g. force-capture recovery where hold is stale)
+        vm.prank(etherFiWallet);
+        pendingHoldsModule.releaseHold(address(safe), PROVIDER_REAP, txId, ReleaseReason.ADMIN);
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), 0);
+        // releaseHold credits back the limit
+        assertEq(cashModule.rawSpendable(address(safe)), rawBefore);
+
+        // Settlement arrives — no-hold path (Settlement is KING), limit NOT charged
+        _spendWithoutHold(txId, BinSponsor.Reap, amount);
+
+        assertTrue(cashModule.transactionCleared(address(safe), txId));
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), 0);
+        // Limit unchanged since no-hold path bypasses it
+        assertEq(cashModule.rawSpendable(address(safe)), rawBefore);
+    }
+
+    // -------------------------------------------------------------------------
+    // Integration: full flows
+    // -------------------------------------------------------------------------
+
+    function test_integration_fullAuthToSettlement() public {
+        uint256 amount = 100e6;
+        deal(address(usdc), address(safe), amount);
+
+        // 1. Auth acknowledged: add hold
+        _addHold(PROVIDER_REAP, txId, amount);
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), amount);
+
+        // 2. Settlement: spend removes hold
+        _spendWithHold(txId, BinSponsor.Reap, amount);
+
+        // 3. Hold cleared, transaction settled
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), 0);
+        assertTrue(cashModule.transactionCleared(address(safe), txId));
+    }
+
+    function test_integration_reversalFlow() public {
+        uint256 amount = 100e6;
+        deal(address(usdc), address(safe), amount);
+
+        uint256 rawBefore = cashModule.rawSpendable(address(safe));
+        _addHold(PROVIDER_REAP, txId, amount);
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), amount);
+
+        // Network reversal — hold released, limit credited back
+        vm.prank(etherFiWallet);
+        pendingHoldsModule.releaseHold(address(safe), PROVIDER_REAP, txId, ReleaseReason.REVERSAL);
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), 0);
+        assertEq(cashModule.rawSpendable(address(safe)), rawBefore); // limit restored
+
+        // Settlement arrives despite reversal: Settlement is KING — spend() uses no-hold path.
+        // This creates a forced hold internally and settles without charging the limit.
+        deal(address(usdc), address(safe), amount);
+        _spendWithoutHold(txId, BinSponsor.Reap, amount);
+
+        assertTrue(cashModule.transactionCleared(address(safe), txId));
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), 0);
+        // No-hold path: limit is NOT charged
+        assertEq(cashModule.rawSpendable(address(safe)), rawBefore);
+    }
+
+    function test_integration_incrementalAuth() public {
+        uint256 initial = 100e6;
+        uint256 increased = 150e6;
+        uint256 decreased = 120e6;
+
+        _addHold(PROVIDER_REAP, txId, initial);
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), initial);
+
+        // Incremental auth: amount goes up
+        vm.prank(etherFiWallet);
+        pendingHoldsModule.updateHold(address(safe), PROVIDER_REAP, txId, increased);
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), increased);
+
+        // Incremental auth: amount goes down
+        vm.prank(etherFiWallet);
+        pendingHoldsModule.updateHold(address(safe), PROVIDER_REAP, txId, decreased);
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), decreased);
+    }
+
+    function test_integration_withdrawalGuard_addHoldThenBlockThenReleaseThenAllow() public {
+        uint256 amount = 100e6;
+        deal(address(usdc), address(safe), amount);
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = amount;
+
+        _addHold(PROVIDER_REAP, txId, amount);
+
+        // Pre-compute nonce BEFORE vm.expectRevert — safe.nonce() is an external call that would
+        // otherwise consume the expectRevert before requestWithdrawal is reached.
+        uint256 nonce = safe.nonce();
+        vm.expectRevert(abi.encodeWithSignature("WithdrawalBlockedByPendingHolds()"));
+        _requestWithdrawalRaw(nonce, tokens, amounts, withdrawRecipient);
+
+        // Release hold
+        vm.prank(etherFiWallet);
+        pendingHoldsModule.releaseHold(address(safe), PROVIDER_REAP, txId, ReleaseReason.REVERSAL);
+
+        // Withdrawal now allowed — use _requestWithdrawal helper which also checks the emitted event
+        _requestWithdrawal(tokens, amounts, withdrawRecipient);
+    }
+}
+
+// =============================================================================
+// CashLens pending holds views
+// =============================================================================
+
+contract PendingHoldsLensTest is PendingHoldsTestSetup {
+
+    function test_spendable_noHolds_equalsRawSpendable() public view {
+        uint256 raw = cashModule.rawSpendable(address(safe));
+        assertEq(cashLens.spendable(address(safe)), raw);
+    }
+
+    function test_spendable_withHolds_reflectsLimitConsumption() public {
+        uint256 holdAmount = 100e6;
+        _addHold(PROVIDER_REAP, txId, holdAmount);
+
+        // addHold consumes from spentToday; rawSpendable already reflects the hold.
+        // spendable() == rawSpendable() — no separate deduction.
+        uint256 raw = cashModule.rawSpendable(address(safe));
+        assertEq(cashLens.spendable(address(safe)), raw);
+    }
+
+    function test_canSpend_noHolds_returnsTrueWhenFits() public {
+        // With no holds canSpend behaves identically to the pre-holds path
+        uint256 amountUsd = 100e6;
+        deal(address(usdc), address(safe), amountUsd);
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = amountUsd;
+
+        bytes32 newTxId = keccak256("canSpend_noHolds");
+        (bool ok, ) = cashLens.canSpend(address(safe), newTxId, tokens, amounts);
+        assertTrue(ok);
+    }
+
+    function test_canSpend_holdsMakeItExceed_returnsFalse() public {
+        // Fill most of the capacity with a hold so the next auth cannot fit
+        _addHold(PROVIDER_REAP, txId, 9_900e6);
+
+        // 200 USD would push total (holds + amount) past the 10_000 USD daily limit
+        uint256 amountUsd = 200e6;
+        deal(address(usdc), address(safe), amountUsd);
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = amountUsd;
+
+        bytes32 newTxId = keccak256("canSpend_exceed");
+        (bool ok, ) = cashLens.canSpend(address(safe), newTxId, tokens, amounts);
+        assertFalse(ok);
+    }
+
+    function test_canSpend_holdsReduceCapacity_butAmountStillFits() public {
+        uint256 existingHold = 500e6;
+        _addHold(PROVIDER_REAP, txId, existingHold);
+
+        // 300 USD fits within the remaining 9_500 USD capacity
+        uint256 amountUsd = 300e6;
+        deal(address(usdc), address(safe), amountUsd);
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = amountUsd;
+
+        bytes32 newTxId = keccak256("canSpend_fits");
+        (bool ok, ) = cashLens.canSpend(address(safe), newTxId, tokens, amounts);
+        assertTrue(ok);
+    }
+
+    function test_holdsSummary_returnsConsistentValues() public {
+        uint256 holdAmount = 250e6;
+        _addHold(PROVIDER_REAP, txId, holdAmount);
+
+        (uint256 totalHolds, uint256 spendableAmt, uint256 rawSpendableAmt) = cashLens.holdsSummary(address(safe));
+
+        // totalHolds tracks the on-chain hold for the withdrawal guard and display.
+        assertEq(totalHolds, holdAmount);
+        // rawSpendable already reflects the hold (charged to spentToday at addHold time).
+        assertEq(rawSpendableAmt, cashModule.rawSpendable(address(safe)));
+        // spendableAmt == rawSpendableAmt — holds are in spentToday, not a separate deduction.
+        assertEq(spendableAmt, rawSpendableAmt);
+        // Cross-check with standalone spendable()
+        assertEq(spendableAmt, cashLens.spendable(address(safe)));
+    }
+
+    function test_holdsSummary_noHolds_spendableEqualsRaw() public view {
+        (uint256 totalHolds, uint256 spendableAmt, uint256 rawSpendableAmt) = cashLens.holdsSummary(address(safe));
+
+        assertEq(totalHolds, 0);
+        assertEq(spendableAmt, rawSpendableAmt);
+    }
+}
+
+// =============================================================================
+// Bytecode size gate — CashModuleCore must stay under EVM 24KB limit
+// =============================================================================
+
+contract CashModuleCoreBytecodeSizeTest is Test {
+    function test_cashModuleCore_deployedSize_underLimit() public {
+        // CashModuleCore must not exceed 24,576 bytes (EIP-170 limit)
+        uint256 limit = 24_576;
+        uint256 coreSize = address(new _CashModuleCoreForSizeCheck()).code.length;
+        assertLt(coreSize, limit, "CashModuleCore deployed bytecode exceeds 24KB EVM limit");
+    }
+}
+
+// Minimal deployment helper — avoids importing the full constructor chain in this file
+import { CashModuleCore } from "../../../../src/modules/cash/CashModuleCore.sol";
+import { EtherFiDataProvider } from "../../../../src/data-provider/EtherFiDataProvider.sol";
+
+contract _CashModuleCoreForSizeCheck is CashModuleCore {
+    constructor() CashModuleCore(address(1)) { }
+}

--- a/test/safe/modules/cash/PendingHoldsModuleTest.t.sol
+++ b/test/safe/modules/cash/PendingHoldsModuleTest.t.sol
@@ -848,18 +848,41 @@ contract PendingHoldsLensTest is PendingHoldsTestSetup {
 // =============================================================================
 
 contract CashModuleCoreBytecodeSizeTest is Test {
+    uint256 constant EIP170_LIMIT = 24_576;
+
     function test_cashModuleCore_deployedSize_underLimit() public {
-        // CashModuleCore must not exceed 24,576 bytes (EIP-170 limit)
-        uint256 limit = 24_576;
         uint256 coreSize = address(new _CashModuleCoreForSizeCheck()).code.length;
-        assertLt(coreSize, limit, "CashModuleCore deployed bytecode exceeds 24KB EVM limit");
+        assertLt(coreSize, EIP170_LIMIT, "CashModuleCore deployed bytecode exceeds 24KB EVM limit");
+    }
+
+    // Setters is deployed standalone (delegatecall target) and is also subject to EIP-170. The PR
+    // moved code into Setters to protect Core's ceiling, which previously pushed Setters over the
+    // limit; this gate prevents that regression.
+    function test_cashModuleSetters_deployedSize_underLimit() public {
+        uint256 settersSize = address(new _CashModuleSettersForSizeCheck()).code.length;
+        assertLt(settersSize, EIP170_LIMIT, "CashModuleSetters deployed bytecode exceeds 24KB EVM limit");
+    }
+
+    function test_cashModuleSettersExt_deployedSize_underLimit() public {
+        uint256 extSize = address(new _CashModuleSettersExtForSizeCheck()).code.length;
+        assertLt(extSize, EIP170_LIMIT, "CashModuleSettersExt deployed bytecode exceeds 24KB EVM limit");
     }
 }
 
-// Minimal deployment helper — avoids importing the full constructor chain in this file
+// Minimal deployment helpers — avoid importing the full constructor chain in this file
 import { CashModuleCore } from "../../../../src/modules/cash/CashModuleCore.sol";
+import { CashModuleSetters } from "../../../../src/modules/cash/CashModuleSetters.sol";
+import { CashModuleSettersExt } from "../../../../src/modules/cash/CashModuleSettersExt.sol";
 import { EtherFiDataProvider } from "../../../../src/data-provider/EtherFiDataProvider.sol";
 
 contract _CashModuleCoreForSizeCheck is CashModuleCore {
     constructor() CashModuleCore(address(1)) { }
+}
+
+contract _CashModuleSettersForSizeCheck is CashModuleSetters {
+    constructor() CashModuleSetters(address(1)) { }
+}
+
+contract _CashModuleSettersExtForSizeCheck is CashModuleSettersExt {
+    constructor() CashModuleSettersExt(address(1)) { }
 }

--- a/test/safe/modules/cash/PendingHoldsModuleTest.t.sol
+++ b/test/safe/modules/cash/PendingHoldsModuleTest.t.sol
@@ -409,9 +409,10 @@ contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
         assertTrue(cashModule.transactionCleared(address(safe), txId));
     }
 
-    function test_spend_withNoMatchingHold_settlementIsKing_succeedsAndBypassesLimit() public {
+    function test_spend_withNoMatchingHold_settlementIsKing_succeedsAndChargesLimit() public {
         // "Settlement is KING": spend() with no prior hold creates a forced hold and settles.
-        // The spending limit is NOT charged (bypass), and the transaction is cleared.
+        // The spending limit IS charged (the limit is the primary risk control and must reflect
+        // funds leaving the safe), and the transaction is cleared.
         uint256 amount = 100e6;
         deal(address(usdc), address(safe), amount);
 
@@ -424,8 +425,8 @@ contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
         emit IPendingHoldsModule.HoldRemoved(address(safe), PROVIDER_REAP, txId, amount, block.timestamp);
         _spendWithoutHold(txId, BinSponsor.Reap, amount);
 
-        // Limit is bypassed (Settlement is KING)
-        assertEq(cashModule.rawSpendable(address(safe)), rawBefore);
+        // Limit is charged the full settled amount (no longer bypassed)
+        assertEq(cashModule.rawSpendable(address(safe)), rawBefore - amount);
         // Hold is gone after settlement
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), 0);
         assertTrue(cashModule.transactionCleared(address(safe), txId));
@@ -550,7 +551,7 @@ contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
     // The no-hold path is "Settlement is KING": a forced hold is created and immediately removed,
     // and the spending limit is NOT charged (bypass).
 
-    function test_spend_withNoHold_deductsBalanceAndBypassesLimit() public {
+    function test_spend_withNoHold_deductsBalanceAndChargesLimit() public {
         uint256 amount = 100e6;
         deal(address(usdc), address(safe), amount);
 
@@ -563,8 +564,8 @@ contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
         assertEq(usdc.balanceOf(address(safe)), safeBalBefore - debtManager.convertUsdToCollateralToken(address(usdc), amount));
         assertGt(usdc.balanceOf(address(settlementDispatcherReap)), dispatcherBalBefore);
         assertTrue(cashModule.transactionCleared(address(safe), txId));
-        // Limit is bypassed (Settlement is KING)
-        assertEq(cashModule.rawSpendable(address(safe)), rawBefore);
+        // Limit IS charged the settled amount (no longer bypassed)
+        assertEq(cashModule.rawSpendable(address(safe)), rawBefore - amount);
     }
 
     function test_spend_withNoHold_emitsCorrectSpendEvent() public {
@@ -634,7 +635,7 @@ contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
     function test_releaseHoldThenSpend_settlementIsKing_consistentState() public {
         // After a hold is released (e.g. reversal), the settlement might still arrive.
         // spend() with no existing hold (Settlement is KING): creates a forced hold and settles.
-        // Limit is NOT charged since the no-hold path bypasses it.
+        // Limit IS charged for the settled amount (the no-hold path no longer bypasses it).
         uint256 amount = 100e6;
         deal(address(usdc), address(safe), amount);
 
@@ -648,13 +649,13 @@ contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
         // releaseHold credits back the limit
         assertEq(cashModule.rawSpendable(address(safe)), rawBefore);
 
-        // Settlement arrives — no-hold path (Settlement is KING), limit NOT charged
+        // Settlement arrives — no-hold path (Settlement is KING), limit charged for the settled amount
         _spendWithoutHold(txId, BinSponsor.Reap, amount);
 
         assertTrue(cashModule.transactionCleared(address(safe), txId));
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), 0);
-        // Limit unchanged since no-hold path bypasses it
-        assertEq(cashModule.rawSpendable(address(safe)), rawBefore);
+        // Limit charged the settled amount
+        assertEq(cashModule.rawSpendable(address(safe)), rawBefore - amount);
     }
 
     // -------------------------------------------------------------------------
@@ -692,14 +693,14 @@ contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
         assertEq(cashModule.rawSpendable(address(safe)), rawBefore); // limit restored
 
         // Settlement arrives despite reversal: Settlement is KING — spend() uses no-hold path.
-        // This creates a forced hold internally and settles without charging the limit.
+        // This creates a forced hold internally and settles, charging the limit for the settled amount.
         deal(address(usdc), address(safe), amount);
         _spendWithoutHold(txId, BinSponsor.Reap, amount);
 
         assertTrue(cashModule.transactionCleared(address(safe), txId));
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), 0);
-        // No-hold path: limit is NOT charged
-        assertEq(cashModule.rawSpendable(address(safe)), rawBefore);
+        // No-hold path now charges the limit for the settled amount
+        assertEq(cashModule.rawSpendable(address(safe)), rawBefore - amount);
     }
 
     function test_integration_incrementalAuth() public {

--- a/test/safe/modules/cash/PendingHoldsModuleTest.t.sol
+++ b/test/safe/modules/cash/PendingHoldsModuleTest.t.sol
@@ -49,9 +49,9 @@ contract PendingHoldsTestSetup is CashModuleTestSetup {
     // Helpers
     // -------------------------------------------------------------------------
 
-    function _addHold(bytes4 providerCode, bytes32 _txId, uint256 amountUsd) internal {
+    function _addHold(BinSponsor binSponsor, bytes32 _txId, uint256 amountUsd) internal {
         vm.prank(etherFiWallet);
-        pendingHoldsModule.addHold(address(safe), providerCode, _txId, amountUsd);
+        pendingHoldsModule.addHold(address(safe), binSponsor, _txId, amountUsd);
     }
 
     function _spendWithHold(bytes32 _txId, BinSponsor binSponsor, uint256 amountUsd) internal {
@@ -127,7 +127,7 @@ contract PendingHoldsModuleUnitTest is PendingHoldsTestSetup {
         vm.prank(etherFiWallet);
         vm.expectEmit(true, true, true, true);
         emit IPendingHoldsModule.HoldAdded(address(safe), PROVIDER_REAP, txId, amount, block.timestamp, false);
-        pendingHoldsModule.addHold(address(safe), PROVIDER_REAP, txId, amount);
+        pendingHoldsModule.addHold(address(safe), BinSponsor.Reap, txId, amount);
 
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), amount);
 
@@ -140,17 +140,17 @@ contract PendingHoldsModuleUnitTest is PendingHoldsTestSetup {
 
     function test_addHold_revertsOnDuplicate() public {
         uint256 amount = 100e6;
-        _addHold(PROVIDER_REAP, txId, amount);
+        _addHold(BinSponsor.Reap, txId, amount);
 
         vm.prank(etherFiWallet);
         vm.expectRevert(IPendingHoldsModule.DuplicateHold.selector);
-        pendingHoldsModule.addHold(address(safe), PROVIDER_REAP, txId, amount);
+        pendingHoldsModule.addHold(address(safe), BinSponsor.Reap, txId, amount);
     }
 
     function test_addHold_revertsOnZeroAmount() public {
         vm.prank(etherFiWallet);
         vm.expectRevert(IPendingHoldsModule.InvalidAmount.selector);
-        pendingHoldsModule.addHold(address(safe), PROVIDER_REAP, txId, 0);
+        pendingHoldsModule.addHold(address(safe), BinSponsor.Reap, txId, 0);
     }
 
     function test_addHold_revertsWhenExceedsDailyLimit() public {
@@ -159,22 +159,22 @@ contract PendingHoldsModuleUnitTest is PendingHoldsTestSetup {
 
         vm.prank(etherFiWallet);
         vm.expectRevert(SpendingLimitLib.ExceededDailySpendingLimit.selector);
-        pendingHoldsModule.addHold(address(safe), PROVIDER_REAP, txId, exceedingAmount);
+        pendingHoldsModule.addHold(address(safe), BinSponsor.Reap, txId, exceedingAmount);
     }
 
     function test_addHold_revertsWhenNotEtherFiWallet() public {
         vm.prank(address(0xdead));
         vm.expectRevert();
-        pendingHoldsModule.addHold(address(safe), PROVIDER_REAP, txId, 100e6);
+        pendingHoldsModule.addHold(address(safe), BinSponsor.Reap, txId, 100e6);
     }
 
     function test_addHold_providerCodeNamespacing_noCollisionBetweenProviders() public {
         uint256 amount = 100e6;
-        _addHold(PROVIDER_REAP, txId, amount);
+        _addHold(BinSponsor.Reap, txId, amount);
 
         // Same txId, different providerCode — should succeed (separate namespace)
         vm.prank(etherFiWallet);
-        pendingHoldsModule.addHold(address(safe), PROVIDER_RAIN, txId, amount);
+        pendingHoldsModule.addHold(address(safe), BinSponsor.Rain, txId, amount);
 
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), amount * 2);
     }
@@ -189,7 +189,7 @@ contract PendingHoldsModuleUnitTest is PendingHoldsTestSetup {
         vm.prank(etherFiWallet);
         vm.expectEmit(true, true, true, true);
         emit IPendingHoldsModule.HoldAdded(address(safe), PROVIDER_REAP, txId, exceedingAmount, block.timestamp, true);
-        pendingHoldsModule.forceAddHold(address(safe), PROVIDER_REAP, txId, exceedingAmount);
+        pendingHoldsModule.forceAddHold(address(safe), BinSponsor.Reap, txId, exceedingAmount);
 
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), exceedingAmount);
 
@@ -198,11 +198,11 @@ contract PendingHoldsModuleUnitTest is PendingHoldsTestSetup {
     }
 
     function test_forceAddHold_revertsOnDuplicate() public {
-        _addHold(PROVIDER_REAP, txId, 100e6);
+        _addHold(BinSponsor.Reap, txId, 100e6);
 
         vm.prank(etherFiWallet);
         vm.expectRevert(IPendingHoldsModule.DuplicateHold.selector);
-        pendingHoldsModule.forceAddHold(address(safe), PROVIDER_REAP, txId, 100e6);
+        pendingHoldsModule.forceAddHold(address(safe), BinSponsor.Reap, txId, 100e6);
     }
 
     // -------------------------------------------------------------------------
@@ -213,13 +213,13 @@ contract PendingHoldsModuleUnitTest is PendingHoldsTestSetup {
         uint256 initial = 100e6;
         uint256 increased = 200e6;
 
-        _addHold(PROVIDER_REAP, txId, initial);
+        _addHold(BinSponsor.Reap, txId, initial);
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), initial);
 
         vm.prank(etherFiWallet);
         vm.expectEmit(true, true, true, true);
         emit IPendingHoldsModule.HoldUpdated(address(safe), PROVIDER_REAP, txId, initial, increased, block.timestamp);
-        pendingHoldsModule.updateHold(address(safe), PROVIDER_REAP, txId, increased);
+        pendingHoldsModule.updateHold(address(safe), BinSponsor.Reap, txId, increased);
 
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), increased);
         assertEq(pendingHoldsModule.getHold(address(safe), PROVIDER_REAP, txId).amountUsd, increased);
@@ -229,10 +229,10 @@ contract PendingHoldsModuleUnitTest is PendingHoldsTestSetup {
         uint256 initial = 200e6;
         uint256 decreased = 100e6;
 
-        _addHold(PROVIDER_REAP, txId, initial);
+        _addHold(BinSponsor.Reap, txId, initial);
 
         vm.prank(etherFiWallet);
-        pendingHoldsModule.updateHold(address(safe), PROVIDER_REAP, txId, decreased);
+        pendingHoldsModule.updateHold(address(safe), BinSponsor.Reap, txId, decreased);
 
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), decreased);
         assertEq(pendingHoldsModule.getHold(address(safe), PROVIDER_REAP, txId).amountUsd, decreased);
@@ -243,17 +243,17 @@ contract PendingHoldsModuleUnitTest is PendingHoldsTestSetup {
         // After addHold(9_900), spentToday=9_900, remaining=100. Delta of 101 breaches limit.
         uint256 exceedingIncrease = 10_001e6;
 
-        _addHold(PROVIDER_REAP, txId, initial);
+        _addHold(BinSponsor.Reap, txId, initial);
 
         vm.prank(etherFiWallet);
         vm.expectRevert(SpendingLimitLib.ExceededDailySpendingLimit.selector);
-        pendingHoldsModule.updateHold(address(safe), PROVIDER_REAP, txId, exceedingIncrease);
+        pendingHoldsModule.updateHold(address(safe), BinSponsor.Reap, txId, exceedingIncrease);
     }
 
     function test_updateHold_revertsOnHoldNotFound() public {
         vm.prank(etherFiWallet);
         vm.expectRevert(IPendingHoldsModule.HoldNotFound.selector);
-        pendingHoldsModule.updateHold(address(safe), PROVIDER_REAP, txId, 100e6);
+        pendingHoldsModule.updateHold(address(safe), BinSponsor.Reap, txId, 100e6);
     }
 
     // -------------------------------------------------------------------------
@@ -262,12 +262,12 @@ contract PendingHoldsModuleUnitTest is PendingHoldsTestSetup {
 
     function test_releaseHold_reversal_decrementsAndDeletes() public {
         uint256 amount = 100e6;
-        _addHold(PROVIDER_REAP, txId, amount);
+        _addHold(BinSponsor.Reap, txId, amount);
 
         vm.prank(etherFiWallet);
         vm.expectEmit(true, true, true, true);
         emit IPendingHoldsModule.HoldReleased(address(safe), PROVIDER_REAP, txId, amount, ReleaseReason.REVERSAL, block.timestamp);
-        pendingHoldsModule.releaseHold(address(safe), PROVIDER_REAP, txId, ReleaseReason.REVERSAL);
+        pendingHoldsModule.releaseHold(address(safe), BinSponsor.Reap, txId, ReleaseReason.REVERSAL);
 
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), 0);
         assertEq(pendingHoldsModule.getHold(address(safe), PROVIDER_REAP, txId).createdAt, 0);
@@ -275,12 +275,12 @@ contract PendingHoldsModuleUnitTest is PendingHoldsTestSetup {
 
     function test_releaseHold_admin_works() public {
         uint256 amount = 100e6;
-        _addHold(PROVIDER_REAP, txId, amount);
+        _addHold(BinSponsor.Reap, txId, amount);
 
         vm.prank(etherFiWallet);
         vm.expectEmit(true, true, true, true);
         emit IPendingHoldsModule.HoldReleased(address(safe), PROVIDER_REAP, txId, amount, ReleaseReason.ADMIN, block.timestamp);
-        pendingHoldsModule.releaseHold(address(safe), PROVIDER_REAP, txId, ReleaseReason.ADMIN);
+        pendingHoldsModule.releaseHold(address(safe), BinSponsor.Reap, txId, ReleaseReason.ADMIN);
 
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), 0);
     }
@@ -288,7 +288,7 @@ contract PendingHoldsModuleUnitTest is PendingHoldsTestSetup {
     function test_releaseHold_revertsOnHoldNotFound() public {
         vm.prank(etherFiWallet);
         vm.expectRevert(IPendingHoldsModule.HoldNotFound.selector);
-        pendingHoldsModule.releaseHold(address(safe), PROVIDER_REAP, txId, ReleaseReason.REVERSAL);
+        pendingHoldsModule.releaseHold(address(safe), BinSponsor.Reap, txId, ReleaseReason.REVERSAL);
     }
 
     // -------------------------------------------------------------------------
@@ -296,7 +296,7 @@ contract PendingHoldsModuleUnitTest is PendingHoldsTestSetup {
     // -------------------------------------------------------------------------
 
     function test_removeHold_revertsWhenCalledByNonCore() public {
-        _addHold(PROVIDER_REAP, txId, 100e6);
+        _addHold(BinSponsor.Reap, txId, 100e6);
 
         vm.prank(etherFiWallet);
         vm.expectRevert(IPendingHoldsModule.OnlyCashModuleCore.selector);
@@ -306,7 +306,7 @@ contract PendingHoldsModuleUnitTest is PendingHoldsTestSetup {
     function test_removeHold_succeedsWhenModulePaused() public {
         // removeHold must not be blocked by pause — pausing PHM should halt new hold creation
         // but must not freeze in-flight settlements that CashModuleCore drives via spend().
-        _addHold(PROVIDER_REAP, txId, 100e6);
+        _addHold(BinSponsor.Reap, txId, 100e6);
 
         vm.prank(pauser);
         PendingHoldsModule(address(pendingHoldsModule)).pause();
@@ -326,18 +326,18 @@ contract PendingHoldsModuleUnitTest is PendingHoldsTestSetup {
         uint256 amount = 200e6;
         bytes32 txId2 = keccak256("txId2");
 
-        _addHold(PROVIDER_REAP, txId, amount);
-        _addHold(PROVIDER_RAIN, txId2, amount);
+        _addHold(BinSponsor.Reap, txId, amount);
+        _addHold(BinSponsor.Rain, txId2, amount);
         // totalHolds = 400e6
 
         // Release txId2 via releaseHold — totalHolds drops to 200e6
         vm.prank(etherFiWallet);
-        pendingHoldsModule.releaseHold(address(safe), PROVIDER_RAIN, txId2, ReleaseReason.ADMIN);
+        pendingHoldsModule.releaseHold(address(safe), BinSponsor.Rain, txId2, ReleaseReason.ADMIN);
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), amount);
 
         // Decreasing update on txId (200e6 → 50e6) — floor kicks in if drift exists; normal path here
         vm.prank(etherFiWallet);
-        pendingHoldsModule.updateHold(address(safe), PROVIDER_REAP, txId, 50e6);
+        pendingHoldsModule.updateHold(address(safe), BinSponsor.Reap, txId, 50e6);
 
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), 50e6);
         assertEq(pendingHoldsModule.getHold(address(safe), PROVIDER_REAP, txId).amountUsd, 50e6);
@@ -397,7 +397,7 @@ contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
         uint256 amount = 100e6;
         deal(address(usdc), address(safe), amount);
 
-        _addHold(PROVIDER_REAP, txId, amount);
+        _addHold(BinSponsor.Reap, txId, amount);
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), amount);
 
         vm.expectEmit(true, true, true, true);
@@ -441,7 +441,7 @@ contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
         deal(address(usdc), address(safe), holdAmount);
         uint256 rawBefore = cashModule.rawSpendable(address(safe));
 
-        _addHold(PROVIDER_REAP, txId, holdAmount);
+        _addHold(BinSponsor.Reap, txId, holdAmount);
         // addHold consumed $150 from limit
         assertEq(cashModule.rawSpendable(address(safe)), rawBefore - holdAmount);
 
@@ -461,7 +461,7 @@ contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
         deal(address(usdc), address(safe), settleAmount);
         uint256 rawBefore = cashModule.rawSpendable(address(safe));
 
-        _addHold(PROVIDER_REAP, txId, holdAmount);
+        _addHold(BinSponsor.Reap, txId, holdAmount);
         assertEq(cashModule.rawSpendable(address(safe)), rawBefore - holdAmount);
 
         _spendWithHold(txId, BinSponsor.Reap, settleAmount);
@@ -481,7 +481,7 @@ contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
 
         // Force-add: no limit consumption
         vm.prank(etherFiWallet);
-        pendingHoldsModule.forceAddHold(address(safe), PROVIDER_REAP, txId, amount);
+        pendingHoldsModule.forceAddHold(address(safe), BinSponsor.Reap, txId, amount);
         assertEq(cashModule.rawSpendable(address(safe)), rawBefore); // limit unchanged
 
         // Normal spend() clears the forced hold and NOW charges the limit
@@ -499,7 +499,7 @@ contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
     function test_requestWithdrawal_blockedWhenHoldsExist() public {
         uint256 amount = 100e6;
         deal(address(usdc), address(safe), amount);
-        _addHold(PROVIDER_REAP, txId, amount);
+        _addHold(BinSponsor.Reap, txId, amount);
 
         address[] memory tokens = new address[](1);
         tokens[0] = address(usdc);
@@ -529,11 +529,11 @@ contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
     function test_requestWithdrawal_allowedAfterHoldReleased() public {
         uint256 amount = 100e6;
         deal(address(usdc), address(safe), amount);
-        _addHold(PROVIDER_REAP, txId, amount);
+        _addHold(BinSponsor.Reap, txId, amount);
 
         // Release hold first
         vm.prank(etherFiWallet);
-        pendingHoldsModule.releaseHold(address(safe), PROVIDER_REAP, txId, ReleaseReason.REVERSAL);
+        pendingHoldsModule.releaseHold(address(safe), BinSponsor.Reap, txId, ReleaseReason.REVERSAL);
 
         // Now withdrawal should succeed
         address[] memory tokens = new address[](1);
@@ -595,7 +595,7 @@ contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
         uint256 spendAmount = 50e6;
         deal(address(usdc), address(safe), holdAmount + spendAmount);
 
-        _addHold(PROVIDER_REAP, txId, holdAmount);
+        _addHold(BinSponsor.Reap, txId, holdAmount);
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), holdAmount);
 
         // spend() on a different txId (no-hold path) — creates and immediately removes a forced hold
@@ -618,7 +618,7 @@ contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
 
         // Force-capture: place a hold without a balance check (no limit consumption)
         vm.prank(etherFiWallet);
-        pendingHoldsModule.forceAddHold(address(safe), PROVIDER_REAP, txId, amount);
+        pendingHoldsModule.forceAddHold(address(safe), BinSponsor.Reap, txId, amount);
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), amount);
         assertEq(cashModule.rawSpendable(address(safe)), rawBefore); // limit unchanged
 
@@ -640,11 +640,11 @@ contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
         deal(address(usdc), address(safe), amount);
 
         uint256 rawBefore = cashModule.rawSpendable(address(safe));
-        _addHold(PROVIDER_REAP, txId, amount);
+        _addHold(BinSponsor.Reap, txId, amount);
 
         // Admin releases the hold (e.g. force-capture recovery where hold is stale)
         vm.prank(etherFiWallet);
-        pendingHoldsModule.releaseHold(address(safe), PROVIDER_REAP, txId, ReleaseReason.ADMIN);
+        pendingHoldsModule.releaseHold(address(safe), BinSponsor.Reap, txId, ReleaseReason.ADMIN);
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), 0);
         // releaseHold credits back the limit
         assertEq(cashModule.rawSpendable(address(safe)), rawBefore);
@@ -667,7 +667,7 @@ contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
         deal(address(usdc), address(safe), amount);
 
         // 1. Auth acknowledged: add hold
-        _addHold(PROVIDER_REAP, txId, amount);
+        _addHold(BinSponsor.Reap, txId, amount);
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), amount);
 
         // 2. Settlement: spend removes hold
@@ -683,12 +683,12 @@ contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
         deal(address(usdc), address(safe), amount);
 
         uint256 rawBefore = cashModule.rawSpendable(address(safe));
-        _addHold(PROVIDER_REAP, txId, amount);
+        _addHold(BinSponsor.Reap, txId, amount);
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), amount);
 
         // Network reversal — hold released, limit credited back
         vm.prank(etherFiWallet);
-        pendingHoldsModule.releaseHold(address(safe), PROVIDER_REAP, txId, ReleaseReason.REVERSAL);
+        pendingHoldsModule.releaseHold(address(safe), BinSponsor.Reap, txId, ReleaseReason.REVERSAL);
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), 0);
         assertEq(cashModule.rawSpendable(address(safe)), rawBefore); // limit restored
 
@@ -708,17 +708,17 @@ contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
         uint256 increased = 150e6;
         uint256 decreased = 120e6;
 
-        _addHold(PROVIDER_REAP, txId, initial);
+        _addHold(BinSponsor.Reap, txId, initial);
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), initial);
 
         // Incremental auth: amount goes up
         vm.prank(etherFiWallet);
-        pendingHoldsModule.updateHold(address(safe), PROVIDER_REAP, txId, increased);
+        pendingHoldsModule.updateHold(address(safe), BinSponsor.Reap, txId, increased);
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), increased);
 
         // Incremental auth: amount goes down
         vm.prank(etherFiWallet);
-        pendingHoldsModule.updateHold(address(safe), PROVIDER_REAP, txId, decreased);
+        pendingHoldsModule.updateHold(address(safe), BinSponsor.Reap, txId, decreased);
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), decreased);
     }
 
@@ -730,7 +730,7 @@ contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
         uint256[] memory amounts = new uint256[](1);
         amounts[0] = amount;
 
-        _addHold(PROVIDER_REAP, txId, amount);
+        _addHold(BinSponsor.Reap, txId, amount);
 
         // Pre-compute nonce BEFORE vm.expectRevert — safe.nonce() is an external call that would
         // otherwise consume the expectRevert before requestWithdrawal is reached.
@@ -740,7 +740,7 @@ contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
 
         // Release hold
         vm.prank(etherFiWallet);
-        pendingHoldsModule.releaseHold(address(safe), PROVIDER_REAP, txId, ReleaseReason.REVERSAL);
+        pendingHoldsModule.releaseHold(address(safe), BinSponsor.Reap, txId, ReleaseReason.REVERSAL);
 
         // Withdrawal now allowed — use _requestWithdrawal helper which also checks the emitted event
         _requestWithdrawal(tokens, amounts, withdrawRecipient);
@@ -760,7 +760,7 @@ contract PendingHoldsLensTest is PendingHoldsTestSetup {
 
     function test_spendable_withHolds_reflectsLimitConsumption() public {
         uint256 holdAmount = 100e6;
-        _addHold(PROVIDER_REAP, txId, holdAmount);
+        _addHold(BinSponsor.Reap, txId, holdAmount);
 
         // addHold consumes from spentToday; rawSpendable already reflects the hold.
         // spendable() == rawSpendable() — no separate deduction.
@@ -785,7 +785,7 @@ contract PendingHoldsLensTest is PendingHoldsTestSetup {
 
     function test_canSpend_holdsMakeItExceed_returnsFalse() public {
         // Fill most of the capacity with a hold so the next auth cannot fit
-        _addHold(PROVIDER_REAP, txId, 9_900e6);
+        _addHold(BinSponsor.Reap, txId, 9_900e6);
 
         // 200 USD would push total (holds + amount) past the 10_000 USD daily limit
         uint256 amountUsd = 200e6;
@@ -803,7 +803,7 @@ contract PendingHoldsLensTest is PendingHoldsTestSetup {
 
     function test_canSpend_holdsReduceCapacity_butAmountStillFits() public {
         uint256 existingHold = 500e6;
-        _addHold(PROVIDER_REAP, txId, existingHold);
+        _addHold(BinSponsor.Reap, txId, existingHold);
 
         // 300 USD fits within the remaining 9_500 USD capacity
         uint256 amountUsd = 300e6;
@@ -821,7 +821,7 @@ contract PendingHoldsLensTest is PendingHoldsTestSetup {
 
     function test_holdsSummary_returnsConsistentValues() public {
         uint256 holdAmount = 250e6;
-        _addHold(PROVIDER_REAP, txId, holdAmount);
+        _addHold(BinSponsor.Reap, txId, holdAmount);
 
         (uint256 totalHolds, uint256 spendableAmt, uint256 rawSpendableAmt) = cashLens.holdsSummary(address(safe));
 

--- a/test/safe/modules/cash/Spend.t.sol
+++ b/test/safe/modules/cash/Spend.t.sol
@@ -456,23 +456,23 @@ contract CashModuleSpendTest is CashModuleTestSetup {
     function test_spend_withNoCashback() public {
         uint256 amount = 100e6;
         deal(address(usdc), address(safe), amount);
-
-        // Get initial cashback token balances
-        uint256 safeCashbackBalBefore = cashbackToken.balanceOf(address(safe));
-
+        
+        // Get initial token balances
+        uint256 safeTokenBalBefore = cashbackToken.balanceOf(address(safe));
+        
         address[] memory spendTokens = new address[](1);
         spendTokens[0] = address(usdc);
         uint256[] memory spendAmounts = new uint256[](1);
         spendAmounts[0] = amount;
 
         Cashback[] memory cashbacks;
-
+        
         vm.prank(etherFiWallet);
         // Spend with shouldReceiveCashback set to false
         cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
-
+        
         // Verify no cashback was received
-        assertEq(cashbackToken.balanceOf(address(safe)), safeCashbackBalBefore);
+        assertEq(cashbackToken.balanceOf(address(safe)), safeTokenBalBefore);
     }
     
     function test_spend_whenPaused() public {
@@ -540,17 +540,19 @@ contract CashModuleSpendTest is CashModuleTestSetup {
     }
         
     function test_spend_inDebitModeWithInsufficientBalance() public {
+        // In no-PHM mode, partial settlement has nowhere to track the remainder —
+        // spend() must revert on insufficient balance to preserve strict debit semantics.
         uint256 amount = 100e6;
         uint256 availableAmount = 50e6;
         deal(address(usdc), address(safe), availableAmount);
-        
+
         address[] memory spendTokens = new address[](1);
         spendTokens[0] = address(usdc);
         uint256[] memory spendAmounts = new uint256[](1);
         spendAmounts[0] = amount;
 
         Cashback[] memory cashbacks;
-        
+
         vm.prank(etherFiWallet);
         vm.expectRevert(ICashModule.InsufficientBalance.selector);
         cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);

--- a/test/upgrade-bytecode-verification/VerifyOPMainnet.t.sol
+++ b/test/upgrade-bytecode-verification/VerifyOPMainnet.t.sol
@@ -193,7 +193,7 @@ contract VerifyOPMainnetBytecode is ContractCodeChecker, Utils {
     }
 
     function test_verifyBytecode_CashLens() public {
-        address local = address(new CashLens(cashModuleProxy, dataProviderProxy));
+        address local = address(new CashLens(cashModuleProxy, dataProviderProxy, address(0)));
         _verify("CashLens", cashLensImpl, local);
     }
 


### PR DESCRIPTION
## Summary

Introduces **PendingHoldsModule (PHM)** — a provider-namespaced on-chain registry of card-transaction holds — and unifies settlement into a single `spend()` path. The spending limit is consumed at **auth-ack** (the moment a swipe is authorized), and **settlement reconciles** the hold against the actual merchant amount. Under-funded settlements are first-class: the safe pays what it can and the remainder is tracked as on-chain debt that ops sweeps later.

> Moved from `sc-cash-internal#20` (the op-migration temporary repo).
>
> This branch also folds in two rounds of review hardening + structural cleanup (`#127`, `#128`, both merged here). The mechanics below reflect the **current** state — earlier descriptions that said "Settlement is KING bypasses the limit" or "`spendable` subtracts holds" are superseded.

## Core mechanics

- **Auth-ack → `addHold(safe, BinSponsor, txId, amountUsd)`** consumes the daily/monthly spending limit immediately. Reverts `Exceeded{Daily,Monthly}SpendingLimit` if the hold would breach the limit.
- **`spendable(safe) == rawSpendable(safe)`** — holds are charged into `spentToday`/`spentThisMonth` at `addHold`, so `rawSpendable` already reflects them. **Do not subtract `totalPendingHolds` again** (double-counts). `totalPendingHolds` drives only the withdrawal guard / display.
- **Settlement → `spend()`** reconciles the hold to the actual settlement amount via one primitive, `reconcileLimit(oldCharged, newOwed)`: charge the delta if settlement > auth (tip), release if settlement < auth.
- **Settlement is KING** — no matching hold (late settlement / backend gap) still settles: a forced hold is created **and the limit is charged** the settled amount (the limit is the primary risk control and must reflect funds leaving the safe).
- **Under-funded settlement** — transfer what's available, park the remainder in a forced hold; ops later sweeps it with **`collectRemaining(safe, txId, BinSponsor, token)`** (no double limit charge).
- **Withdrawals are blocked while `totalPendingHolds(safe) > 0`**, enforced at **both** request and finalize.
- **Reversal → `releaseHold(REVERSAL)`** credits the limit back; no token movement.
- **Hold keys are provider-namespaced** — `keccak256(safe, providerCode, txId)`, `providerCode` derived **on-chain** from `BinSponsor` at every write, so auth-time and settlement-time keys always match.

---

## End-to-end call flows

Worked examples on a **$10,000/day** limit. `BinSponsor.Rain → providerCode "RAIN"`; same mechanics apply to Reap / PIX / CardOrder.

### Flow A — happy path: auth → full settlement

**1. Cardholder swipes $100 — auth-ack**
```
Rain → EtherFi wallet → PHM.addHold(safe, BinSponsor.Rain, txId, 100e6)
```
- PHM → `CashModuleCore.consumeSpendingLimit(safe, 100e6)` → `spentToday += 100` (reverts if it would breach the limit)
- stores `HoldRecord { amountUsd: 100, createdAt, providerCode: "RAIN", forced: false }`; `totalHolds[safe] += 100`
- emits `HoldAdded(safe, "RAIN", txId, 100e6, …, forced=false)`

→ `rawSpendable` immediately drops $10,000 → $9,900. User can't double-spend the authorized $100.

**2. Settlement $100 arrives**
```
Rain → EtherFi wallet → CashModuleCore.spend(safe, txId, BinSponsor.Rain, [usdc], [100e6], cashbacks)
```
- `_validateSpend` — checks, sets `transactionCleared[txId] = true` (replays revert `TransactionAlreadyCleared`)
- `_phmSettleHold` → `PHM.settlementSyncHold(...)` returns `(existed=true, wasForced=false, oldAmount=100)`
  - `oldCharged = 100`; `reconcileLimit(100, 100)` → **no-op** (limit already reflects it)
- `_spendDebitPartial` — safe has ≥ $100, transfers `100e6` USDC → settlement dispatcher; `actual = 100`
- `_phmFinalize(total=100, actual=100)` → `remaining = 0` → `PHM.removeHold(...)`; `totalHolds -= 100`
- emits `Spend(…, 100e6, Debit)` + `HoldRemoved(…)`

→ Net: `spentToday = 100`, hold cleared, `$100` moved. **`limit charged == value moved`.** ✔

### Flow B — tip / incremental auth (settlement > auth)

Auth $100 (Flow A step 1). Two ways the extra is captured:
- **Incremental auth:** `PHM.updateHold(safe, Rain, txId, 120e6)` → charges the `+$20` delta now; `HoldUpdated(100→120)`.
- **At settlement:** `spend(… 120e6)` → `settlementSyncHold` returns `oldAmount=100`; `reconcileLimit(100, 120)` → `spend(20)`. Total limit charged = $120. ✔

### Flow C — settlement < auth (merchant charged less)

Auth $200, settlement $120:
- `settlementSyncHold` returns `oldAmount=200`; `reconcileLimit(200, 120)` → `release(80)` → credits $80 back to the limit
- hold synced to $120, then fully settled & removed

→ The unused $80 of authorization is returned to the user's limit at settlement. ✔

### Flow D — "Settlement is KING" (no matching hold)

Settlement $100 arrives but no hold exists (late presentment / reversed-then-settled / backend gap):
- `settlementSyncHold` finds nothing → **creates a forced hold** for $100, returns `existed=false`
- `_phmSettleHold`: `oldCharged = 0` → `reconcileLimit(0, 100)` → `spend(100)` → **limit IS charged $100**
- transfer + finalize as normal

→ Settlement is always honored, and the limit still reflects the funds that left. (Earlier design bypassed the limit here — fixed.) ✔

### Flow E — under-funded settlement + ops collection

Auth $100 (limit charged $100), but the safe only holds **$40** of USDC at settlement:
1. `spend(… 100e6)` → `_spendDebitPartial` transfers `$40`, `actual = 40`
2. `_phmFinalize(total=100, actual=40)` → `remaining = 60` → `PHM.settlementSetRemainingHold(…, 60)` (forced); `totalHolds = 60`
   - emits `Spend(…, 40e6, Debit)`; **withdrawals now blocked** by the $60 hold
3. User funds the safe; ops sweeps the debt:
```
EtherFi wallet → CashModuleCore.collectRemaining(safe, txId, BinSponsor.Rain, usdc)   (routed → CashModuleSettersExt)
```
   - reads remaining = $60, transfers up to $60 from the safe → dispatcher, reduces the hold; when it hits 0 → `removeHold`
   - **no limit charge** (the full $100 was charged at step 1) — guarded to post-settlement debt only (`transactionCleared == true`)

→ remainder collected, hold cleared, withdrawals unblock. ✔

### Flow F — reversal

```
Rain → EtherFi wallet → PHM.releaseHold(safe, BinSponsor.Rain, txId, ReleaseReason.REVERSAL)
```
- credits the limit back for non-forced holds (forced holds never consumed it), deletes the hold, `totalHolds -= amount`; `HoldReleased(…)`. No token movement.

### Flow G — withdrawal guard

`requestWithdrawal` **and** `processWithdrawal` both revert `WithdrawalBlockedByPendingHolds` while `totalPendingHolds(safe) > 0` — so a hold added during the withdrawal delay window can't be bypassed at finalize.

---

## What shipped

### New contracts
- `src/modules/cash/PendingHoldsModule.sol` — UUPS module, ERC-7201 namespaced storage, provider-namespaced keys, full hold lifecycle (`addHold` / `forceAddHold` / `updateHold` / `releaseHold`; settlement-only `settlementSyncHold` / `settlementSetRemainingHold` / `removeHold`).
- `src/interfaces/IPendingHoldsModule.sol` — `HoldRecord`, `ReleaseReason`, events, errors.
- `src/modules/cash/CashModuleSettersExt.sol` — second overflow contract (see Architecture); holds `repay` + `collectRemaining`.

### CashModuleCore
- Unified `spend()` into `_phmSettleHold` → transfer → `_phmFinalize`. `_spendDebitPartial` caps each token at available balance and returns actual USD. All limit accounting done in Core (no PHM→Core callback) to avoid reentrancy into the `nonReentrant` context.

### Architecture — fallback delegatecall chain (EIP-170)
`CashModule` is one logical contract split across **Core → Setters → SettersExt**, chained by fallback `delegatecall`, to stay under the 24,576-byte limit (all three are size-constrained; `optimizer_runs = 0` is the floor). Storage + `msg.sender` preserved across hops. **Size gates** assert each implementation stays under the limit.

### Accounting primitives
- `SpendingLimitLib.reconcileLimit()` — single owner of the charge/release-delta math.
- `PendingHoldsModule._replaceTotalHolds()` — the one `totalHolds` mutator; **reverts `TotalHoldsUnderflow`** on an invariant break rather than silently flooring the withdrawal-guard sum.
- Single source of truth for the `BinSponsor → settlement dispatcher` mapping.

### Tests
- `PendingHoldsModuleTest.t.sol` — full lifecycle + integration (covers Flows A–G) + bytecode-size gates.
- `PendingHoldsFindings.t.sol` — regression proofs (Flows D & E, finalize guard) + `totalPendingHolds == Σ holds` invariant across the lifecycle and the collect path.

## ⚠️ Backend / indexer note
`addHold` / `forceAddHold` / `updateHold` / `releaseHold` now take **`BinSponsor`** (not raw `bytes4 providerCode`) — the EtherFi wallet caller must update. Events still emit the derived `bytes4 providerCode`, so indexers are unaffected.

## Deployment
`scripts/gnosis-txs/UpgradeCashModuleWithPendingHolds.s.sol` (one atomic Gnosis batch): upgrade Core → point at new Setters → wire `CashModuleSettersExt` → wire `PendingHoldsModule`. No window where Core points at new code without the holds guard.

## Known follow-ups (tracked, out of scope here)
- `HoldKind` enum to replace the overloaded `forced` bool (changes `HoldRecord`/`getHold` ABI + `HoldAdded` event — needs indexer sign-off).
- TXN-2678 (cross-day `release()` headroom), TXN-2680 (`forceAddHold` freeze mitigation), TXN-2681 (`HoldUpdated` `forced` field), TXN-2682 (pre-existing `_cashback` loop), refund/chargeback path, hold expiry TTL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
