### PR TITLE
fix: migrated workflow from scroll to op

### DIFF
--- a/.github/workflows/recovery-hash.yml
+++ b/.github/workflows/recovery-hash.yml
@@ -11,11 +11,11 @@ on:
         description: 'New Owner Address (e.g., 0x...)'
         required: true
         type: string
-      scroll_rpc:
-        description: 'Scroll RPC URL (optional, defaults to public RPC)'
+      chain_rpc:
+        description: 'Chain RPC URL (optional, defaults to Optimism public RPC)'
         required: false
         type: string
-        default: 'https://rpc.scroll.io'
+        default: 'https://mainnet.optimism.io'
 
 jobs:
   build-message-hash:
@@ -37,7 +37,7 @@ jobs:
           echo "================================================"
           echo "Recovery Safe Address: ${{ github.event.inputs.recovery_safe_address }}"
           echo "New Owner Address: ${{ github.event.inputs.recovery_new_owner }}"
-          echo "Scroll RPC: ${{ github.event.inputs.scroll_rpc }}"
+          echo "Chain RPC: ${{ github.event.inputs.chain_rpc }}"
           echo "================================================"
       
       - name: Run Build Message Hash Test
@@ -47,4 +47,4 @@ jobs:
         env:
           RECOVERY_SAFE_ADDRESS: ${{ github.event.inputs.recovery_safe_address }}
           RECOVERY_NEW_OWNER: ${{ github.event.inputs.recovery_new_owner }}
-          SCROLL_RPC: ${{ github.event.inputs.scroll_rpc }}
+          CHAIN_RPC: ${{ github.event.inputs.chain_rpc }}

--- a/.github/workflows/recovery-hash.yml
+++ b/.github/workflows/recovery-hash.yml
@@ -26,12 +26,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
-      
+
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: nightly
-      
+
       - name: Display Input Parameters
         run: |
           echo "================================================"
@@ -39,7 +39,7 @@ jobs:
           echo "New Owner Address: ${{ github.event.inputs.recovery_new_owner }}"
           echo "Chain RPC: ${{ github.event.inputs.chain_rpc }}"
           echo "================================================"
-      
+
       - name: Run Build Message Hash Test
         run: |
           echo "Building message hash for recovery..."

--- a/test/safe/RecoveryUsingSafeWithGithub.t.sol
+++ b/test/safe/RecoveryUsingSafeWithGithub.t.sol
@@ -15,7 +15,7 @@ contract RecoveryUsingSafeWithGithub is Test {
     address safeAddress;
 
     function setUp() public {
-        string memory chainRpc = vm.envString("CHAIN_RPC");
+        string memory chainRpc = vm.envOr("CHAIN_RPC", string("https://mainnet.optimism.io"));
 
         try vm.envAddress("RECOVERY_SAFE_ADDRESS") returns (address addr) {
             safeAddress = addr;
@@ -35,7 +35,6 @@ contract RecoveryUsingSafeWithGithub is Test {
         }
 
         safe = EtherFiSafe(payable(safeAddress));
-        if (bytes(chainRpc).length == 0) chainRpc = "https://mainnet.optimism.io";
         vm.createSelectFork(chainRpc);
     }
 
@@ -43,11 +42,6 @@ contract RecoveryUsingSafeWithGithub is Test {
         bytes32 structHash = keccak256(abi.encode(safe.RECOVER_SAFE_TYPEHASH(), newOwner, safe.nonce()));
         bytes32 digestHash = keccak256(abi.encodePacked("\x19\x01", safe.getDomainSeparator(), structHash));
 
-        emit log_named_address("safe", safeAddress);
-        emit log_named_address("newOwner", newOwner);
-        emit log_named_uint("chainId", block.chainid);
-        emit log_named_uint("nonce", safe.nonce());
-        emit log_named_bytes32("domainSeparator", safe.getDomainSeparator());
         emit log_named_bytes32("structHash", structHash);
         emit log_named_bytes32("digestHash", digestHash);
     }

--- a/test/safe/RecoveryUsingSafeWithGithub.t.sol
+++ b/test/safe/RecoveryUsingSafeWithGithub.t.sol
@@ -15,8 +15,8 @@ contract RecoveryUsingSafeWithGithub is Test {
     address safeAddress;
 
     function setUp() public {
-        string memory scrollRpc = vm.envString("SCROLL_RPC");
-        
+        string memory chainRpc = vm.envString("CHAIN_RPC");
+
         try vm.envAddress("RECOVERY_SAFE_ADDRESS") returns (address addr) {
             safeAddress = addr;
         } catch {
@@ -35,14 +35,19 @@ contract RecoveryUsingSafeWithGithub is Test {
         }
 
         safe = EtherFiSafe(payable(safeAddress));
-        if (bytes(scrollRpc).length == 0) scrollRpc = "https://rpc.scroll.io"; 
-        vm.createSelectFork(scrollRpc);
+        if (bytes(chainRpc).length == 0) chainRpc = "https://mainnet.optimism.io";
+        vm.createSelectFork(chainRpc);
     }
 
     function test_BuildMessageHashAndDigestGithub() external {
         bytes32 structHash = keccak256(abi.encode(safe.RECOVER_SAFE_TYPEHASH(), newOwner, safe.nonce()));
         bytes32 digestHash = keccak256(abi.encodePacked("\x19\x01", safe.getDomainSeparator(), structHash));
 
+        emit log_named_address("safe", safeAddress);
+        emit log_named_address("newOwner", newOwner);
+        emit log_named_uint("chainId", block.chainid);
+        emit log_named_uint("nonce", safe.nonce());
+        emit log_named_bytes32("domainSeparator", safe.getDomainSeparator());
         emit log_named_bytes32("structHash", structHash);
         emit log_named_bytes32("digestHash", digestHash);
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only adjusts CI/workflow inputs and the test harness fork RPC selection, with no production contract logic changes.
> 
> **Overview**
> Switches the `recovery-hash.yml` manual workflow input from `scroll_rpc` to `chain_rpc`, defaulting to Optimism (`https://mainnet.optimism.io`), and wires it through as `CHAIN_RPC`.
> 
> Updates `RecoveryUsingSafeWithGithub.t.sol` to read `CHAIN_RPC` (with an Optimism default) and fork that chain instead of relying on `SCROLL_RPC`/Scroll defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e0f32ea91e1618d6e294a333675dd56fda58110. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->