### PR TITLE
Review fixes for #120: limit-bypass, under-funded collector, Setters size blocker, providerCode key match

### DIFF
--- a/scripts/Setup.s.sol
+++ b/scripts/Setup.s.sol
@@ -114,7 +114,7 @@ contract Setup is Utils {
         _setupPriceProvider();
         _setupCashbackDispatcher();
 
-        address cashLensImpl = deployWithCreate3(abi.encodePacked(type(CashLens).creationCode, abi.encode(address(cashModule), address(dataProvider))), getSalt(CASH_LENS_IMPL));
+        address cashLensImpl = deployWithCreate3(abi.encodePacked(type(CashLens).creationCode, abi.encode(address(cashModule), address(dataProvider), address(0))), getSalt(CASH_LENS_IMPL));
         cashLens = CashLens(deployWithCreate3(abi.encodePacked(type(UUPSProxy).creationCode, abi.encode(cashLensImpl, "")), getSalt(CASH_LENS_PROXY)));
         cashLens.initialize(address(roleRegistry));
 

--- a/scripts/gnosis-txs/UpgradeCashModuleWithPendingHolds.s.sol
+++ b/scripts/gnosis-txs/UpgradeCashModuleWithPendingHolds.s.sol
@@ -6,6 +6,7 @@ import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils
 
 import { CashModuleCore } from "../../src/modules/cash/CashModuleCore.sol";
 import { CashModuleSetters } from "../../src/modules/cash/CashModuleSetters.sol";
+import { CashModuleSettersExt } from "../../src/modules/cash/CashModuleSettersExt.sol";
 import { ICashModule } from "../../src/interfaces/ICashModule.sol";
 import { GnosisHelpers } from "../utils/GnosisHelpers.sol";
 import { Utils } from "../utils/Utils.sol";
@@ -50,6 +51,7 @@ contract UpgradeCashModuleWithPendingHolds is GnosisHelpers, Utils {
         // Deploy new implementations (broadcast pays gas; Safe executes the upgrades)
         address newCoreImpl = address(new CashModuleCore(dataProvider));
         address newSettersImpl = address(new CashModuleSetters(dataProvider));
+        address newSettersExtImpl = address(new CashModuleSettersExt(dataProvider));
 
         // --- Build Gnosis Safe transaction batch ---
         string memory txs = _getGnosisHeader(chainId, addressToHex(cashControllerSafe));
@@ -66,7 +68,14 @@ contract UpgradeCashModuleWithPendingHolds is GnosisHelpers, Utils {
         );
         txs = string(abi.encodePacked(txs, _getGnosisTransaction(addressToHex(cashModule), setSettersCalldata, "0", false)));
 
-        // Tx 3: wire PendingHoldsModule into CashModule (routed via fallback → CashModuleSetters)
+        // Tx 3: wire CashModuleSettersExt (second fallback hop: repay + collectRemaining live here).
+        // Must precede any repay/collectRemaining call, else CashModuleSetters.fallback() reverts.
+        string memory setSettersExtCalldata = iToHex(
+            abi.encodeWithSelector(ICashModule.setCashModuleSettersExt.selector, newSettersExtImpl)
+        );
+        txs = string(abi.encodePacked(txs, _getGnosisTransaction(addressToHex(cashModule), setSettersExtCalldata, "0", false)));
+
+        // Tx 4: wire PendingHoldsModule into CashModule (routed via fallback → CashModuleSetters)
         string memory setPhmCalldata = iToHex(
             abi.encodeWithSelector(ICashModule.setPendingHoldsModule.selector, phmProxy)
         );

--- a/src/interfaces/ICashModule.sol
+++ b/src/interfaces/ICashModule.sol
@@ -683,4 +683,18 @@ interface ICashModule {
      * @param _pendingHoldsModule Address of the deployed PendingHoldsModule proxy
      */
     function setPendingHoldsModule(address _pendingHoldsModule) external;
+
+    /**
+     * @notice Sets the CashModuleSettersExt address — the second fallback-hop overflow contract.
+     * @dev Only callable by accounts with CASH_MODULE_CONTROLLER_ROLE. Functions not present in Core
+     *      or Setters (e.g. repay, collectRemaining) are delegatecalled here. Must be wired before any
+     *      such function is invoked, or the call reverts in CashModuleSetters.fallback().
+     * @param _cashModuleSettersExt Address of the deployed CashModuleSettersExt
+     */
+    function setCashModuleSettersExt(address _cashModuleSettersExt) external;
+
+    /**
+     * @notice Returns the CashModuleSettersExt address.
+     */
+    function getCashModuleSettersExt() external view returns (address);
 }

--- a/src/interfaces/ICashModule.sol
+++ b/src/interfaces/ICashModule.sol
@@ -574,6 +574,20 @@ interface ICashModule {
     function spend(address safe, bytes32 txId, BinSponsor binSponsor, address[] calldata tokens, uint256[] calldata amountsInUsd, Cashback[] calldata cashbacks) external;
 
     /**
+     * @notice Collects the outstanding remainder of an under-funded settlement from the safe's balance.
+     * @dev When a debit spend() could not fully cover the settlement, the unpaid remainder is parked in
+     *      a forced hold that blocks withdrawals. Once the safe is funded, ops calls this to sweep the
+     *      remainder from `token` to the settlement dispatcher and clear the hold. The spending limit is
+     *      NOT charged again (already charged at the original settlement). Only valid for already-settled
+     *      transactions (transactionCleared == true). Routed to CashModuleSetters via Core's fallback().
+     * @param safe Address of the EtherFi Safe
+     * @param txId Transaction identifier
+     * @param binSponsor Bin sponsor the settlement was made under
+     * @param token Borrow token to collect the remainder from
+     */
+    function collectRemaining(address safe, bytes32 txId, BinSponsor binSponsor, address token) external;
+
+    /**
      * @notice Clears pending cashback for users
      * @param users Addresses of users to clear the pending cashback for
      * @param tokens Addresses of cashback tokens

--- a/src/interfaces/IPendingHoldsModule.sol
+++ b/src/interfaces/IPendingHoldsModule.sol
@@ -297,6 +297,17 @@ interface IPendingHoldsModule {
     function getHold(address safe, bytes4 providerCode, bytes32 txId) external view returns (HoldRecord memory hold);
 
     /**
+     * @notice Returns the outstanding hold amount for a (safe, binSponsor, txId), in USD (1e6)
+     * @dev Convenience for the settlement / collection path which keys by BinSponsor. Returns 0 if
+     *      no hold exists. Used by collectRemaining() to size the outstanding under-funded debt.
+     * @param safe Safe address
+     * @param binSponsor The bin sponsor enum value
+     * @param txId Provider transaction identifier
+     * @return Outstanding hold amount in USD (1e6)
+     */
+    function remainingHold(address safe, BinSponsor binSponsor, bytes32 txId) external view returns (uint256);
+
+    /**
      * @notice Returns the 4-byte provider code for a given BinSponsor
      * @dev Pure utility — callers use this to convert BinSponsor to the bytes4 used in hold keys.
      * @param binSponsor The bin sponsor enum value

--- a/src/interfaces/IPendingHoldsModule.sol
+++ b/src/interfaces/IPendingHoldsModule.sol
@@ -44,8 +44,11 @@ struct HoldRecord {
  *        forceAddHold() — force-capture / recovery path, operator-only, bypasses balance check
  *        updateHold()   — incremental auth adjustment, called by EtherFi wallet (backend)
  *
- *      Spendable invariant enforced at hold-write time:
- *        totalPendingHolds(safe) + newAmount <= rawSpendable(safe)
+ *      Limit accounting at hold-write time:
+ *        addHold()/updateHold()-increase charge the daily/monthly spending limit (via
+ *        CashModuleCore.consumeSpendingLimit) and revert if the limit would be breached. Holds are
+ *        thus bounded by the spending limit, NOT separately re-checked against rawSpendable or token
+ *        balance. forceAddHold() bypasses this charge entirely (operator recovery).
  *
  *      Provider-namespaced keys prevent txId collisions between Rain / Reap / PIX.
  *      Use providerCodeFromBinSponsor() to convert BinSponsor enum values to bytes4.

--- a/src/interfaces/IPendingHoldsModule.sol
+++ b/src/interfaces/IPendingHoldsModule.sol
@@ -167,11 +167,12 @@ interface IPendingHoldsModule {
      *      hold would breach the limit.
      *      Only callable by EtherFi wallet (backend service wallet).
      * @param safe Safe address
-     * @param providerCode 4-byte provider code (use providerCodeFromBinSponsor to convert)
+     * @param binSponsor Bin sponsor; the provider code (hold-key namespace) is derived on-chain so
+     *        the auth-time key provably matches the settlement-time key
      * @param txId Provider transaction identifier
      * @param amountUsd Amount to hold in USD (1e6)
      */
-    function addHold(address safe, bytes4 providerCode, bytes32 txId, uint256 amountUsd) external;
+    function addHold(address safe, BinSponsor binSponsor, bytes32 txId, uint256 amountUsd) external;
 
     /**
      * @notice Adds a hold without checking the spendable balance (operator recovery path)
@@ -179,11 +180,11 @@ interface IPendingHoldsModule {
      *      Emits HoldAdded with forced=true.
      *      Only callable by EtherFi wallet.
      * @param safe Safe address
-     * @param providerCode 4-byte provider code (use providerCodeFromBinSponsor to convert)
+     * @param binSponsor Bin sponsor; provider code derived on-chain
      * @param txId Provider transaction identifier
      * @param amountUsd Amount to hold in USD (1e6)
      */
-    function forceAddHold(address safe, bytes4 providerCode, bytes32 txId, uint256 amountUsd) external;
+    function forceAddHold(address safe, BinSponsor binSponsor, bytes32 txId, uint256 amountUsd) external;
 
     /**
      * @notice Updates an existing hold amount atomically (incremental auth adjustment)
@@ -191,22 +192,22 @@ interface IPendingHoldsModule {
      *      If newAmountUsd < oldAmountUsd, credits the delta back to the spending limit.
      *      Only callable by EtherFi wallet (backend service wallet).
      * @param safe Safe address
-     * @param providerCode 4-byte provider code
+     * @param binSponsor Bin sponsor; provider code derived on-chain
      * @param txId Provider transaction identifier
      * @param newAmountUsd New hold amount in USD (1e6)
      */
-    function updateHold(address safe, bytes4 providerCode, bytes32 txId, uint256 newAmountUsd) external;
+    function updateHold(address safe, BinSponsor binSponsor, bytes32 txId, uint256 newAmountUsd) external;
 
     /**
      * @notice Releases a hold without a corresponding spend (network reversal or admin action)
      * @dev Does NOT call spend() — only decrements the hold accumulator.
      *      Only callable by EtherFi wallet.
      * @param safe Safe address
-     * @param providerCode 4-byte provider code
+     * @param binSponsor Bin sponsor; provider code derived on-chain
      * @param txId Provider transaction identifier
      * @param reason Why the hold is being released
      */
-    function releaseHold(address safe, bytes4 providerCode, bytes32 txId, ReleaseReason reason) external;
+    function releaseHold(address safe, BinSponsor binSponsor, bytes32 txId, ReleaseReason reason) external;
 
     // -------------------------------------------------------------------------
     // Write functions — CashModuleCore only

--- a/src/modules/cash/CashModuleCore.sol
+++ b/src/modules/cash/CashModuleCore.sol
@@ -419,12 +419,13 @@ contract CashModuleCore is CashModuleStorageContract {
      *      Extracted to its own stack frame to avoid stack-too-deep in callers.
      *
      *      Limit accounting rules after settlementSyncHold() returns:
-     *        - No hold existed (Settlement is KING): bypass limit — no charge.
+     *        - No hold existed (Settlement is KING): charge full settlement to limit now (the
+     *                                               forced hold created at sync bypassed it).
+     *        - Forced hold (forceAddHold path):     charge full settlement to limit now,
+     *                                               since limit was bypassed at forceAddHold.
      *        - Non-forced hold, settlement > old:   charge delta to limit.
      *        - Non-forced hold, settlement < old:   release delta from limit.
      *        - Non-forced hold, settlement == old:  no-op.
-     *        - Forced hold (forceAddHold path):     charge full settlement to limit now,
-     *                                               since limit was bypassed at forceAddHold.
      *        - No PHM:                              charge spendingLimit.spend(amount) directly.
      *
      *      Limit adjustments are performed in Core — NOT via a PHM→Core callback — to avoid
@@ -438,20 +439,19 @@ contract CashModuleCore is CashModuleStorageContract {
         }
         (bool existed, bool wasForced, uint256 oldAmount) =
             IPendingHoldsModule(phm).settlementSyncHold(safe, binSponsor, txId, amount);
-        if (!existed) {
-            // Settlement is KING — no prior hold, bypass limit entirely.
-            return;
-        }
-        if (!wasForced) {
-            // Non-forced hold: limit was pre-charged at addHold for oldAmount; adjust for delta.
+        if (!existed || wasForced) {
+            // No prior hold ("Settlement is KING", created as a forced hold inside settlementSyncHold)
+            // OR a forceAddHold hold: in both cases the spending limit was bypassed at creation, so
+            // charge the full settlement amount now. The limit is the primary risk control and must
+            // reflect funds leaving the safe even when settlement arrives without a matching auth hold.
+            $.safeCashConfig[safe].spendingLimit.spend(amount);
+        } else {
+            // Non-forced hold: limit was pre-charged at addHold for oldAmount; adjust for the delta.
             if (amount > oldAmount) {
                 $.safeCashConfig[safe].spendingLimit.spend(amount - oldAmount);
             } else if (amount < oldAmount) {
                 $.safeCashConfig[safe].spendingLimit.release(oldAmount - amount);
             }
-        } else {
-            // Forced hold (forceAddHold path): limit was bypassed at creation — charge now.
-            $.safeCashConfig[safe].spendingLimit.spend(amount);
         }
     }
 

--- a/src/modules/cash/CashModuleSetters.sol
+++ b/src/modules/cash/CashModuleSetters.sol
@@ -354,54 +354,6 @@ function _requestWithdrawal(address safe, address[] memory tokens, uint256[] mem
     }
 
     // -------------------------------------------------------------------------
-    // Repayment — moved here from CashModuleCore to preserve Core's 24KB ceiling
-    // -------------------------------------------------------------------------
-
-    /**
-     * @notice Repays borrowed tokens
-     * @dev Only callable by EtherFi wallet for valid EtherFi Safe addresses.
-     *      Routed from Core via fallback() delegatecall.
-     * @param safe Address of the EtherFi Safe
-     * @param token Address of the token to repay
-     * @param amountInUsd Amount to repay in USD
-     * @custom:throws OnlyBorrowToken if token is not a valid borrow token
-     */
-    function repay(address safe, address token, uint256 amountInUsd) public whenNotPaused nonReentrant onlyEtherFiWallet onlyEtherFiSafe(safe) {
-        IDebtManager debtManager = _getDebtManager();
-        if (!_isBorrowToken(debtManager, token)) revert OnlyBorrowToken();
-        _repay(safe, debtManager, token, amountInUsd);
-    }
-
-    /**
-     * @dev Internal function to execute the repayment transaction
-     * @param safe Address of the EtherFi Safe
-     * @param debtManager Reference to the debt manager contract
-     * @param token Address of the token to repay
-     * @param amountInUsd Amount to repay in USD
-     * @custom:throws AmountZero if the converted amount is zero
-     */
-    function _repay(address safe, IDebtManager debtManager, address token, uint256 amountInUsd) internal {
-        uint256 amount = IDebtManager(debtManager).convertUsdToCollateralToken(token, amountInUsd);
-        if (amount == 0) revert AmountZero();
-        _cancelWithdrawalRequestIfNecessary(safe, token, amount);
-
-        address[] memory to = new address[](3);
-        bytes[] memory data = new bytes[](3);
-        uint256[] memory values = new uint256[](3);
-
-        to[0] = token;
-        to[1] = address(debtManager);
-        to[2] = token;
-
-        data[0] = abi.encodeWithSelector(IERC20.approve.selector, address(debtManager), amount);
-        data[1] = abi.encodeWithSelector(IDebtManager.repay.selector, safe, token, amount);
-        data[2] = abi.encodeWithSelector(IERC20.approve.selector, address(debtManager), 0);
-
-        IEtherFiSafe(safe).execTransactionFromModule(to, values, data);
-        _getCashModuleStorage().cashEventEmitter.emitRepayDebtManager(safe, token, amount, amountInUsd);
-    }
-
-    // -------------------------------------------------------------------------
     // PendingHoldsModule integration
     // -------------------------------------------------------------------------
 
@@ -462,105 +414,46 @@ function _requestWithdrawal(address safe, address[] memory tokens, uint256[] mem
         _getCashModuleStorage().pendingHoldsModule = _pendingHoldsModule;
     }
 
+    // -------------------------------------------------------------------------
+    // CashModuleSettersExt routing (second overflow hop)
+    // -------------------------------------------------------------------------
+
     /**
-     * @notice Collects the outstanding remainder of an under-funded settlement from the safe's balance.
-     * @dev When spend() settled a transaction the safe could not fully cover, the unpaid remainder is
-     *      parked in a forced "remaining" hold (see CashModuleCore._phmFinalize). This lets ops sweep
-     *      that remainder once the safe is funded: it pays up to the outstanding remainder from `token`,
-     *      reduces the hold, and removes it (unblocking withdrawals) once fully paid.
-     *
-     *      The spending limit is NOT charged again — the full settlement amount was already charged at
-     *      the original spend(). Only operates on already-settled transactions (transactionCleared == true),
-     *      which distinguishes a post-settlement debt from a pre-settlement forceAddHold hold.
-     *
-     *      Lives here (not in Core) to preserve Core's EVM 24KB bytecode ceiling; routed via fallback().
-     * @param safe Address of the EtherFi Safe
-     * @param txId Transaction identifier (the original authorization/settlement id)
-     * @param binSponsor Bin sponsor the settlement was made under
-     * @param token Borrow token to collect the remainder from
-     * @custom:throws InvalidInput if PHM unset, txId not yet settled, or no remainder outstanding
-     * @custom:throws UnsupportedToken if token is not a borrow token
-     * @custom:throws InsufficientBalance if the safe holds nothing collectable in token
+     * @notice Sets the CashModuleSettersExt address — the second fallback-hop overflow contract.
+     * @dev Only callable by accounts with CASH_MODULE_CONTROLLER_ROLE. Functions not found in Core
+     *      or Setters are delegatecalled here (e.g. repay, collectRemaining).
+     * @param _cashModuleSettersExt Address of the deployed CashModuleSettersExt
      */
-    function collectRemaining(address safe, bytes32 txId, BinSponsor binSponsor, address token)
-        external
-        whenNotPaused
-        nonReentrant
-        onlyEtherFiWallet
-        onlyEtherFiSafe(safe)
-    {
-        CashModuleStorage storage $ = _getCashModuleStorage();
-        address phm = $.pendingHoldsModule;
-        if (phm == address(0)) revert InvalidInput();
-        // Must be a post-settlement debt, not a pre-settlement forceAddHold hold awaiting spend().
-        if (!$.safeCashConfig[safe].transactionCleared[txId]) revert InvalidInput();
-        if (!_isBorrowToken($.debtManager, token)) revert UnsupportedToken();
-
-        uint256 remaining = IPendingHoldsModule(phm).remainingHold(safe, binSponsor, txId);
-        if (remaining == 0) revert InvalidInput();
-
-        (uint256 payToken, uint256 paidUsd) = _collectAmounts($, safe, token, remaining);
-
-        _cancelWithdrawalRequestIfNecessary(safe, token, payToken);
-        _collectTransferAndEmit($, safe, binSponsor, txId, token, payToken, paidUsd);
-
-        // Reduce or clear the hold. No limit charge — already charged at the original settlement.
-        if (remaining - paidUsd == 0) IPendingHoldsModule(phm).removeHold(safe, binSponsor, txId);
-        else IPendingHoldsModule(phm).settlementSetRemainingHold(safe, binSponsor, txId, remaining - paidUsd);
-
-        $.debtManager.ensureHealth(safe);
+    function setCashModuleSettersExt(address _cashModuleSettersExt) external {
+        if (!roleRegistry().hasRole(CASH_MODULE_CONTROLLER_ROLE, msg.sender)) revert OnlyCashModuleController();
+        if (_cashModuleSettersExt == address(0)) revert InvalidInput();
+        _getCashModuleStorage().cashModuleSettersExt = _cashModuleSettersExt;
     }
 
-    /// @dev Computes how much of `remaining` (USD 1e6) can be collected from the safe's `token` balance.
-    ///      Rounds USD down (favors the safe). Reverts if nothing meaningful is collectable.
-    function _collectAmounts(CashModuleStorage storage $, address safe, address token, uint256 remaining)
-        private
-        view
-        returns (uint256 payToken, uint256 paidUsd)
-    {
-        uint256 required = $.debtManager.convertUsdToCollateralToken(token, remaining);
-        if (required == 0) revert AmountZero();
-        uint256 available = IERC20(token).balanceOf(safe);
-        if (available < required) {
-            payToken = available;
-            paidUsd = remaining * available / required; // round down — never over-credits the debt
-        } else {
-            payToken = required;
-            paidUsd = remaining;
+    /**
+     * @notice Returns the CashModuleSettersExt address.
+     */
+    function getCashModuleSettersExt() public view returns (address) {
+        return _getCashModuleStorage().cashModuleSettersExt;
+    }
+
+    /**
+     * @dev Second fallback hop. Core delegatecalls Setters for any selector not in Core; if the
+     *      selector is not in Setters either, this forwards (still by delegatecall, so Core's storage
+     *      and the original msg.sender are preserved) to CashModuleSettersExt.
+     */
+    // solhint-disable-next-line no-complex-fallback
+    fallback() external {
+        address extImpl = _getCashModuleStorage().cashModuleSettersExt;
+        if (extImpl == address(0)) revert InvalidInput();
+        // solhint-disable-next-line no-inline-assembly
+        assembly ("memory-safe") {
+            calldatacopy(0, 0, calldatasize())
+            let result := delegatecall(gas(), extImpl, 0, calldatasize(), 0, 0)
+            returndatacopy(0, 0, returndatasize())
+            switch result
+            case 0 { revert(0, returndatasize()) }
+            default { return(0, returndatasize()) }
         }
-        // Refuse a transfer that would move tokens without reducing the recorded debt (dust guard).
-        if (paidUsd == 0) revert InsufficientBalance();
-    }
-
-    /// @dev Transfers the collected tokens to the settlement dispatcher and emits a Spend event.
-    function _collectTransferAndEmit(
-        CashModuleStorage storage $,
-        address safe,
-        BinSponsor binSponsor,
-        bytes32 txId,
-        address token,
-        uint256 payToken,
-        uint256 paidUsd
-    ) private {
-        address[] memory to = new address[](1);
-        bytes[] memory data = new bytes[](1);
-        to[0] = token;
-        data[0] = abi.encodeWithSelector(IERC20.transfer.selector, _settlementDispatcherFor($, binSponsor), payToken);
-        IEtherFiSafe(safe).execTransactionFromModule(to, new uint256[](1), data);
-
-        uint256[] memory tokenAmounts = new uint256[](1);
-        uint256[] memory usdAmounts = new uint256[](1);
-        tokenAmounts[0] = payToken;
-        usdAmounts[0] = paidUsd;
-        $.cashEventEmitter.emitSpend(safe, txId, binSponsor, to, tokenAmounts, usdAmounts, paidUsd, Mode.Debit);
-    }
-
-    /// @dev Resolves the settlement dispatcher for a bin sponsor (mirrors CashModuleCore.getSettlementDispatcher).
-    function _settlementDispatcherFor(CashModuleStorage storage $, BinSponsor binSponsor) private view returns (address dispatcher) {
-        if (binSponsor == BinSponsor.Rain) dispatcher = $.settlementDispatcherRain;
-        else if (binSponsor == BinSponsor.PIX) dispatcher = $.settlementDispatcherPix;
-        else if (binSponsor == BinSponsor.CardOrder) dispatcher = $.settlementDispatcherCardOrder;
-        else dispatcher = $.settlementDispatcherReap;
-        if (dispatcher == address(0)) revert SettlementDispatcherNotSetForBinSponsor();
     }
 }

--- a/src/modules/cash/CashModuleSetters.sol
+++ b/src/modules/cash/CashModuleSetters.sol
@@ -461,4 +461,106 @@ function _requestWithdrawal(address safe, address[] memory tokens, uint256[] mem
         if (_pendingHoldsModule == address(0)) revert InvalidInput();
         _getCashModuleStorage().pendingHoldsModule = _pendingHoldsModule;
     }
+
+    /**
+     * @notice Collects the outstanding remainder of an under-funded settlement from the safe's balance.
+     * @dev When spend() settled a transaction the safe could not fully cover, the unpaid remainder is
+     *      parked in a forced "remaining" hold (see CashModuleCore._phmFinalize). This lets ops sweep
+     *      that remainder once the safe is funded: it pays up to the outstanding remainder from `token`,
+     *      reduces the hold, and removes it (unblocking withdrawals) once fully paid.
+     *
+     *      The spending limit is NOT charged again — the full settlement amount was already charged at
+     *      the original spend(). Only operates on already-settled transactions (transactionCleared == true),
+     *      which distinguishes a post-settlement debt from a pre-settlement forceAddHold hold.
+     *
+     *      Lives here (not in Core) to preserve Core's EVM 24KB bytecode ceiling; routed via fallback().
+     * @param safe Address of the EtherFi Safe
+     * @param txId Transaction identifier (the original authorization/settlement id)
+     * @param binSponsor Bin sponsor the settlement was made under
+     * @param token Borrow token to collect the remainder from
+     * @custom:throws InvalidInput if PHM unset, txId not yet settled, or no remainder outstanding
+     * @custom:throws UnsupportedToken if token is not a borrow token
+     * @custom:throws InsufficientBalance if the safe holds nothing collectable in token
+     */
+    function collectRemaining(address safe, bytes32 txId, BinSponsor binSponsor, address token)
+        external
+        whenNotPaused
+        nonReentrant
+        onlyEtherFiWallet
+        onlyEtherFiSafe(safe)
+    {
+        CashModuleStorage storage $ = _getCashModuleStorage();
+        address phm = $.pendingHoldsModule;
+        if (phm == address(0)) revert InvalidInput();
+        // Must be a post-settlement debt, not a pre-settlement forceAddHold hold awaiting spend().
+        if (!$.safeCashConfig[safe].transactionCleared[txId]) revert InvalidInput();
+        if (!_isBorrowToken($.debtManager, token)) revert UnsupportedToken();
+
+        uint256 remaining = IPendingHoldsModule(phm).remainingHold(safe, binSponsor, txId);
+        if (remaining == 0) revert InvalidInput();
+
+        (uint256 payToken, uint256 paidUsd) = _collectAmounts($, safe, token, remaining);
+
+        _cancelWithdrawalRequestIfNecessary(safe, token, payToken);
+        _collectTransferAndEmit($, safe, binSponsor, txId, token, payToken, paidUsd);
+
+        // Reduce or clear the hold. No limit charge — already charged at the original settlement.
+        if (remaining - paidUsd == 0) IPendingHoldsModule(phm).removeHold(safe, binSponsor, txId);
+        else IPendingHoldsModule(phm).settlementSetRemainingHold(safe, binSponsor, txId, remaining - paidUsd);
+
+        $.debtManager.ensureHealth(safe);
+    }
+
+    /// @dev Computes how much of `remaining` (USD 1e6) can be collected from the safe's `token` balance.
+    ///      Rounds USD down (favors the safe). Reverts if nothing meaningful is collectable.
+    function _collectAmounts(CashModuleStorage storage $, address safe, address token, uint256 remaining)
+        private
+        view
+        returns (uint256 payToken, uint256 paidUsd)
+    {
+        uint256 required = $.debtManager.convertUsdToCollateralToken(token, remaining);
+        if (required == 0) revert AmountZero();
+        uint256 available = IERC20(token).balanceOf(safe);
+        if (available < required) {
+            payToken = available;
+            paidUsd = remaining * available / required; // round down — never over-credits the debt
+        } else {
+            payToken = required;
+            paidUsd = remaining;
+        }
+        // Refuse a transfer that would move tokens without reducing the recorded debt (dust guard).
+        if (paidUsd == 0) revert InsufficientBalance();
+    }
+
+    /// @dev Transfers the collected tokens to the settlement dispatcher and emits a Spend event.
+    function _collectTransferAndEmit(
+        CashModuleStorage storage $,
+        address safe,
+        BinSponsor binSponsor,
+        bytes32 txId,
+        address token,
+        uint256 payToken,
+        uint256 paidUsd
+    ) private {
+        address[] memory to = new address[](1);
+        bytes[] memory data = new bytes[](1);
+        to[0] = token;
+        data[0] = abi.encodeWithSelector(IERC20.transfer.selector, _settlementDispatcherFor($, binSponsor), payToken);
+        IEtherFiSafe(safe).execTransactionFromModule(to, new uint256[](1), data);
+
+        uint256[] memory tokenAmounts = new uint256[](1);
+        uint256[] memory usdAmounts = new uint256[](1);
+        tokenAmounts[0] = payToken;
+        usdAmounts[0] = paidUsd;
+        $.cashEventEmitter.emitSpend(safe, txId, binSponsor, to, tokenAmounts, usdAmounts, paidUsd, Mode.Debit);
+    }
+
+    /// @dev Resolves the settlement dispatcher for a bin sponsor (mirrors CashModuleCore.getSettlementDispatcher).
+    function _settlementDispatcherFor(CashModuleStorage storage $, BinSponsor binSponsor) private view returns (address dispatcher) {
+        if (binSponsor == BinSponsor.Rain) dispatcher = $.settlementDispatcherRain;
+        else if (binSponsor == BinSponsor.PIX) dispatcher = $.settlementDispatcherPix;
+        else if (binSponsor == BinSponsor.CardOrder) dispatcher = $.settlementDispatcherCardOrder;
+        else dispatcher = $.settlementDispatcherReap;
+        if (dispatcher == address(0)) revert SettlementDispatcherNotSetForBinSponsor();
+    }
 }

--- a/src/modules/cash/CashModuleSettersExt.sol
+++ b/src/modules/cash/CashModuleSettersExt.sol
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import { Mode, BinSponsor } from "../../interfaces/ICashModule.sol";
+import { IDebtManager } from "../../interfaces/IDebtManager.sol";
+import { IEtherFiSafe } from "../../interfaces/IEtherFiSafe.sol";
+import { IPendingHoldsModule } from "../../interfaces/IPendingHoldsModule.sol";
+import { CashModuleStorageContract } from "./CashModuleStorageContract.sol";
+
+/**
+ * @title CashModuleSettersExt
+ * @author ether.fi
+ * @notice Second overflow implementation for the Cash Module. Reached via a fallback hop:
+ *         CashModuleCore.fallback() → delegatecall CashModuleSetters → CashModuleSetters.fallback()
+ *         → delegatecall CashModuleSettersExt. Every hop is a delegatecall, so all functions here run
+ *         in Core's storage context with the original msg.sender preserved.
+ *
+ * @dev Exists purely to keep CashModuleCore and CashModuleSetters under the EIP-170 24KB bytecode
+ *      limit. Functions are placed here when neither Core nor Setters has room. This contract shares
+ *      the exact storage layout of Core/Setters via CashModuleStorageContract and must NEVER declare
+ *      its own state variables outside that layout.
+ */
+contract CashModuleSettersExt is CashModuleStorageContract {
+    constructor(address _etherFiDataProvider) CashModuleStorageContract(_etherFiDataProvider) {
+        _disableInitializers();
+    }
+
+    // -------------------------------------------------------------------------
+    // Repayment (relocated from CashModuleSetters to free bytecode room)
+    // -------------------------------------------------------------------------
+
+    /**
+     * @notice Repays borrowed tokens
+     * @dev Only callable by EtherFi wallet for valid EtherFi Safe addresses. Routed via fallback hops.
+     * @param safe Address of the EtherFi Safe
+     * @param token Address of the token to repay
+     * @param amountInUsd Amount to repay in USD
+     * @custom:throws OnlyBorrowToken if token is not a valid borrow token
+     */
+    function repay(address safe, address token, uint256 amountInUsd) public whenNotPaused nonReentrant onlyEtherFiWallet onlyEtherFiSafe(safe) {
+        IDebtManager debtManager = _getDebtManager();
+        if (!_isBorrowToken(debtManager, token)) revert OnlyBorrowToken();
+        _repay(safe, debtManager, token, amountInUsd);
+    }
+
+    /**
+     * @dev Internal function to execute the repayment transaction
+     * @custom:throws AmountZero if the converted amount is zero
+     */
+    function _repay(address safe, IDebtManager debtManager, address token, uint256 amountInUsd) internal {
+        uint256 amount = IDebtManager(debtManager).convertUsdToCollateralToken(token, amountInUsd);
+        if (amount == 0) revert AmountZero();
+        _cancelWithdrawalRequestIfNecessary(safe, token, amount);
+
+        address[] memory to = new address[](3);
+        bytes[] memory data = new bytes[](3);
+        uint256[] memory values = new uint256[](3);
+
+        to[0] = token;
+        to[1] = address(debtManager);
+        to[2] = token;
+
+        data[0] = abi.encodeWithSelector(IERC20.approve.selector, address(debtManager), amount);
+        data[1] = abi.encodeWithSelector(IDebtManager.repay.selector, safe, token, amount);
+        data[2] = abi.encodeWithSelector(IERC20.approve.selector, address(debtManager), 0);
+
+        IEtherFiSafe(safe).execTransactionFromModule(to, values, data);
+        _getCashModuleStorage().cashEventEmitter.emitRepayDebtManager(safe, token, amount, amountInUsd);
+    }
+
+    // -------------------------------------------------------------------------
+    // Under-funded settlement collection (C1)
+    // -------------------------------------------------------------------------
+
+    /**
+     * @notice Collects the outstanding remainder of an under-funded settlement from the safe's balance.
+     * @dev When spend() settled a transaction the safe could not fully cover, the unpaid remainder is
+     *      parked in a forced "remaining" hold (see CashModuleCore._phmFinalize). This lets ops sweep
+     *      that remainder once the safe is funded: it pays up to the outstanding remainder from `token`,
+     *      reduces the hold, and removes it (unblocking withdrawals) once fully paid.
+     *
+     *      The spending limit is NOT charged again — the full settlement amount was already charged at
+     *      the original spend(). Only operates on already-settled transactions (transactionCleared == true),
+     *      which distinguishes a post-settlement debt from a pre-settlement forceAddHold hold.
+     * @param safe Address of the EtherFi Safe
+     * @param txId Transaction identifier (the original authorization/settlement id)
+     * @param binSponsor Bin sponsor the settlement was made under
+     * @param token Borrow token to collect the remainder from
+     * @custom:throws InvalidInput if PHM unset, txId not yet settled, or no remainder outstanding
+     * @custom:throws UnsupportedToken if token is not a borrow token
+     * @custom:throws InsufficientBalance if the safe holds nothing collectable in token
+     */
+    function collectRemaining(address safe, bytes32 txId, BinSponsor binSponsor, address token)
+        external
+        whenNotPaused
+        nonReentrant
+        onlyEtherFiWallet
+        onlyEtherFiSafe(safe)
+    {
+        CashModuleStorage storage $ = _getCashModuleStorage();
+        address phm = $.pendingHoldsModule;
+        if (phm == address(0)) revert InvalidInput();
+        // Must be a post-settlement debt, not a pre-settlement forceAddHold hold awaiting spend().
+        if (!$.safeCashConfig[safe].transactionCleared[txId]) revert InvalidInput();
+        if (!_isBorrowToken($.debtManager, token)) revert UnsupportedToken();
+
+        uint256 remaining = IPendingHoldsModule(phm).remainingHold(safe, binSponsor, txId);
+        if (remaining == 0) revert InvalidInput();
+
+        (uint256 payToken, uint256 paidUsd) = _collectAmounts($, safe, token, remaining);
+
+        _cancelWithdrawalRequestIfNecessary(safe, token, payToken);
+        _collectTransferAndEmit($, safe, binSponsor, txId, token, payToken, paidUsd);
+
+        // Reduce or clear the hold. No limit charge — already charged at the original settlement.
+        if (remaining - paidUsd == 0) IPendingHoldsModule(phm).removeHold(safe, binSponsor, txId);
+        else IPendingHoldsModule(phm).settlementSetRemainingHold(safe, binSponsor, txId, remaining - paidUsd);
+
+        $.debtManager.ensureHealth(safe);
+    }
+
+    /// @dev Computes how much of `remaining` (USD 1e6) can be collected from the safe's `token` balance.
+    ///      Rounds USD down (favors the safe). Reverts if nothing meaningful is collectable.
+    function _collectAmounts(CashModuleStorage storage $, address safe, address token, uint256 remaining)
+        private
+        view
+        returns (uint256 payToken, uint256 paidUsd)
+    {
+        uint256 required = $.debtManager.convertUsdToCollateralToken(token, remaining);
+        if (required == 0) revert AmountZero();
+        uint256 available = IERC20(token).balanceOf(safe);
+        if (available < required) {
+            payToken = available;
+            paidUsd = remaining * available / required; // round down — never over-credits the debt
+        } else {
+            payToken = required;
+            paidUsd = remaining;
+        }
+        // Refuse a transfer that would move tokens without reducing the recorded debt (dust guard).
+        if (paidUsd == 0) revert InsufficientBalance();
+    }
+
+    /// @dev Transfers the collected tokens to the settlement dispatcher and emits a Spend event.
+    function _collectTransferAndEmit(
+        CashModuleStorage storage $,
+        address safe,
+        BinSponsor binSponsor,
+        bytes32 txId,
+        address token,
+        uint256 payToken,
+        uint256 paidUsd
+    ) private {
+        address[] memory to = new address[](1);
+        bytes[] memory data = new bytes[](1);
+        to[0] = token;
+        data[0] = abi.encodeWithSelector(IERC20.transfer.selector, _settlementDispatcherFor($, binSponsor), payToken);
+        IEtherFiSafe(safe).execTransactionFromModule(to, new uint256[](1), data);
+
+        uint256[] memory tokenAmounts = new uint256[](1);
+        uint256[] memory usdAmounts = new uint256[](1);
+        tokenAmounts[0] = payToken;
+        usdAmounts[0] = paidUsd;
+        $.cashEventEmitter.emitSpend(safe, txId, binSponsor, to, tokenAmounts, usdAmounts, paidUsd, Mode.Debit);
+    }
+
+    /// @dev Resolves the settlement dispatcher for a bin sponsor (mirrors CashModuleCore.getSettlementDispatcher).
+    function _settlementDispatcherFor(CashModuleStorage storage $, BinSponsor binSponsor) private view returns (address dispatcher) {
+        if (binSponsor == BinSponsor.Rain) dispatcher = $.settlementDispatcherRain;
+        else if (binSponsor == BinSponsor.PIX) dispatcher = $.settlementDispatcherPix;
+        else if (binSponsor == BinSponsor.CardOrder) dispatcher = $.settlementDispatcherCardOrder;
+        else dispatcher = $.settlementDispatcherReap;
+        if (dispatcher == address(0)) revert SettlementDispatcherNotSetForBinSponsor();
+    }
+}

--- a/src/modules/cash/CashModuleStorageContract.sol
+++ b/src/modules/cash/CashModuleStorageContract.sol
@@ -74,6 +74,9 @@ contract CashModuleStorageContract is UpgradeableProxy, ModuleBase {
         address settlementDispatcherCardOrder;
         /// @notice Address of the PendingHoldsModule registry contract
         address pendingHoldsModule;
+        /// @notice Address of the CashModuleSettersExt overflow contract (second fallback hop).
+        ///         Holds functions that no longer fit in Core or Setters under the EIP-170 24KB cap.
+        address cashModuleSettersExt;
     }
 
     // keccak256(abi.encode(uint256(keccak256("etherfi.storage.CashModuleStorage")) - 1)) & ~bytes32(uint256(0xff))

--- a/src/modules/cash/CashModuleStorageContract.sol
+++ b/src/modules/cash/CashModuleStorageContract.sol
@@ -12,6 +12,7 @@ import { ICashbackDispatcher } from "../../interfaces/ICashbackDispatcher.sol";
 import { IDebtManager } from "../../interfaces/IDebtManager.sol";
 import { IEtherFiDataProvider } from "../../interfaces/IEtherFiDataProvider.sol";
 import { IEtherFiSafe } from "../../interfaces/IEtherFiSafe.sol";
+import { IPendingHoldsModule } from "../../interfaces/IPendingHoldsModule.sol";
 import { ArrayDeDupLib } from "../../libraries/ArrayDeDupLib.sol";
 import { CashVerificationLib } from "../../libraries/CashVerificationLib.sol";
 import { SignatureUtils } from "../../libraries/SignatureUtils.sol";
@@ -308,6 +309,12 @@ contract CashModuleStorageContract is UpgradeableProxy, ModuleBase {
         if ($$.pendingWithdrawalRequest.tokens.length == 0) revert WithdrawalDoesNotExist();
 
         if ($$.pendingWithdrawalRequest.finalizeTime > block.timestamp) revert CannotWithdrawYet();
+
+        // Re-check pending holds at finalize, not only at request time. A hold may have been added
+        // during the withdrawal delay window; processing anyway would drain funds the hold reserves.
+        address phm = $.pendingHoldsModule;
+        if (phm != address(0) && IPendingHoldsModule(phm).totalPendingHolds(safe) > 0) revert WithdrawalBlockedByPendingHolds();
+
         // Ensure that if the recipient of withdrawal is a whitelisted withdrawal module, only that module can process the withdrawal
         if ($.whitelistedModulesCanRequestWithdraw.contains($$.pendingWithdrawalRequest.recipient)) {
             if (msg.sender != $$.pendingWithdrawalRequest.recipient) revert OnlyModuleThatRequestedCanWithdraw();

--- a/src/modules/cash/PendingHoldsModule.sol
+++ b/src/modules/cash/PendingHoldsModule.sol
@@ -141,7 +141,7 @@ contract PendingHoldsModule is UpgradeableProxy, ModuleBase, IPendingHoldsModule
     // -------------------------------------------------------------------------
 
     /// @inheritdoc IPendingHoldsModule
-    function addHold(address safe, bytes4 providerCode, bytes32 txId, uint256 amountUsd)
+    function addHold(address safe, BinSponsor binSponsor, bytes32 txId, uint256 amountUsd)
         external
         whenNotPaused
         nonReentrant
@@ -149,6 +149,7 @@ contract PendingHoldsModule is UpgradeableProxy, ModuleBase, IPendingHoldsModule
     {
         if (amountUsd == 0) revert InvalidAmount();
 
+        bytes4 providerCode = providerCodeFromBinSponsor(binSponsor);
         bytes32 key = _holdKey(safe, providerCode, txId);
         PendingHoldsModuleStorage storage $ = _getPendingHoldsModuleStorage();
 
@@ -171,7 +172,7 @@ contract PendingHoldsModule is UpgradeableProxy, ModuleBase, IPendingHoldsModule
     }
 
     /// @inheritdoc IPendingHoldsModule
-    function forceAddHold(address safe, bytes4 providerCode, bytes32 txId, uint256 amountUsd)
+    function forceAddHold(address safe, BinSponsor binSponsor, bytes32 txId, uint256 amountUsd)
         external
         whenNotPaused
         nonReentrant
@@ -179,6 +180,7 @@ contract PendingHoldsModule is UpgradeableProxy, ModuleBase, IPendingHoldsModule
     {
         if (amountUsd == 0) revert InvalidAmount();
 
+        bytes4 providerCode = providerCodeFromBinSponsor(binSponsor);
         bytes32 key = _holdKey(safe, providerCode, txId);
         PendingHoldsModuleStorage storage $ = _getPendingHoldsModuleStorage();
 
@@ -197,7 +199,7 @@ contract PendingHoldsModule is UpgradeableProxy, ModuleBase, IPendingHoldsModule
     }
 
     /// @inheritdoc IPendingHoldsModule
-    function updateHold(address safe, bytes4 providerCode, bytes32 txId, uint256 newAmountUsd)
+    function updateHold(address safe, BinSponsor binSponsor, bytes32 txId, uint256 newAmountUsd)
         external
         whenNotPaused
         nonReentrant
@@ -205,6 +207,7 @@ contract PendingHoldsModule is UpgradeableProxy, ModuleBase, IPendingHoldsModule
     {
         if (newAmountUsd == 0) revert InvalidAmount();
 
+        bytes4 providerCode = providerCodeFromBinSponsor(binSponsor);
         bytes32 key = _holdKey(safe, providerCode, txId);
         PendingHoldsModuleStorage storage $ = _getPendingHoldsModuleStorage();
 
@@ -236,12 +239,13 @@ contract PendingHoldsModule is UpgradeableProxy, ModuleBase, IPendingHoldsModule
     }
 
     /// @inheritdoc IPendingHoldsModule
-    function releaseHold(address safe, bytes4 providerCode, bytes32 txId, ReleaseReason reason)
+    function releaseHold(address safe, BinSponsor binSponsor, bytes32 txId, ReleaseReason reason)
         external
         whenNotPaused
         nonReentrant
         onlyEtherFiWallet
     {
+        bytes4 providerCode = providerCodeFromBinSponsor(binSponsor);
         bytes32 key = _holdKey(safe, providerCode, txId);
         PendingHoldsModuleStorage storage $ = _getPendingHoldsModuleStorage();
 

--- a/src/modules/cash/PendingHoldsModule.sol
+++ b/src/modules/cash/PendingHoldsModule.sol
@@ -390,6 +390,12 @@ contract PendingHoldsModule is UpgradeableProxy, ModuleBase, IPendingHoldsModule
     }
 
     /// @inheritdoc IPendingHoldsModule
+    function remainingHold(address safe, BinSponsor binSponsor, bytes32 txId) external view returns (uint256) {
+        bytes4 providerCode = providerCodeFromBinSponsor(binSponsor);
+        return _getPendingHoldsModuleStorage().holds[_holdKey(safe, providerCode, txId)].amountUsd;
+    }
+
+    /// @inheritdoc IPendingHoldsModule
     function cashModuleCore() external view returns (address) {
         return _getPendingHoldsModuleStorage().cashModuleCore;
     }

--- a/src/modules/cash/PendingHoldsModule.sol
+++ b/src/modules/cash/PendingHoldsModule.sol
@@ -14,7 +14,11 @@ import { UpgradeableProxy } from "../../utils/UpgradeableProxy.sol";
  * @dev Architecture:
  *   - Pure registry: stores holds, sums them per safe, emits rich indexed events.
  *   - Zero spend() logic: CashModuleCore owns settlement; it calls removeHold() after spend().
- *   - Spendable invariant: spendable(safe) = rawSpendable(safe) - totalPendingHolds(safe)
+ *   - Spendable accounting: non-forced holds are charged to spentToday/spentThisMonth at addHold()
+ *     time, so rawSpendable(safe) already reflects them. spendable(safe) == rawSpendable(safe);
+ *     do NOT subtract totalPendingHolds again (that double-counts). Forced holds (forceAddHold and
+ *     settlement-created "Settlement is KING" holds) deliberately bypass the limit until settlement,
+ *     so they are NOT reflected in rawSpendable; totalPendingHolds drives only the withdrawal guard.
  *   - Hold keys are provider-namespaced: keccak256(abi.encode(safe, providerCode, txId))
  *     This prevents txId collisions across Rain / Reap / PIX namespaces.
  *

--- a/test/safe/SafeTestSetup.t.sol
+++ b/test/safe/SafeTestSetup.t.sol
@@ -22,6 +22,7 @@ import { CashLens } from "../../src/modules/cash/CashLens.sol";
 import { CashEventEmitter } from "../../src/modules/cash/CashEventEmitter.sol";
 import { CashModuleCore } from "../../src/modules/cash/CashModuleCore.sol";
 import { CashModuleSetters } from "../../src/modules/cash/CashModuleSetters.sol";
+import { CashModuleSettersExt } from "../../src/modules/cash/CashModuleSettersExt.sol";
 import { RoleRegistry } from "../../src/role-registry/RoleRegistry.sol";
 import { ArrayDeDupLib, EtherFiSafe, EtherFiSafeBase, EtherFiSafeErrors } from "../../src/safe/EtherFiSafe.sol";
 import { EtherFiSafeFactory } from "../../src/safe/EtherFiSafeFactory.sol";
@@ -199,6 +200,10 @@ contract SafeTestSetup is Utils {
 
         roleRegistry.grantRole(cashModule.ETHER_FI_WALLET_ROLE(), etherFiWallet);
         roleRegistry.grantRole(cashModule.CASH_MODULE_CONTROLLER_ROLE(), owner);
+
+        // Wire the second-hop overflow contract (repay, collectRemaining live here).
+        address cashModuleSettersExtImpl = address(new CashModuleSettersExt(address(dataProvider)));
+        CashModuleSetters(address(cashModule)).setCashModuleSettersExt(cashModuleSettersExtImpl);
 
         _setupWithdrawTokenWhitelist();
 

--- a/test/safe/modules/cash/PendingHoldsFindings.t.sol
+++ b/test/safe/modules/cash/PendingHoldsFindings.t.sol
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
+import { ICashModule, BinSponsor, Cashback, Mode } from "../../../../src/interfaces/ICashModule.sol";
+import { HoldRecord, IPendingHoldsModule, ReleaseReason } from "../../../../src/interfaces/IPendingHoldsModule.sol";
+import { PendingHoldsModule } from "../../../../src/modules/cash/PendingHoldsModule.sol";
+import { PendingHoldsTestSetup } from "./PendingHoldsModuleTest.t.sol";
+
+/**
+ * @title PendingHoldsFindings
+ * @notice Proving tests for PR #120 review findings. Each asserts the *desired* (correct) behavior,
+ *         so it is RED against the original code (proving the bug) and GREEN after the fix.
+ *
+ *  C2  — no-hold "Settlement is KING" path must charge the spending limit.
+ *  C1  — under-funded settlement leftover must be collectable later via collectRemaining().
+ *  M1  — the pending-holds withdrawal block must be enforced at finalize, not only at request.
+ */
+contract PendingHoldsFindingsTest is PendingHoldsTestSetup {
+
+    // ---------------------------------------------------------------------
+    // C2: no-hold settlement must charge the spending limit
+    // ---------------------------------------------------------------------
+    function test_C2_noHoldSettlement_chargesLimit() public {
+        uint256 amount = 100e6;
+        deal(address(usdc), address(safe), amount);
+
+        uint256 rawBefore = cashModule.rawSpendable(address(safe));
+
+        _spendWithoutHold(txId, BinSponsor.Reap, amount);
+
+        // The limit is debited by the settled amount (no longer bypassed).
+        assertEq(cashModule.rawSpendable(address(safe)), rawBefore - amount, "C2: no-hold settlement must charge limit");
+    }
+
+    // ---------------------------------------------------------------------
+    // C1: under-funded settlement leaves a collectable remainder
+    // ---------------------------------------------------------------------
+    function test_C1_underfundedSettlement_remainderCollectable() public {
+        uint256 authAmount = 100e6;
+        uint256 funded = 40e6; // safe can only cover $40 of the $100 settlement
+        deal(address(usdc), address(safe), funded);
+
+        uint256 rawBefore = cashModule.rawSpendable(address(safe));
+
+        _addHold(PROVIDER_REAP, txId, authAmount);                 // limit charged $100
+        assertEq(cashModule.rawSpendable(address(safe)), rawBefore - authAmount);
+
+        // Settlement $100 against a $40 balance → partial: $40 moves, $60 remains as a forced hold.
+        _spendWithHold(txId, BinSponsor.Reap, authAmount);
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), 60e6, "C1: $60 remainder parked");
+        assertTrue(cashModule.transactionCleared(address(safe), txId));
+
+        // User later funds the safe; ops sweeps the remainder.
+        deal(address(usdc), address(safe), 60e6);
+        vm.prank(etherFiWallet);
+        cashModule.collectRemaining(address(safe), txId, BinSponsor.Reap, address(usdc));
+
+        // Remainder cleared → withdrawals unblock; limit reflects exactly $100 (no double charge).
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), 0, "C1: remainder must collect to 0");
+        assertEq(cashModule.rawSpendable(address(safe)), rawBefore - authAmount, "C1: no double charge to limit");
+    }
+
+    // ---------------------------------------------------------------------
+    // M1: withdrawal block must be enforced at finalize, not only at request
+    // ---------------------------------------------------------------------
+    function test_M1_withdrawalBlock_enforcedAtFinalize() public {
+        // Give withdrawals a delay so request and finalize are distinct steps.
+        (, uint64 spendLimitDelay, uint64 modeDelay) = cashModule.getDelays();
+        vm.prank(owner);
+        cashModule.setDelays(1 days, spendLimitDelay, modeDelay);
+
+        uint256 amount = 100e6;
+        deal(address(usdc), address(safe), amount);
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = amount;
+
+        // Request a withdrawal while there are NO holds (passes the request-time guard).
+        _requestWithdrawal(tokens, amounts, withdrawRecipient);
+
+        // A card hold appears during the delay window.
+        _addHold(PROVIDER_REAP, txId, 50e6);
+
+        // Delay elapses; finalize must be blocked because a hold now exists.
+        vm.warp(block.timestamp + 1 days + 1);
+        vm.expectRevert(abi.encodeWithSignature("WithdrawalBlockedByPendingHolds()"));
+        cashModule.processWithdrawal(address(safe));
+    }
+}

--- a/test/safe/modules/cash/PendingHoldsFindings.t.sol
+++ b/test/safe/modules/cash/PendingHoldsFindings.t.sol
@@ -43,7 +43,7 @@ contract PendingHoldsFindingsTest is PendingHoldsTestSetup {
 
         uint256 rawBefore = cashModule.rawSpendable(address(safe));
 
-        _addHold(PROVIDER_REAP, txId, authAmount);                 // limit charged $100
+        _addHold(BinSponsor.Reap, txId, authAmount);                 // limit charged $100
         assertEq(cashModule.rawSpendable(address(safe)), rawBefore - authAmount);
 
         // Settlement $100 against a $40 balance → partial: $40 moves, $60 remains as a forced hold.
@@ -82,7 +82,7 @@ contract PendingHoldsFindingsTest is PendingHoldsTestSetup {
         _requestWithdrawal(tokens, amounts, withdrawRecipient);
 
         // A card hold appears during the delay window.
-        _addHold(PROVIDER_REAP, txId, 50e6);
+        _addHold(BinSponsor.Reap, txId, 50e6);
 
         // Delay elapses; finalize must be blocked because a hold now exists.
         vm.warp(block.timestamp + 1 days + 1);

--- a/test/safe/modules/cash/PendingHoldsModuleTest.t.sol
+++ b/test/safe/modules/cash/PendingHoldsModuleTest.t.sol
@@ -848,18 +848,41 @@ contract PendingHoldsLensTest is PendingHoldsTestSetup {
 // =============================================================================
 
 contract CashModuleCoreBytecodeSizeTest is Test {
+    uint256 constant EIP170_LIMIT = 24_576;
+
     function test_cashModuleCore_deployedSize_underLimit() public {
-        // CashModuleCore must not exceed 24,576 bytes (EIP-170 limit)
-        uint256 limit = 24_576;
         uint256 coreSize = address(new _CashModuleCoreForSizeCheck()).code.length;
-        assertLt(coreSize, limit, "CashModuleCore deployed bytecode exceeds 24KB EVM limit");
+        assertLt(coreSize, EIP170_LIMIT, "CashModuleCore deployed bytecode exceeds 24KB EVM limit");
+    }
+
+    // Setters is deployed standalone (delegatecall target) and is also subject to EIP-170. The PR
+    // moved code into Setters to protect Core's ceiling, which previously pushed Setters over the
+    // limit; this gate prevents that regression.
+    function test_cashModuleSetters_deployedSize_underLimit() public {
+        uint256 settersSize = address(new _CashModuleSettersForSizeCheck()).code.length;
+        assertLt(settersSize, EIP170_LIMIT, "CashModuleSetters deployed bytecode exceeds 24KB EVM limit");
+    }
+
+    function test_cashModuleSettersExt_deployedSize_underLimit() public {
+        uint256 extSize = address(new _CashModuleSettersExtForSizeCheck()).code.length;
+        assertLt(extSize, EIP170_LIMIT, "CashModuleSettersExt deployed bytecode exceeds 24KB EVM limit");
     }
 }
 
-// Minimal deployment helper — avoids importing the full constructor chain in this file
+// Minimal deployment helpers — avoid importing the full constructor chain in this file
 import { CashModuleCore } from "../../../../src/modules/cash/CashModuleCore.sol";
+import { CashModuleSetters } from "../../../../src/modules/cash/CashModuleSetters.sol";
+import { CashModuleSettersExt } from "../../../../src/modules/cash/CashModuleSettersExt.sol";
 import { EtherFiDataProvider } from "../../../../src/data-provider/EtherFiDataProvider.sol";
 
 contract _CashModuleCoreForSizeCheck is CashModuleCore {
     constructor() CashModuleCore(address(1)) { }
+}
+
+contract _CashModuleSettersForSizeCheck is CashModuleSetters {
+    constructor() CashModuleSetters(address(1)) { }
+}
+
+contract _CashModuleSettersExtForSizeCheck is CashModuleSettersExt {
+    constructor() CashModuleSettersExt(address(1)) { }
 }

--- a/test/safe/modules/cash/PendingHoldsModuleTest.t.sol
+++ b/test/safe/modules/cash/PendingHoldsModuleTest.t.sol
@@ -409,9 +409,10 @@ contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
         assertTrue(cashModule.transactionCleared(address(safe), txId));
     }
 
-    function test_spend_withNoMatchingHold_settlementIsKing_succeedsAndBypassesLimit() public {
+    function test_spend_withNoMatchingHold_settlementIsKing_succeedsAndChargesLimit() public {
         // "Settlement is KING": spend() with no prior hold creates a forced hold and settles.
-        // The spending limit is NOT charged (bypass), and the transaction is cleared.
+        // The spending limit IS charged (the limit is the primary risk control and must reflect
+        // funds leaving the safe), and the transaction is cleared.
         uint256 amount = 100e6;
         deal(address(usdc), address(safe), amount);
 
@@ -424,8 +425,8 @@ contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
         emit IPendingHoldsModule.HoldRemoved(address(safe), PROVIDER_REAP, txId, amount, block.timestamp);
         _spendWithoutHold(txId, BinSponsor.Reap, amount);
 
-        // Limit is bypassed (Settlement is KING)
-        assertEq(cashModule.rawSpendable(address(safe)), rawBefore);
+        // Limit is charged the full settled amount (no longer bypassed)
+        assertEq(cashModule.rawSpendable(address(safe)), rawBefore - amount);
         // Hold is gone after settlement
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), 0);
         assertTrue(cashModule.transactionCleared(address(safe), txId));
@@ -550,7 +551,7 @@ contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
     // The no-hold path is "Settlement is KING": a forced hold is created and immediately removed,
     // and the spending limit is NOT charged (bypass).
 
-    function test_spend_withNoHold_deductsBalanceAndBypassesLimit() public {
+    function test_spend_withNoHold_deductsBalanceAndChargesLimit() public {
         uint256 amount = 100e6;
         deal(address(usdc), address(safe), amount);
 
@@ -563,8 +564,8 @@ contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
         assertEq(usdc.balanceOf(address(safe)), safeBalBefore - debtManager.convertUsdToCollateralToken(address(usdc), amount));
         assertGt(usdc.balanceOf(address(settlementDispatcherReap)), dispatcherBalBefore);
         assertTrue(cashModule.transactionCleared(address(safe), txId));
-        // Limit is bypassed (Settlement is KING)
-        assertEq(cashModule.rawSpendable(address(safe)), rawBefore);
+        // Limit IS charged the settled amount (no longer bypassed)
+        assertEq(cashModule.rawSpendable(address(safe)), rawBefore - amount);
     }
 
     function test_spend_withNoHold_emitsCorrectSpendEvent() public {
@@ -634,7 +635,7 @@ contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
     function test_releaseHoldThenSpend_settlementIsKing_consistentState() public {
         // After a hold is released (e.g. reversal), the settlement might still arrive.
         // spend() with no existing hold (Settlement is KING): creates a forced hold and settles.
-        // Limit is NOT charged since the no-hold path bypasses it.
+        // Limit IS charged for the settled amount (the no-hold path no longer bypasses it).
         uint256 amount = 100e6;
         deal(address(usdc), address(safe), amount);
 
@@ -648,13 +649,13 @@ contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
         // releaseHold credits back the limit
         assertEq(cashModule.rawSpendable(address(safe)), rawBefore);
 
-        // Settlement arrives — no-hold path (Settlement is KING), limit NOT charged
+        // Settlement arrives — no-hold path (Settlement is KING), limit charged for the settled amount
         _spendWithoutHold(txId, BinSponsor.Reap, amount);
 
         assertTrue(cashModule.transactionCleared(address(safe), txId));
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), 0);
-        // Limit unchanged since no-hold path bypasses it
-        assertEq(cashModule.rawSpendable(address(safe)), rawBefore);
+        // Limit charged the settled amount
+        assertEq(cashModule.rawSpendable(address(safe)), rawBefore - amount);
     }
 
     // -------------------------------------------------------------------------
@@ -692,14 +693,14 @@ contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
         assertEq(cashModule.rawSpendable(address(safe)), rawBefore); // limit restored
 
         // Settlement arrives despite reversal: Settlement is KING — spend() uses no-hold path.
-        // This creates a forced hold internally and settles without charging the limit.
+        // This creates a forced hold internally and settles, charging the limit for the settled amount.
         deal(address(usdc), address(safe), amount);
         _spendWithoutHold(txId, BinSponsor.Reap, amount);
 
         assertTrue(cashModule.transactionCleared(address(safe), txId));
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), 0);
-        // No-hold path: limit is NOT charged
-        assertEq(cashModule.rawSpendable(address(safe)), rawBefore);
+        // No-hold path now charges the limit for the settled amount
+        assertEq(cashModule.rawSpendable(address(safe)), rawBefore - amount);
     }
 
     function test_integration_incrementalAuth() public {

--- a/test/safe/modules/cash/PendingHoldsModuleTest.t.sol
+++ b/test/safe/modules/cash/PendingHoldsModuleTest.t.sol
@@ -49,9 +49,9 @@ contract PendingHoldsTestSetup is CashModuleTestSetup {
     // Helpers
     // -------------------------------------------------------------------------
 
-    function _addHold(bytes4 providerCode, bytes32 _txId, uint256 amountUsd) internal {
+    function _addHold(BinSponsor binSponsor, bytes32 _txId, uint256 amountUsd) internal {
         vm.prank(etherFiWallet);
-        pendingHoldsModule.addHold(address(safe), providerCode, _txId, amountUsd);
+        pendingHoldsModule.addHold(address(safe), binSponsor, _txId, amountUsd);
     }
 
     function _spendWithHold(bytes32 _txId, BinSponsor binSponsor, uint256 amountUsd) internal {
@@ -127,7 +127,7 @@ contract PendingHoldsModuleUnitTest is PendingHoldsTestSetup {
         vm.prank(etherFiWallet);
         vm.expectEmit(true, true, true, true);
         emit IPendingHoldsModule.HoldAdded(address(safe), PROVIDER_REAP, txId, amount, block.timestamp, false);
-        pendingHoldsModule.addHold(address(safe), PROVIDER_REAP, txId, amount);
+        pendingHoldsModule.addHold(address(safe), BinSponsor.Reap, txId, amount);
 
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), amount);
 
@@ -140,17 +140,17 @@ contract PendingHoldsModuleUnitTest is PendingHoldsTestSetup {
 
     function test_addHold_revertsOnDuplicate() public {
         uint256 amount = 100e6;
-        _addHold(PROVIDER_REAP, txId, amount);
+        _addHold(BinSponsor.Reap, txId, amount);
 
         vm.prank(etherFiWallet);
         vm.expectRevert(IPendingHoldsModule.DuplicateHold.selector);
-        pendingHoldsModule.addHold(address(safe), PROVIDER_REAP, txId, amount);
+        pendingHoldsModule.addHold(address(safe), BinSponsor.Reap, txId, amount);
     }
 
     function test_addHold_revertsOnZeroAmount() public {
         vm.prank(etherFiWallet);
         vm.expectRevert(IPendingHoldsModule.InvalidAmount.selector);
-        pendingHoldsModule.addHold(address(safe), PROVIDER_REAP, txId, 0);
+        pendingHoldsModule.addHold(address(safe), BinSponsor.Reap, txId, 0);
     }
 
     function test_addHold_revertsWhenExceedsDailyLimit() public {
@@ -159,22 +159,22 @@ contract PendingHoldsModuleUnitTest is PendingHoldsTestSetup {
 
         vm.prank(etherFiWallet);
         vm.expectRevert(SpendingLimitLib.ExceededDailySpendingLimit.selector);
-        pendingHoldsModule.addHold(address(safe), PROVIDER_REAP, txId, exceedingAmount);
+        pendingHoldsModule.addHold(address(safe), BinSponsor.Reap, txId, exceedingAmount);
     }
 
     function test_addHold_revertsWhenNotEtherFiWallet() public {
         vm.prank(address(0xdead));
         vm.expectRevert();
-        pendingHoldsModule.addHold(address(safe), PROVIDER_REAP, txId, 100e6);
+        pendingHoldsModule.addHold(address(safe), BinSponsor.Reap, txId, 100e6);
     }
 
     function test_addHold_providerCodeNamespacing_noCollisionBetweenProviders() public {
         uint256 amount = 100e6;
-        _addHold(PROVIDER_REAP, txId, amount);
+        _addHold(BinSponsor.Reap, txId, amount);
 
         // Same txId, different providerCode — should succeed (separate namespace)
         vm.prank(etherFiWallet);
-        pendingHoldsModule.addHold(address(safe), PROVIDER_RAIN, txId, amount);
+        pendingHoldsModule.addHold(address(safe), BinSponsor.Rain, txId, amount);
 
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), amount * 2);
     }
@@ -189,7 +189,7 @@ contract PendingHoldsModuleUnitTest is PendingHoldsTestSetup {
         vm.prank(etherFiWallet);
         vm.expectEmit(true, true, true, true);
         emit IPendingHoldsModule.HoldAdded(address(safe), PROVIDER_REAP, txId, exceedingAmount, block.timestamp, true);
-        pendingHoldsModule.forceAddHold(address(safe), PROVIDER_REAP, txId, exceedingAmount);
+        pendingHoldsModule.forceAddHold(address(safe), BinSponsor.Reap, txId, exceedingAmount);
 
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), exceedingAmount);
 
@@ -198,11 +198,11 @@ contract PendingHoldsModuleUnitTest is PendingHoldsTestSetup {
     }
 
     function test_forceAddHold_revertsOnDuplicate() public {
-        _addHold(PROVIDER_REAP, txId, 100e6);
+        _addHold(BinSponsor.Reap, txId, 100e6);
 
         vm.prank(etherFiWallet);
         vm.expectRevert(IPendingHoldsModule.DuplicateHold.selector);
-        pendingHoldsModule.forceAddHold(address(safe), PROVIDER_REAP, txId, 100e6);
+        pendingHoldsModule.forceAddHold(address(safe), BinSponsor.Reap, txId, 100e6);
     }
 
     // -------------------------------------------------------------------------
@@ -213,13 +213,13 @@ contract PendingHoldsModuleUnitTest is PendingHoldsTestSetup {
         uint256 initial = 100e6;
         uint256 increased = 200e6;
 
-        _addHold(PROVIDER_REAP, txId, initial);
+        _addHold(BinSponsor.Reap, txId, initial);
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), initial);
 
         vm.prank(etherFiWallet);
         vm.expectEmit(true, true, true, true);
         emit IPendingHoldsModule.HoldUpdated(address(safe), PROVIDER_REAP, txId, initial, increased, block.timestamp);
-        pendingHoldsModule.updateHold(address(safe), PROVIDER_REAP, txId, increased);
+        pendingHoldsModule.updateHold(address(safe), BinSponsor.Reap, txId, increased);
 
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), increased);
         assertEq(pendingHoldsModule.getHold(address(safe), PROVIDER_REAP, txId).amountUsd, increased);
@@ -229,10 +229,10 @@ contract PendingHoldsModuleUnitTest is PendingHoldsTestSetup {
         uint256 initial = 200e6;
         uint256 decreased = 100e6;
 
-        _addHold(PROVIDER_REAP, txId, initial);
+        _addHold(BinSponsor.Reap, txId, initial);
 
         vm.prank(etherFiWallet);
-        pendingHoldsModule.updateHold(address(safe), PROVIDER_REAP, txId, decreased);
+        pendingHoldsModule.updateHold(address(safe), BinSponsor.Reap, txId, decreased);
 
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), decreased);
         assertEq(pendingHoldsModule.getHold(address(safe), PROVIDER_REAP, txId).amountUsd, decreased);
@@ -243,17 +243,17 @@ contract PendingHoldsModuleUnitTest is PendingHoldsTestSetup {
         // After addHold(9_900), spentToday=9_900, remaining=100. Delta of 101 breaches limit.
         uint256 exceedingIncrease = 10_001e6;
 
-        _addHold(PROVIDER_REAP, txId, initial);
+        _addHold(BinSponsor.Reap, txId, initial);
 
         vm.prank(etherFiWallet);
         vm.expectRevert(SpendingLimitLib.ExceededDailySpendingLimit.selector);
-        pendingHoldsModule.updateHold(address(safe), PROVIDER_REAP, txId, exceedingIncrease);
+        pendingHoldsModule.updateHold(address(safe), BinSponsor.Reap, txId, exceedingIncrease);
     }
 
     function test_updateHold_revertsOnHoldNotFound() public {
         vm.prank(etherFiWallet);
         vm.expectRevert(IPendingHoldsModule.HoldNotFound.selector);
-        pendingHoldsModule.updateHold(address(safe), PROVIDER_REAP, txId, 100e6);
+        pendingHoldsModule.updateHold(address(safe), BinSponsor.Reap, txId, 100e6);
     }
 
     // -------------------------------------------------------------------------
@@ -262,12 +262,12 @@ contract PendingHoldsModuleUnitTest is PendingHoldsTestSetup {
 
     function test_releaseHold_reversal_decrementsAndDeletes() public {
         uint256 amount = 100e6;
-        _addHold(PROVIDER_REAP, txId, amount);
+        _addHold(BinSponsor.Reap, txId, amount);
 
         vm.prank(etherFiWallet);
         vm.expectEmit(true, true, true, true);
         emit IPendingHoldsModule.HoldReleased(address(safe), PROVIDER_REAP, txId, amount, ReleaseReason.REVERSAL, block.timestamp);
-        pendingHoldsModule.releaseHold(address(safe), PROVIDER_REAP, txId, ReleaseReason.REVERSAL);
+        pendingHoldsModule.releaseHold(address(safe), BinSponsor.Reap, txId, ReleaseReason.REVERSAL);
 
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), 0);
         assertEq(pendingHoldsModule.getHold(address(safe), PROVIDER_REAP, txId).createdAt, 0);
@@ -275,12 +275,12 @@ contract PendingHoldsModuleUnitTest is PendingHoldsTestSetup {
 
     function test_releaseHold_admin_works() public {
         uint256 amount = 100e6;
-        _addHold(PROVIDER_REAP, txId, amount);
+        _addHold(BinSponsor.Reap, txId, amount);
 
         vm.prank(etherFiWallet);
         vm.expectEmit(true, true, true, true);
         emit IPendingHoldsModule.HoldReleased(address(safe), PROVIDER_REAP, txId, amount, ReleaseReason.ADMIN, block.timestamp);
-        pendingHoldsModule.releaseHold(address(safe), PROVIDER_REAP, txId, ReleaseReason.ADMIN);
+        pendingHoldsModule.releaseHold(address(safe), BinSponsor.Reap, txId, ReleaseReason.ADMIN);
 
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), 0);
     }
@@ -288,7 +288,7 @@ contract PendingHoldsModuleUnitTest is PendingHoldsTestSetup {
     function test_releaseHold_revertsOnHoldNotFound() public {
         vm.prank(etherFiWallet);
         vm.expectRevert(IPendingHoldsModule.HoldNotFound.selector);
-        pendingHoldsModule.releaseHold(address(safe), PROVIDER_REAP, txId, ReleaseReason.REVERSAL);
+        pendingHoldsModule.releaseHold(address(safe), BinSponsor.Reap, txId, ReleaseReason.REVERSAL);
     }
 
     // -------------------------------------------------------------------------
@@ -296,7 +296,7 @@ contract PendingHoldsModuleUnitTest is PendingHoldsTestSetup {
     // -------------------------------------------------------------------------
 
     function test_removeHold_revertsWhenCalledByNonCore() public {
-        _addHold(PROVIDER_REAP, txId, 100e6);
+        _addHold(BinSponsor.Reap, txId, 100e6);
 
         vm.prank(etherFiWallet);
         vm.expectRevert(IPendingHoldsModule.OnlyCashModuleCore.selector);
@@ -306,7 +306,7 @@ contract PendingHoldsModuleUnitTest is PendingHoldsTestSetup {
     function test_removeHold_succeedsWhenModulePaused() public {
         // removeHold must not be blocked by pause — pausing PHM should halt new hold creation
         // but must not freeze in-flight settlements that CashModuleCore drives via spend().
-        _addHold(PROVIDER_REAP, txId, 100e6);
+        _addHold(BinSponsor.Reap, txId, 100e6);
 
         vm.prank(pauser);
         PendingHoldsModule(address(pendingHoldsModule)).pause();
@@ -326,18 +326,18 @@ contract PendingHoldsModuleUnitTest is PendingHoldsTestSetup {
         uint256 amount = 200e6;
         bytes32 txId2 = keccak256("txId2");
 
-        _addHold(PROVIDER_REAP, txId, amount);
-        _addHold(PROVIDER_RAIN, txId2, amount);
+        _addHold(BinSponsor.Reap, txId, amount);
+        _addHold(BinSponsor.Rain, txId2, amount);
         // totalHolds = 400e6
 
         // Release txId2 via releaseHold — totalHolds drops to 200e6
         vm.prank(etherFiWallet);
-        pendingHoldsModule.releaseHold(address(safe), PROVIDER_RAIN, txId2, ReleaseReason.ADMIN);
+        pendingHoldsModule.releaseHold(address(safe), BinSponsor.Rain, txId2, ReleaseReason.ADMIN);
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), amount);
 
         // Decreasing update on txId (200e6 → 50e6) — floor kicks in if drift exists; normal path here
         vm.prank(etherFiWallet);
-        pendingHoldsModule.updateHold(address(safe), PROVIDER_REAP, txId, 50e6);
+        pendingHoldsModule.updateHold(address(safe), BinSponsor.Reap, txId, 50e6);
 
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), 50e6);
         assertEq(pendingHoldsModule.getHold(address(safe), PROVIDER_REAP, txId).amountUsd, 50e6);
@@ -397,7 +397,7 @@ contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
         uint256 amount = 100e6;
         deal(address(usdc), address(safe), amount);
 
-        _addHold(PROVIDER_REAP, txId, amount);
+        _addHold(BinSponsor.Reap, txId, amount);
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), amount);
 
         vm.expectEmit(true, true, true, true);
@@ -441,7 +441,7 @@ contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
         deal(address(usdc), address(safe), holdAmount);
         uint256 rawBefore = cashModule.rawSpendable(address(safe));
 
-        _addHold(PROVIDER_REAP, txId, holdAmount);
+        _addHold(BinSponsor.Reap, txId, holdAmount);
         // addHold consumed $150 from limit
         assertEq(cashModule.rawSpendable(address(safe)), rawBefore - holdAmount);
 
@@ -461,7 +461,7 @@ contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
         deal(address(usdc), address(safe), settleAmount);
         uint256 rawBefore = cashModule.rawSpendable(address(safe));
 
-        _addHold(PROVIDER_REAP, txId, holdAmount);
+        _addHold(BinSponsor.Reap, txId, holdAmount);
         assertEq(cashModule.rawSpendable(address(safe)), rawBefore - holdAmount);
 
         _spendWithHold(txId, BinSponsor.Reap, settleAmount);
@@ -481,7 +481,7 @@ contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
 
         // Force-add: no limit consumption
         vm.prank(etherFiWallet);
-        pendingHoldsModule.forceAddHold(address(safe), PROVIDER_REAP, txId, amount);
+        pendingHoldsModule.forceAddHold(address(safe), BinSponsor.Reap, txId, amount);
         assertEq(cashModule.rawSpendable(address(safe)), rawBefore); // limit unchanged
 
         // Normal spend() clears the forced hold and NOW charges the limit
@@ -499,7 +499,7 @@ contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
     function test_requestWithdrawal_blockedWhenHoldsExist() public {
         uint256 amount = 100e6;
         deal(address(usdc), address(safe), amount);
-        _addHold(PROVIDER_REAP, txId, amount);
+        _addHold(BinSponsor.Reap, txId, amount);
 
         address[] memory tokens = new address[](1);
         tokens[0] = address(usdc);
@@ -529,11 +529,11 @@ contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
     function test_requestWithdrawal_allowedAfterHoldReleased() public {
         uint256 amount = 100e6;
         deal(address(usdc), address(safe), amount);
-        _addHold(PROVIDER_REAP, txId, amount);
+        _addHold(BinSponsor.Reap, txId, amount);
 
         // Release hold first
         vm.prank(etherFiWallet);
-        pendingHoldsModule.releaseHold(address(safe), PROVIDER_REAP, txId, ReleaseReason.REVERSAL);
+        pendingHoldsModule.releaseHold(address(safe), BinSponsor.Reap, txId, ReleaseReason.REVERSAL);
 
         // Now withdrawal should succeed
         address[] memory tokens = new address[](1);
@@ -595,7 +595,7 @@ contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
         uint256 spendAmount = 50e6;
         deal(address(usdc), address(safe), holdAmount + spendAmount);
 
-        _addHold(PROVIDER_REAP, txId, holdAmount);
+        _addHold(BinSponsor.Reap, txId, holdAmount);
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), holdAmount);
 
         // spend() on a different txId (no-hold path) — creates and immediately removes a forced hold
@@ -618,7 +618,7 @@ contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
 
         // Force-capture: place a hold without a balance check (no limit consumption)
         vm.prank(etherFiWallet);
-        pendingHoldsModule.forceAddHold(address(safe), PROVIDER_REAP, txId, amount);
+        pendingHoldsModule.forceAddHold(address(safe), BinSponsor.Reap, txId, amount);
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), amount);
         assertEq(cashModule.rawSpendable(address(safe)), rawBefore); // limit unchanged
 
@@ -640,11 +640,11 @@ contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
         deal(address(usdc), address(safe), amount);
 
         uint256 rawBefore = cashModule.rawSpendable(address(safe));
-        _addHold(PROVIDER_REAP, txId, amount);
+        _addHold(BinSponsor.Reap, txId, amount);
 
         // Admin releases the hold (e.g. force-capture recovery where hold is stale)
         vm.prank(etherFiWallet);
-        pendingHoldsModule.releaseHold(address(safe), PROVIDER_REAP, txId, ReleaseReason.ADMIN);
+        pendingHoldsModule.releaseHold(address(safe), BinSponsor.Reap, txId, ReleaseReason.ADMIN);
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), 0);
         // releaseHold credits back the limit
         assertEq(cashModule.rawSpendable(address(safe)), rawBefore);
@@ -667,7 +667,7 @@ contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
         deal(address(usdc), address(safe), amount);
 
         // 1. Auth acknowledged: add hold
-        _addHold(PROVIDER_REAP, txId, amount);
+        _addHold(BinSponsor.Reap, txId, amount);
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), amount);
 
         // 2. Settlement: spend removes hold
@@ -683,12 +683,12 @@ contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
         deal(address(usdc), address(safe), amount);
 
         uint256 rawBefore = cashModule.rawSpendable(address(safe));
-        _addHold(PROVIDER_REAP, txId, amount);
+        _addHold(BinSponsor.Reap, txId, amount);
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), amount);
 
         // Network reversal — hold released, limit credited back
         vm.prank(etherFiWallet);
-        pendingHoldsModule.releaseHold(address(safe), PROVIDER_REAP, txId, ReleaseReason.REVERSAL);
+        pendingHoldsModule.releaseHold(address(safe), BinSponsor.Reap, txId, ReleaseReason.REVERSAL);
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), 0);
         assertEq(cashModule.rawSpendable(address(safe)), rawBefore); // limit restored
 
@@ -708,17 +708,17 @@ contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
         uint256 increased = 150e6;
         uint256 decreased = 120e6;
 
-        _addHold(PROVIDER_REAP, txId, initial);
+        _addHold(BinSponsor.Reap, txId, initial);
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), initial);
 
         // Incremental auth: amount goes up
         vm.prank(etherFiWallet);
-        pendingHoldsModule.updateHold(address(safe), PROVIDER_REAP, txId, increased);
+        pendingHoldsModule.updateHold(address(safe), BinSponsor.Reap, txId, increased);
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), increased);
 
         // Incremental auth: amount goes down
         vm.prank(etherFiWallet);
-        pendingHoldsModule.updateHold(address(safe), PROVIDER_REAP, txId, decreased);
+        pendingHoldsModule.updateHold(address(safe), BinSponsor.Reap, txId, decreased);
         assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), decreased);
     }
 
@@ -730,7 +730,7 @@ contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
         uint256[] memory amounts = new uint256[](1);
         amounts[0] = amount;
 
-        _addHold(PROVIDER_REAP, txId, amount);
+        _addHold(BinSponsor.Reap, txId, amount);
 
         // Pre-compute nonce BEFORE vm.expectRevert — safe.nonce() is an external call that would
         // otherwise consume the expectRevert before requestWithdrawal is reached.
@@ -740,7 +740,7 @@ contract PendingHoldsIntegrationTest is PendingHoldsTestSetup {
 
         // Release hold
         vm.prank(etherFiWallet);
-        pendingHoldsModule.releaseHold(address(safe), PROVIDER_REAP, txId, ReleaseReason.REVERSAL);
+        pendingHoldsModule.releaseHold(address(safe), BinSponsor.Reap, txId, ReleaseReason.REVERSAL);
 
         // Withdrawal now allowed — use _requestWithdrawal helper which also checks the emitted event
         _requestWithdrawal(tokens, amounts, withdrawRecipient);
@@ -760,7 +760,7 @@ contract PendingHoldsLensTest is PendingHoldsTestSetup {
 
     function test_spendable_withHolds_reflectsLimitConsumption() public {
         uint256 holdAmount = 100e6;
-        _addHold(PROVIDER_REAP, txId, holdAmount);
+        _addHold(BinSponsor.Reap, txId, holdAmount);
 
         // addHold consumes from spentToday; rawSpendable already reflects the hold.
         // spendable() == rawSpendable() — no separate deduction.
@@ -785,7 +785,7 @@ contract PendingHoldsLensTest is PendingHoldsTestSetup {
 
     function test_canSpend_holdsMakeItExceed_returnsFalse() public {
         // Fill most of the capacity with a hold so the next auth cannot fit
-        _addHold(PROVIDER_REAP, txId, 9_900e6);
+        _addHold(BinSponsor.Reap, txId, 9_900e6);
 
         // 200 USD would push total (holds + amount) past the 10_000 USD daily limit
         uint256 amountUsd = 200e6;
@@ -803,7 +803,7 @@ contract PendingHoldsLensTest is PendingHoldsTestSetup {
 
     function test_canSpend_holdsReduceCapacity_butAmountStillFits() public {
         uint256 existingHold = 500e6;
-        _addHold(PROVIDER_REAP, txId, existingHold);
+        _addHold(BinSponsor.Reap, txId, existingHold);
 
         // 300 USD fits within the remaining 9_500 USD capacity
         uint256 amountUsd = 300e6;
@@ -821,7 +821,7 @@ contract PendingHoldsLensTest is PendingHoldsTestSetup {
 
     function test_holdsSummary_returnsConsistentValues() public {
         uint256 holdAmount = 250e6;
-        _addHold(PROVIDER_REAP, txId, holdAmount);
+        _addHold(BinSponsor.Reap, txId, holdAmount);
 
         (uint256 totalHolds, uint256 spendableAmt, uint256 rawSpendableAmt) = cashLens.holdsSummary(address(safe));
 

--- a/test/upgrade-bytecode-verification/VerifyOPMainnet.t.sol
+++ b/test/upgrade-bytecode-verification/VerifyOPMainnet.t.sol
@@ -193,7 +193,7 @@ contract VerifyOPMainnetBytecode is ContractCodeChecker, Utils {
     }
 
     function test_verifyBytecode_CashLens() public {
-        address local = address(new CashLens(cashModuleProxy, dataProviderProxy));
+        address local = address(new CashLens(cashModuleProxy, dataProviderProxy, address(0)));
         _verify("CashLens", cashLensImpl, local);
     }
 


### PR DESCRIPTION
## What this is

Review fixes for #120 (on-chain pending holds + unified `spend()` settlement), from a multi-lens review (credit-card systems, Solidity audit, math/invariants, accounting, adversarial). Targets the PR branch so the diff is reviewable on top of #120.

Every fix was proven **RED → GREEN**: a failing test first demonstrates the bug, then the fix makes it pass. No regressions across the PHM, Spend, MultiSpend, and Repay suites (OP fork).

## Fixed

| ID | Sev | Issue | Fix |
|----|-----|-------|-----|
| F0 | Blocker | Suite didn't compile — two `CashLens` call sites missing the new 3rd ctor arg | added arg in `Setup.s.sol`, `VerifyOPMainnet.t.sol` |
| **Size** | **Critical** | **`CashModuleSetters` = 24,974 B > EIP-170 24,576 — undeployable on OP.** The PR moved `repay`+PHM helpers into Setters to protect Core's ceiling but blew Setters' own. No size test existed for Setters. | New `CashModuleSettersExt` reached via a second fallback hop (Core→Setters→Ext). Moved `repay` + new `collectRemaining` there. All three now fit (Core 24,388 / Setters 23,520 / Ext 9,014). **Added size gates for Setters + Ext.** |
| C2 | Critical | No-hold "Settlement is KING" path moved funds while charging the spending limit **$0** (limit bypass) | no-hold settlement now charges the full settled amount, like the `forceAddHold` path |
| C1 | Critical | Under-funded settlement parked the leftover in a hold that **could never be collected** (no clearance fn; `txId` single-use) and froze withdrawals | new ops-only `collectRemaining(safe, txId, binSponsor, token)` sweeps the leftover from the funded safe, clears the hold, no limit double-charge |
| H1 | High | `addHold` took a raw `bytes4` providerCode while settlement derived it from `BinSponsor` — a mismatch orphaned the hold + double-charged | hold-write fns (`addHold`/`forceAddHold`/`updateHold`/`releaseHold`) now take `BinSponsor`; code derived on-chain so auth/settlement keys always match (**ABI change — backend must update**) |
| M1 | Medium | Pending-holds withdrawal block enforced only at request, bypassable via the delay window | re-check `totalPendingHolds` in `_processWithdrawal` |
| L2 | Info | Stale `spendable = rawSpendable − totalHolds` doc (contradicted the code) | corrected in PHM + interface |

## Deferred to follow-up tickets

M2 (cross-day `release()` headroom loss), M3 (`totalHolds` floors mask drift), M5 (`forceAddHold` rogue-wallet freeze), M6 (`HoldUpdated` missing `forced` flag), L5 (pre-existing `_cashback` infinite-loop on `address(0)`). These are tradeoffs / pre-existing / event-schema changes better handled separately.

## Note for the backend team

H1 changes the PHM ABI: `addHold`/`forceAddHold`/`updateHold`/`releaseHold` now take `BinSponsor` instead of `bytes4 providerCode`. Update the EtherFi wallet caller accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core card settlement, spending limits, withdrawal guards, and a new delegatecall routing path; Gnosis must wire SettersExt before repay/collectRemaining, and the backend must adopt the PHM BinSponsor ABI.
> 
> **Overview**
> This PR layers **review fixes on top of pending-holds / unified `spend()`** work: it tightens settlement accounting, closes an undeployable bytecode gap, and aligns ops tooling with the new module layout.
> 
> **`CashModuleSettersExt`** is introduced as a **second delegatecall fallback hop** (Core → Setters → Ext) so **`repay`** and the new **`collectRemaining`** live outside Core/Setters while staying under the **EIP-170 24KB** cap. Storage gains **`cashModuleSettersExt`**; **`setCashModuleSettersExt` / `getCashModuleSettersExt`** are on the interface and wired in tests and the **Gnosis upgrade batch** (must run before `repay` / `collectRemaining`). **`repay`** is removed from **`CashModuleSetters`**.
> 
> **Settlement / limits:** **`_phmSettleHold`** now **charges the full settlement** when there was **no prior hold** or a **forced** hold (fixing a no-hold “Settlement is KING” **limit bypass**). **`collectRemaining`** lets ops sweep **under-funded debit** remainders after `transactionCleared`, without a second limit charge.
> 
> **Pending holds API:** wallet-facing **`addHold` / `forceAddHold` / `updateHold` / `releaseHold`** take **`BinSponsor`** (provider code derived on-chain). **`remainingHold`** supports collection. Docs drop the old **`rawSpendable − totalPendingHolds`** invariant.
> 
> **Withdrawals:** **`_processWithdrawal`** re-checks **`totalPendingHolds`** at finalize (not only at request).
> 
> **Deploy / verify:** **`CashLens`** ctor gets a third arg (`address(0)` in setup/bytecode verify). Tests add **RED→GREEN** finding tests and **bytecode size gates** for Setters and Ext.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 997d4ca0e4b6de388aaac1855f1c7439f7a39ca5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->