### PR TITLE
refactor(cash): Tier 1 structural simplifications (reconcileLimit, checked totalHolds, dispatcher dedup)

### DIFF
--- a/src/interfaces/IPendingHoldsModule.sol
+++ b/src/interfaces/IPendingHoldsModule.sol
@@ -155,6 +155,11 @@ interface IPendingHoldsModule {
     /// @notice Thrown when address(0) is passed as cashModuleCore
     error ZeroCashModuleCore();
 
+    /// @notice Thrown when a per-hold amount exceeds the running totalHolds sum — i.e. totalHolds has
+    ///         drifted from the sum of individual holds (an invariant break). Surfaced loudly rather
+    ///         than silently floored, because totalHolds drives the withdrawal guard.
+    error TotalHoldsUnderflow();
+
     // -------------------------------------------------------------------------
     // Write functions — EtherFi wallet (backend) only
     // -------------------------------------------------------------------------

--- a/src/libraries/SpendingLimitLib.sol
+++ b/src/libraries/SpendingLimitLib.sol
@@ -123,8 +123,31 @@ library SpendingLimitLib {
      */
     function release(SpendingLimit storage limit, uint256 amount) internal {
         currentLimit(limit);
-        limit.spentToday = amount <= limit.spentToday ? limit.spentToday - amount : 0;
-        limit.spentThisMonth = amount <= limit.spentThisMonth ? limit.spentThisMonth - amount : 0;
+        // Floor at 0 is legitimate here: currentLimit() may have reset the counters at a day/month
+        // rollover, after which crediting back a stale charge underflows by design.
+        limit.spentToday = _subFloor(limit.spentToday, amount);
+        limit.spentThisMonth = _subFloor(limit.spentThisMonth, amount);
+    }
+
+    /**
+     * @notice Reconciles the limit when the charged amount for an obligation changes from
+     *         oldCharged to newOwed (e.g. settlement amount differs from the authorized hold).
+     * @dev Single primitive for "the limit currently reflects oldCharged; make it reflect newOwed."
+     *      Charges the positive delta (subject to limit checks) or releases the negative delta.
+     *      Pass oldCharged = 0 to charge the full newOwed (forced / no-prior-hold settlement).
+     * @param limit Storage reference to the SpendingLimit
+     * @param oldCharged Amount already reflected in the limit for this obligation (USD 1e6)
+     * @param newOwed Amount that should now be reflected (USD 1e6)
+     */
+    function reconcileLimit(SpendingLimit storage limit, uint256 oldCharged, uint256 newOwed) internal {
+        if (newOwed > oldCharged) spend(limit, newOwed - oldCharged);
+        else if (newOwed < oldCharged) release(limit, oldCharged - newOwed);
+    }
+
+    /// @dev Saturating subtraction: max(a - b, 0). Use only where underflow is an expected,
+    ///      documented consequence (e.g. day/month limit rollover), never to mask an invariant break.
+    function _subFloor(uint256 a, uint256 b) private pure returns (uint256) {
+        unchecked { return a >= b ? a - b : 0; }
     }
 
     /**

--- a/src/modules/cash/CashModuleCore.sol
+++ b/src/modules/cash/CashModuleCore.sol
@@ -439,20 +439,12 @@ contract CashModuleCore is CashModuleStorageContract {
         }
         (bool existed, bool wasForced, uint256 oldAmount) =
             IPendingHoldsModule(phm).settlementSyncHold(safe, binSponsor, txId, amount);
-        if (!existed || wasForced) {
-            // No prior hold ("Settlement is KING", created as a forced hold inside settlementSyncHold)
-            // OR a forceAddHold hold: in both cases the spending limit was bypassed at creation, so
-            // charge the full settlement amount now. The limit is the primary risk control and must
-            // reflect funds leaving the safe even when settlement arrives without a matching auth hold.
-            $.safeCashConfig[safe].spendingLimit.spend(amount);
-        } else {
-            // Non-forced hold: limit was pre-charged at addHold for oldAmount; adjust for the delta.
-            if (amount > oldAmount) {
-                $.safeCashConfig[safe].spendingLimit.spend(amount - oldAmount);
-            } else if (amount < oldAmount) {
-                $.safeCashConfig[safe].spendingLimit.release(oldAmount - amount);
-            }
-        }
+        // The limit already reflects `oldCharged` for this obligation; make it reflect `amount`.
+        //   - non-forced hold: limit was pre-charged at addHold for oldAmount → reconcile the delta.
+        //   - forced hold / no prior hold ("Settlement is KING"): limit was bypassed at creation
+        //     (oldCharged = 0) → reconcileLimit charges the full settlement amount now.
+        uint256 oldCharged = (existed && !wasForced) ? oldAmount : 0;
+        $.safeCashConfig[safe].spendingLimit.reconcileLimit(oldCharged, amount);
     }
 
     /**

--- a/src/modules/cash/CashModuleSettersExt.sol
+++ b/src/modules/cash/CashModuleSettersExt.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.28;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-import { Mode, BinSponsor } from "../../interfaces/ICashModule.sol";
+import { ICashModule, Mode, BinSponsor } from "../../interfaces/ICashModule.sol";
 import { IDebtManager } from "../../interfaces/IDebtManager.sol";
 import { IEtherFiSafe } from "../../interfaces/IEtherFiSafe.sol";
 import { IPendingHoldsModule } from "../../interfaces/IPendingHoldsModule.sol";
@@ -152,10 +152,14 @@ contract CashModuleSettersExt is CashModuleStorageContract {
         uint256 payToken,
         uint256 paidUsd
     ) private {
+        // Single source of truth for the dispatcher mapping: CashModuleCore.getSettlementDispatcher.
+        // Ext runs in Core's storage via delegatecall, so address(this) is the Core proxy.
+        address dispatcher = ICashModule(address(this)).getSettlementDispatcher(binSponsor);
+
         address[] memory to = new address[](1);
         bytes[] memory data = new bytes[](1);
         to[0] = token;
-        data[0] = abi.encodeWithSelector(IERC20.transfer.selector, _settlementDispatcherFor($, binSponsor), payToken);
+        data[0] = abi.encodeWithSelector(IERC20.transfer.selector, dispatcher, payToken);
         IEtherFiSafe(safe).execTransactionFromModule(to, new uint256[](1), data);
 
         uint256[] memory tokenAmounts = new uint256[](1);
@@ -163,14 +167,5 @@ contract CashModuleSettersExt is CashModuleStorageContract {
         tokenAmounts[0] = payToken;
         usdAmounts[0] = paidUsd;
         $.cashEventEmitter.emitSpend(safe, txId, binSponsor, to, tokenAmounts, usdAmounts, paidUsd, Mode.Debit);
-    }
-
-    /// @dev Resolves the settlement dispatcher for a bin sponsor (mirrors CashModuleCore.getSettlementDispatcher).
-    function _settlementDispatcherFor(CashModuleStorage storage $, BinSponsor binSponsor) private view returns (address dispatcher) {
-        if (binSponsor == BinSponsor.Rain) dispatcher = $.settlementDispatcherRain;
-        else if (binSponsor == BinSponsor.PIX) dispatcher = $.settlementDispatcherPix;
-        else if (binSponsor == BinSponsor.CardOrder) dispatcher = $.settlementDispatcherCardOrder;
-        else dispatcher = $.settlementDispatcherReap;
-        if (dispatcher == address(0)) revert SettlementDispatcherNotSetForBinSponsor();
     }
 }

--- a/src/modules/cash/PendingHoldsModule.sol
+++ b/src/modules/cash/PendingHoldsModule.sol
@@ -136,6 +136,19 @@ contract PendingHoldsModule is UpgradeableProxy, ModuleBase, IPendingHoldsModule
         return keccak256(abi.encode(safe, providerCode, txId));
     }
 
+    /**
+     * @dev Replaces `oldAmount` with `newAmount` in totalHolds[safe] (pass newAmount = 0 to remove).
+     *      Reverts with TotalHoldsUnderflow if oldAmount exceeds the running sum. oldAmount is always
+     *      read from the very HoldRecord being mutated, and every increment paired its stored amount,
+     *      so oldAmount <= totalHolds is an invariant. A silent floor here would corrupt the running
+     *      sum — and thus the withdrawal guard — so we fail loudly instead.
+     */
+    function _replaceTotalHolds(PendingHoldsModuleStorage storage $, address safe, uint256 oldAmount, uint256 newAmount) private {
+        uint256 current = $.totalHolds[safe];
+        if (oldAmount > current) revert TotalHoldsUnderflow();
+        $.totalHolds[safe] = current - oldAmount + newAmount;
+    }
+
     // -------------------------------------------------------------------------
     // Write functions — EtherFi wallet only
     // -------------------------------------------------------------------------
@@ -216,22 +229,16 @@ contract PendingHoldsModule is UpgradeableProxy, ModuleBase, IPendingHoldsModule
 
         uint256 oldAmountUsd = record.amountUsd;
 
-        if (newAmountUsd > oldAmountUsd) {
-            // Increasing hold — consume delta from the spending limit immediately.
-            // Non-forced holds were originally charged at addHold; charge only the delta.
-            // Forced holds bypassed the limit at creation; charge the full delta now.
-            uint256 delta = newAmountUsd - oldAmountUsd;
-            if (!record.forced) ICashModuleForHolds($.cashModuleCore).consumeSpendingLimit(safe, delta);
-            $.totalHolds[safe] = $.totalHolds[safe] - oldAmountUsd + newAmountUsd;
-        } else {
-            // Decreasing hold — credit delta back to the spending limit for non-forced holds.
-            // Apply the same defensive floor as releaseHold/removeHold to guard against any
-            // totalHolds drift (e.g., caused by a prior forceAddHold + forceSpend sequence).
-            uint256 delta = oldAmountUsd - newAmountUsd;
-            if (!record.forced) ICashModuleForHolds($.cashModuleCore).releaseSpendingLimit(safe, delta);
-            uint256 current = $.totalHolds[safe];
-            $.totalHolds[safe] = (oldAmountUsd <= current ? current - oldAmountUsd : 0) + newAmountUsd;
+        // Adjust the spending limit for non-forced holds (forced holds bypassed it at creation):
+        // charge the delta on an increase, credit it back on a decrease.
+        if (!record.forced) {
+            if (newAmountUsd > oldAmountUsd) {
+                ICashModuleForHolds($.cashModuleCore).consumeSpendingLimit(safe, newAmountUsd - oldAmountUsd);
+            } else if (newAmountUsd < oldAmountUsd) {
+                ICashModuleForHolds($.cashModuleCore).releaseSpendingLimit(safe, oldAmountUsd - newAmountUsd);
+            }
         }
+        _replaceTotalHolds($, safe, oldAmountUsd, newAmountUsd);
 
         record.amountUsd = newAmountUsd;
 
@@ -254,8 +261,7 @@ contract PendingHoldsModule is UpgradeableProxy, ModuleBase, IPendingHoldsModule
 
         uint256 holdAmount = record.amountUsd;
         bool wasForced = record.forced;
-        uint256 current = $.totalHolds[safe];
-        $.totalHolds[safe] = holdAmount <= current ? current - holdAmount : 0;
+        _replaceTotalHolds($, safe, holdAmount, 0);
 
         delete $.holds[key];
 
@@ -291,12 +297,7 @@ contract PendingHoldsModule is UpgradeableProxy, ModuleBase, IPendingHoldsModule
             existed = true;
 
             if (settlementAmount != oldAmount) {
-                if (settlementAmount > oldAmount) {
-                    $.totalHolds[safe] = $.totalHolds[safe] - oldAmount + settlementAmount;
-                } else {
-                    uint256 current = $.totalHolds[safe];
-                    $.totalHolds[safe] = (oldAmount <= current ? current - oldAmount : 0) + settlementAmount;
-                }
+                _replaceTotalHolds($, safe, oldAmount, settlementAmount);
                 record.amountUsd = settlementAmount;
                 emit HoldUpdated(safe, providerCode, txId, oldAmount, settlementAmount, block.timestamp);
             }
@@ -330,8 +331,7 @@ contract PendingHoldsModule is UpgradeableProxy, ModuleBase, IPendingHoldsModule
         if (record.createdAt == 0) revert HoldNotFound();
 
         uint256 oldAmount = record.amountUsd;
-        uint256 current = $.totalHolds[safe];
-        $.totalHolds[safe] = (oldAmount <= current ? current - oldAmount : 0) + remaining;
+        _replaceTotalHolds($, safe, oldAmount, remaining);
         record.amountUsd = remaining;
         // Mark forced so the special-function path does not double-charge the spending limit.
         // The limit was already fully charged for the settlement amount at settlementSyncHold.
@@ -354,8 +354,7 @@ contract PendingHoldsModule is UpgradeableProxy, ModuleBase, IPendingHoldsModule
         if (record.createdAt == 0) revert HoldNotFound();
 
         uint256 holdAmount = record.amountUsd;
-        uint256 current = $.totalHolds[safe];
-        $.totalHolds[safe] = holdAmount <= current ? current - holdAmount : 0;
+        _replaceTotalHolds($, safe, holdAmount, 0);
 
         delete $.holds[key];
 

--- a/test/safe/modules/cash/PendingHoldsFindings.t.sol
+++ b/test/safe/modules/cash/PendingHoldsFindings.t.sol
@@ -89,4 +89,64 @@ contract PendingHoldsFindingsTest is PendingHoldsTestSetup {
         vm.expectRevert(abi.encodeWithSignature("WithdrawalBlockedByPendingHolds()"));
         cashModule.processWithdrawal(address(safe));
     }
+
+    // ---------------------------------------------------------------------
+    // Invariant: totalPendingHolds(safe) == Σ getHold(...).amountUsd, preserved across
+    // every mutation path. Validates the checked _replaceTotalHolds helper (Tier 1 #3).
+    // ---------------------------------------------------------------------
+    bytes32 constant INV_T1 = keccak256("inv-reap");
+    bytes32 constant INV_T2 = keccak256("inv-rain");
+
+    function _sumHolds() internal view returns (uint256) {
+        return pendingHoldsModule.getHold(address(safe), PROVIDER_REAP, INV_T1).amountUsd
+             + pendingHoldsModule.getHold(address(safe), PROVIDER_RAIN, INV_T2).amountUsd;
+    }
+
+    function _assertHoldsInvariant() internal view {
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), _sumHolds(), "totalHolds != sum of holds");
+    }
+
+    function test_invariant_totalHoldsEqualsSumOfHolds_acrossLifecycle() public {
+        deal(address(usdc), address(safe), 1_000e6);
+        _assertHoldsInvariant();                                    // empty
+
+        _addHold(BinSponsor.Reap, INV_T1, 300e6);
+        _assertHoldsInvariant();                                    // 300
+        _addHold(BinSponsor.Rain, INV_T2, 200e6);
+        _assertHoldsInvariant();                                    // 500
+
+        vm.prank(etherFiWallet);
+        pendingHoldsModule.updateHold(address(safe), BinSponsor.Reap, INV_T1, 400e6); // increase
+        _assertHoldsInvariant();                                    // 600
+
+        vm.prank(etherFiWallet);
+        pendingHoldsModule.updateHold(address(safe), BinSponsor.Reap, INV_T1, 150e6); // decrease
+        _assertHoldsInvariant();                                    // 350
+
+        vm.prank(etherFiWallet);
+        pendingHoldsModule.releaseHold(address(safe), BinSponsor.Rain, INV_T2, ReleaseReason.REVERSAL);
+        _assertHoldsInvariant();                                    // 150
+
+        // Full settlement of the remaining hold → totalHolds returns to 0.
+        _spendWithHold(INV_T1, BinSponsor.Reap, 150e6);
+        _assertHoldsInvariant();                                    // 0
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), 0);
+    }
+
+    function test_invariant_totalHoldsConsistent_partialSettleThenCollect() public {
+        // Under-funded settlement leaves a remainder hold; collectRemaining clears it.
+        deal(address(usdc), address(safe), 40e6);
+        _addHold(BinSponsor.Reap, INV_T1, 100e6);
+        _assertHoldsInvariant();                                    // 100
+
+        _spendWithHold(INV_T1, BinSponsor.Reap, 100e6);             // pays 40, 60 remains
+        _assertHoldsInvariant();                                    // 60
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), 60e6);
+
+        deal(address(usdc), address(safe), 60e6);
+        vm.prank(etherFiWallet);
+        cashModule.collectRemaining(address(safe), INV_T1, BinSponsor.Reap, address(usdc));
+        _assertHoldsInvariant();                                    // 0
+        assertEq(pendingHoldsModule.totalPendingHolds(address(safe)), 0);
+    }
 }


### PR DESCRIPTION
## What this is

Tier 1 structural simplifications from the second (hygiene-focused) review of #120, on top of the merged review fixes. **Behavior-preserving** (one intentional exception: a silent floor becomes a loud revert on an invariant break). Targets the feature branch so the diff is reviewable in isolation.

All suites green on the OP fork: PHM + findings + 2 new invariant tests (54), Spend (24), MultiSpend (10), Repay (11), size gates (3). No regressions.

## Changes

### 1. `reconcileLimit()` — one owner for limit-delta math
`SpendingLimitLib.reconcileLimit(limit, oldCharged, newOwed)` charges or releases the delta in one place. `CashModuleCore._phmSettleHold`'s 14-line three-way branch (no-hold / forced / non-forced ↑↓) collapses to:
```solidity
uint256 oldCharged = (existed && !wasForced) ? oldAmount : 0;
$.safeCashConfig[safe].spendingLimit.reconcileLimit(oldCharged, amount);
```
Removes the duplicated charge/release branching the review flagged (5/6 lenses). Net: Core **−44 bytes** (headroom 188 → 232).

### 2. Floor split — silent vs loud
The repeated `(old <= cur ? cur - old : 0)` pattern is split by intent:
- **`SpendingLimitLib._subFloor`** for the limit counters, where a day/month rollover legitimately underflows — keep the silent floor.
- **`PendingHoldsModule._replaceTotalHolds`** for `totalHolds`, where `oldAmount <= total` is an **invariant** (the amount came from the very record being mutated). A silent floor there would corrupt the withdrawal-guard sum, so it now **reverts `TotalHoldsUnderflow`**. Dedups all 5 `totalHolds` mutation sites; PHM **−440 bytes**.

### 3. Single source of truth for the dispatcher mapping
`CashModuleSettersExt` no longer carries a verbatim copy of the BinSponsor→dispatcher resolver; it calls `CashModuleCore.getSettlementDispatcher` (Ext runs in Core's storage via delegatecall). One mapping, not two.

### 4. Invariant tests
`totalPendingHolds(safe) == Σ getHold(...).amountUsd` asserted across add/update↑↓/release/settle, and across the partial-settle → `collectRemaining` path. This is the module's linchpin property and was previously neither stated nor enforced.

## Deferred (needs your sign-off)
- **`HoldKind` enum** (replacing the overloaded `forced` bool) — changes the `HoldRecord`/`getHold` ABI and the `HoldAdded` event, so it needs backend/indexer coordination. Held out of this PR per discussion.
- Event/audit-trail additions (limit-delta event, `RemainingCollected`), naming changes, and the `forceSpend` stale-comment cleanup — separate follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches spending-limit accounting and the withdrawal-blocking totalHolds sum; the intentional TotalHoldsUnderflow revert changes failure mode from silent corruption to loud revert on invariant drift.
> 
> **Overview**
> This PR tightens **cash module hygiene** around spending limits, pending holds, and settlement routing—mostly behavior-preserving except where an invariant break is surfaced as a revert.
> 
> **Spending limits:** `SpendingLimitLib` gains **`reconcileLimit(oldCharged, newOwed)`** so settlement can charge or release the delta in one place. `CashModuleCore._phmSettleHold` replaces its no-hold / forced / non-forced branches with `oldCharged` + `reconcileLimit`. `release()` uses a private **`_subFloor`** only where day/month rollover can legitimately underflow spent counters.
> 
> **Pending holds:** All `totalHolds` updates go through **`_replaceTotalHolds`**, which **reverts `TotalHoldsUnderflow`** if a hold amount exceeds the running sum (replacing silent flooring that could weaken the withdrawal guard). Interface documents the new error.
> 
> **Settlements ext:** `CashModuleSettersExt` drops its duplicate bin-sponsor→dispatcher mapping and calls **`getSettlementDispatcher`** on the Core proxy via delegatecall.
> 
> **Tests:** Two invariant tests assert **`totalPendingHolds == Σ hold amounts`** across add/update/release/settle and partial settle → **`collectRemaining`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 323c8eae0099b5ad105cfb12882b29146fd33500. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->