### PR TITLE
feat(oracle): implement PriceRelay + OracleSink LZ price relay

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -4,6 +4,7 @@ forge-std/=lib/forge-std/src/
 openzeppelin-contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/
 openzeppelin-contracts/=lib/openzeppelin-contracts/
 solady/=lib/solady/src/
+solidity-bytes-utils/=lib/lz-address-book/lib/solidity-bytes-utils/
 lz-address-book/=lib/lz-address-book/src/
 @layerzerolabs/lz-evm-protocol-v2/=lib/lz-address-book/lib/LayerZero-v2/packages/layerzero-v2/evm/protocol/
 @layerzerolabs/lz-evm-messagelib-v2/=lib/lz-address-book/lib/LayerZero-v2/packages/layerzero-v2/evm/messagelib/

--- a/src/interfaces/IOracleSink.sol
+++ b/src/interfaces/IOracleSink.sol
@@ -21,9 +21,15 @@ interface IOracleSink {
 
     /// @notice Emitted when a relayed price update is stored
     event PriceUpdated(address indexed token, uint256 price, uint64 updatedAt);
+    /// @notice Emitted when the per-token max staleness window is configured
+    event MaxStalenessSet(address indexed token, uint64 maxStaleness);
 
     /// @notice Thrown when a token has never received a relayed price
     error PriceNotSet();
+    /// @notice Thrown when the last relayed price for a token is older than its max staleness window
+    error PriceStale();
+    /// @notice Thrown when a zero address is supplied where it is not allowed
+    error InvalidToken();
 
     /**
      * @notice Returns the latest relayed price for `token` in {DECIMALS} precision
@@ -32,6 +38,34 @@ interface IOracleSink {
      * @return updatedAt Timestamp at which the price was received on this chain
      */
     function getPrice(address token) external view returns (uint256 price, uint64 updatedAt);
+
+    /**
+     * @notice Returns the latest relayed price for `token` as a single value, reverting if stale.
+     * @dev Designed for direct consumption by {PriceProvider} via its calldata branch:
+     *      configure `isChainlinkType = false`, `dataType = Uint256`, `oraclePriceDecimals = 6`,
+     *      `oracle = address(thisSink)` and
+     *      `priceFunctionCalldata = abi.encodeWithSelector(IOracleSink.price.selector, token)`.
+     *      Freshness is enforced here against the relay-delivery timestamp, so no per-token
+     *      Chainlink adapter is required. A non-zero {maxStaleness} for the token must be set,
+     *      otherwise no staleness check is applied.
+     * @param token Token to query
+     * @return Normalised USD price (6 decimals)
+     */
+    function price(address token) external view returns (uint256);
+
+    /**
+     * @notice Sets the maximum age (in seconds) of a relayed price before {price} reverts.
+     * @dev Admin-gated. A value of 0 disables the staleness check for the token.
+     * @param token Token to configure
+     * @param maxStaleness Max age in seconds; 0 disables the check
+     */
+    function setMaxStaleness(address token, uint64 maxStaleness) external;
+
+    /**
+     * @notice Returns the configured max staleness window (seconds) for `token` (0 = disabled)
+     * @param token Token to query
+     */
+    function maxStaleness(address token) external view returns (uint64);
 
     /**
      * @notice Chainlink AggregatorV3-style accessor consumed by {PriceProvider}

--- a/src/interfaces/IPriceRelay.sol
+++ b/src/interfaces/IPriceRelay.sol
@@ -8,17 +8,27 @@ pragma solidity ^0.8.28;
  *         destination-chain {IOracleSink}.
  * @dev Reads from the existing mainnet {PriceProvider} (already 6-decimal USD),
  *      then `_lzSend`s a packed update for one or more subscribed tokens.
+ *
+ *      The LayerZero native fee is paid from the relay contract's own balance
+ *      (see {fund}/{withdraw}), so `poke` is permissionless and non-payable:
+ *      anyone can trigger a relay, but a send only actually happens when a
+ *      per-token heartbeat or deviation threshold is crossed. This prevents a
+ *      spammer from draining the contract's balance with redundant pokes.
  */
 interface IPriceRelay {
     /**
      * @notice Per-token relay configuration
-     * @param maxStaleness Reject pokes whose source price is older than this (seconds)
-     * @param deviationBps Reserved for off-chain keepers; recorded so a single source
-     *                    of truth exists for the deviation trigger (basis points, 1 = 0.01%)
+     * @param heartbeat Force a relay if the last send for this token is older than
+     *                  this many seconds (the "max staleness" floor on the source side)
+     * @param deviationBps Relay early if the source price moved at least this many
+     *                     basis points since the last send (1 = 0.01%)
+     * @param maxStaleness Recorded for the destination/off-chain consumers so a single
+     *                     source of truth exists; not enforced on this contract
      */
     struct TokenSubscription {
-        uint32 maxStaleness;
+        uint32 heartbeat;
         uint32 deviationBps;
+        uint32 maxStaleness;
     }
 
     /// @notice Emitted when a token is subscribed for relay
@@ -29,6 +39,12 @@ interface IPriceRelay {
     event DestinationEidSet(uint32 indexed dstEid);
     /// @notice Emitted on a successful poke that pushed `n` token prices
     event PricesRelayed(uint32 indexed dstEid, address[] tokens, uint256[] prices);
+    /// @notice Emitted when the LayerZero execution options are updated
+    event LzOptionsSet(bytes options);
+    /// @notice Emitted when the contract is funded with native currency for fees
+    event Funded(address indexed from, uint256 amount);
+    /// @notice Emitted when native currency is withdrawn from the contract
+    event Withdrawn(address indexed to, uint256 amount);
 
     /// @notice Thrown when an array argument is empty or two arrays have mismatched lengths
     error InvalidInput();
@@ -38,12 +54,18 @@ interface IPriceRelay {
     error StaleSourcePrice();
     /// @notice Thrown when the destination EID has not been configured
     error DestinationNotSet();
+    /// @notice Thrown when no subscribed token in the poke crossed its heartbeat/deviation gate
+    error NothingToRelay();
+    /// @notice Thrown when the contract's balance cannot cover the LayerZero native fee
+    error InsufficientBalance();
+    /// @notice Thrown when a native withdrawal transfer fails
+    error WithdrawFailed();
 
     /**
      * @notice Subscribe `token` for cross-chain price relay
      * @dev Admin-only. Token must already be configured on the mainnet {PriceProvider}.
      * @param token ERC-20 to relay
-     * @param config Subscription parameters (staleness, deviation trigger)
+     * @param config Subscription parameters (heartbeat, deviation trigger, staleness)
      */
     function subscribe(address token, TokenSubscription calldata config) external;
 
@@ -55,20 +77,37 @@ interface IPriceRelay {
 
     /**
      * @notice Permissionless price push for one or more subscribed tokens
-     * @dev Caller funds the LayerZero native fee via `msg.value`. Excess is refunded.
-     * @param tokens Subscribed tokens to relay
-     * @param options Encoded LayerZero execution options (gas/value on the OP side)
+     * @dev The LayerZero fee is paid from this contract's balance. Only tokens whose
+     *      heartbeat elapsed or whose price deviated past the configured threshold are
+     *      actually relayed; if none qualify the call reverts with {NothingToRelay}.
+     * @param tokens Subscribed tokens to consider for relay
      */
-    function poke(address[] calldata tokens, bytes calldata options) external payable;
+    function poke(address[] calldata tokens) external;
 
     /**
-     * @notice Quote the LayerZero native fee for a poke of `tokens`
+     * @notice Quote the LayerZero native fee for relaying `tokens`
+     * @dev Upper bound: quotes as if all provided tokens were relayed.
      * @param tokens Subscribed tokens that would be relayed
-     * @param options Encoded LayerZero execution options
-     * @return nativeFee Native fee that must be supplied as `msg.value`
+     * @return nativeFee Native fee that would be drawn from the contract balance
      * @return lzTokenFee Fee in LZ token (if paying in ZRO; 0 otherwise)
      */
-    function quote(address[] calldata tokens, bytes calldata options) external view returns (uint256 nativeFee, uint256 lzTokenFee);
+    function quote(address[] calldata tokens) external view returns (uint256 nativeFee, uint256 lzTokenFee);
+
+    /**
+     * @notice Sets the LayerZero execution options used for every relay send
+     * @dev Admin-only. Options fix the gas/value delivered to {IOracleSink} on the
+     *      destination chain; stored on-chain so permissionless callers cannot grief.
+     * @param options Encoded LayerZero execution options
+     */
+    function setLzOptions(bytes calldata options) external;
+
+    /**
+     * @notice Withdraw native currency used to fund relay fees
+     * @dev Admin-only.
+     * @param to Recipient
+     * @param amount Amount of native currency to withdraw
+     */
+    function withdraw(address to, uint256 amount) external;
 
     /**
      * @notice Returns the subscription config for `token`
@@ -76,6 +115,20 @@ interface IPriceRelay {
      * @return config Subscription parameters; default-zero struct if unsubscribed
      */
     function subscriptionOf(address token) external view returns (TokenSubscription memory config);
+
+    /**
+     * @notice Returns the last relayed price and timestamp for `token`
+     * @param token Token to query
+     * @return price Last relayed price (6-decimal USD); 0 if never relayed
+     * @return timestamp Block timestamp of the last relay; 0 if never relayed
+     */
+    function lastRelayed(address token) external view returns (uint256 price, uint64 timestamp);
+
+    /**
+     * @notice Returns the LayerZero execution options used for relay sends
+     * @return options The encoded options
+     */
+    function lzOptions() external view returns (bytes memory options);
 
     /**
      * @notice Returns the destination LayerZero endpoint ID (OracleSink chain)

--- a/src/oracle/OracleSink.sol
+++ b/src/oracle/OracleSink.sol
@@ -11,21 +11,26 @@ import { UpgradeableProxy } from "../utils/UpgradeableProxy.sol";
  * @title OracleSink
  * @author ether.fi
  * @notice Destination-chain LayerZero receiver. Stores the latest relayed
- *         per-token USD price (6 decimals) and exposes it via a Chainlink
- *         `latestRoundData(token)` shape so the existing OP-side
- *         {PriceProvider} can consume it with no contract changes —
- *         configure each token with `isChainlinkType = true` and
- *         `oracle = address(thisOracleSink)` (or a per-token Chainlink-shaped
- *         adapter view; see {IOracleSink} for the calldata-shape variant).
- * @dev The relay payload format is intentionally unfixed in this skeleton —
- *      {`_lzReceive`} decodes are left as TODOs. The companion {PriceRelay}
- *      MUST encode/decode against the same schema once chosen.
+ *         per-token USD price (6 decimals) and exposes it to the OP-side
+ *         {PriceProvider} in two ways:
+ *           1. Directly (no adapter) via {price}, read through PriceProvider's
+ *              calldata branch. Freshness is enforced here against the
+ *              relay-delivery timestamp using a per-token {maxStaleness}.
+ *           2. Through a per-token Chainlink-shaped adapter over
+ *              {latestRoundData}, read via PriceProvider's `isChainlinkType` branch.
+ * @dev Because the relay only ships a normalised 6-decimal USD price (no source
+ *      timestamp), the relay-delivery time recorded on this chain is the single
+ *      freshness signal: if the relay stops delivering, {price} ages out and
+ *      reverts. This is what lets even no-timestamp source oracles (e.g. a
+ *      rate-provider `getRate()`) be consumed as fresh feeds on L2.
  */
 contract OracleSink is IOracleSink, UpgradeableProxy, OAppReceiverUpgradeable {
     /// @custom:storage-location erc7201:etherfi.storage.OracleSink
     struct OracleSinkStorage {
         /// @notice Latest stored price per token
         mapping(address token => PricePoint) latest;
+        /// @notice Max age (seconds) of a relayed price before {price} reverts (0 = disabled)
+        mapping(address token => uint64) maxStaleness;
     }
 
     // keccak256(abi.encode(uint256(keccak256("etherfi.storage.OracleSink")) - 1)) & ~bytes32(uint256(0xff))
@@ -34,6 +39,9 @@ contract OracleSink is IOracleSink, UpgradeableProxy, OAppReceiverUpgradeable {
     /// @notice Matches {PriceProvider}.DECIMALS — kept here for the
     ///         Chainlink-shaped `decimals()` accessor.
     uint8 public constant DECIMALS = 6;
+
+    /// @notice Role required to configure per-token staleness windows
+    bytes32 public constant ORACLE_SINK_ADMIN_ROLE = keccak256("ORACLE_SINK_ADMIN_ROLE");
 
     /// @notice Thrown when constructor or initializer receives a zero address
     error InvalidAddress();
@@ -61,10 +69,34 @@ contract OracleSink is IOracleSink, UpgradeableProxy, OAppReceiverUpgradeable {
     }
 
     /// @inheritdoc IOracleSink
-    function getPrice(address token) external view returns (uint256 price, uint64 updatedAt) {
+    function getPrice(address token) external view returns (uint256, uint64) {
         PricePoint memory p = _getStorage().latest[token];
         if (p.updatedAt == 0) revert PriceNotSet();
         return (p.price, p.updatedAt);
+    }
+
+    /// @inheritdoc IOracleSink
+    function price(address token) external view returns (uint256) {
+        OracleSinkStorage storage $ = _getStorage();
+        PricePoint memory p = $.latest[token];
+        if (p.updatedAt == 0) revert PriceNotSet();
+
+        uint64 maxStaleness_ = $.maxStaleness[token];
+        if (maxStaleness_ != 0 && block.timestamp > uint256(p.updatedAt) + maxStaleness_) revert PriceStale();
+
+        return p.price;
+    }
+
+    /// @inheritdoc IOracleSink
+    function setMaxStaleness(address token, uint64 maxStaleness_) external onlyRole(ORACLE_SINK_ADMIN_ROLE) {
+        if (token == address(0)) revert InvalidToken();
+        _getStorage().maxStaleness[token] = maxStaleness_;
+        emit MaxStalenessSet(token, maxStaleness_);
+    }
+
+    /// @inheritdoc IOracleSink
+    function maxStaleness(address token) external view returns (uint64) {
+        return _getStorage().maxStaleness[token];
     }
 
     /// @inheritdoc IOracleSink

--- a/src/oracle/OracleSink.sol
+++ b/src/oracle/OracleSink.sol
@@ -85,28 +85,35 @@ contract OracleSink is IOracleSink, UpgradeableProxy, OAppReceiverUpgradeable {
 
     /**
      * @dev LayerZero callback. Decodes the relay payload and stores the
-     *      per-token updates. Skeleton: payload encoding is a TODO.
-     * @param _origin LZ origin metadata (peer + nonce)
-     * @param _guid Globally-unique message id
-     * @param _message Encoded relay payload (schema TBD with {PriceRelay})
+     *      per-token updates. The peer/origin authentication ("only the mainnet
+     *      {PriceRelay} can write here") is already enforced upstream in
+     *      {OAppReceiverUpgradeable.lzReceive} via the `OnlyPeer` check, so this
+     *      function trusts `_message` once invoked.
+     *
+     *      Payload schema (must match {PriceRelay.poke}):
+     *      `abi.encode(address[] tokens, uint256[] prices, uint64 srcTimestamp)`.
+     *      `updatedAt` is stamped with the destination-chain `block.timestamp`
+     *      (the time the price became readable here) so the OP-side
+     *      {PriceProvider} staleness check measures local arrival, not source time.
+     * @param _message Encoded relay payload
      */
-    function _lzReceive(Origin calldata _origin, bytes32 _guid, bytes calldata _message, address, bytes calldata)
+    function _lzReceive(Origin calldata, bytes32, bytes calldata _message, address, bytes calldata)
         internal
         virtual
         override
     {
-        _origin;
-        _guid;
+        (address[] memory tokens, uint256[] memory prices, ) = abi.decode(_message, (address[], uint256[], uint64));
 
-        // TODO: decode payload (tokens[], prices[], srcTimestamp) and
-        // write into `_getStorage().latest[token] = PricePoint(price, uint64(block.timestamp));`
-        // Example placeholder:
-        // (address[] memory tokens, uint256[] memory prices, ) = abi.decode(_message, (address[], uint256[], uint64));
-        // for (uint256 i = 0; i < tokens.length; ++i) {
-        //     _getStorage().latest[tokens[i]] = PricePoint(prices[i], uint64(block.timestamp));
-        //     emit PriceUpdated(tokens[i], prices[i], uint64(block.timestamp));
-        // }
-        _message;
+        OracleSinkStorage storage $ = _getStorage();
+        uint64 nowTs = uint64(block.timestamp);
+        uint256 len = tokens.length;
+        for (uint256 i = 0; i < len;) {
+            $.latest[tokens[i]] = PricePoint(prices[i], nowTs);
+            emit PriceUpdated(tokens[i], prices[i], nowTs);
+            unchecked {
+                ++i;
+            }
+        }
     }
 
     function _getStorage() private pure returns (OracleSinkStorage storage $) {

--- a/src/oracle/PriceRelay.sol
+++ b/src/oracle/PriceRelay.sol
@@ -154,8 +154,9 @@ contract PriceRelay is IPriceRelay, UpgradeableProxy, OAppSenderUpgradeable {
             uint256 currentPrice = $.priceProvider.price(token);
             TokenSubscription memory sub = $.subscriptions[token];
 
+            bool firstSend = $.lastSentAt[token] == 0;
             bool heartbeatDue = block.timestamp - $.lastSentAt[token] >= sub.heartbeat;
-            if (heartbeatDue || _deviated($.lastSentPrice[token], currentPrice, sub.deviationBps)) {
+            if (firstSend || heartbeatDue || _deviated($.lastSentPrice[token], currentPrice, sub.deviationBps)) {
                 outTokens[count] = token;
                 outPrices[count] = currentPrice;
                 unchecked {
@@ -261,9 +262,17 @@ contract PriceRelay is IPriceRelay, UpgradeableProxy, OAppSenderUpgradeable {
 
     /**
      * @dev Returns true if `current` deviates from `last` by at least `bps` basis points.
-     *      Always true when there is no prior price (`last == 0`), forcing the first send.
+     * @dev Gating rules (the "first send" case is handled by the caller via `lastSentAt == 0`,
+     *      so here `last` is the value of a prior *successful* relay):
+     *      - `bps == 0`: the deviation trigger is disabled; rely solely on the heartbeat.
+     *        (Without this, `diff * BPS >= 0` is always true and every poke would relay.)
+     *      - `last == current`: no movement, so never a deviation. This also prevents a
+     *        previously-relayed price of 0 from making this branch permanently true.
+     *      - `last == 0` with a non-zero `current`: an unbounded move (0 -> non-zero), relay.
      */
     function _deviated(uint256 last, uint256 current, uint32 bps) private pure returns (bool) {
+        if (bps == 0) return false;
+        if (last == current) return false;
         if (last == 0) return true;
         uint256 diff = current > last ? current - last : last - current;
         return diff * BPS_DENOMINATOR >= uint256(bps) * last;

--- a/src/oracle/PriceRelay.sol
+++ b/src/oracle/PriceRelay.sol
@@ -19,10 +19,14 @@ import { UpgradeableProxy } from "../utils/UpgradeableProxy.sol";
  * @dev Combines the cash-v3 access-control stack ({UpgradeableProxy} +
  *      {IRoleRegistry}) with the LZ OApp sender stack. `OwnableUpgradeable`
  *      (required by LZ for `setPeer`/delegate ops) is initialized to the
- *      role-registry owner.
+ *      role-registry owner / configured delegate.
  *
- *      Subscription set, sending payload encoding, and quote semantics are
- *      stubbed here as TODOs — this file is the compiling skeleton.
+ *      The LayerZero native fee is paid from this contract's own balance (the
+ *      {_payNative} override below), so {poke} is permissionless and non-payable.
+ *      To stop a spammer from draining that balance with redundant pokes, a send
+ *      only happens for a token once its heartbeat elapsed or its price deviated
+ *      past the configured threshold — which also implements the spec's
+ *      "every N min, deviation X%" oracle update model on-chain.
  */
 contract PriceRelay is IPriceRelay, UpgradeableProxy, OAppSenderUpgradeable {
     using EnumerableSetLib for EnumerableSetLib.AddressSet;
@@ -33,14 +37,23 @@ contract PriceRelay is IPriceRelay, UpgradeableProxy, OAppSenderUpgradeable {
         IPriceProvider priceProvider;
         /// @notice Destination LayerZero endpoint ID (the OracleSink chain)
         uint32 destinationEid;
+        /// @notice LayerZero execution options applied to every relay send
+        bytes lzOptions;
         /// @notice Tokens currently subscribed for relay
         EnumerableSetLib.AddressSet subscribed;
         /// @notice Per-token subscription parameters
         mapping(address token => TokenSubscription) subscriptions;
+        /// @notice Last price relayed per token (6-decimal USD)
+        mapping(address token => uint256) lastSentPrice;
+        /// @notice Block timestamp of the last relay per token
+        mapping(address token => uint64) lastSentAt;
     }
 
     // keccak256(abi.encode(uint256(keccak256("etherfi.storage.PriceRelay")) - 1)) & ~bytes32(uint256(0xff))
     bytes32 private constant PriceRelayStorageLocation = 0xa5f763f5f22412144904c62075e838be98e71aa6e5b4ffe579f23d0f3e43c800;
+
+    /// @notice Basis-points denominator (100% = 10_000 bps)
+    uint256 private constant BPS_DENOMINATOR = 10_000;
 
     /// @notice Role required to subscribe / unsubscribe tokens and configure the relay
     bytes32 public constant PRICE_RELAY_ADMIN_ROLE = keccak256("PRICE_RELAY_ADMIN_ROLE");
@@ -103,34 +116,85 @@ contract PriceRelay is IPriceRelay, UpgradeableProxy, OAppSenderUpgradeable {
         PriceRelayStorage storage $ = _getStorage();
         if (!$.subscribed.remove(token)) revert TokenNotSubscribed();
         delete $.subscriptions[token];
+        delete $.lastSentPrice[token];
+        delete $.lastSentAt[token];
         emit TokenUnsubscribed(token);
     }
 
     /// @inheritdoc IPriceRelay
-    function poke(address[] calldata tokens, bytes calldata options) external payable whenNotPaused {
+    function setLzOptions(bytes calldata options) external onlyRole(PRICE_RELAY_ADMIN_ROLE) {
+        _getStorage().lzOptions = options;
+        emit LzOptionsSet(options);
+    }
+
+    /// @inheritdoc IPriceRelay
+    function withdraw(address to, uint256 amount) external onlyRole(PRICE_RELAY_ADMIN_ROLE) {
+        if (to == address(0)) revert InvalidInput();
+        if (address(this).balance < amount) revert InsufficientBalance();
+        (bool ok, ) = to.call{ value: amount }("");
+        if (!ok) revert WithdrawFailed();
+        emit Withdrawn(to, amount);
+    }
+
+    /// @inheritdoc IPriceRelay
+    function poke(address[] calldata tokens) external whenNotPaused nonReentrant {
         if (tokens.length == 0) revert InvalidInput();
         PriceRelayStorage storage $ = _getStorage();
         if ($.destinationEid == 0) revert DestinationNotSet();
 
-        uint256[] memory prices = new uint256[](tokens.length);
-        for (uint256 i = 0; i < tokens.length;) {
+        uint256 len = tokens.length;
+        address[] memory outTokens = new address[](len);
+        uint256[] memory outPrices = new uint256[](len);
+        uint256 count;
+
+        for (uint256 i = 0; i < len;) {
             address token = tokens[i];
             if (!$.subscribed.contains(token)) revert TokenNotSubscribed();
-            prices[i] = $.priceProvider.price(token);
+
+            uint256 currentPrice = $.priceProvider.price(token);
+            TokenSubscription memory sub = $.subscriptions[token];
+
+            bool heartbeatDue = block.timestamp - $.lastSentAt[token] >= sub.heartbeat;
+            if (heartbeatDue || _deviated($.lastSentPrice[token], currentPrice, sub.deviationBps)) {
+                outTokens[count] = token;
+                outPrices[count] = currentPrice;
+                unchecked {
+                    ++count;
+                }
+            }
+
             unchecked {
                 ++i;
             }
         }
 
-        // TODO: encode payload (e.g. abi.encode(tokens, prices, block.timestamp))
-        // TODO: _lzSend($.destinationEid, payload, options, MessagingFee(msg.value, 0), msg.sender);
-        options;
+        if (count == 0) revert NothingToRelay();
 
-        emit PricesRelayed($.destinationEid, tokens, prices);
+        // Shrink the in-memory arrays to the number of qualifying tokens.
+        assembly {
+            mstore(outTokens, count)
+            mstore(outPrices, count)
+        }
+
+        bytes memory payload = abi.encode(outTokens, outPrices, uint64(block.timestamp));
+        MessagingFee memory fee = _quote($.destinationEid, payload, $.lzOptions, false);
+        if (address(this).balance < fee.nativeFee) revert InsufficientBalance();
+
+        _lzSend($.destinationEid, payload, $.lzOptions, MessagingFee(fee.nativeFee, 0), address(this));
+
+        for (uint256 i = 0; i < count;) {
+            $.lastSentPrice[outTokens[i]] = outPrices[i];
+            $.lastSentAt[outTokens[i]] = uint64(block.timestamp);
+            unchecked {
+                ++i;
+            }
+        }
+
+        emit PricesRelayed($.destinationEid, outTokens, outPrices);
     }
 
     /// @inheritdoc IPriceRelay
-    function quote(address[] calldata tokens, bytes calldata options)
+    function quote(address[] calldata tokens)
         external
         view
         returns (uint256 nativeFee, uint256 lzTokenFee)
@@ -139,13 +203,11 @@ contract PriceRelay is IPriceRelay, UpgradeableProxy, OAppSenderUpgradeable {
         PriceRelayStorage storage $ = _getStorage();
         if ($.destinationEid == 0) revert DestinationNotSet();
 
-        // TODO: build the same payload as `poke` and call `_quote`.
-        // bytes memory payload = abi.encode(tokens, new uint256[](tokens.length), uint64(0));
-        // MessagingFee memory fee = _quote($.destinationEid, payload, options, false);
-        // return (fee.nativeFee, fee.lzTokenFee);
-        tokens;
-        options;
-        return (0, 0);
+        // Upper-bound quote: price the payload as if every provided token were relayed.
+        uint256[] memory prices = new uint256[](tokens.length);
+        bytes memory payload = abi.encode(tokens, prices, uint64(0));
+        MessagingFee memory fee = _quote($.destinationEid, payload, $.lzOptions, false);
+        return (fee.nativeFee, fee.lzTokenFee);
     }
 
     /// @inheritdoc IPriceRelay
@@ -154,8 +216,24 @@ contract PriceRelay is IPriceRelay, UpgradeableProxy, OAppSenderUpgradeable {
     }
 
     /// @inheritdoc IPriceRelay
+    function lastRelayed(address token) external view returns (uint256 price, uint64 timestamp) {
+        PriceRelayStorage storage $ = _getStorage();
+        return ($.lastSentPrice[token], $.lastSentAt[token]);
+    }
+
+    /// @inheritdoc IPriceRelay
+    function lzOptions() external view returns (bytes memory) {
+        return _getStorage().lzOptions;
+    }
+
+    /// @inheritdoc IPriceRelay
     function destinationEid() external view returns (uint32) {
         return _getStorage().destinationEid;
+    }
+
+    /// @notice Accept native currency used to fund LayerZero relay fees
+    receive() external payable {
+        emit Funded(msg.sender, msg.value);
     }
 
     /// @inheritdoc OAppSenderUpgradeable
@@ -166,6 +244,29 @@ contract PriceRelay is IPriceRelay, UpgradeableProxy, OAppSenderUpgradeable {
         returns (uint64 senderVersion, uint64 receiverVersion)
     {
         return (1, 0);
+    }
+
+    /**
+     * @dev Pay the LayerZero native fee from the contract's own balance instead of
+     *      requiring `msg.value`. This is what lets {poke} be permissionless and
+     *      non-payable: the protocol funds the relay (see {receive}/{withdraw}) and
+     *      any third party can trigger a send without supplying ETH.
+     * @param _nativeFee The native fee required by the endpoint
+     * @return nativeFee The amount forwarded to the endpoint (drawn from this balance)
+     */
+    function _payNative(uint256 _nativeFee) internal view override returns (uint256 nativeFee) {
+        if (address(this).balance < _nativeFee) revert InsufficientBalance();
+        return _nativeFee;
+    }
+
+    /**
+     * @dev Returns true if `current` deviates from `last` by at least `bps` basis points.
+     *      Always true when there is no prior price (`last == 0`), forcing the first send.
+     */
+    function _deviated(uint256 last, uint256 current, uint32 bps) private pure returns (bool) {
+        if (last == 0) return true;
+        uint256 diff = current > last ? current - last : last - current;
+        return diff * BPS_DENOMINATOR >= uint256(bps) * last;
     }
 
     function _getStorage() private pure returns (PriceRelayStorage storage $) {

--- a/test/oracle/PriceRelayOracleSink.t.sol
+++ b/test/oracle/PriceRelayOracleSink.t.sol
@@ -274,6 +274,75 @@ contract PriceRelayOracleSinkTest is Test {
         priceRelay.poke(_single(token));
     }
 
+    // --- Deviation gate edge cases (Bugbot) --------------------------------
+
+    /// @dev deviationBps == 0 must disable the deviation trigger (heartbeat only),
+    ///      not relay on every poke.
+    function test_Deviation_zeroBpsDisablesTriggerButHeartbeatStillWorks() public {
+        address t = makeAddr("zeroBpsToken");
+        priceRelay.subscribe(
+            t, IPriceRelay.TokenSubscription({ heartbeat: HEARTBEAT, deviationBps: 0, maxStaleness: MAX_STALENESS })
+        );
+
+        priceRelay.poke(_single(t)); // first send
+        endpoint.deliver(SRC_EID);
+
+        // Within heartbeat, even a 100% move must NOT relay (deviation disabled).
+        vm.warp(block.timestamp + 1);
+        mockPriceProvider.setPrice(INITIAL_PRICE * 2);
+        vm.expectRevert(IPriceRelay.NothingToRelay.selector);
+        priceRelay.poke(_single(t));
+
+        // Heartbeat still forces a relay once the interval elapses.
+        vm.warp(block.timestamp + HEARTBEAT);
+        priceRelay.poke(_single(t));
+        (, uint64 lastTs) = priceRelay.lastRelayed(t);
+        assertEq(lastTs, uint64(block.timestamp));
+    }
+
+    /// @dev A previously-relayed price of 0 must not make the deviation branch
+    ///      permanently true (no per-poke fee drain while the price stays 0).
+    function test_Deviation_relayedZeroPriceDoesNotSpam() public {
+        address t = makeAddr("zeroPriceToken");
+        priceRelay.subscribe(
+            t,
+            IPriceRelay.TokenSubscription({ heartbeat: HEARTBEAT, deviationBps: DEVIATION_BPS, maxStaleness: MAX_STALENESS })
+        );
+
+        mockPriceProvider.setPrice(0);
+        priceRelay.poke(_single(t));
+        endpoint.deliver(SRC_EID);
+        (uint256 lastPrice,) = priceRelay.lastRelayed(t);
+        assertEq(lastPrice, 0);
+
+        // Still 0 within the heartbeat window -> no deviation -> nothing to relay.
+        vm.warp(block.timestamp + 1);
+        vm.expectRevert(IPriceRelay.NothingToRelay.selector);
+        priceRelay.poke(_single(t));
+    }
+
+    /// @dev Recovery from 0 to a non-zero price is an unbounded move and must relay.
+    function test_Deviation_zeroToNonZeroRelays() public {
+        address t = makeAddr("recoverToken");
+        priceRelay.subscribe(
+            t,
+            IPriceRelay.TokenSubscription({ heartbeat: HEARTBEAT, deviationBps: DEVIATION_BPS, maxStaleness: MAX_STALENESS })
+        );
+
+        mockPriceProvider.setPrice(0);
+        priceRelay.poke(_single(t));
+        endpoint.deliver(SRC_EID);
+
+        // Price recovers within the heartbeat window -> relays.
+        vm.warp(block.timestamp + 1);
+        mockPriceProvider.setPrice(INITIAL_PRICE);
+        priceRelay.poke(_single(t));
+        endpoint.deliver(SRC_EID);
+
+        (uint256 price,) = oracleSink.getPrice(t);
+        assertEq(price, INITIAL_PRICE);
+    }
+
     // --- Peer authentication ----------------------------------------------
 
     function test_PeerRejection_nonPeerCannotUpdateSink() public {

--- a/test/oracle/PriceRelayOracleSink.t.sol
+++ b/test/oracle/PriceRelayOracleSink.t.sol
@@ -384,4 +384,94 @@ contract PriceRelayOracleSinkTest is Test {
 
         assertEq(opPriceProvider.price(token), INITIAL_PRICE);
     }
+
+    // --- OP PriceProvider consumes the sink DIRECTLY (no adapter) -----------
+
+    /// @dev Deploys a bare OP PriceProvider with no token configs.
+    function _deployOpPriceProvider() internal returns (PriceProvider opPriceProvider) {
+        address ppImpl = address(new PriceProvider());
+        address[] memory emptyTokens = new address[](0);
+        PriceProvider.Config[] memory emptyConfigs = new PriceProvider.Config[](0);
+        opPriceProvider = PriceProvider(
+            address(
+                new UUPSProxy(
+                    ppImpl,
+                    abi.encodeWithSelector(
+                        PriceProvider.initialize.selector, address(roleRegistry), emptyTokens, emptyConfigs
+                    )
+                )
+            )
+        );
+        roleRegistry.grantRole(opPriceProvider.PRICE_PROVIDER_ADMIN_ROLE(), address(this));
+    }
+
+    /// @dev Wires the OP PriceProvider to read the multi-token sink directly via the
+    ///      calldata branch (token baked into priceFunctionCalldata), no adapter.
+    function _configureSinkDirect(PriceProvider opPriceProvider) internal {
+        address[] memory tokens = _single(token);
+        PriceProvider.Config[] memory configs = new PriceProvider.Config[](1);
+        configs[0] = PriceProvider.Config({
+            oracle: address(oracleSink),
+            priceFunctionCalldata: abi.encodeWithSelector(IOracleSink.price.selector, token),
+            isChainlinkType: false,
+            oraclePriceDecimals: 6,
+            maxStaleness: 0, // unused on the calldata branch; sink enforces freshness
+            dataType: PriceProvider.ReturnType.Uint256,
+            isBaseTokenEth: false,
+            isStableToken: false,
+            isBaseTokenBtc: false
+        });
+        opPriceProvider.setTokenConfig(tokens, configs);
+    }
+
+    function test_DirectIntegration_priceProviderReadsSink() public {
+        priceRelay.poke(_single(token));
+        endpoint.deliver(SRC_EID);
+
+        roleRegistry.grantRole(oracleSink.ORACLE_SINK_ADMIN_ROLE(), address(this));
+        oracleSink.setMaxStaleness(token, 1 days);
+
+        PriceProvider opPriceProvider = _deployOpPriceProvider();
+        _configureSinkDirect(opPriceProvider);
+
+        assertEq(opPriceProvider.price(token), INITIAL_PRICE);
+    }
+
+    function test_DirectIntegration_staleSinkRevertsInPriceProvider() public {
+        priceRelay.poke(_single(token));
+        endpoint.deliver(SRC_EID);
+
+        roleRegistry.grantRole(oracleSink.ORACLE_SINK_ADMIN_ROLE(), address(this));
+        oracleSink.setMaxStaleness(token, 1 hours);
+
+        PriceProvider opPriceProvider = _deployOpPriceProvider();
+        _configureSinkDirect(opPriceProvider);
+
+        // Fresh read works.
+        assertEq(opPriceProvider.price(token), INITIAL_PRICE);
+
+        // Relay goes quiet: once the delivery ages past the sink window, the sink
+        // reverts (PriceStale), which surfaces as PriceOracleFailed in PriceProvider.
+        vm.warp(block.timestamp + 1 hours + 1);
+        vm.expectRevert(PriceProvider.PriceOracleFailed.selector);
+        opPriceProvider.price(token);
+    }
+
+    function test_DirectIntegration_noStalenessConfiguredNeverAgesOut() public {
+        priceRelay.poke(_single(token));
+        endpoint.deliver(SRC_EID);
+
+        // maxStaleness left at 0 (disabled).
+        PriceProvider opPriceProvider = _deployOpPriceProvider();
+        _configureSinkDirect(opPriceProvider);
+
+        vm.warp(block.timestamp + 3650 days);
+        assertEq(opPriceProvider.price(token), INITIAL_PRICE);
+    }
+
+    function test_SetMaxStaleness_onlyAdmin() public {
+        vm.prank(makeAddr("attacker"));
+        vm.expectRevert();
+        oracleSink.setMaxStaleness(token, 1 days);
+    }
 }

--- a/test/oracle/PriceRelayOracleSink.t.sol
+++ b/test/oracle/PriceRelayOracleSink.t.sol
@@ -1,0 +1,387 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { Test } from "forge-std/Test.sol";
+
+import { OptionsBuilder } from "@layerzerolabs/oapp-evm/contracts/oapp/libs/OptionsBuilder.sol";
+import {
+    MessagingParams,
+    MessagingReceipt,
+    MessagingFee,
+    Origin
+} from "@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol";
+
+import { PriceRelay } from "../../src/oracle/PriceRelay.sol";
+import { OracleSink } from "../../src/oracle/OracleSink.sol";
+import { PriceProvider } from "../../src/oracle/PriceProvider.sol";
+import { IPriceRelay } from "../../src/interfaces/IPriceRelay.sol";
+import { IOracleSink } from "../../src/interfaces/IOracleSink.sol";
+import { MockPriceProvider } from "../../src/mocks/MockPriceProvider.sol";
+import { RoleRegistry } from "../../src/role-registry/RoleRegistry.sol";
+import { UUPSProxy } from "../../src/UUPSProxy.sol";
+
+/// @notice Minimal in-memory LayerZero EndpointV2 stand-in.
+/// @dev Implements only the surface the OApp sender/receiver stack touches:
+///      `setDelegate`, `quote`, `send`. Both the relay and the sink share one
+///      instance (single local EVM), and `deliver` replays the captured packet
+///      into the receiver's `lzReceive` with `msg.sender == endpoint` so the
+///      OApp peer/origin checks run exactly as in production.
+contract MockLZEndpoint {
+    struct Sent {
+        uint32 dstEid;
+        bytes32 receiver;
+        bytes message;
+        bytes options;
+        address sender;
+        bytes32 guid;
+    }
+
+    uint256 public fee = 0.001 ether;
+    Sent public last;
+    bool public hasPending;
+
+    function setFee(uint256 _fee) external {
+        fee = _fee;
+    }
+
+    function setDelegate(address) external {}
+
+    function quote(MessagingParams calldata, address) external view returns (MessagingFee memory) {
+        return MessagingFee({ nativeFee: fee, lzTokenFee: 0 });
+    }
+
+    function send(MessagingParams calldata _params, address) external payable returns (MessagingReceipt memory r) {
+        bytes32 guid = keccak256(abi.encode(_params, msg.sender, block.timestamp));
+        last = Sent({
+            dstEid: _params.dstEid,
+            receiver: _params.receiver,
+            message: _params.message,
+            options: _params.options,
+            sender: msg.sender,
+            guid: guid
+        });
+        hasPending = true;
+        r.guid = guid;
+        r.nonce = 1;
+        r.fee = MessagingFee({ nativeFee: msg.value, lzTokenFee: 0 });
+    }
+
+    /// @notice Replays the last captured packet into `lzReceive` of the receiver.
+    function deliver(uint32 srcEid) external {
+        require(hasPending, "no pending packet");
+        hasPending = false;
+        ILzReceiver(address(uint160(uint256(last.receiver)))).lzReceive(
+            Origin({ srcEid: srcEid, sender: bytes32(uint256(uint160(last.sender))), nonce: 1 }),
+            last.guid,
+            last.message,
+            address(this),
+            ""
+        );
+    }
+}
+
+interface ILzReceiver {
+    function lzReceive(Origin calldata, bytes32, bytes calldata, address, bytes calldata) external payable;
+}
+
+/// @notice Thin per-token Chainlink-shaped adapter over the multi-token {OracleSink}.
+/// @dev The OP {PriceProvider} Chainlink branch calls the no-arg `latestRoundData()`,
+///      but the sink serves many tokens via `latestRoundData(token)`. This bakes in
+///      the token so the sink can be consumed through `isChainlinkType = true` while
+///      still exercising PriceProvider's staleness check. This is the recommended
+///      production consumption pattern for a multi-token sink.
+contract OracleSinkAggregatorAdapter {
+    IOracleSink public immutable sink;
+    address public immutable token;
+
+    constructor(IOracleSink _sink, address _token) {
+        sink = _sink;
+        token = _token;
+    }
+
+    function decimals() external view returns (uint8) {
+        return sink.decimals();
+    }
+
+    function latestRoundData()
+        external
+        view
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+    {
+        return sink.latestRoundData(token);
+    }
+}
+
+contract PriceRelayOracleSinkTest is Test {
+    using OptionsBuilder for bytes;
+
+    uint32 constant SRC_EID = 1; // "mainnet"
+    uint32 constant DST_EID = 2; // "optimism"
+
+    uint256 constant INITIAL_PRICE = 2000e6; // 6-decimal USD
+    uint32 constant HEARTBEAT = 5 minutes;
+    uint32 constant DEVIATION_BPS = 50; // 0.5%
+    uint32 constant MAX_STALENESS = 2 days;
+
+    MockLZEndpoint endpoint;
+    RoleRegistry roleRegistry;
+    MockPriceProvider mockPriceProvider;
+    PriceRelay priceRelay;
+    OracleSink oracleSink;
+
+    address token = makeAddr("token");
+    bytes lzOptions;
+
+    function setUp() public {
+        vm.warp(1_700_000_000);
+        endpoint = new MockLZEndpoint();
+
+        // Role registry (owner = this test contract).
+        address roleRegistryImpl = address(new RoleRegistry(makeAddr("dataProvider")));
+        roleRegistry = RoleRegistry(
+            address(new UUPSProxy(roleRegistryImpl, abi.encodeWithSelector(RoleRegistry.initialize.selector, address(this))))
+        );
+
+        // Mainnet source price provider.
+        mockPriceProvider = new MockPriceProvider(INITIAL_PRICE, address(0));
+
+        // PriceRelay (both OApps share the one local endpoint).
+        address relayImpl = address(new PriceRelay(address(endpoint)));
+        priceRelay = PriceRelay(
+            payable(
+                address(
+                    new UUPSProxy(
+                        relayImpl,
+                        abi.encodeWithSelector(
+                            PriceRelay.initialize.selector,
+                            address(roleRegistry),
+                            address(mockPriceProvider),
+                            address(this),
+                            DST_EID
+                        )
+                    )
+                )
+            )
+        );
+
+        // OracleSink.
+        address sinkImpl = address(new OracleSink(address(endpoint)));
+        oracleSink = OracleSink(
+            address(
+                new UUPSProxy(
+                    sinkImpl, abi.encodeWithSelector(OracleSink.initialize.selector, address(roleRegistry), address(this))
+                )
+            )
+        );
+
+        // Peer wiring: enforces "only the mainnet relay can update the L2 sink".
+        priceRelay.setPeer(DST_EID, _b32(address(oracleSink)));
+        oracleSink.setPeer(SRC_EID, _b32(address(priceRelay)));
+
+        // Admin config.
+        roleRegistry.grantRole(priceRelay.PRICE_RELAY_ADMIN_ROLE(), address(this));
+        lzOptions = OptionsBuilder.newOptions().addExecutorLzReceiveOption(200_000, 0);
+        priceRelay.setLzOptions(lzOptions);
+        priceRelay.subscribe(
+            token,
+            IPriceRelay.TokenSubscription({ heartbeat: HEARTBEAT, deviationBps: DEVIATION_BPS, maxStaleness: MAX_STALENESS })
+        );
+
+        // Fund the relay so it can pay LZ fees itself.
+        vm.deal(address(priceRelay), 100 ether);
+    }
+
+    function _b32(address a) internal pure returns (bytes32) {
+        return bytes32(uint256(uint160(a)));
+    }
+
+    function _single(address t) internal pure returns (address[] memory arr) {
+        arr = new address[](1);
+        arr[0] = t;
+    }
+
+    function _singlePrice(uint256 p) internal pure returns (uint256[] memory arr) {
+        arr = new uint256[](1);
+        arr[0] = p;
+    }
+
+    // --- Round trip --------------------------------------------------------
+
+    function test_RoundTrip_relaysPriceToSink() public {
+        priceRelay.poke(_single(token));
+        endpoint.deliver(SRC_EID);
+
+        (uint256 price, uint64 updatedAt) = oracleSink.getPrice(token);
+        assertEq(price, INITIAL_PRICE);
+        assertEq(updatedAt, uint64(block.timestamp));
+
+        (uint256 lastPrice, uint64 lastTs) = priceRelay.lastRelayed(token);
+        assertEq(lastPrice, INITIAL_PRICE);
+        assertEq(lastTs, uint64(block.timestamp));
+    }
+
+    function test_RoundTrip_feePaidFromContractBalance() public {
+        uint256 balanceBefore = address(priceRelay).balance;
+        priceRelay.poke(_single(token));
+        assertEq(address(priceRelay).balance, balanceBefore - endpoint.fee());
+    }
+
+    // --- Heartbeat gate ----------------------------------------------------
+
+    function test_Heartbeat_triggersAfterInterval() public {
+        priceRelay.poke(_single(token));
+        endpoint.deliver(SRC_EID);
+
+        // Within heartbeat, unchanged price -> nothing to relay.
+        vm.warp(block.timestamp + 1);
+        vm.expectRevert(IPriceRelay.NothingToRelay.selector);
+        priceRelay.poke(_single(token));
+
+        // After heartbeat -> relays again even with unchanged price.
+        vm.warp(block.timestamp + HEARTBEAT);
+        priceRelay.poke(_single(token));
+
+        (, uint64 lastTs) = priceRelay.lastRelayed(token);
+        assertEq(lastTs, uint64(block.timestamp));
+    }
+
+    // --- Deviation gate ----------------------------------------------------
+
+    function test_Deviation_triggersOnPriceMove() public {
+        priceRelay.poke(_single(token));
+        endpoint.deliver(SRC_EID);
+
+        // Move 1% (>= 0.5% threshold) within the heartbeat window.
+        vm.warp(block.timestamp + 1);
+        mockPriceProvider.setPrice((INITIAL_PRICE * 101) / 100);
+
+        priceRelay.poke(_single(token));
+        endpoint.deliver(SRC_EID);
+
+        (uint256 price,) = oracleSink.getPrice(token);
+        assertEq(price, (INITIAL_PRICE * 101) / 100);
+    }
+
+    function test_Deviation_belowThresholdDoesNotTrigger() public {
+        priceRelay.poke(_single(token));
+        endpoint.deliver(SRC_EID);
+
+        // Move 0.1% (< 0.5% threshold) within heartbeat -> no relay.
+        vm.warp(block.timestamp + 1);
+        mockPriceProvider.setPrice((INITIAL_PRICE * 1001) / 1000);
+
+        vm.expectRevert(IPriceRelay.NothingToRelay.selector);
+        priceRelay.poke(_single(token));
+    }
+
+    // --- Peer authentication ----------------------------------------------
+
+    function test_PeerRejection_nonPeerCannotUpdateSink() public {
+        address rogue = makeAddr("rogue");
+        bytes memory message = abi.encode(_single(token), _singlePrice(INITIAL_PRICE), uint64(block.timestamp));
+
+        // Even when impersonating the endpoint, a non-peer source is rejected.
+        vm.prank(address(endpoint));
+        vm.expectRevert();
+        oracleSink.lzReceive(
+            Origin({ srcEid: SRC_EID, sender: _b32(rogue), nonce: 1 }), bytes32(0), message, address(0), ""
+        );
+    }
+
+    function test_PeerRejection_nonEndpointCannotCallLzReceive() public {
+        bytes memory message = abi.encode(_single(token), _singlePrice(INITIAL_PRICE), uint64(block.timestamp));
+        vm.prank(makeAddr("rogue"));
+        vm.expectRevert();
+        oracleSink.lzReceive(
+            Origin({ srcEid: SRC_EID, sender: _b32(address(priceRelay)), nonce: 1 }), bytes32(0), message, address(0), ""
+        );
+    }
+
+    // --- Funding -----------------------------------------------------------
+
+    function test_InsufficientBalance_pokeRevertsWhenUnfunded() public {
+        (uint256 quoted,) = priceRelay.quote(_single(token));
+        assertGt(quoted, 0, "expected non-zero LZ fee");
+
+        address recipient = makeAddr("recipient");
+        priceRelay.withdraw(recipient, address(priceRelay).balance);
+        assertEq(address(priceRelay).balance, 0);
+
+        vm.expectRevert(IPriceRelay.InsufficientBalance.selector);
+        priceRelay.poke(_single(token));
+    }
+
+    function test_Withdraw_movesFunds() public {
+        address recipient = makeAddr("recipient");
+        priceRelay.withdraw(recipient, 1 ether);
+        assertEq(recipient.balance, 1 ether);
+    }
+
+    function test_Withdraw_revertsWhenAmountExceedsBalance() public {
+        vm.expectRevert(IPriceRelay.InsufficientBalance.selector);
+        priceRelay.withdraw(makeAddr("recipient"), 1000 ether);
+    }
+
+    function test_Withdraw_onlyAdmin() public {
+        vm.prank(makeAddr("attacker"));
+        vm.expectRevert();
+        priceRelay.withdraw(makeAddr("recipient"), 1 ether);
+    }
+
+    // --- Subscription gating ----------------------------------------------
+
+    function test_Poke_revertsForUnsubscribedToken() public {
+        vm.expectRevert(IPriceRelay.TokenNotSubscribed.selector);
+        priceRelay.poke(_single(makeAddr("other")));
+    }
+
+    function test_Poke_isPermissionless() public {
+        vm.prank(makeAddr("anyone"));
+        priceRelay.poke(_single(token));
+        endpoint.deliver(SRC_EID);
+
+        (uint256 price,) = oracleSink.getPrice(token);
+        assertEq(price, INITIAL_PRICE);
+    }
+
+    // --- OP PriceProvider consumes the sink --------------------------------
+
+    function test_OpPriceProvider_readsRelayedPrice() public {
+        priceRelay.poke(_single(token));
+        endpoint.deliver(SRC_EID);
+
+        address ppImpl = address(new PriceProvider());
+        address[] memory emptyTokens = new address[](0);
+        PriceProvider.Config[] memory emptyConfigs = new PriceProvider.Config[](0);
+        PriceProvider opPriceProvider = PriceProvider(
+            address(
+                new UUPSProxy(
+                    ppImpl,
+                    abi.encodeWithSelector(
+                        PriceProvider.initialize.selector, address(roleRegistry), emptyTokens, emptyConfigs
+                    )
+                )
+            )
+        );
+        roleRegistry.grantRole(opPriceProvider.PRICE_PROVIDER_ADMIN_ROLE(), address(this));
+
+        OracleSinkAggregatorAdapter adapter = new OracleSinkAggregatorAdapter(IOracleSink(address(oracleSink)), token);
+
+        address[] memory tokens = _single(token);
+        PriceProvider.Config[] memory configs = new PriceProvider.Config[](1);
+        configs[0] = PriceProvider.Config({
+            oracle: address(adapter),
+            priceFunctionCalldata: hex"",
+            isChainlinkType: true,
+            oraclePriceDecimals: 6,
+            maxStaleness: 1 days,
+            dataType: PriceProvider.ReturnType.Int256,
+            isBaseTokenEth: false,
+            isStableToken: false,
+            isBaseTokenBtc: false
+        });
+        opPriceProvider.setTokenConfig(tokens, configs);
+
+        assertEq(opPriceProvider.price(token), INITIAL_PRICE);
+    }
+}


### PR DESCRIPTION
## Summary

Fills in the LayerZero send/receive logic in the `PriceRelay` (mainnet sender) and `OracleSink` (OP receiver) skeletons from the boilerplate, so a price set on the mainnet `PriceProvider` is relayed cross-chain to OP.

- **PriceRelay (mainnet OApp sender)** pays the LZ native fee from its **own balance** (`receive()` to fund, admin `withdraw`), so `poke` is **permissionless and non-payable**. `poke(tokens)` only relays a token once its **heartbeat** elapsed or its price **deviated** past the configured bps threshold; reverts `NothingToRelay` otherwise. This implements the heartbeat + deviation oracle update model on-chain and prevents a griefer from draining the relay's ETH with redundant pokes.
- **OracleSink (OP OApp receiver)** `_lzReceive` decodes `(tokens, prices, timestamp)` and stores each `PricePoint{price, block.timestamp}`. "Only the mainnet relay can update the L2 oracle" is enforced for free by `OAppReceiverUpgradeable`'s `OnlyPeer` check via `setPeer`.
- **IPriceRelay**: added `heartbeat` to `TokenSubscription`; dropped the caller `options` param from `poke`/`quote` (LZ options are admin-set on-chain via `setLzOptions`); added `withdraw`, `lastRelayed`, `lzOptions` + events/errors (`LzOptionsSet`, `Funded`, `Withdrawn`, `NothingToRelay`, `InsufficientBalance`, `WithdrawFailed`).

Payload schema (both sides): `abi.encode(address[] tokens, uint256[] prices, uint64 timestamp)`, prices already normalized to 6-decimal USD by the mainnet `PriceProvider`.

## Test plan

- [x] `forge test --match-path test/oracle/PriceRelayOracleSink.t.sol` — 14 passing tests covering: round-trip relay, fee-paid-from-balance, heartbeat trigger, deviation trigger (and below-threshold no-op), `NothingToRelay`, peer rejection (non-peer + non-endpoint callers), `InsufficientBalance`, withdraw paths, permissionless poke, and the OP `PriceProvider.price()` reading the relayed price via a per-token Chainlink-shaped sink adapter.

## Notes

- Tests use a minimal local `MockLZEndpoint` rather than LayerZero's `TestHelperOz5`, since the vendored `lz-address-book` is missing the `@layerzerolabs/lz-evm-v1-0.7` mock dependencies `TestHelperOz5` imports. The mock still exercises the real OApp send/receive/peer paths.
- Consuming the multi-token sink through `isChainlinkType = true` requires a thin per-token adapter (the sink's `latestRoundData` takes a `token`, while `PriceProvider` calls the no-arg version). An example `OracleSinkAggregatorAdapter` is included in the test file; promoting it to a production contract can be a follow-up.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes cross-chain oracle delivery and L2 price freshness semantics; misconfiguration or relay outages can cause stale or missing prices for downstream protocol logic.
> 
> **Overview**
> Implements the **LayerZero cross-chain price relay** end-to-end: mainnet **`PriceRelay`** reads **`PriceProvider`**, gates sends on **heartbeat / deviation**, pays LZ fees from a **protocol-funded balance** (permissionless **`poke`**), and **`OracleSink`** on the destination decodes **`(tokens, prices, timestamp)`** and stores per-token 6-decimal USD.
> 
> **`OracleSink`** adds **`price(token)`** with optional **per-token `maxStaleness`** (admin **`setMaxStaleness`**) so L2 **`PriceProvider`** can read the sink directly via calldata without a Chainlink adapter; **`latestRoundData`** remains for adapter-based consumption.
> 
> **`IPriceRelay`** reshapes subscriptions (**`heartbeat`**, **`deviationBps`**, recorded **`maxStaleness`**), drops caller-supplied LZ **`options`** from **`poke`/`quote`** (admin **`setLzOptions`**), and adds funding/withdraw and **`NothingToRelay`** / balance errors. A **`solidity-bytes-utils`** remapping and a broad **`PriceRelayOracleSink`** test suite (mock endpoint, gating, peers, OP **`PriceProvider`** integration) land with the contracts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa8832cfb67eba505b19639691adf5e63f753ad6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->