### PR TITLE
feat(oft): mainnet-OP OFT listing primitive

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -11,3 +11,5 @@ lz-address-book/=lib/lz-address-book/src/
 @layerzerolabs/oapp-evm/=lib/lz-address-book/lib/devtools/packages/oapp-evm/
 @layerzerolabs/oft-evm-upgradeable/=lib/lz-address-book/lib/devtools/packages/oft-evm-upgradeable/
 @layerzerolabs/oapp-evm-upgradeable/=lib/lz-address-book/lib/devtools/packages/oapp-evm-upgradeable/
+@layerzerolabs/test-devtools-evm-foundry/=lib/lz-address-book/lib/devtools/packages/test-devtools-evm-foundry/
+@layerzerolabs/lz-evm-v1-0.7/=test/oft/vendor/lz-evm-v1-0.7/

--- a/scripts/DeployOFTAdapterSide.s.sol
+++ b/scripts/DeployOFTAdapterSide.s.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { console } from "forge-std/console.sol";
+
+import { UUPSProxy } from "../src/UUPSProxy.sol";
+import { EtherFiOFTAdapter } from "../src/oft/EtherFiOFTAdapter.sol";
+import { OFTAdapterFactory } from "../src/oft/OFTAdapterFactory.sol";
+import { OFTConfigRegistry } from "../src/oft/OFTConfigRegistry.sol";
+import { RoleRegistry } from "../src/role-registry/RoleRegistry.sol";
+
+import { Utils } from "./utils/Utils.sol";
+
+/**
+ * @title DeployOFTAdapterSide
+ * @author ether.fi
+ * @notice Deploys the mainnet (lock-on-deposit) side of the OFT listing primitive with an EOA:
+ *         a dedicated {RoleRegistry}, the {OFTConfigRegistry}, the {EtherFiOFTAdapter} beacon
+ *         implementation, and the {OFTAdapterFactory}. Per-asset adapters are listed afterwards
+ *         via {OFTAdapterFactory-deployAdapter}; that and all other privileged wiring (role
+ *         grants, setPathwayConfig, setPeer) is performed by the RoleRegistry owner, not the EOA.
+ * @dev The deployer EOA only deploys. Ownership of the RoleRegistry is set to OFT_REGISTRY_OWNER
+ *      (the protocol Safe) so no privileged power is retained by an EOA. Run on Ethereum mainnet:
+ *
+ *      Set OFT_OWNER_MAINNET (and PRIVATE_KEY / MAINNET_RPC) in .env, then:
+ *          forge script scripts/DeployOFTAdapterSide.s.sol --rpc-url mainnet --broadcast --verify
+ */
+contract DeployOFTAdapterSide is Utils {
+    /// @dev LayerZero V2 endpoint on Ethereum mainnet (EID 30101).
+    ///      Source: lz-address-book `LayerZeroV2EthereumMainnet.ENDPOINT_V2`.
+    address constant LZ_ENDPOINT = 0x1a44076050125825900e736c501f859c50fE728c;
+
+    function run() public {
+        require(block.chainid == 1, "run on Ethereum mainnet (chainId 1)");
+
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        address deployer = vm.addr(deployerPrivateKey);
+        // RoleRegistry owner = the protocol Safe on this chain (recommended). Falls back to the
+        // deployer only if OFT_OWNER_MAINNET is unset (a transient bring-up; hand off to the
+        // Safe after). Per-chain var name so the mainnet and Optimism owners can coexist in .env.
+        address owner = vm.envOr("OFT_OWNER_MAINNET", deployer);
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        // 1. Dedicated RoleRegistry for the OFT subsystem. The data provider is only used by
+        //    configureSafeAdmins, which the OFT system never calls, so it is left as address(0).
+        address roleRegistryImpl = address(new RoleRegistry(address(0)));
+        RoleRegistry roleRegistry = RoleRegistry(address(new UUPSProxy(roleRegistryImpl, abi.encodeCall(RoleRegistry.initialize, (owner)))));
+
+        // 2. Canonical LayerZero DVN/library config registry; bridges pull from it via syncConfig.
+        address configRegistryImpl = address(new OFTConfigRegistry());
+        OFTConfigRegistry configRegistry = OFTConfigRegistry(address(new UUPSProxy(configRegistryImpl, abi.encodeCall(OFTConfigRegistry.initialize, (address(roleRegistry))))));
+
+        // 3. Single beacon implementation reused by every per-asset adapter proxy.
+        address adapterImpl = address(new EtherFiOFTAdapter(LZ_ENDPOINT, address(configRegistry)));
+
+        // 4. Factory. initialize() creates the shared UpgradeableBeacon internally.
+        address adapterFactoryImpl = address(new OFTAdapterFactory());
+        OFTAdapterFactory adapterFactory = OFTAdapterFactory(address(new UUPSProxy(adapterFactoryImpl, abi.encodeCall(OFTAdapterFactory.initialize, (address(roleRegistry), adapterImpl)))));
+
+        vm.stopBroadcast();
+
+        console.log("OFT mainnet (adapter) side deployed on chainId", block.chainid);
+        console.log("  RoleRegistry owner:    ", owner);
+        console.log("  OFTRoleRegistry:       ", address(roleRegistry));
+        console.log("  OFTRoleRegistryImpl:   ", roleRegistryImpl);
+        console.log("  OFTConfigRegistry:     ", address(configRegistry));
+        console.log("  OFTConfigRegistryImpl: ", configRegistryImpl);
+        console.log("  EtherFiOFTAdapterImpl: ", adapterImpl);
+        console.log("  OFTAdapterFactory:     ", address(adapterFactory));
+        console.log("  OFTAdapterFactoryImpl: ", adapterFactoryImpl);
+        console.log("  Beacon:                ", adapterFactory.beacon());
+
+        // Persist into the existing per-chain deployments.json, preserving all existing keys.
+        string memory path = string.concat(vm.projectRoot(), "/deployments/", getEnv(), "/", vm.toString(block.chainid), "/deployments.json");
+        vm.writeJson(vm.toString(address(roleRegistry)), path, ".addresses.OFTRoleRegistry");
+        vm.writeJson(vm.toString(roleRegistryImpl), path, ".addresses.OFTRoleRegistryImpl");
+        vm.writeJson(vm.toString(address(configRegistry)), path, ".addresses.OFTConfigRegistry");
+        vm.writeJson(vm.toString(configRegistryImpl), path, ".addresses.OFTConfigRegistryImpl");
+        vm.writeJson(vm.toString(adapterImpl), path, ".addresses.EtherFiOFTAdapterImpl");
+        vm.writeJson(vm.toString(address(adapterFactory)), path, ".addresses.OFTAdapterFactory");
+        vm.writeJson(vm.toString(adapterFactoryImpl), path, ".addresses.OFTAdapterFactoryImpl");
+    }
+}

--- a/scripts/DeployOFTShadowSide.s.sol
+++ b/scripts/DeployOFTShadowSide.s.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { console } from "forge-std/console.sol";
+
+import { UUPSProxy } from "../src/UUPSProxy.sol";
+import { RoleRegistry } from "../src/role-registry/RoleRegistry.sol";
+import { OFTConfigRegistry } from "../src/oft/OFTConfigRegistry.sol";
+import { EtherFiShadowOFT } from "../src/oft/EtherFiShadowOFT.sol";
+import { ShadowOFTFactory } from "../src/oft/ShadowOFTFactory.sol";
+
+import { Utils } from "./utils/Utils.sol";
+
+/**
+ * @title DeployOFTShadowSide
+ * @author ether.fi
+ * @notice Deploys the Optimism (mint/burn iTOKEN) side of the OFT listing primitive with an EOA:
+ *         a dedicated {RoleRegistry}, the {OFTConfigRegistry}, the {EtherFiShadowOFT} beacon
+ *         implementation, and the {ShadowOFTFactory}. Per-asset iTOKENs are listed afterwards
+ *         via {ShadowOFTFactory-deployShadowOFT}; that and all other privileged wiring (role
+ *         grants, setPathwayConfig, setPeer) is performed by the RoleRegistry owner, not the EOA.
+ * @dev The deployer EOA only deploys. Ownership of the RoleRegistry is set to OFT_REGISTRY_OWNER
+ *      (the protocol Safe) so no privileged power is retained by an EOA. Run on Optimism:
+ *
+ *      Set OFT_OWNER_OPTIMISM (and PRIVATE_KEY / OPTIMISM_RPC) in .env, then:
+ *          forge script scripts/DeployOFTShadowSide.s.sol --rpc-url optimism --broadcast --verify
+ */
+contract DeployOFTShadowSide is Utils {
+    /// @dev LayerZero V2 endpoint on Optimism (EID 30111).
+    ///      Source: lz-address-book `LayerZeroV2OptimismMainnet.ENDPOINT_V2`.
+    address constant LZ_ENDPOINT = 0x1a44076050125825900e736c501f859c50fE728c;
+
+    function run() public {
+        require(block.chainid == 10, "run on Optimism (chainId 10)");
+
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        address deployer = vm.addr(deployerPrivateKey);
+        // RoleRegistry owner = the protocol Safe on this chain (recommended). Falls back to the
+        // deployer only if OFT_OWNER_OPTIMISM is unset (a transient bring-up; hand off to the
+        // Safe after). Per-chain var name so the mainnet and Optimism owners can coexist in .env.
+        address owner = vm.envOr("OFT_OWNER_OPTIMISM", deployer);
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        // 1. Dedicated RoleRegistry for the OFT subsystem. The data provider is only used by
+        //    configureSafeAdmins, which the OFT system never calls, so it is left as address(0).
+        address roleRegistryImpl = address(new RoleRegistry(address(0)));
+        RoleRegistry roleRegistry =
+            RoleRegistry(address(new UUPSProxy(roleRegistryImpl, abi.encodeCall(RoleRegistry.initialize, (owner)))));
+
+        // 2. Canonical LayerZero DVN/library config registry; bridges pull from it via syncConfig.
+        address configRegistryImpl = address(new OFTConfigRegistry());
+        OFTConfigRegistry configRegistry = OFTConfigRegistry(
+            address(new UUPSProxy(configRegistryImpl, abi.encodeCall(OFTConfigRegistry.initialize, (address(roleRegistry)))))
+        );
+
+        // 3. Single beacon implementation reused by every per-asset iTOKEN proxy.
+        address shadowImpl = address(new EtherFiShadowOFT(LZ_ENDPOINT, address(configRegistry)));
+
+        // 4. Factory. initialize() creates the shared UpgradeableBeacon internally.
+        address shadowFactoryImpl = address(new ShadowOFTFactory());
+        ShadowOFTFactory shadowFactory = ShadowOFTFactory(
+            address(
+                new UUPSProxy(
+                    shadowFactoryImpl, abi.encodeCall(ShadowOFTFactory.initialize, (address(roleRegistry), shadowImpl))
+                )
+            )
+        );
+
+        vm.stopBroadcast();
+
+        console.log("OFT Optimism (shadow) side deployed on chainId", block.chainid);
+        console.log("  RoleRegistry owner:    ", owner);
+        console.log("  OFTRoleRegistry:       ", address(roleRegistry));
+        console.log("  OFTRoleRegistryImpl:   ", roleRegistryImpl);
+        console.log("  OFTConfigRegistry:     ", address(configRegistry));
+        console.log("  OFTConfigRegistryImpl: ", configRegistryImpl);
+        console.log("  EtherFiShadowOFTImpl:  ", shadowImpl);
+        console.log("  ShadowOFTFactory:      ", address(shadowFactory));
+        console.log("  ShadowOFTFactoryImpl:  ", shadowFactoryImpl);
+        console.log("  Beacon:                ", shadowFactory.beacon());
+
+        // Persist into the existing per-chain deployments.json, preserving all existing keys.
+        string memory path =
+            string.concat(vm.projectRoot(), "/deployments/", getEnv(), "/", vm.toString(block.chainid), "/deployments.json");
+        vm.writeJson(vm.toString(address(roleRegistry)), path, ".addresses.OFTRoleRegistry");
+        vm.writeJson(vm.toString(roleRegistryImpl), path, ".addresses.OFTRoleRegistryImpl");
+        vm.writeJson(vm.toString(address(configRegistry)), path, ".addresses.OFTConfigRegistry");
+        vm.writeJson(vm.toString(configRegistryImpl), path, ".addresses.OFTConfigRegistryImpl");
+        vm.writeJson(vm.toString(shadowImpl), path, ".addresses.EtherFiShadowOFTImpl");
+        vm.writeJson(vm.toString(address(shadowFactory)), path, ".addresses.ShadowOFTFactory");
+        vm.writeJson(vm.toString(shadowFactoryImpl), path, ".addresses.ShadowOFTFactoryImpl");
+    }
+}

--- a/src/interfaces/IConfigurableOFT.sol
+++ b/src/interfaces/IConfigurableOFT.sol
@@ -18,7 +18,4 @@ interface IConfigurableOFT {
 
     /// @notice The shared config registry this bridge reads from
     function configRegistry() external view returns (address);
-
-    /// @notice The registry config version this bridge last synced to
-    function syncedConfigVersion() external view returns (uint256);
 }

--- a/src/interfaces/IConfigurableOFT.sol
+++ b/src/interfaces/IConfigurableOFT.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/**
+ * @title IConfigurableOFT
+ * @author ether.fi
+ * @notice Interface for an OFT bridge that pulls its LayerZero security config
+ *         (DVNs / libraries) from a shared {OFTConfigRegistry} and applies it to
+ *         itself on the endpoint.
+ */
+interface IConfigurableOFT {
+    /**
+     * @notice Pulls the canonical config from the registry and applies it to this
+     *         bridge's own endpoint rows for each destination.
+     * @param dstEids Destination endpoint IDs to (re)configure
+     */
+    function syncConfig(uint32[] calldata dstEids) external;
+
+    /// @notice The shared config registry this bridge reads from
+    function configRegistry() external view returns (address);
+
+    /// @notice The registry config version this bridge last synced to
+    function syncedConfigVersion() external view returns (uint256);
+}

--- a/src/interfaces/IOFTAdapterFactory.sol
+++ b/src/interfaces/IOFTAdapterFactory.sol
@@ -24,8 +24,6 @@ interface IOFTAdapterFactory {
     error InvalidUnderlying();
     /// @notice Thrown when an adapter already exists for the supplied salt/underlying
     error AdapterAlreadyExists();
-    /// @notice Thrown when the start index passed to {getDeployedAdapters} is out of bounds
-    error InvalidStartIndex();
 
     /**
      * @notice Deploys a new OFTAdapter beacon proxy for `underlyingToken`

--- a/src/interfaces/IOFTConfigRegistry.sol
+++ b/src/interfaces/IOFTConfigRegistry.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/**
+ * @title IOFTConfigRegistry
+ * @author ether.fi
+ * @notice Single source of truth for the LayerZero security config (DVN stack +
+ *         libraries) that every OFT bridge on this chain pulls from. Lets us
+ *         update the canonical config once and push it to all bridges.
+ */
+interface IOFTConfigRegistry {
+    /// @notice Canonical LZ config for one destination pathway (per dstEid)
+    struct PathwayConfig {
+        address sendLib; // LZ SendUln302
+        address receiveLib; // LZ ReceiveUln302
+        uint64 confirmations; // block confirmations before delivery
+        uint8 optionalDVNThreshold; // how many optional DVNs must sign
+        address[] requiredDVNs; // sorted ascending, no duplicates
+        address[] optionalDVNs; // sorted ascending, no duplicates
+    }
+
+    event PathwayConfigSet(uint32 indexed dstEid, uint256 version);
+    event BridgeRegistered(address indexed bridge);
+    event ConfigPushed(address indexed bridge, uint32[] dstEids);
+
+    error InvalidInput();
+    error OnlyConfigAdmin();
+    error OnlyRegistrar();
+
+    /// @notice Set/replace the canonical config for a destination (bumps version)
+    function setPathwayConfig(uint32 dstEid, PathwayConfig calldata cfg) external;
+
+    function getPathwayConfig(uint32 dstEid) external view returns (PathwayConfig memory);
+    function configVersion() external view returns (uint256);
+    function activeDstEids() external view returns (uint32[] memory);
+
+    /// @notice Record a bridge so {pushToAll} can enumerate it (registrar only)
+    function registerBridge(address bridge) external;
+    function getBridges(uint256 start, uint256 n) external view returns (address[] memory);
+    function numBridges() external view returns (uint256);
+
+    /// @notice Make the given bridges re-pull config (admin only)
+    function pushTo(address[] calldata bridges, uint32[] calldata dstEids) external;
+    /// @notice Make every registered bridge re-pull config (admin only)
+    function pushToAll(uint32[] calldata dstEids) external;
+    /// @notice Paginated {pushToAll} for large bridge sets (admin only)
+    function pushToRange(uint256 start, uint256 count, uint32[] calldata dstEids) external;
+}

--- a/src/interfaces/IShadowOFTFactory.sol
+++ b/src/interfaces/IShadowOFTFactory.sol
@@ -22,8 +22,6 @@ interface IShadowOFTFactory {
     error OnlyAdmin();
     /// @notice Thrown when a Shadow OFT already exists for the supplied salt
     error ShadowOFTAlreadyExists();
-    /// @notice Thrown when the start index passed to {getDeployedShadowOFTs} is out of bounds
-    error InvalidStartIndex();
 
     /**
      * @notice Deploys a new Shadow OFT (iTOKEN) beacon proxy
@@ -31,10 +29,11 @@ interface IShadowOFTFactory {
      * @param salt CREATE3 salt; must match the mainnet `OFTAdapterFactory.deployAdapter` salt
      * @param name ERC-20 name of the iTOKEN (convention: "EtherFi <NAME>")
      * @param symbol ERC-20 symbol of the iTOKEN (convention: "i<SYMBOL>")
+     * @param decimals Decimals to mirror from the mainnet underlying token
      * @param delegate LayerZero delegate (typically the protocol owner/multisig)
      * @return shadowOFT Address of the deployed iTOKEN proxy
      */
-    function deployShadowOFT(bytes32 salt, string calldata name, string calldata symbol, address delegate) external returns (address shadowOFT);
+    function deployShadowOFT(bytes32 salt, string calldata name, string calldata symbol, uint8 decimals, address delegate) external returns (address shadowOFT);
 
     /**
      * @notice Paginated enumeration of deployed Shadow OFT addresses

--- a/src/oft/ConfigurableOFTBase.sol
+++ b/src/oft/ConfigurableOFTBase.sol
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { UlnConfig } from "@layerzerolabs/lz-evm-messagelib-v2/contracts/uln/UlnBase.sol";
+import { SetConfigParam } from "@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessageLibManager.sol";
+import { OFTCoreUpgradeable } from "@layerzerolabs/oft-evm-upgradeable/contracts/oft/OFTCoreUpgradeable.sol";
+
+import { IConfigurableOFT } from "../interfaces/IConfigurableOFT.sol";
+import { IOFTConfigRegistry } from "../interfaces/IOFTConfigRegistry.sol";
+
+/**
+ * @title ConfigurableOFTBase
+ * @author ether.fi
+ * @notice Shared mixin for the beacon OFT impls (adapter + shadow). Adds a
+ *         pull-based LayerZero security-config sync: the bridge reads the
+ *         canonical DVN/library config from a shared {OFTConfigRegistry} and
+ *         writes it to ITS OWN rows on the endpoint.
+ * @dev Self-configuration works because LayerZero authorizes
+ *      `msg.sender == oapp` for `setConfig` (verified in EndpointV2), so no
+ *      delegate transfer is needed. The registry address is immutable (one per
+ *      chain, like the endpoint); the synced version lives in per-proxy storage.
+ *
+ *      Only the DVN/library config (endpoint-side) is synced here. Enforced
+ *      options are owner-gated on the OApp and are set separately by the owner.
+ */
+abstract contract ConfigurableOFTBase is OFTCoreUpgradeable, IConfigurableOFT {
+    /// @notice Shared config registry, fixed at impl deploy (one per chain)
+    address public immutable override configRegistry;
+
+    /// @custom:storage-location erc7201:etherfi.storage.ConfigurableOFT
+    struct ConfigurableOFTStorage {
+        /// @notice Registry config version this proxy last synced to
+        uint256 syncedVersion;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("etherfi.storage.ConfigurableOFT")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant ConfigurableOFTStorageLocation = 0xd18e887461873c61ac61602c54f3a01e3e69d73cf3dd7f9579b5f219dabfca00;
+
+    /// @dev LayerZero ULN config type id used by `setConfig`
+    uint32 private constant CONFIG_TYPE_ULN = 2;
+
+    error RegistryNotSet();
+
+    event ConfigSynced(uint32[] dstEids, uint256 version);
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor(address _configRegistry) {
+        configRegistry = _configRegistry;
+    }
+
+    /// @inheritdoc IConfigurableOFT
+    function syncedConfigVersion() public view override returns (uint256) {
+        return _getConfigurableOFTStorage().syncedVersion;
+    }
+
+    /// @inheritdoc IConfigurableOFT
+    function syncConfig(uint32[] calldata dstEids) external override {
+        address reg = configRegistry;
+        if (reg == address(0)) revert RegistryNotSet();
+
+        for (uint256 i; i < dstEids.length;) {
+            IOFTConfigRegistry.PathwayConfig memory c = IOFTConfigRegistry(reg).getPathwayConfig(dstEids[i]);
+
+            UlnConfig memory uln = UlnConfig({ confirmations: c.confirmations, requiredDVNCount: uint8(c.requiredDVNs.length), optionalDVNCount: uint8(c.optionalDVNs.length), optionalDVNThreshold: c.optionalDVNThreshold, requiredDVNs: c.requiredDVNs, optionalDVNs: c.optionalDVNs });
+
+            SetConfigParam[] memory params = new SetConfigParam[](1);
+            params[0] = SetConfigParam({ eid: dstEids[i], configType: CONFIG_TYPE_ULN, config: abi.encode(uln) });
+
+            // Self-authorized: msg.sender (this bridge) == oapp. No delegate needed.
+            endpoint.setConfig(address(this), c.sendLib, params);
+            endpoint.setConfig(address(this), c.receiveLib, params);
+
+            unchecked {
+                ++i;
+            }
+        }
+
+        uint256 v = IOFTConfigRegistry(reg).configVersion();
+        _getConfigurableOFTStorage().syncedVersion = v;
+        emit ConfigSynced(dstEids, v);
+    }
+
+    function _getConfigurableOFTStorage() private pure returns (ConfigurableOFTStorage storage $) {
+        assembly {
+            $.slot := ConfigurableOFTStorageLocation
+        }
+    }
+}

--- a/src/oft/ConfigurableOFTBase.sol
+++ b/src/oft/ConfigurableOFTBase.sol
@@ -18,7 +18,8 @@ import { IOFTConfigRegistry } from "../interfaces/IOFTConfigRegistry.sol";
  * @dev Self-configuration works because LayerZero authorizes
  *      `msg.sender == oapp` for `setConfig` (verified in EndpointV2), so no
  *      delegate transfer is needed. The registry address is immutable (one per
- *      chain, like the endpoint); the synced version lives in per-proxy storage.
+ *      chain, like the endpoint); the bridge keeps no per-proxy sync state —
+ *      each sync is observable via the {ConfigSynced} event.
  *
  *      Only the DVN/library config (endpoint-side) is synced here. Enforced
  *      options are owner-gated on the OApp and are set separately by the owner.
@@ -26,15 +27,6 @@ import { IOFTConfigRegistry } from "../interfaces/IOFTConfigRegistry.sol";
 abstract contract ConfigurableOFTBase is OFTCoreUpgradeable, IConfigurableOFT {
     /// @notice Shared config registry, fixed at impl deploy (one per chain)
     address public immutable override configRegistry;
-
-    /// @custom:storage-location erc7201:etherfi.storage.ConfigurableOFT
-    struct ConfigurableOFTStorage {
-        /// @notice Registry config version this proxy last synced to
-        uint256 syncedVersion;
-    }
-
-    // keccak256(abi.encode(uint256(keccak256("etherfi.storage.ConfigurableOFT")) - 1)) & ~bytes32(uint256(0xff))
-    bytes32 private constant ConfigurableOFTStorageLocation = 0xd18e887461873c61ac61602c54f3a01e3e69d73cf3dd7f9579b5f219dabfca00;
 
     /// @dev LayerZero ULN config type id used by `setConfig`
     uint32 private constant CONFIG_TYPE_ULN = 2;
@@ -49,18 +41,11 @@ abstract contract ConfigurableOFTBase is OFTCoreUpgradeable, IConfigurableOFT {
     }
 
     /**
-     * @notice The registry config version this bridge last synced to
-     * @return The last-synced config version (per-proxy)
-     */
-    function syncedConfigVersion() public view override returns (uint256) {
-        return _getConfigurableOFTStorage().syncedVersion;
-    }
-
-    /**
      * @notice Pulls the canonical config from the registry and applies it to this
      *         bridge's own endpoint rows for each destination.
      * @dev Self-authorized: `msg.sender == oapp` lets this bridge call `setConfig` on the
-     *      endpoint without a delegate. Records the synced version in per-proxy storage.
+     *      endpoint without a delegate. Emits {ConfigSynced}; the bridge keeps no per-proxy
+     *      sync state, so verify applied config by reading the endpoint rows.
      * @param dstEids Destination endpoint IDs to (re)configure
      */
     function syncConfig(uint32[] calldata dstEids) external override {
@@ -84,14 +69,6 @@ abstract contract ConfigurableOFTBase is OFTCoreUpgradeable, IConfigurableOFT {
             }
         }
 
-        uint256 v = IOFTConfigRegistry(reg).configVersion();
-        _getConfigurableOFTStorage().syncedVersion = v;
-        emit ConfigSynced(dstEids, v);
-    }
-
-    function _getConfigurableOFTStorage() private pure returns (ConfigurableOFTStorage storage $) {
-        assembly {
-            $.slot := ConfigurableOFTStorageLocation
-        }
+        emit ConfigSynced(dstEids, IOFTConfigRegistry(reg).configVersion());
     }
 }

--- a/src/oft/ConfigurableOFTBase.sol
+++ b/src/oft/ConfigurableOFTBase.sol
@@ -33,7 +33,7 @@ abstract contract ConfigurableOFTBase is OFTCoreUpgradeable, IConfigurableOFT {
 
     error RegistryNotSet();
 
-    event ConfigSynced(uint32[] dstEids, uint256 version);
+    event ConfigSynced(uint32[] dstEids);
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(address _configRegistry) {
@@ -69,6 +69,6 @@ abstract contract ConfigurableOFTBase is OFTCoreUpgradeable, IConfigurableOFT {
             }
         }
 
-        emit ConfigSynced(dstEids, IOFTConfigRegistry(reg).configVersion());
+        emit ConfigSynced(dstEids);
     }
 }

--- a/src/oft/ConfigurableOFTBase.sol
+++ b/src/oft/ConfigurableOFTBase.sol
@@ -48,12 +48,21 @@ abstract contract ConfigurableOFTBase is OFTCoreUpgradeable, IConfigurableOFT {
         configRegistry = _configRegistry;
     }
 
-    /// @inheritdoc IConfigurableOFT
+    /**
+     * @notice The registry config version this bridge last synced to
+     * @return The last-synced config version (per-proxy)
+     */
     function syncedConfigVersion() public view override returns (uint256) {
         return _getConfigurableOFTStorage().syncedVersion;
     }
 
-    /// @inheritdoc IConfigurableOFT
+    /**
+     * @notice Pulls the canonical config from the registry and applies it to this
+     *         bridge's own endpoint rows for each destination.
+     * @dev Self-authorized: `msg.sender == oapp` lets this bridge call `setConfig` on the
+     *      endpoint without a delegate. Records the synced version in per-proxy storage.
+     * @param dstEids Destination endpoint IDs to (re)configure
+     */
     function syncConfig(uint32[] calldata dstEids) external override {
         address reg = configRegistry;
         if (reg == address(0)) revert RegistryNotSet();

--- a/src/oft/EtherFiOFTAdapter.sol
+++ b/src/oft/EtherFiOFTAdapter.sol
@@ -101,12 +101,12 @@ contract EtherFiOFTAdapter is ConfigurableOFTBase {
     // ---------------------------------------------------------------------
 
     /// @dev SD -> LD: scale up by the per-proxy {conversionRate}.
-    function _toLD(uint64 _amountSD) internal view virtual override returns (uint256 amountLD) {
+    function _toLD(uint64 _amountSD) internal view virtual override returns (uint256) {
         return _amountSD * _getStorage().decimalConversionRate;
     }
 
     /// @dev LD -> SD: scale down by the per-proxy {conversionRate}; reverts if the result exceeds uint64.
-    function _toSD(uint256 _amountLD) internal view virtual override returns (uint64 amountSD) {
+    function _toSD(uint256 _amountLD) internal view virtual override returns (uint64) {
         uint256 sd = _amountLD / _getStorage().decimalConversionRate;
         if (sd > type(uint64).max) revert AmountSDOverflowed(sd);
         // casting to 'uint64' is safe because the line above reverts when sd exceeds type(uint64).max
@@ -115,7 +115,7 @@ contract EtherFiOFTAdapter is ConfigurableOFTBase {
     }
 
     /// @dev Floors `_amountLD` to a whole multiple of the per-proxy {conversionRate}, dropping sub-SD dust.
-    function _removeDust(uint256 _amountLD) internal view virtual override returns (uint256 amountLD) {
+    function _removeDust(uint256 _amountLD) internal view virtual override returns (uint256) {
         uint256 rate = _getStorage().decimalConversionRate;
         // Intentional: floors _amountLD to a multiple of `rate`, discarding dust (matches LayerZero OFTCore).
         // forge-lint: disable-next-line(divide-before-multiply)
@@ -133,14 +133,15 @@ contract EtherFiOFTAdapter is ConfigurableOFTBase {
      *      rather than silently under-collateralizing the shadow supply. Supporting
      *      them (bridging the post-fee amount) is a deliberate per-asset follow-up.
      */
-    function _debit(address _from, uint256 _amountLD, uint256 _minAmountLD, uint32 _dstEid) internal virtual override returns (uint256 amountSentLD, uint256 amountReceivedLD) {
-        (amountSentLD, amountReceivedLD) = _debitView(_amountLD, _minAmountLD, _dstEid);
+    function _debit(address _from, uint256 _amountLD, uint256 _minAmountLD, uint32 _dstEid) internal virtual override returns (uint256, uint256) {
+        (uint256 amountSentLD, uint256 amountReceivedLD) = _debitView(_amountLD, _minAmountLD, _dstEid);
 
         IERC20 underlying = IERC20(_getStorage().innerToken);
         uint256 balanceBefore = underlying.balanceOf(address(this));
         underlying.safeTransferFrom(_from, address(this), amountSentLD);
         uint256 received = underlying.balanceOf(address(this)) - balanceBefore;
         if (received != amountSentLD) revert NonLosslessTransfer(amountSentLD, received);
+        return (amountSentLD, amountReceivedLD);
     }
 
     /**
@@ -154,7 +155,7 @@ contract EtherFiOFTAdapter is ConfigurableOFTBase {
         internal
         virtual
         override
-        returns (uint256 amountReceivedLD)
+        returns (uint256)
     {
         IERC20(_getStorage().innerToken).safeTransfer(_to, _amountLD);
         return _amountLD;

--- a/src/oft/EtherFiOFTAdapter.sol
+++ b/src/oft/EtherFiOFTAdapter.sol
@@ -1,48 +1,64 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
+import { IERC20, IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
 import { OFTCoreUpgradeable } from "@layerzerolabs/oft-evm-upgradeable/contracts/oft/OFTCoreUpgradeable.sol";
+
+import { ConfigurableOFTBase } from "./ConfigurableOFTBase.sol";
 
 /**
  * @title EtherFiOFTAdapter
  * @author ether.fi
- * @notice Lock-on-deposit OFT adapter beacon implementation deployed once per chain
+ * @notice Lock-on-deposit OFT adapter beacon implementation deployed ONCE per chain
  *         and reused for every wrapped ERC-20 via a {BeaconFactory}-style proxy.
- * @dev Unlike the upstream `OFTAdapterUpgradeable`, the underlying token is held in
- *      ERC-7201 storage rather than as an immutable. This is what lets ONE
- *      implementation back many per-token beacon proxies (the {OFTAdapterFactory}
- *      pattern).
+ * @dev Option 1 (single beacon for all assets). Both the underlying token AND its
+ *      decimal conversion rate live in ERC-7201 per-proxy storage, set in
+ *      {initialize}. That is what lets ONE implementation back proxies for tokens
+ *      of any decimal precision (6 / 8 / 18 ...), unlike the upstream
+ *      `OFTAdapterUpgradeable` which bakes both into immutables.
  *
- *      The LayerZero endpoint and shared `decimalConversionRate` are immutable in
- *      {OFTCoreUpgradeable}'s constructor. That is fine for the impl: one endpoint
- *      per chain, and `_localDecimals` is set conservatively (default 18). Tokens
- *      whose mainnet decimals differ from this impl's `_localDecimals` must use a
- *      separate beacon impl.
+ *      The LayerZero endpoint stays immutable in {OFTCoreUpgradeable} (constant per
+ *      chain, so one beacon impl per chain is correct). The parent's immutable
+ *      `decimalConversionRate` is set to a dead placeholder and is fully shadowed
+ *      by the storage value via the {_toLD}/{_toSD}/{_removeDust} overrides below.
  *
- *      Per-proxy logic (deposit lock / withdraw unlock) is left as a TODO so this
- *      file remains a compiling skeleton.
+ *      KNOWN WART: the inherited public getter `decimalConversionRate()` returns the
+ *      dead placeholder, not the per-proxy rate. Solidity does not allow overriding
+ *      an auto-generated getter. Internal math is correct; external readers should
+ *      use {conversionRate()}.
  */
-contract EtherFiOFTAdapter is OFTCoreUpgradeable {
+contract EtherFiOFTAdapter is ConfigurableOFTBase {
+    using SafeERC20 for IERC20;
+
     /// @custom:storage-location erc7201:etherfi.storage.EtherFiOFTAdapter
     struct EtherFiOFTAdapterStorage {
         /// @notice The underlying ERC-20 locked by this adapter
         address innerToken;
+        /// @notice 10 ** (innerToken.decimals() - sharedDecimals()); shadows the parent immutable
+        uint256 decimalConversionRate;
     }
 
     // keccak256(abi.encode(uint256(keccak256("etherfi.storage.EtherFiOFTAdapter")) - 1)) & ~bytes32(uint256(0xff))
     bytes32 private constant EtherFiOFTAdapterStorageLocation = 0x200710ada2aa0ef551cda8c009b7014f4db5ac2e23f395322943d7626f47ff00;
 
+    /// @dev Dead placeholder fed to the parent constructor; the real rate lives in storage.
+    uint8 private constant PLACEHOLDER_LOCAL_DECIMALS = 18;
+
     /// @notice Thrown when constructor or initializer receives a zero address
     error InvalidAddress();
+    /// @notice Thrown when the underlying is not a lossless (1-in-1-out) token, e.g. fee-on-transfer
+    error NonLosslessTransfer(uint256 expected, uint256 received);
 
     /**
-     * @dev Constructor fixes the LZ endpoint and local decimals for this beacon impl.
+     * @dev Constructor fixes only the LZ endpoint for this beacon impl. Decimals are
+     *      per-proxy (storage), so no per-impl decimals argument is needed.
      * @param _lzEndpoint LayerZero endpoint on the local chain
-     * @param _localDecimals Local decimal precision the impl supports (e.g. 18)
      */
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor(address _lzEndpoint, uint8 _localDecimals) OFTCoreUpgradeable(_localDecimals, _lzEndpoint) {
-        if (_lzEndpoint == address(0)) revert InvalidAddress();
+    constructor(address _lzEndpoint, address _configRegistry) OFTCoreUpgradeable(PLACEHOLDER_LOCAL_DECIMALS, _lzEndpoint) ConfigurableOFTBase(_configRegistry) {
+        if (_lzEndpoint == address(0) || _configRegistry == address(0)) revert InvalidAddress();
         _disableInitializers();
     }
 
@@ -56,59 +72,88 @@ contract EtherFiOFTAdapter is OFTCoreUpgradeable {
         __Ownable_init(_delegate);
         __OFTCore_init(_delegate);
 
-        _getStorage().innerToken = _innerToken;
+        uint8 localDecimals = IERC20Metadata(_innerToken).decimals();
+        if (localDecimals < sharedDecimals()) revert InvalidLocalDecimals();
+
+        EtherFiOFTAdapterStorage storage $ = _getStorage();
+        $.innerToken = _innerToken;
+        $.decimalConversionRate = 10 ** (localDecimals - sharedDecimals());
     }
 
-    /**
-     * @notice Returns the underlying ERC-20 wrapped by this adapter
-     * @return The inner token address
-     */
+    /// @notice Returns the underlying ERC-20 wrapped by this adapter
     function token() public view returns (address) {
         return _getStorage().innerToken;
     }
 
-    /**
-     * @notice Indicates that callers must approve {token()} before sending
-     * @return True — lock-on-deposit requires ERC-20 approval
-     */
+    /// @notice The per-proxy decimal conversion rate (use this, not the inherited getter)
+    function conversionRate() public view returns (uint256) {
+        return _getStorage().decimalConversionRate;
+    }
+
+    /// @notice Lock-on-deposit requires ERC-20 approval of {token()}
     function approvalRequired() external pure virtual returns (bool) {
         return true;
     }
 
+    // ---------------------------------------------------------------------
+    // Decimal scaling — overridden to read the per-proxy rate from storage
+    // instead of the parent's immutable. This is the crux of Option 1.
+    // ---------------------------------------------------------------------
+
+    function _toLD(uint64 _amountSD) internal view virtual override returns (uint256 amountLD) {
+        return _amountSD * _getStorage().decimalConversionRate;
+    }
+
+    function _toSD(uint256 _amountLD) internal view virtual override returns (uint64 amountSD) {
+        uint256 sd = _amountLD / _getStorage().decimalConversionRate;
+        if (sd > type(uint64).max) revert AmountSDOverflowed(sd);
+        // casting to 'uint64' is safe because the line above reverts when sd exceeds type(uint64).max
+        // forge-lint: disable-next-line(unsafe-typecast)
+        return uint64(sd);
+    }
+
+    function _removeDust(uint256 _amountLD) internal view virtual override returns (uint256 amountLD) {
+        uint256 rate = _getStorage().decimalConversionRate;
+        // Intentional: floors _amountLD to a multiple of `rate`, discarding dust (matches LayerZero OFTCore).
+        // forge-lint: disable-next-line(divide-before-multiply)
+        return (_amountLD / rate) * rate;
+    }
+
+    // ---------------------------------------------------------------------
+    // Lock / unlock — read the underlying from storage
+    // ---------------------------------------------------------------------
+
     /**
-     * @dev Lock the caller's underlying tokens before bridging out
-     * @param _from Source of funds
-     * @param _amountLD Local-decimal amount the user wants to send
-     * @param _minAmountLD Minimum acceptable receive amount (slippage)
-     * @param _dstEid Destination LayerZero endpoint ID
-     * @return amountSentLD Amount actually pulled in local decimals
-     * @return amountReceivedLD Amount that will be credited on the remote
+     * @dev Lock the caller's underlying tokens before bridging out.
+     * @dev Enforces a lossless (1-in-1-out) transfer via a pre/post balance check.
+     *      Fee-on-transfer assets (e.g. PAXG with the fee switched on) revert here
+     *      rather than silently under-collateralizing the shadow supply. Supporting
+     *      them (bridging the post-fee amount) is a deliberate per-asset follow-up.
      */
-    function _debit(address _from, uint256 _amountLD, uint256 _minAmountLD, uint32 _dstEid)
-        internal
-        virtual
-        override
-        returns (uint256 amountSentLD, uint256 amountReceivedLD)
-    {
+    function _debit(address _from, uint256 _amountLD, uint256 _minAmountLD, uint32 _dstEid) internal virtual override returns (uint256 amountSentLD, uint256 amountReceivedLD) {
         (amountSentLD, amountReceivedLD) = _debitView(_amountLD, _minAmountLD, _dstEid);
-        _from;
-        // TODO: IERC20(token()).safeTransferFrom(_from, address(this), amountSentLD);
+
+        IERC20 underlying = IERC20(_getStorage().innerToken);
+        uint256 balanceBefore = underlying.balanceOf(address(this));
+        underlying.safeTransferFrom(_from, address(this), amountSentLD);
+        uint256 received = underlying.balanceOf(address(this)) - balanceBefore;
+        if (received != amountSentLD) revert NonLosslessTransfer(amountSentLD, received);
     }
 
     /**
-     * @dev Unlock and transfer underlying tokens to the recipient on credit
-     * @param _to Recipient
-     * @param _amountLD Local-decimal amount to release
-     * @return amountReceivedLD Amount actually transferred out
+     * @dev Unlock and transfer underlying tokens to the recipient on credit.
      */
-    function _credit(address _to, uint256 _amountLD, uint32 /*_srcEid*/ )
+    function _credit(
+        address _to,
+        uint256 _amountLD,
+        uint32 /*_srcEid*/
+    )
         internal
         virtual
         override
         returns (uint256 amountReceivedLD)
     {
-        _to;
-        // TODO: IERC20(token()).safeTransfer(_to, _amountLD);
+        IERC20(_getStorage().innerToken).safeTransfer(_to, _amountLD);
         return _amountLD;
     }
 

--- a/src/oft/EtherFiOFTAdapter.sol
+++ b/src/oft/EtherFiOFTAdapter.sol
@@ -100,10 +100,12 @@ contract EtherFiOFTAdapter is ConfigurableOFTBase {
     // instead of the parent's immutable. This is the crux of Option 1.
     // ---------------------------------------------------------------------
 
+    /// @dev SD -> LD: scale up by the per-proxy {conversionRate}.
     function _toLD(uint64 _amountSD) internal view virtual override returns (uint256 amountLD) {
         return _amountSD * _getStorage().decimalConversionRate;
     }
 
+    /// @dev LD -> SD: scale down by the per-proxy {conversionRate}; reverts if the result exceeds uint64.
     function _toSD(uint256 _amountLD) internal view virtual override returns (uint64 amountSD) {
         uint256 sd = _amountLD / _getStorage().decimalConversionRate;
         if (sd > type(uint64).max) revert AmountSDOverflowed(sd);
@@ -112,6 +114,7 @@ contract EtherFiOFTAdapter is ConfigurableOFTBase {
         return uint64(sd);
     }
 
+    /// @dev Floors `_amountLD` to a whole multiple of the per-proxy {conversionRate}, dropping sub-SD dust.
     function _removeDust(uint256 _amountLD) internal view virtual override returns (uint256 amountLD) {
         uint256 rate = _getStorage().decimalConversionRate;
         // Intentional: floors _amountLD to a multiple of `rate`, discarding dust (matches LayerZero OFTCore).

--- a/src/oft/EtherFiShadowOFT.sol
+++ b/src/oft/EtherFiShadowOFT.sol
@@ -81,10 +81,12 @@ contract EtherFiShadowOFT is OFTUpgradeable, ConfigurableOFTBase {
     // Decimal scaling — overridden to read the per-proxy rate from storage
     // ---------------------------------------------------------------------
 
+    /// @dev SD -> LD: scale up by the per-proxy {conversionRate}.
     function _toLD(uint64 _amountSD) internal view virtual override returns (uint256 amountLD) {
         return _amountSD * _getStorage().decimalConversionRate;
     }
 
+    /// @dev LD -> SD: scale down by the per-proxy {conversionRate}; reverts if the result exceeds uint64.
     function _toSD(uint256 _amountLD) internal view virtual override returns (uint64 amountSD) {
         uint256 sd = _amountLD / _getStorage().decimalConversionRate;
         if (sd > type(uint64).max) revert AmountSDOverflowed(sd);
@@ -93,6 +95,7 @@ contract EtherFiShadowOFT is OFTUpgradeable, ConfigurableOFTBase {
         return uint64(sd);
     }
 
+    /// @dev Floors `_amountLD` to a whole multiple of the per-proxy {conversionRate}, dropping sub-SD dust.
     function _removeDust(uint256 _amountLD) internal view virtual override returns (uint256 amountLD) {
         uint256 rate = _getStorage().decimalConversionRate;
         // Intentional: floors _amountLD to a multiple of `rate`, discarding dust (matches LayerZero OFTCore).

--- a/src/oft/EtherFiShadowOFT.sol
+++ b/src/oft/EtherFiShadowOFT.sol
@@ -3,27 +3,47 @@ pragma solidity ^0.8.28;
 
 import { OFTUpgradeable } from "@layerzerolabs/oft-evm-upgradeable/contracts/oft/OFTUpgradeable.sol";
 
+import { ConfigurableOFTBase } from "./ConfigurableOFTBase.sol";
+
 /**
  * @title EtherFiShadowOFT
  * @author ether.fi
- * @notice Mintable iTOKEN beacon implementation deployed once per destination chain
+ * @notice Mintable iTOKEN beacon implementation deployed ONCE per destination chain
  *         (e.g. Optimism) and reused for every listed asset via the
- *         {ShadowOFTFactory}. Each proxy is its own ERC-20 with a distinct
- *         name/symbol, but shares this single implementation behind a beacon.
- * @dev The LayerZero endpoint and `decimalConversionRate` are immutable per impl.
- *      Tokens with non-standard decimals should use a separate impl/beacon.
+ *         {ShadowOFTFactory}. Each proxy is its own ERC-20 (distinct name/symbol/
+ *         decimals) but shares this single implementation behind a beacon.
+ * @dev Option 1 (single beacon for all assets). The local decimals and the decimal
+ *      conversion rate live in ERC-7201 per-proxy storage, set in {initialize}, so
+ *      ONE implementation serves iTOKENs of any precision and each mirrors its
+ *      underlying's `decimals()` exactly (the COR-699 requirement).
+ *
+ *      The parent's immutable `decimalConversionRate` is shadowed by the storage
+ *      value via the {_toLD}/{_toSD}/{_removeDust} overrides. {decimals} is read
+ *      from storage; before initialization it returns a safe placeholder so the
+ *      parent constructor (which reads `decimals()`) does not revert.
  */
-contract EtherFiShadowOFT is OFTUpgradeable {
+contract EtherFiShadowOFT is OFTUpgradeable, ConfigurableOFTBase {
+    /// @custom:storage-location erc7201:etherfi.storage.EtherFiShadowOFT
+    struct EtherFiShadowOFTStorage {
+        /// @notice Local decimals, mirrors the mainnet underlying
+        uint8 localDecimals;
+        /// @notice 10 ** (localDecimals - sharedDecimals())
+        uint256 decimalConversionRate;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("etherfi.storage.EtherFiShadowOFT")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant EtherFiShadowOFTStorageLocation = 0xacd5171b564d1e274f93f0efa9a43f5c85ba6a0cbb05f0ccd0a8bb49c007b800;
+
+    /// @dev Returned by {decimals} before initialization so the parent constructor's
+    ///      `decimals()` read passes the `>= sharedDecimals()` check.
+    uint8 private constant PLACEHOLDER_LOCAL_DECIMALS = 18;
+
     /// @notice Thrown when constructor or initializer receives a zero address
     error InvalidAddress();
 
-    /**
-     * @dev Constructor fixes the LZ endpoint for this beacon impl.
-     * @param _lzEndpoint LayerZero endpoint on the local chain
-     */
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor(address _lzEndpoint) OFTUpgradeable(_lzEndpoint) {
-        if (_lzEndpoint == address(0)) revert InvalidAddress();
+    constructor(address _lzEndpoint, address _configRegistry) OFTUpgradeable(_lzEndpoint) ConfigurableOFTBase(_configRegistry) {
+        if (_lzEndpoint == address(0) || _configRegistry == address(0)) revert InvalidAddress();
         _disableInitializers();
     }
 
@@ -31,11 +51,58 @@ contract EtherFiShadowOFT is OFTUpgradeable {
      * @notice Initializes a Shadow OFT proxy as a fresh ERC-20 + OApp
      * @param _name ERC-20 name (convention: "EtherFi <NAME>")
      * @param _symbol ERC-20 symbol (convention: "i<SYMBOL>")
+     * @param _localDecimals Decimals to mirror from the mainnet underlying
      * @param _delegate LayerZero delegate (OApp owner; can set peers/options)
      */
-    function initialize(string memory _name, string memory _symbol, address _delegate) external initializer {
+    function initialize(string memory _name, string memory _symbol, uint8 _localDecimals, address _delegate) external initializer {
         if (_delegate == address(0)) revert InvalidAddress();
+        if (_localDecimals < sharedDecimals()) revert InvalidLocalDecimals();
+
         __Ownable_init(_delegate);
         __OFT_init(_name, _symbol, _delegate);
+
+        EtherFiShadowOFTStorage storage $ = _getStorage();
+        $.localDecimals = _localDecimals;
+        $.decimalConversionRate = 10 ** (_localDecimals - sharedDecimals());
+    }
+
+    /// @notice iTOKEN decimals, mirroring the underlying. Placeholder until initialized.
+    function decimals() public view override returns (uint8) {
+        uint8 d = _getStorage().localDecimals;
+        return d == 0 ? PLACEHOLDER_LOCAL_DECIMALS : d;
+    }
+
+    /// @notice The per-proxy decimal conversion rate (use this, not the inherited getter)
+    function conversionRate() public view returns (uint256) {
+        return _getStorage().decimalConversionRate;
+    }
+
+    // ---------------------------------------------------------------------
+    // Decimal scaling — overridden to read the per-proxy rate from storage
+    // ---------------------------------------------------------------------
+
+    function _toLD(uint64 _amountSD) internal view virtual override returns (uint256 amountLD) {
+        return _amountSD * _getStorage().decimalConversionRate;
+    }
+
+    function _toSD(uint256 _amountLD) internal view virtual override returns (uint64 amountSD) {
+        uint256 sd = _amountLD / _getStorage().decimalConversionRate;
+        if (sd > type(uint64).max) revert AmountSDOverflowed(sd);
+        // casting to 'uint64' is safe because the line above reverts when sd exceeds type(uint64).max
+        // forge-lint: disable-next-line(unsafe-typecast)
+        return uint64(sd);
+    }
+
+    function _removeDust(uint256 _amountLD) internal view virtual override returns (uint256 amountLD) {
+        uint256 rate = _getStorage().decimalConversionRate;
+        // Intentional: floors _amountLD to a multiple of `rate`, discarding dust (matches LayerZero OFTCore).
+        // forge-lint: disable-next-line(divide-before-multiply)
+        return (_amountLD / rate) * rate;
+    }
+
+    function _getStorage() private pure returns (EtherFiShadowOFTStorage storage $) {
+        assembly {
+            $.slot := EtherFiShadowOFTStorageLocation
+        }
     }
 }

--- a/src/oft/EtherFiShadowOFT.sol
+++ b/src/oft/EtherFiShadowOFT.sol
@@ -82,12 +82,12 @@ contract EtherFiShadowOFT is OFTUpgradeable, ConfigurableOFTBase {
     // ---------------------------------------------------------------------
 
     /// @dev SD -> LD: scale up by the per-proxy {conversionRate}.
-    function _toLD(uint64 _amountSD) internal view virtual override returns (uint256 amountLD) {
+    function _toLD(uint64 _amountSD) internal view virtual override returns (uint256) {
         return _amountSD * _getStorage().decimalConversionRate;
     }
 
     /// @dev LD -> SD: scale down by the per-proxy {conversionRate}; reverts if the result exceeds uint64.
-    function _toSD(uint256 _amountLD) internal view virtual override returns (uint64 amountSD) {
+    function _toSD(uint256 _amountLD) internal view virtual override returns (uint64) {
         uint256 sd = _amountLD / _getStorage().decimalConversionRate;
         if (sd > type(uint64).max) revert AmountSDOverflowed(sd);
         // casting to 'uint64' is safe because the line above reverts when sd exceeds type(uint64).max
@@ -96,7 +96,7 @@ contract EtherFiShadowOFT is OFTUpgradeable, ConfigurableOFTBase {
     }
 
     /// @dev Floors `_amountLD` to a whole multiple of the per-proxy {conversionRate}, dropping sub-SD dust.
-    function _removeDust(uint256 _amountLD) internal view virtual override returns (uint256 amountLD) {
+    function _removeDust(uint256 _amountLD) internal view virtual override returns (uint256) {
         uint256 rate = _getStorage().decimalConversionRate;
         // Intentional: floors _amountLD to a multiple of `rate`, discarding dust (matches LayerZero OFTCore).
         // forge-lint: disable-next-line(divide-before-multiply)

--- a/src/oft/OFTAdapterFactory.sol
+++ b/src/oft/OFTAdapterFactory.sol
@@ -56,7 +56,15 @@ contract OFTAdapterFactory is IOFTAdapterFactory, BeaconFactory {
         __BeaconFactory_initialize(_roleRegistry, _adapterImpl);
     }
 
-    /// @inheritdoc IOFTAdapterFactory
+    /**
+     * @notice Deploys a new OFTAdapter beacon proxy for `underlyingToken`
+     * @dev Caller must hold the factory admin role. Address is deterministic via CREATE3
+     *      so the OP-side `ShadowOFTFactory` can mirror it with the same `salt`.
+     * @param salt CREATE3 salt; conventionally `keccak256(abi.encode("EtherFiOFT", underlyingToken))`
+     * @param underlyingToken The mainnet ERC-20 to wrap
+     * @param delegate LayerZero delegate (typically the protocol owner/multisig)
+     * @return adapter Address of the deployed adapter proxy
+     */
     function deployAdapter(bytes32 salt, address underlyingToken, address delegate) external whenNotPaused returns (address adapter) {
         if (!roleRegistry().hasRole(OFT_ADAPTER_FACTORY_ADMIN_ROLE, msg.sender)) revert OnlyAdmin();
         if (underlyingToken == address(0)) revert InvalidUnderlying();
@@ -82,17 +90,30 @@ contract OFTAdapterFactory is IOFTAdapterFactory, BeaconFactory {
         IConfigurableOFT(adapter).syncConfig(IOFTConfigRegistry(registry).activeDstEids());
     }
 
-    /// @inheritdoc IOFTAdapterFactory
+    /**
+     * @notice Returns the adapter deployed for an underlying token, or zero if none
+     * @param underlyingToken The mainnet ERC-20
+     * @return adapter The adapter proxy address (0 if not deployed)
+     */
     function adapterOf(address underlyingToken) external view returns (address adapter) {
         return _getStorage().adapterOfUnderlying[underlyingToken];
     }
 
-    /// @inheritdoc IOFTAdapterFactory
+    /**
+     * @notice Returns the underlying token wrapped by a given adapter
+     * @param adapter The adapter proxy
+     * @return underlyingToken The wrapped ERC-20 address
+     */
     function underlyingOf(address adapter) external view returns (address underlyingToken) {
         return _getStorage().underlyingOfAdapter[adapter];
     }
 
-    /// @inheritdoc IOFTAdapterFactory
+    /**
+     * @notice Paginated enumeration of deployed adapter addresses
+     * @param start Starting index in the deployment set
+     * @param n Maximum number of entries to return
+     * @return adapters Array of adapter proxy addresses
+     */
     function getDeployedAdapters(uint256 start, uint256 n) external view returns (address[] memory adapters) {
         OFTAdapterFactoryStorage storage $ = _getStorage();
         uint256 length = $.deployed.length();
@@ -108,7 +129,10 @@ contract OFTAdapterFactory is IOFTAdapterFactory, BeaconFactory {
         }
     }
 
-    /// @inheritdoc IOFTAdapterFactory
+    /**
+     * @notice Total number of adapters deployed by this factory
+     * @return Number of deployed adapters
+     */
     function numAdaptersDeployed() external view returns (uint256) {
         return _getStorage().deployed.length();
     }

--- a/src/oft/OFTAdapterFactory.sol
+++ b/src/oft/OFTAdapterFactory.sol
@@ -5,6 +5,8 @@ import { EnumerableSetLib } from "solady/utils/EnumerableSetLib.sol";
 
 import { BeaconFactory } from "../beacon-factory/BeaconFactory.sol";
 import { IOFTAdapterFactory } from "../interfaces/IOFTAdapterFactory.sol";
+import { IConfigurableOFT } from "../interfaces/IConfigurableOFT.sol";
+import { IOFTConfigRegistry } from "../interfaces/IOFTConfigRegistry.sol";
 import { EtherFiOFTAdapter } from "./EtherFiOFTAdapter.sol";
 
 /**
@@ -14,9 +16,12 @@ import { EtherFiOFTAdapter } from "./EtherFiOFTAdapter.sol";
  *         per listed ERC-20.
  * @dev Mirrors the {EtherFiSafeFactory} pattern: all adapters share one
  *      {EtherFiOFTAdapter} implementation behind a single {UpgradeableBeacon},
- *      and per-token instances are cheap CREATE3 beacon proxies. The same
- *      `salt` is reused on the destination chain via {ShadowOFTFactory} so the
- *      iTOKEN address mirrors the adapter address one-to-one.
+ *      and per-token instances are cheap CREATE3 beacon proxies. A CREATE3
+ *      address is deterministic in `(factory, salt)`, so an adapter's address is
+ *      predictable on its own chain. Matching the mainnet adapter and OP iTOKEN
+ *      addresses one-to-one is a non-goal (it would also require both factories
+ *      at the same address per chain); the `salt` is about per-chain
+ *      predictability, not cross-chain mirroring.
  */
 contract OFTAdapterFactory is IOFTAdapterFactory, BeaconFactory {
     using EnumerableSetLib for EnumerableSetLib.AddressSet;
@@ -52,19 +57,14 @@ contract OFTAdapterFactory is IOFTAdapterFactory, BeaconFactory {
     }
 
     /// @inheritdoc IOFTAdapterFactory
-    function deployAdapter(bytes32 salt, address underlyingToken, address delegate)
-        external
-        whenNotPaused
-        returns (address adapter)
-    {
+    function deployAdapter(bytes32 salt, address underlyingToken, address delegate) external whenNotPaused returns (address adapter) {
         if (!roleRegistry().hasRole(OFT_ADAPTER_FACTORY_ADMIN_ROLE, msg.sender)) revert OnlyAdmin();
         if (underlyingToken == address(0)) revert InvalidUnderlying();
 
         OFTAdapterFactoryStorage storage $ = _getStorage();
         if ($.adapterOfUnderlying[underlyingToken] != address(0)) revert AdapterAlreadyExists();
 
-        bytes memory initData =
-            abi.encodeWithSelector(EtherFiOFTAdapter.initialize.selector, underlyingToken, delegate);
+        bytes memory initData = abi.encodeWithSelector(EtherFiOFTAdapter.initialize.selector, underlyingToken, delegate);
 
         adapter = _deployBeacon(salt, initData);
 
@@ -73,6 +73,13 @@ contract OFTAdapterFactory is IOFTAdapterFactory, BeaconFactory {
         $.underlyingOfAdapter[adapter] = underlyingToken;
 
         emit OFTAdapterDeployed(salt, underlyingToken, adapter);
+
+        // Auto-register + pull canonical LZ config so the new bridge is live without
+        // manual setup. Reverts if the factory lacks CONFIG_REGISTRAR_ROLE or the
+        // registry is unreachable (fail-hard: never leave a bridge unregistered).
+        address registry = IConfigurableOFT(adapter).configRegistry();
+        IOFTConfigRegistry(registry).registerBridge(adapter);
+        IConfigurableOFT(adapter).syncConfig(IOFTConfigRegistry(registry).activeDstEids());
     }
 
     /// @inheritdoc IOFTAdapterFactory
@@ -89,7 +96,7 @@ contract OFTAdapterFactory is IOFTAdapterFactory, BeaconFactory {
     function getDeployedAdapters(uint256 start, uint256 n) external view returns (address[] memory adapters) {
         OFTAdapterFactoryStorage storage $ = _getStorage();
         uint256 length = $.deployed.length();
-        if (start >= length) revert InvalidStartIndex();
+        if (start >= length) return new address[](0);
         if (start + n > length) n = length - start;
 
         adapters = new address[](n);

--- a/src/oft/OFTAdapterFactory.sol
+++ b/src/oft/OFTAdapterFactory.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.8.28;
 import { EnumerableSetLib } from "solady/utils/EnumerableSetLib.sol";
 
 import { BeaconFactory } from "../beacon-factory/BeaconFactory.sol";
-import { IOFTAdapterFactory } from "../interfaces/IOFTAdapterFactory.sol";
 import { IConfigurableOFT } from "../interfaces/IConfigurableOFT.sol";
+import { IOFTAdapterFactory } from "../interfaces/IOFTAdapterFactory.sol";
 import { IOFTConfigRegistry } from "../interfaces/IOFTConfigRegistry.sol";
 import { EtherFiOFTAdapter } from "./EtherFiOFTAdapter.sol";
 

--- a/src/oft/OFTAdapterFactory.sol
+++ b/src/oft/OFTAdapterFactory.sol
@@ -65,7 +65,7 @@ contract OFTAdapterFactory is IOFTAdapterFactory, BeaconFactory {
      * @param delegate LayerZero delegate (typically the protocol owner/multisig)
      * @return adapter Address of the deployed adapter proxy
      */
-    function deployAdapter(bytes32 salt, address underlyingToken, address delegate) external whenNotPaused returns (address adapter) {
+    function deployAdapter(bytes32 salt, address underlyingToken, address delegate) external whenNotPaused returns (address) {
         if (!roleRegistry().hasRole(OFT_ADAPTER_FACTORY_ADMIN_ROLE, msg.sender)) revert OnlyAdmin();
         if (underlyingToken == address(0)) revert InvalidUnderlying();
 
@@ -74,7 +74,7 @@ contract OFTAdapterFactory is IOFTAdapterFactory, BeaconFactory {
 
         bytes memory initData = abi.encodeWithSelector(EtherFiOFTAdapter.initialize.selector, underlyingToken, delegate);
 
-        adapter = _deployBeacon(salt, initData);
+        address adapter = _deployBeacon(salt, initData);
 
         $.deployed.add(adapter);
         $.adapterOfUnderlying[underlyingToken] = adapter;
@@ -88,6 +88,7 @@ contract OFTAdapterFactory is IOFTAdapterFactory, BeaconFactory {
         address registry = IConfigurableOFT(adapter).configRegistry();
         IOFTConfigRegistry(registry).registerBridge(adapter);
         IConfigurableOFT(adapter).syncConfig(IOFTConfigRegistry(registry).activeDstEids());
+        return adapter;
     }
 
     /**
@@ -95,7 +96,7 @@ contract OFTAdapterFactory is IOFTAdapterFactory, BeaconFactory {
      * @param underlyingToken The mainnet ERC-20
      * @return adapter The adapter proxy address (0 if not deployed)
      */
-    function adapterOf(address underlyingToken) external view returns (address adapter) {
+    function adapterOf(address underlyingToken) external view returns (address) {
         return _getStorage().adapterOfUnderlying[underlyingToken];
     }
 
@@ -104,7 +105,7 @@ contract OFTAdapterFactory is IOFTAdapterFactory, BeaconFactory {
      * @param adapter The adapter proxy
      * @return underlyingToken The wrapped ERC-20 address
      */
-    function underlyingOf(address adapter) external view returns (address underlyingToken) {
+    function underlyingOf(address adapter) external view returns (address) {
         return _getStorage().underlyingOfAdapter[adapter];
     }
 
@@ -114,19 +115,20 @@ contract OFTAdapterFactory is IOFTAdapterFactory, BeaconFactory {
      * @param n Maximum number of entries to return
      * @return adapters Array of adapter proxy addresses
      */
-    function getDeployedAdapters(uint256 start, uint256 n) external view returns (address[] memory adapters) {
+    function getDeployedAdapters(uint256 start, uint256 n) external view returns (address[] memory) {
         OFTAdapterFactoryStorage storage $ = _getStorage();
         uint256 length = $.deployed.length();
         if (start >= length) return new address[](0);
         if (start + n > length) n = length - start;
 
-        adapters = new address[](n);
+        address[] memory adapters = new address[](n);
         for (uint256 i = 0; i < n;) {
             adapters[i] = $.deployed.at(start + i);
             unchecked {
                 ++i;
             }
         }
+        return adapters;
     }
 
     /**

--- a/src/oft/OFTConfigRegistry.sol
+++ b/src/oft/OFTConfigRegistry.sol
@@ -87,15 +87,16 @@ contract OFTConfigRegistry is IOFTConfigRegistry, UpgradeableProxy {
      * @notice All destination endpoint ids that have a configured pathway
      * @return eids The active destination endpoint ids
      */
-    function activeDstEids() external view override returns (uint32[] memory eids) {
+    function activeDstEids() external view override returns (uint32[] memory) {
         uint256[] memory raw = _getStorage().activeDstEidSet.values();
-        eids = new uint32[](raw.length);
+        uint32[] memory eids = new uint32[](raw.length);
         for (uint256 i; i < raw.length;) {
             eids[i] = uint32(raw[i]);
             unchecked {
                 ++i;
             }
         }
+        return eids;
     }
 
     /**
@@ -116,18 +117,19 @@ contract OFTConfigRegistry is IOFTConfigRegistry, UpgradeableProxy {
      * @param n Maximum number of entries to return
      * @return bridges Array of registered bridge addresses
      */
-    function getBridges(uint256 start, uint256 n) external view override returns (address[] memory bridges) {
+    function getBridges(uint256 start, uint256 n) external view override returns (address[] memory) {
         OFTConfigRegistryStorage storage $ = _getStorage();
         uint256 len = $.bridgeSet.length();
         if (start >= len) return new address[](0);
         if (start + n > len) n = len - start;
-        bridges = new address[](n);
+        address[] memory bridges = new address[](n);
         for (uint256 i; i < n;) {
             bridges[i] = $.bridgeSet.at(start + i);
             unchecked {
                 ++i;
             }
         }
+        return bridges;
     }
 
     /**

--- a/src/oft/OFTConfigRegistry.sol
+++ b/src/oft/OFTConfigRegistry.sol
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { EnumerableSetLib } from "solady/utils/EnumerableSetLib.sol";
+
+import { IConfigurableOFT } from "../interfaces/IConfigurableOFT.sol";
+import { IOFTConfigRegistry } from "../interfaces/IOFTConfigRegistry.sol";
+import { UpgradeableProxy } from "../utils/UpgradeableProxy.sol";
+
+/**
+ * @title OFTConfigRegistry
+ * @author ether.fi
+ * @notice Single source of truth (per chain) for the LayerZero security config
+ *         (DVN stack + libraries) used by every OFT bridge. Bridges pull from it
+ *         via {IConfigurableOFT-syncConfig}; admins update it once and push to all.
+ * @dev UUPS-upgradeable via {UpgradeableProxy} (gated by the RoleRegistry owner).
+ *      Config edits require CONFIG_ADMIN_ROLE; factories that auto-register new
+ *      bridges hold CONFIG_REGISTRAR_ROLE.
+ */
+contract OFTConfigRegistry is IOFTConfigRegistry, UpgradeableProxy {
+    using EnumerableSetLib for EnumerableSetLib.AddressSet;
+    using EnumerableSetLib for EnumerableSetLib.Uint256Set;
+
+    /// @custom:storage-location erc7201:etherfi.storage.OFTConfigRegistry
+    struct OFTConfigRegistryStorage {
+        mapping(uint32 dstEid => PathwayConfig) pathway;
+        EnumerableSetLib.AddressSet bridgeSet;
+        EnumerableSetLib.Uint256Set activeDstEidSet;
+        uint256 version;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("etherfi.storage.OFTConfigRegistry")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant OFTConfigRegistryStorageLocation = 0x8af526858b42bae478f5f49bbcba7c9c8d3658bf37ed842573174e7417591900;
+
+    /// @notice Role allowed to edit canonical config + trigger pushes
+    bytes32 public constant CONFIG_ADMIN_ROLE = keccak256("OFT_CONFIG_ADMIN_ROLE");
+    /// @notice Role allowed to register new bridges (the factories)
+    bytes32 public constant CONFIG_REGISTRAR_ROLE = keccak256("OFT_CONFIG_REGISTRAR_ROLE");
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(address _roleRegistry) external initializer {
+        __UpgradeableProxy_init(_roleRegistry);
+        __Pausable_init();
+    }
+
+    /// @inheritdoc IOFTConfigRegistry
+    function setPathwayConfig(uint32 dstEid, PathwayConfig calldata cfg) external override whenNotPaused {
+        if (!roleRegistry().hasRole(CONFIG_ADMIN_ROLE, msg.sender)) revert OnlyConfigAdmin();
+        if (cfg.sendLib == address(0) || cfg.receiveLib == address(0) || cfg.requiredDVNs.length == 0) revert InvalidInput();
+
+        OFTConfigRegistryStorage storage $ = _getStorage();
+        $.pathway[dstEid] = cfg;
+        $.activeDstEidSet.add(dstEid); // idempotent: a re-configured destination is not double-listed
+        unchecked {
+            $.version += 1;
+        }
+        emit PathwayConfigSet(dstEid, $.version);
+    }
+
+    /// @inheritdoc IOFTConfigRegistry
+    function getPathwayConfig(uint32 dstEid) external view override returns (PathwayConfig memory) {
+        return _getStorage().pathway[dstEid];
+    }
+
+    /// @inheritdoc IOFTConfigRegistry
+    function configVersion() external view override returns (uint256) {
+        return _getStorage().version;
+    }
+
+    /// @inheritdoc IOFTConfigRegistry
+    function activeDstEids() external view override returns (uint32[] memory eids) {
+        uint256[] memory raw = _getStorage().activeDstEidSet.values();
+        eids = new uint32[](raw.length);
+        for (uint256 i; i < raw.length;) {
+            eids[i] = uint32(raw[i]);
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    /// @inheritdoc IOFTConfigRegistry
+    function registerBridge(address bridge) external override whenNotPaused {
+        if (!roleRegistry().hasRole(CONFIG_REGISTRAR_ROLE, msg.sender)) revert OnlyRegistrar();
+        if (bridge == address(0)) revert InvalidInput();
+        _getStorage().bridgeSet.add(bridge);
+        emit BridgeRegistered(bridge);
+    }
+
+    /// @inheritdoc IOFTConfigRegistry
+    function getBridges(uint256 start, uint256 n) external view override returns (address[] memory bridges) {
+        OFTConfigRegistryStorage storage $ = _getStorage();
+        uint256 len = $.bridgeSet.length();
+        if (start >= len) return new address[](0);
+        if (start + n > len) n = len - start;
+        bridges = new address[](n);
+        for (uint256 i; i < n;) {
+            bridges[i] = $.bridgeSet.at(start + i);
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    /// @inheritdoc IOFTConfigRegistry
+    function numBridges() external view override returns (uint256) {
+        return _getStorage().bridgeSet.length();
+    }
+
+    /// @inheritdoc IOFTConfigRegistry
+    function pushTo(address[] calldata bridges, uint32[] calldata dstEids) external override whenNotPaused {
+        if (!roleRegistry().hasRole(CONFIG_ADMIN_ROLE, msg.sender)) revert OnlyConfigAdmin();
+        for (uint256 i; i < bridges.length;) {
+            IConfigurableOFT(bridges[i]).syncConfig(dstEids);
+            emit ConfigPushed(bridges[i], dstEids);
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    /// @inheritdoc IOFTConfigRegistry
+    function pushToAll(uint32[] calldata dstEids) external override whenNotPaused {
+        if (!roleRegistry().hasRole(CONFIG_ADMIN_ROLE, msg.sender)) revert OnlyConfigAdmin();
+        OFTConfigRegistryStorage storage $ = _getStorage();
+        uint256 len = $.bridgeSet.length();
+        for (uint256 i; i < len;) {
+            address b = $.bridgeSet.at(i);
+            IConfigurableOFT(b).syncConfig(dstEids);
+            emit ConfigPushed(b, dstEids);
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    /// @inheritdoc IOFTConfigRegistry
+    function pushToRange(uint256 start, uint256 count, uint32[] calldata dstEids) external override whenNotPaused {
+        if (!roleRegistry().hasRole(CONFIG_ADMIN_ROLE, msg.sender)) revert OnlyConfigAdmin();
+        OFTConfigRegistryStorage storage $ = _getStorage();
+        uint256 len = $.bridgeSet.length();
+        if (start >= len) return;
+        if (start + count > len) count = len - start;
+        for (uint256 i; i < count;) {
+            address b = $.bridgeSet.at(start + i);
+            IConfigurableOFT(b).syncConfig(dstEids);
+            emit ConfigPushed(b, dstEids);
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    function _getStorage() private pure returns (OFTConfigRegistryStorage storage $) {
+        assembly {
+            $.slot := OFTConfigRegistryStorageLocation
+        }
+    }
+}

--- a/src/oft/OFTConfigRegistry.sol
+++ b/src/oft/OFTConfigRegistry.sol
@@ -107,8 +107,8 @@ contract OFTConfigRegistry is IOFTConfigRegistry, UpgradeableProxy {
     function registerBridge(address bridge) external override whenNotPaused {
         if (!roleRegistry().hasRole(CONFIG_REGISTRAR_ROLE, msg.sender)) revert OnlyRegistrar();
         if (bridge == address(0)) revert InvalidInput();
-        _getStorage().bridgeSet.add(bridge);
-        emit BridgeRegistered(bridge);
+        // Gate the event on a genuine insertion so re-registering a known bridge is a silent no-op.
+        if (_getStorage().bridgeSet.add(bridge)) emit BridgeRegistered(bridge);
     }
 
     /**

--- a/src/oft/OFTConfigRegistry.sol
+++ b/src/oft/OFTConfigRegistry.sol
@@ -47,7 +47,12 @@ contract OFTConfigRegistry is IOFTConfigRegistry, UpgradeableProxy {
         __Pausable_init();
     }
 
-    /// @inheritdoc IOFTConfigRegistry
+    /**
+     * @notice Set/replace the canonical config for a destination (bumps version)
+     * @dev Restricted to CONFIG_ADMIN_ROLE. Reverts on a zero send/receive lib or empty required DVN set.
+     * @param dstEid LayerZero destination endpoint id
+     * @param cfg Full pathway config (libraries, confirmations, DVN stack)
+     */
     function setPathwayConfig(uint32 dstEid, PathwayConfig calldata cfg) external override whenNotPaused {
         if (!roleRegistry().hasRole(CONFIG_ADMIN_ROLE, msg.sender)) revert OnlyConfigAdmin();
         if (cfg.sendLib == address(0) || cfg.receiveLib == address(0) || cfg.requiredDVNs.length == 0) revert InvalidInput();
@@ -61,17 +66,27 @@ contract OFTConfigRegistry is IOFTConfigRegistry, UpgradeableProxy {
         emit PathwayConfigSet(dstEid, $.version);
     }
 
-    /// @inheritdoc IOFTConfigRegistry
+    /**
+     * @notice Returns the canonical config for a destination pathway
+     * @param dstEid LayerZero destination endpoint id
+     * @return The stored pathway config (zero-valued if never set)
+     */
     function getPathwayConfig(uint32 dstEid) external view override returns (PathwayConfig memory) {
         return _getStorage().pathway[dstEid];
     }
 
-    /// @inheritdoc IOFTConfigRegistry
+    /**
+     * @notice Current config version, bumped on every {setPathwayConfig}
+     * @return The monotonic config version
+     */
     function configVersion() external view override returns (uint256) {
         return _getStorage().version;
     }
 
-    /// @inheritdoc IOFTConfigRegistry
+    /**
+     * @notice All destination endpoint ids that have a configured pathway
+     * @return eids The active destination endpoint ids
+     */
     function activeDstEids() external view override returns (uint32[] memory eids) {
         uint256[] memory raw = _getStorage().activeDstEidSet.values();
         eids = new uint32[](raw.length);
@@ -83,7 +98,11 @@ contract OFTConfigRegistry is IOFTConfigRegistry, UpgradeableProxy {
         }
     }
 
-    /// @inheritdoc IOFTConfigRegistry
+    /**
+     * @notice Record a bridge so {pushToAll} can enumerate it (registrar only)
+     * @dev Restricted to CONFIG_REGISTRAR_ROLE (the factories). Reverts on a zero address; idempotent.
+     * @param bridge The OFT bridge to register
+     */
     function registerBridge(address bridge) external override whenNotPaused {
         if (!roleRegistry().hasRole(CONFIG_REGISTRAR_ROLE, msg.sender)) revert OnlyRegistrar();
         if (bridge == address(0)) revert InvalidInput();
@@ -91,7 +110,12 @@ contract OFTConfigRegistry is IOFTConfigRegistry, UpgradeableProxy {
         emit BridgeRegistered(bridge);
     }
 
-    /// @inheritdoc IOFTConfigRegistry
+    /**
+     * @notice Paginated enumeration of registered bridges
+     * @param start Starting index in the bridge set
+     * @param n Maximum number of entries to return
+     * @return bridges Array of registered bridge addresses
+     */
     function getBridges(uint256 start, uint256 n) external view override returns (address[] memory bridges) {
         OFTConfigRegistryStorage storage $ = _getStorage();
         uint256 len = $.bridgeSet.length();
@@ -106,12 +130,20 @@ contract OFTConfigRegistry is IOFTConfigRegistry, UpgradeableProxy {
         }
     }
 
-    /// @inheritdoc IOFTConfigRegistry
+    /**
+     * @notice Total number of registered bridges
+     * @return Number of registered bridges
+     */
     function numBridges() external view override returns (uint256) {
         return _getStorage().bridgeSet.length();
     }
 
-    /// @inheritdoc IOFTConfigRegistry
+    /**
+     * @notice Make the given bridges re-pull config (admin only)
+     * @dev Restricted to CONFIG_ADMIN_ROLE. Calls {IConfigurableOFT-syncConfig} on each bridge.
+     * @param bridges Bridges to refresh
+     * @param dstEids Destination endpoint ids to (re)configure on each bridge
+     */
     function pushTo(address[] calldata bridges, uint32[] calldata dstEids) external override whenNotPaused {
         if (!roleRegistry().hasRole(CONFIG_ADMIN_ROLE, msg.sender)) revert OnlyConfigAdmin();
         for (uint256 i; i < bridges.length;) {
@@ -123,7 +155,12 @@ contract OFTConfigRegistry is IOFTConfigRegistry, UpgradeableProxy {
         }
     }
 
-    /// @inheritdoc IOFTConfigRegistry
+    /**
+     * @notice Make every registered bridge re-pull config (admin only)
+     * @dev Restricted to CONFIG_ADMIN_ROLE. Iterates the full bridge set; for large sets that
+     *      risk the block gas limit, use {pushToRange} to paginate.
+     * @param dstEids Destination endpoint ids to (re)configure on each bridge
+     */
     function pushToAll(uint32[] calldata dstEids) external override whenNotPaused {
         if (!roleRegistry().hasRole(CONFIG_ADMIN_ROLE, msg.sender)) revert OnlyConfigAdmin();
         OFTConfigRegistryStorage storage $ = _getStorage();
@@ -138,7 +175,13 @@ contract OFTConfigRegistry is IOFTConfigRegistry, UpgradeableProxy {
         }
     }
 
-    /// @inheritdoc IOFTConfigRegistry
+    /**
+     * @notice Paginated {pushToAll} for large bridge sets (admin only)
+     * @dev Restricted to CONFIG_ADMIN_ROLE.
+     * @param start Starting index in the bridge set
+     * @param count Maximum number of bridges to refresh
+     * @param dstEids Destination endpoint ids to (re)configure on each bridge
+     */
     function pushToRange(uint256 start, uint256 count, uint32[] calldata dstEids) external override whenNotPaused {
         if (!roleRegistry().hasRole(CONFIG_ADMIN_ROLE, msg.sender)) revert OnlyConfigAdmin();
         OFTConfigRegistryStorage storage $ = _getStorage();

--- a/src/oft/ShadowOFTFactory.sol
+++ b/src/oft/ShadowOFTFactory.sol
@@ -49,7 +49,16 @@ contract ShadowOFTFactory is IShadowOFTFactory, BeaconFactory {
         __BeaconFactory_initialize(_roleRegistry, _shadowOFTImpl);
     }
 
-    /// @inheritdoc IShadowOFTFactory
+    /**
+     * @notice Deploys a new Shadow OFT (iTOKEN) beacon proxy
+     * @dev Caller must hold the factory admin role.
+     * @param salt CREATE3 salt; must match the mainnet `OFTAdapterFactory.deployAdapter` salt
+     * @param name ERC-20 name of the iTOKEN (convention: "EtherFi <NAME>")
+     * @param symbol ERC-20 symbol of the iTOKEN (convention: "i<SYMBOL>")
+     * @param decimals Decimals to mirror from the mainnet underlying token
+     * @param delegate LayerZero delegate (typically the protocol owner/multisig)
+     * @return shadowOFT Address of the deployed iTOKEN proxy
+     */
     function deployShadowOFT(bytes32 salt, string calldata name, string calldata symbol, uint8 decimals, address delegate)
         external
         whenNotPaused
@@ -75,7 +84,12 @@ contract ShadowOFTFactory is IShadowOFTFactory, BeaconFactory {
         IConfigurableOFT(shadowOFT).syncConfig(IOFTConfigRegistry(registry).activeDstEids());
     }
 
-    /// @inheritdoc IShadowOFTFactory
+    /**
+     * @notice Paginated enumeration of deployed Shadow OFT addresses
+     * @param start Starting index in the deployment set
+     * @param n Maximum number of entries to return
+     * @return shadowOFTs Array of iTOKEN proxy addresses
+     */
     function getDeployedShadowOFTs(uint256 start, uint256 n) external view returns (address[] memory shadowOFTs) {
         ShadowOFTFactoryStorage storage $ = _getStorage();
         uint256 length = $.deployed.length();
@@ -91,12 +105,19 @@ contract ShadowOFTFactory is IShadowOFTFactory, BeaconFactory {
         }
     }
 
-    /// @inheritdoc IShadowOFTFactory
+    /**
+     * @notice Total number of Shadow OFTs deployed by this factory
+     * @return Number of deployed iTOKENs
+     */
     function numShadowOFTsDeployed() external view returns (uint256) {
         return _getStorage().deployed.length();
     }
 
-    /// @inheritdoc IShadowOFTFactory
+    /**
+     * @notice Returns whether `account` is an iTOKEN deployed by this factory
+     * @param account Address to query
+     * @return True if `account` was deployed by this factory
+     */
     function isShadowOFT(address account) external view returns (bool) {
         return _getStorage().deployed.contains(account);
     }

--- a/src/oft/ShadowOFTFactory.sol
+++ b/src/oft/ShadowOFTFactory.sol
@@ -62,7 +62,7 @@ contract ShadowOFTFactory is IShadowOFTFactory, BeaconFactory {
     function deployShadowOFT(bytes32 salt, string calldata name, string calldata symbol, uint8 decimals, address delegate)
         external
         whenNotPaused
-        returns (address shadowOFT)
+        returns (address)
     {
         if (!roleRegistry().hasRole(SHADOW_OFT_FACTORY_ADMIN_ROLE, msg.sender)) revert OnlyAdmin();
 
@@ -71,7 +71,7 @@ contract ShadowOFTFactory is IShadowOFTFactory, BeaconFactory {
         if ($.deployed.contains(predicted)) revert ShadowOFTAlreadyExists();
 
         bytes memory initData = abi.encodeWithSelector(EtherFiShadowOFT.initialize.selector, name, symbol, decimals, delegate);
-        shadowOFT = _deployBeacon(salt, initData);
+        address shadowOFT = _deployBeacon(salt, initData);
 
         $.deployed.add(shadowOFT);
         emit ShadowOFTDeployed(salt, shadowOFT, name, symbol);
@@ -82,6 +82,7 @@ contract ShadowOFTFactory is IShadowOFTFactory, BeaconFactory {
         address registry = IConfigurableOFT(shadowOFT).configRegistry();
         IOFTConfigRegistry(registry).registerBridge(shadowOFT);
         IConfigurableOFT(shadowOFT).syncConfig(IOFTConfigRegistry(registry).activeDstEids());
+        return shadowOFT;
     }
 
     /**
@@ -90,19 +91,20 @@ contract ShadowOFTFactory is IShadowOFTFactory, BeaconFactory {
      * @param n Maximum number of entries to return
      * @return shadowOFTs Array of iTOKEN proxy addresses
      */
-    function getDeployedShadowOFTs(uint256 start, uint256 n) external view returns (address[] memory shadowOFTs) {
+    function getDeployedShadowOFTs(uint256 start, uint256 n) external view returns (address[] memory) {
         ShadowOFTFactoryStorage storage $ = _getStorage();
         uint256 length = $.deployed.length();
         if (start >= length) return new address[](0);
         if (start + n > length) n = length - start;
 
-        shadowOFTs = new address[](n);
+        address[] memory shadowOFTs = new address[](n);
         for (uint256 i = 0; i < n;) {
             shadowOFTs[i] = $.deployed.at(start + i);
             unchecked {
                 ++i;
             }
         }
+        return shadowOFTs;
     }
 
     /**

--- a/src/oft/ShadowOFTFactory.sol
+++ b/src/oft/ShadowOFTFactory.sol
@@ -5,6 +5,8 @@ import { EnumerableSetLib } from "solady/utils/EnumerableSetLib.sol";
 
 import { BeaconFactory } from "../beacon-factory/BeaconFactory.sol";
 import { IShadowOFTFactory } from "../interfaces/IShadowOFTFactory.sol";
+import { IConfigurableOFT } from "../interfaces/IConfigurableOFT.sol";
+import { IOFTConfigRegistry } from "../interfaces/IOFTConfigRegistry.sol";
 import { EtherFiShadowOFT } from "./EtherFiShadowOFT.sol";
 
 /**
@@ -12,9 +14,11 @@ import { EtherFiShadowOFT } from "./EtherFiShadowOFT.sol";
  * @author ether.fi
  * @notice Destination-chain (e.g. Optimism) beacon factory that deploys mintable
  *         iTOKEN ERC-20s per listed asset.
- * @dev Mirror of {OFTAdapterFactory}. Reusing the same CREATE3 `salt` from the
- *      mainnet adapter deployment makes the iTOKEN address deterministic and
- *      one-to-one with its mainnet adapter.
+ * @dev Mirror of {OFTAdapterFactory}. A CREATE3 address is deterministic in
+ *      `(factory, salt)`, so the iTOKEN address is predictable on this chain. It
+ *      is NOT guaranteed identical to its mainnet adapter address (matching
+ *      cross-chain addresses is a non-goal); the `salt` is about per-chain
+ *      predictability, not cross-chain mirroring.
  */
 contract ShadowOFTFactory is IShadowOFTFactory, BeaconFactory {
     using EnumerableSetLib for EnumerableSetLib.AddressSet;
@@ -46,7 +50,7 @@ contract ShadowOFTFactory is IShadowOFTFactory, BeaconFactory {
     }
 
     /// @inheritdoc IShadowOFTFactory
-    function deployShadowOFT(bytes32 salt, string calldata name, string calldata symbol, address delegate)
+    function deployShadowOFT(bytes32 salt, string calldata name, string calldata symbol, uint8 decimals, address delegate)
         external
         whenNotPaused
         returns (address shadowOFT)
@@ -57,18 +61,25 @@ contract ShadowOFTFactory is IShadowOFTFactory, BeaconFactory {
         address predicted = getDeterministicAddress(salt);
         if ($.deployed.contains(predicted)) revert ShadowOFTAlreadyExists();
 
-        bytes memory initData = abi.encodeWithSelector(EtherFiShadowOFT.initialize.selector, name, symbol, delegate);
+        bytes memory initData = abi.encodeWithSelector(EtherFiShadowOFT.initialize.selector, name, symbol, decimals, delegate);
         shadowOFT = _deployBeacon(salt, initData);
 
         $.deployed.add(shadowOFT);
         emit ShadowOFTDeployed(salt, shadowOFT, name, symbol);
+
+        // Auto-register + pull canonical LZ config so the new bridge is live without
+        // manual setup. Reverts if the factory lacks CONFIG_REGISTRAR_ROLE or the
+        // registry is unreachable (fail-hard: never leave a bridge unregistered).
+        address registry = IConfigurableOFT(shadowOFT).configRegistry();
+        IOFTConfigRegistry(registry).registerBridge(shadowOFT);
+        IConfigurableOFT(shadowOFT).syncConfig(IOFTConfigRegistry(registry).activeDstEids());
     }
 
     /// @inheritdoc IShadowOFTFactory
     function getDeployedShadowOFTs(uint256 start, uint256 n) external view returns (address[] memory shadowOFTs) {
         ShadowOFTFactoryStorage storage $ = _getStorage();
         uint256 length = $.deployed.length();
-        if (start >= length) revert InvalidStartIndex();
+        if (start >= length) return new address[](0);
         if (start + n > length) n = length - start;
 
         shadowOFTs = new address[](n);

--- a/test/oft/EtherFiOFTAdapter.t.sol
+++ b/test/oft/EtherFiOFTAdapter.t.sol
@@ -9,9 +9,11 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { EtherFiOFTAdapter } from "../../src/oft/EtherFiOFTAdapter.sol";
 import { MockERC20, MockFeeOnTransferERC20, OFTTestSetup } from "./OFTTestSetup.t.sol";
 
-/* Test-only subclass that exposes the internal lock/unlock hooks (_debit/_credit) as external
-   functions, so the lossless guard + lock/unlock can be tested directly without driving a full
-   cross-chain send() (which our recording mock endpoint can't route). */
+/**
+ * Test-only subclass that exposes the internal lock/unlock hooks (_debit/_credit) as external
+ * functions, so the lossless guard + lock/unlock can be tested directly without driving a full
+ * cross-chain send() (which our recording mock endpoint can't route).
+ */
 contract OFTAdapterHarness is EtherFiOFTAdapter {
     constructor(address ep, address reg) EtherFiOFTAdapter(ep, reg) { }
 
@@ -40,8 +42,10 @@ contract EtherFiOFTAdapterTest is OFTTestSetup {
         return EtherFiOFTAdapter(address(new BeaconProxy(adapterFactory.beacon(), "")));
     }
 
-    /* helper: deploy a harness-backed adapter (its own beacon) initialized for `token`, so we can
-       reach the internal _debit/_credit hooks. */
+    /**
+     * helper: deploy a harness-backed adapter (its own beacon) initialized for `token`, so we can
+     * reach the internal _debit/_credit hooks.
+     */
     function _deployHarness(address token) internal returns (OFTAdapterHarness h) {
         address impl = address(new OFTAdapterHarness(address(endpoint), address(configRegistry)));
         UpgradeableBeacon beacon = new UpgradeableBeacon(impl, owner);

--- a/test/oft/EtherFiOFTAdapter.t.sol
+++ b/test/oft/EtherFiOFTAdapter.t.sol
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { IOFT } from "@layerzerolabs/oft-evm/contracts/interfaces/IOFT.sol";
+import { BeaconProxy } from "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
+import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import { EtherFiOFTAdapter } from "../../src/oft/EtherFiOFTAdapter.sol";
+import { MockERC20, MockFeeOnTransferERC20, OFTTestSetup } from "./OFTTestSetup.t.sol";
+
+/* Test-only subclass that exposes the internal lock/unlock hooks (_debit/_credit) as external
+   functions, so the lossless guard + lock/unlock can be tested directly without driving a full
+   cross-chain send() (which our recording mock endpoint can't route). */
+contract OFTAdapterHarness is EtherFiOFTAdapter {
+    constructor(address ep, address reg) EtherFiOFTAdapter(ep, reg) { }
+
+    function exposedDebit(address from, uint256 amt, uint256 minAmt, uint32 dstEid) external returns (uint256, uint256) {
+        return _debit(from, amt, minAmt, dstEid);
+    }
+
+    function exposedCredit(address to, uint256 amt, uint32 srcEid) external returns (uint256) {
+        return _credit(to, amt, srcEid);
+    }
+}
+
+contract EtherFiOFTAdapterTest is OFTTestSetup {
+    uint8 internal constant SHARED_DECIMALS = 6;
+
+    // helper: deploy a real adapter via the factory (also exercises auto-sync).
+    function _deployAdapterViaFactory(address token) internal returns (EtherFiOFTAdapter) {
+        vm.prank(factoryAdmin);
+        // salt convention = keccak256(underlying); factory dedupes one adapter per token
+        address adapter = adapterFactory.deployAdapter(keccak256(abi.encode(token)), token, delegate);
+        return EtherFiOFTAdapter(adapter);
+    }
+
+    // helper: an UNinitialized adapter proxy so we can call initialize() directly and catch its reverts.
+    function _uninitializedAdapter() internal returns (EtherFiOFTAdapter) {
+        return EtherFiOFTAdapter(address(new BeaconProxy(adapterFactory.beacon(), "")));
+    }
+
+    /* helper: deploy a harness-backed adapter (its own beacon) initialized for `token`, so we can
+       reach the internal _debit/_credit hooks. */
+    function _deployHarness(address token) internal returns (OFTAdapterHarness h) {
+        address impl = address(new OFTAdapterHarness(address(endpoint), address(configRegistry)));
+        UpgradeableBeacon beacon = new UpgradeableBeacon(impl, owner);
+        bytes memory initData = abi.encodeWithSelector(EtherFiOFTAdapter.initialize.selector, token, delegate);
+        h = OFTAdapterHarness(address(new BeaconProxy(address(beacon), initData)));
+    }
+
+    // ----------------------------------------------------------------- decimal math
+
+    // The per-proxy conversion rate is 10**(tokenDecimals - 6): USDC(6)->1, WBTC(8)->100, PAXG(18)->1e12.
+    function test_conversionRate_perDecimals() public {
+        assertEq(_deployAdapterViaFactory(address(token6)).conversionRate(), 1);
+        assertEq(_deployAdapterViaFactory(address(token8)).conversionRate(), 100);
+        assertEq(_deployAdapterViaFactory(address(token18)).conversionRate(), 1e12);
+    }
+
+    // token() returns the underlying ERC-20 this adapter locks.
+    function test_token_returnsUnderlying() public {
+        EtherFiOFTAdapter a = _deployAdapterViaFactory(address(token6));
+        assertEq(a.token(), address(token6));
+    }
+
+    // approvalRequired() is true — it's a lock adapter, so the user must approve it to pull the token.
+    function test_approvalRequired_isTrue() public {
+        assertTrue(_deployAdapterViaFactory(address(token6)).approvalRequired());
+    }
+
+    // Documents the known wart: the inherited auto-getter returns the dead placeholder rate
+    // (10**(18-6)=1e12), while conversionRate() is the real per-proxy rate. External readers
+    // must use conversionRate(); internal math is correct (it reads storage via the overrides).
+    function test_inheritedDecimalConversionRateGetter_isPlaceholderWart() public {
+        EtherFiOFTAdapter a = _deployAdapterViaFactory(address(token6));
+        assertEq(a.conversionRate(), 1); // correct, per-proxy
+        assertEq(a.decimalConversionRate(), 1e12); // placeholder (18 decimals) — the wart
+    }
+
+    // ----------------------------------------------------------------- init guards
+
+    // initialize rejects a zero underlying token.
+    function test_initialize_reverts_onZeroToken() public {
+        EtherFiOFTAdapter a = _uninitializedAdapter();
+        vm.expectRevert(EtherFiOFTAdapter.InvalidAddress.selector);
+        a.initialize(address(0), delegate);
+    }
+
+    // initialize rejects a zero delegate.
+    function test_initialize_reverts_onZeroDelegate() public {
+        EtherFiOFTAdapter a = _uninitializedAdapter();
+        vm.expectRevert(EtherFiOFTAdapter.InvalidAddress.selector);
+        a.initialize(address(token6), address(0));
+    }
+
+    // initialize rejects an underlying with fewer than 6 decimals (e.g. GUSD=2) — out of scope.
+    function test_initialize_reverts_belowSharedDecimals() public {
+        MockERC20 token2 = new MockERC20("Gemini Dollar", "GUSD", 2);
+        EtherFiOFTAdapter a = _uninitializedAdapter();
+        vm.expectRevert(IOFT.InvalidLocalDecimals.selector);
+        a.initialize(address(token2), delegate);
+    }
+
+    // ----------------------------------------------------------------- lock (debit) / unlock (credit)
+
+    // _debit locks a normal (lossless) token: pulls exactly `amt` from the user into the adapter.
+    function test_debit_locksLosslessToken() public {
+        OFTAdapterHarness h = _deployHarness(address(token6));
+        uint256 amt = 1000e6;
+        token6.mint(alice, amt);
+
+        vm.prank(alice);
+        token6.approve(address(h), amt); // adapter pulls via transferFrom, so user approves it
+
+        (uint256 sent, uint256 received) = h.exposedDebit(alice, amt, 0, DST_EID_OP);
+        assertEq(sent, amt); // no fee in our adapter -> sent == received
+        assertEq(received, amt);
+        assertEq(token6.balanceOf(address(h)), amt); // tokens now locked in the adapter
+        assertEq(token6.balanceOf(alice), 0);
+    }
+
+    // _debit reverts on a fee-on-transfer token: the adapter receives less than it pulled, which
+    // would under-collateralize the mirror, so the lossless guard reverts instead.
+    function test_debit_reverts_onFeeOnTransfer() public {
+        MockFeeOnTransferERC20 feeToken = new MockFeeOnTransferERC20(6, 10); // 0.10% fee
+        OFTAdapterHarness h = _deployHarness(address(feeToken));
+        uint256 amt = 1000e6;
+        feeToken.mint(alice, amt);
+
+        vm.prank(alice);
+        feeToken.approve(address(h), amt);
+
+        uint256 fee = (amt * 10) / 10_000; // what the token skims on transfer
+        // guard reverts with (expected=amt, received=amt-fee)
+        vm.expectRevert(abi.encodeWithSelector(EtherFiOFTAdapter.NonLosslessTransfer.selector, amt, amt - fee));
+        h.exposedDebit(alice, amt, 0, DST_EID_OP);
+    }
+
+    // _credit unlocks: transfers the adapter's held underlying out to the recipient.
+    function test_credit_unlocksToRecipient() public {
+        OFTAdapterHarness h = _deployHarness(address(token6));
+        uint256 amt = 500e6;
+        token6.mint(address(h), amt); // simulate a previously locked balance
+
+        uint256 got = h.exposedCredit(alice, amt, DST_EID_OP);
+        assertEq(got, amt);
+        assertEq(token6.balanceOf(alice), amt); // recipient received the unlocked tokens
+        assertEq(token6.balanceOf(address(h)), 0);
+    }
+}

--- a/test/oft/EtherFiShadowOFT.t.sol
+++ b/test/oft/EtherFiShadowOFT.t.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { IOFT } from "@layerzerolabs/oft-evm/contracts/interfaces/IOFT.sol";
+import { BeaconProxy } from "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
+
+import { EtherFiShadowOFT } from "../../src/oft/EtherFiShadowOFT.sol";
+import { OFTTestSetup } from "./OFTTestSetup.t.sol";
+
+contract EtherFiShadowOFTTest is OFTTestSetup {
+    uint8 internal constant SHARED_DECIMALS = 6;
+
+    /* helper: deploy an initialized iTOKEN proxy off the shadow factory's beacon. We build the
+       proxy directly (not via the factory) so an initialize revert surfaces the real error,
+       not the factory's wrapped InitializationFailed. */
+    function _deployShadow(string memory name, string memory symbol, uint8 dec, address del) internal returns (EtherFiShadowOFT) {
+        bytes memory initData = abi.encodeWithSelector(EtherFiShadowOFT.initialize.selector, name, symbol, dec, del);
+        return EtherFiShadowOFT(address(new BeaconProxy(shadowFactory.beacon(), initData)));
+    }
+
+    // helper: an UNinitialized proxy (empty initData) so we can call initialize() directly in tests.
+    function _uninitializedShadow() internal returns (EtherFiShadowOFT) {
+        return EtherFiShadowOFT(address(new BeaconProxy(shadowFactory.beacon(), "")));
+    }
+
+    // decimals() must mirror the underlying token's decimals (iUSDC=6, iWBTC=8, iPAXG=18).
+    function test_decimals_mirrorUnderlying() public {
+        assertEq(_deployShadow("EtherFi USDC", "iUSDC", 6, delegate).decimals(), 6);
+        assertEq(_deployShadow("EtherFi WBTC", "iWBTC", 8, delegate).decimals(), 8);
+        assertEq(_deployShadow("EtherFi PAXG", "iPAXG", 18, delegate).decimals(), 18);
+    }
+
+    // The per-proxy conversion rate is 10**(localDecimals - 6): 6->1, 8->100, 18->1e12.
+    function test_conversionRate_perDecimals() public {
+        assertEq(_deployShadow("a", "a", 6, delegate).conversionRate(), 1);
+        assertEq(_deployShadow("b", "b", 8, delegate).conversionRate(), 100);
+        assertEq(_deployShadow("c", "c", 18, delegate).conversionRate(), 1e12);
+    }
+
+    // Each iTOKEN proxy is its own ERC-20 with the name/symbol passed at init.
+    function test_nameAndSymbolSet() public {
+        EtherFiShadowOFT s = _deployShadow("EtherFi USDC", "iUSDC", 6, delegate);
+        assertEq(s.name(), "EtherFi USDC");
+        assertEq(s.symbol(), "iUSDC");
+    }
+
+    // Before init, decimals() returns the placeholder (18) instead of 0.
+    function test_decimals_returnsPlaceholderBeforeInit() public {
+        // Uninitialized proxy: storage localDecimals == 0 -> placeholder (18). This is exactly
+        // what lets the parent constructor's `decimals() >= sharedDecimals` check pass at IMPL
+        // deploy (when storage is still zero); returning 0 there would revert the impl deploy.
+        assertEq(_uninitializedShadow().decimals(), 18);
+    }
+
+    // initialize rejects sub-6 decimals (LZ wire format is 6-dec; sub-6 is out of scope).
+    function test_initialize_reverts_belowSharedDecimals() public {
+        EtherFiShadowOFT s = _uninitializedShadow();
+        vm.expectRevert(IOFT.InvalidLocalDecimals.selector);
+        s.initialize("x", "x", SHARED_DECIMALS - 1, delegate);
+    }
+
+    // initialize rejects a zero delegate (checked before the decimals check).
+    function test_initialize_reverts_onZeroDelegate() public {
+        EtherFiShadowOFT s = _uninitializedShadow();
+        vm.expectRevert(EtherFiShadowOFT.InvalidAddress.selector);
+        s.initialize("x", "x", 6, address(0));
+    }
+
+    // initialize can only run once per proxy (OZ initializer guard).
+    function test_initialize_cannotReinitialize() public {
+        EtherFiShadowOFT s = _deployShadow("a", "a", 6, delegate);
+        vm.expectRevert(); // InvalidInitialization (OZ) — already initialized
+        s.initialize("a", "a", 6, delegate);
+    }
+}

--- a/test/oft/EtherFiShadowOFT.t.sol
+++ b/test/oft/EtherFiShadowOFT.t.sol
@@ -10,9 +10,11 @@ import { OFTTestSetup } from "./OFTTestSetup.t.sol";
 contract EtherFiShadowOFTTest is OFTTestSetup {
     uint8 internal constant SHARED_DECIMALS = 6;
 
-    /* helper: deploy an initialized iTOKEN proxy off the shadow factory's beacon. We build the
-       proxy directly (not via the factory) so an initialize revert surfaces the real error,
-       not the factory's wrapped InitializationFailed. */
+    /**
+     * helper: deploy an initialized iTOKEN proxy off the shadow factory's beacon. We build the
+     * proxy directly (not via the factory) so an initialize revert surfaces the real error,
+     * not the factory's wrapped InitializationFailed.
+     */
     function _deployShadow(string memory name, string memory symbol, uint8 dec, address del) internal returns (EtherFiShadowOFT) {
         bytes memory initData = abi.encodeWithSelector(EtherFiShadowOFT.initialize.selector, name, symbol, dec, del);
         return EtherFiShadowOFT(address(new BeaconProxy(shadowFactory.beacon(), initData)));

--- a/test/oft/OFTAdversarial.t.sol
+++ b/test/oft/OFTAdversarial.t.sol
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { Origin } from "@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol";
+import { ILayerZeroEndpointV2 } from "@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol";
+import { PacketV1Codec } from "@layerzerolabs/lz-evm-protocol-v2/contracts/messagelib/libs/PacketV1Codec.sol";
+import { OAppReceiverUpgradeable } from "@layerzerolabs/oapp-evm-upgradeable/contracts/oapp/OAppReceiverUpgradeable.sol";
+import { MessagingFee } from "@layerzerolabs/oapp-evm/contracts/oapp/OAppSender.sol";
+import { IOAppCore } from "@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppCore.sol";
+import { OptionsBuilder } from "@layerzerolabs/oapp-evm/contracts/oapp/libs/OptionsBuilder.sol";
+import { IOFT, SendParam } from "@layerzerolabs/oft-evm/contracts/interfaces/IOFT.sol";
+
+import { stdError } from "forge-std/StdError.sol";
+
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+
+import { EtherFiOFTAdapter } from "../../src/oft/EtherFiOFTAdapter.sol";
+import { EtherFiShadowOFT } from "../../src/oft/EtherFiShadowOFT.sol";
+import { OFTCrossChainSetup } from "./OFTCrossChainSetup.t.sol";
+
+/**
+ * @title OFTAdversarialTest
+ * @notice Adversarial / negative cross-chain. Covers the inbound trust boundary (only the
+ *         endpoint and only the registered peer may drive `lzReceive`), replay protection at the
+ *         endpoint, owner-gated peer/delegate wiring, the proxy re-initialization guard (closing
+ *         the previously-untested adapter gap), and reentrancy on the lock path.
+ */
+contract OFTAdversarialTest is OFTCrossChainSetup {
+    using OptionsBuilder for bytes;
+    using PacketV1Codec for bytes;
+
+    function setUp() public override {
+        super.setUp();
+        _deployPair(8);
+    }
+
+    /// @dev External so PacketV1Codec (calldata-only) can read the queued packet bytes.
+    function decodePacket(bytes calldata p) external pure returns (uint32 srcEid, bytes32 sender, uint64 nonce, bytes32 guid, bytes memory message) {
+        return (p.srcEid(), p.sender(), p.nonce(), p.guid(), p.message());
+    }
+
+    // ----------------------------------------------------------------- inbound peer enforcement
+
+    address internal attacker = makeAddr("attacker");
+
+    // Anyone other than the local endpoint calling lzReceive directly is rejected.
+    function test_lzReceive_revertsForNonEndpointCaller() public {
+        Origin memory o = Origin({ srcEid: A_EID, sender: _b32(address(adapter)), nonce: 1 });
+        vm.prank(attacker);
+        vm.expectRevert(abi.encodeWithSelector(OAppReceiverUpgradeable.OnlyEndpoint.selector, attacker));
+        shadow.lzReceive(o, bytes32(0), "", address(0), "");
+    }
+
+    // A message whose srcEid is correct but sender is NOT the wired peer is rejected.
+    function test_lzReceive_revertsForNonPeerSender() public {
+        Origin memory o = Origin({ srcEid: A_EID, sender: _b32(attacker), nonce: 1 });
+        vm.prank(endpoints[B_EID]);
+        vm.expectRevert(abi.encodeWithSelector(IOAppCore.OnlyPeer.selector, A_EID, _b32(attacker)));
+        shadow.lzReceive(o, bytes32(0), "", address(0), "");
+    }
+
+    // A message from an eid with no configured peer is rejected (NoPeer), even from the endpoint.
+    function test_lzReceive_revertsForUnknownSrcEid() public {
+        uint32 unknownEid = 4444;
+        Origin memory o = Origin({ srcEid: unknownEid, sender: _b32(address(adapter)), nonce: 1 });
+        vm.prank(endpoints[B_EID]);
+        vm.expectRevert(abi.encodeWithSelector(IOAppCore.NoPeer.selector, unknownEid));
+        shadow.lzReceive(o, bytes32(0), "", address(0), "");
+    }
+
+    // ----------------------------------------------------------------- replay protection
+
+    /**
+     * Replaying an already-executed inbound packet through the endpoint does not double-mint:
+     * the endpoint clears the payload hash on execution, so a second lzReceive for the same
+     * nonce reverts and the iTOKEN supply is unchanged.
+     */
+    function test_replay_noDoubleMint() public {
+        uint256 amount = 500e8;
+        underlying.mint(alice, amount);
+
+        bytes memory options = OptionsBuilder.newOptions().addExecutorLzReceiveOption(200_000, 0);
+        SendParam memory sp = SendParam(B_EID, _b32(alice), amount, 0, options, "", "");
+        MessagingFee memory fee = adapter.quoteSend(sp, false);
+
+        vm.startPrank(alice);
+        underlying.approve(address(adapter), amount);
+        adapter.send{ value: fee.nativeFee }(sp, fee, payable(alice));
+        vm.stopPrank();
+
+        // Grab the in-flight packet before delivery so we can attempt to re-execute it.
+        bytes memory packet = getNextInflightPacket(uint16(B_EID), _b32(address(shadow)));
+        (uint32 srcEid, bytes32 sender, uint64 nonce, bytes32 guid, bytes memory message) = this.decodePacket(packet);
+        Origin memory o = Origin({ srcEid: srcEid, sender: sender, nonce: nonce });
+
+        // First delivery mints exactly `amount`.
+        verifyPackets(B_EID, _b32(address(shadow)));
+        assertEq(shadow.totalSupply(), amount);
+        assertEq(shadow.balanceOf(alice), amount);
+
+        // Replaying the same nonce through the endpoint reverts; supply stays put.
+        vm.expectRevert();
+        ILayerZeroEndpointV2(endpoints[B_EID]).lzReceive(o, address(shadow), guid, message, "");
+        assertEq(shadow.totalSupply(), amount, "replay double-minted");
+    }
+
+    // ----------------------------------------------------------------- owner-gated wiring
+
+    function test_setPeer_onlyOwner() public {
+        vm.prank(attacker);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, attacker));
+        adapter.setPeer(B_EID, _b32(attacker));
+    }
+
+    function test_setDelegate_onlyOwner() public {
+        vm.prank(attacker);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, attacker));
+        adapter.setDelegate(attacker);
+    }
+
+    // The wired owner CAN re-point a peer (sanity that the gate is the only obstacle).
+    function test_setPeer_ownerSucceeds() public {
+        address newPeer = makeAddr("newPeer");
+        vm.prank(delegate);
+        adapter.setPeer(B_EID, _b32(newPeer));
+        assertEq(adapter.peers(B_EID), _b32(newPeer));
+    }
+
+    // ----------------------------------------------------------------- re-initialization guard
+
+    /**
+     * The adapter's reinit guard was previously untested (only the shadow's was). A factory-deployed,
+     * already-initialized adapter proxy cannot be re-initialized.
+     */
+    function test_adapter_cannotReinitialize() public {
+        vm.expectRevert(Initializable.InvalidInitialization.selector);
+        adapter.initialize(address(underlying), delegate);
+    }
+
+    function test_shadow_cannotReinitialize() public {
+        vm.expectRevert(Initializable.InvalidInitialization.selector);
+        shadow.initialize("x", "x", 8, delegate);
+    }
+
+    // ----------------------------------------------------------------- reentrancy on lock path
+
+    /**
+     * A malicious underlying that re-enters adapter.send() mid-transfer cannot corrupt accounting.
+     * The re-entrant send triggers a second lock whose transferFrom pulls from the TOKEN contract
+     * (the nested send's caller), which holds no allowance/balance — so it underflows and the whole
+     * outer send reverts atomically: nothing is locked and nothing is minted on the destination.
+     *
+     * The token is funded with ETH so the nested send can pay its messaging fee; this isolates the
+     * failure to the genuine double-spend path rather than incidental gas/fee starvation.
+     */
+    function test_reentrancy_onLock_isContained() public {
+        ReentrantToken evil = new ReentrantToken();
+        // Deploy a dedicated adapter for the evil token via the factory.
+        vm.prank(factoryAdmin);
+        EtherFiOFTAdapter evilAdapter = EtherFiOFTAdapter(adapterFactory.deployAdapter(keccak256("evil"), address(evil), delegate));
+        vm.startPrank(delegate);
+        evilAdapter.setPeer(B_EID, _b32(address(shadow)));
+        vm.stopPrank();
+
+        uint256 amount = 100e8;
+        evil.mint(alice, amount);
+
+        bytes memory options = OptionsBuilder.newOptions().addExecutorLzReceiveOption(200_000, 0);
+        SendParam memory sp = SendParam(B_EID, _b32(alice), amount, 0, options, "", "");
+        MessagingFee memory fee = evilAdapter.quoteSend(sp, false);
+
+        evil.arm(address(evilAdapter), sp, fee);
+        vm.deal(address(evil), 100 ether); // so the nested send isn't blocked by fee starvation
+
+        vm.startPrank(alice);
+        evil.approve(address(evilAdapter), amount);
+        // the re-entrant lock double-spends an allowance the token contract doesn't hold -> underflow
+        vm.expectRevert(stdError.arithmeticError);
+        evilAdapter.send{ value: fee.nativeFee }(sp, fee, payable(alice));
+        vm.stopPrank();
+
+        assertEq(evil.balanceOf(address(evilAdapter)), 0, "tokens locked despite reverting send");
+        assertEq(shadow.totalSupply(), 0, "iTOKEN minted despite reverting send");
+    }
+}
+
+/**
+ *  Underlying that re-enters the adapter's send() during the lock transferFrom.
+ */
+contract ReentrantToken {
+    string public name = "Evil";
+    string public symbol = "EVIL";
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    bool internal armed;
+    address internal adapter;
+    SendParam internal sp;
+    MessagingFee internal fee;
+
+    function decimals() external pure returns (uint8) {
+        return 8;
+    }
+
+    function mint(address to, uint256 amt) external {
+        balanceOf[to] += amt;
+    }
+
+    function approve(address spender, uint256 amt) external returns (bool) {
+        allowance[msg.sender][spender] = amt;
+        return true;
+    }
+
+    function transfer(address to, uint256 amt) external returns (bool) {
+        balanceOf[msg.sender] -= amt;
+        balanceOf[to] += amt;
+        return true;
+    }
+
+    function arm(address _adapter, SendParam memory _sp, MessagingFee memory _fee) external {
+        armed = true;
+        adapter = _adapter;
+        sp = _sp;
+        fee = _fee;
+    }
+
+    function transferFrom(address from, address to, uint256 amt) external returns (bool) {
+        if (armed) {
+            armed = false; // re-enter exactly once
+            EtherFiOFTAdapter(adapter).send{ value: fee.nativeFee }(sp, fee, payable(from));
+        }
+        allowance[from][msg.sender] -= amt;
+        balanceOf[from] -= amt;
+        balanceOf[to] += amt;
+        return true;
+    }
+}

--- a/test/oft/OFTConfigRegistry.t.sol
+++ b/test/oft/OFTConfigRegistry.t.sol
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
+
+import { IOFTConfigRegistry } from "../../src/interfaces/IOFTConfigRegistry.sol";
+import { OFTConfigRegistry } from "../../src/oft/OFTConfigRegistry.sol";
+import { MockConfigurableOFT, OFTTestSetup } from "./OFTTestSetup.t.sol";
+
+contract OFTConfigRegistryTest is OFTTestSetup {
+    // helper: set a pathway as the config admin (the only role allowed to)
+    function _setPathway(uint32 dstEid, uint64 confirmations) internal {
+        vm.prank(configAdmin);
+        configRegistry.setPathwayConfig(dstEid, _samplePathway(confirmations));
+    }
+
+    // ----------------------------------------------------------------- setPathwayConfig
+
+    // Setting a pathway stores the config, bumps the version 0 -> 1, and lists the destination.
+    function test_setPathwayConfig_storesAndBumpsVersion() public {
+        assertEq(configRegistry.configVersion(), 0);
+
+        // event carries the new version (1)
+        vm.expectEmit(true, false, false, true);
+        emit IOFTConfigRegistry.PathwayConfigSet(DST_EID_OP, 1);
+        _setPathway(DST_EID_OP, 15);
+
+        assertEq(configRegistry.configVersion(), 1);
+
+        IOFTConfigRegistry.PathwayConfig memory got = configRegistry.getPathwayConfig(DST_EID_OP);
+        assertEq(got.confirmations, 15);
+        assertEq(got.requiredDVNs.length, 2);
+        assertTrue(got.sendLib != address(0));
+        assertTrue(got.receiveLib != address(0));
+
+        uint32[] memory active = configRegistry.activeDstEids();
+        assertEq(active.length, 1);
+        assertEq(active[0], DST_EID_OP);
+    }
+
+    // A second, distinct destination is appended to activeDstEids and bumps the version again.
+    function test_setPathwayConfig_secondEid_appendsToActiveList_andBumpsVersion() public {
+        _setPathway(DST_EID_OP, 15);
+        _setPathway(DST_EID_ETH, 20);
+
+        assertEq(configRegistry.configVersion(), 2);
+        uint32[] memory active = configRegistry.activeDstEids();
+        assertEq(active.length, 2);
+        assertEq(active[0], DST_EID_OP);
+        assertEq(active[1], DST_EID_ETH);
+    }
+
+    // Re-configuring an existing destination updates it + bumps version, but must NOT duplicate it
+    // in activeDstEids (the EnumerableSet dedups).
+    function test_setPathwayConfig_sameEidTwice_doesNotDuplicateActive_butBumpsVersion() public {
+        _setPathway(DST_EID_OP, 15);
+        _setPathway(DST_EID_OP, 25); // overwrite same dstEid with new confirmations
+
+        assertEq(configRegistry.configVersion(), 2); // version bumps on every edit...
+        assertEq(configRegistry.activeDstEids().length, 1); // ...but the destination is listed once
+        assertEq(configRegistry.getPathwayConfig(DST_EID_OP).confirmations, 25); // latest config wins
+    }
+
+    // Only CONFIG_ADMIN_ROLE may set config.
+    function test_setPathwayConfig_reverts_whenNotConfigAdmin() public {
+        vm.prank(alice);
+        vm.expectRevert(IOFTConfigRegistry.OnlyConfigAdmin.selector);
+        configRegistry.setPathwayConfig(DST_EID_OP, _samplePathway(15));
+    }
+
+    // A zero send library is rejected — can't configure an incomplete pathway.
+    function test_setPathwayConfig_reverts_onZeroSendLib() public {
+        IOFTConfigRegistry.PathwayConfig memory cfg = _samplePathway(15);
+        cfg.sendLib = address(0);
+        vm.prank(configAdmin);
+        vm.expectRevert(IOFTConfigRegistry.InvalidInput.selector);
+        configRegistry.setPathwayConfig(DST_EID_OP, cfg);
+    }
+
+    // A pathway with no required DVNs is rejected — zero verifiers would be insecure.
+    function test_setPathwayConfig_reverts_onEmptyRequiredDVNs() public {
+        IOFTConfigRegistry.PathwayConfig memory cfg = _samplePathway(15);
+        cfg.requiredDVNs = new address[](0);
+        vm.prank(configAdmin);
+        vm.expectRevert(IOFTConfigRegistry.InvalidInput.selector);
+        configRegistry.setPathwayConfig(DST_EID_OP, cfg);
+    }
+
+    // ----------------------------------------------------------------- registerBridge / enumeration
+
+    // The registrar can add a bridge; it lands in the enumerable set and emits.
+    function test_registerBridge_addsToSet_andEmits() public {
+        address bridge = address(new MockConfigurableOFT(address(configRegistry)));
+
+        vm.expectEmit(true, false, false, false);
+        emit IOFTConfigRegistry.BridgeRegistered(bridge);
+        vm.prank(registrar);
+        configRegistry.registerBridge(bridge);
+
+        assertEq(configRegistry.numBridges(), 1);
+        address[] memory got = configRegistry.getBridges(0, 10);
+        assertEq(got.length, 1);
+        assertEq(got[0], bridge);
+    }
+
+    // Only CONFIG_REGISTRAR_ROLE may register bridges.
+    function test_registerBridge_reverts_whenNotRegistrar() public {
+        address bridge = address(new MockConfigurableOFT(address(configRegistry)));
+        vm.prank(alice);
+        vm.expectRevert(IOFTConfigRegistry.OnlyRegistrar.selector);
+        configRegistry.registerBridge(bridge);
+    }
+
+    // Zero bridge address is rejected.
+    function test_registerBridge_reverts_onZeroAddress() public {
+        vm.prank(registrar);
+        vm.expectRevert(IOFTConfigRegistry.InvalidInput.selector);
+        configRegistry.registerBridge(address(0));
+    }
+
+    // Registering the same bridge twice is a no-op (set semantics), not a double-count.
+    function test_registerBridge_isIdempotent() public {
+        address bridge = address(new MockConfigurableOFT(address(configRegistry)));
+        vm.startPrank(registrar);
+        configRegistry.registerBridge(bridge);
+        configRegistry.registerBridge(bridge); // second add is ignored by the set
+        vm.stopPrank();
+        assertEq(configRegistry.numBridges(), 1);
+    }
+
+    // getBridges returns the requested window, clamps an over-long count to what's left, and
+    // returns empty when start is past the end (the pagination contract).
+    function test_getBridges_paginates() public {
+        address[] memory bridges = new address[](5);
+        vm.startPrank(registrar);
+        for (uint256 i; i < 5; ++i) {
+            bridges[i] = address(new MockConfigurableOFT(address(configRegistry)));
+            configRegistry.registerBridge(bridges[i]);
+        }
+        vm.stopPrank();
+
+        assertEq(configRegistry.numBridges(), 5);
+
+        // a normal window [1,3)
+        address[] memory page = configRegistry.getBridges(1, 2);
+        assertEq(page.length, 2);
+        assertEq(page[0], bridges[1]);
+        assertEq(page[1], bridges[2]);
+
+        // count over-asks past the end -> clamps to the 2 remaining (indices 3,4)
+        address[] memory tail = configRegistry.getBridges(3, 100);
+        assertEq(tail.length, 2);
+
+        // start == length -> empty, no revert
+        assertEq(configRegistry.getBridges(5, 1).length, 0);
+    }
+
+    // ----------------------------------------------------------------- push*
+
+    // helper: deploy n fake bridges (MockConfigurableOFT records syncConfig calls) and register them
+    function _deployAndRegisterMocks(uint256 n) internal returns (MockConfigurableOFT[] memory mocks) {
+        mocks = new MockConfigurableOFT[](n);
+        vm.startPrank(registrar);
+        for (uint256 i; i < n; ++i) {
+            mocks[i] = new MockConfigurableOFT(address(configRegistry));
+            configRegistry.registerBridge(address(mocks[i]));
+        }
+        vm.stopPrank();
+    }
+
+    // pushToAll triggers syncConfig on EVERY registered bridge; each mock records that it was
+    // called once, with which dstEids, and the registry version it synced to.
+    function test_pushToAll_callsSyncOnEveryBridge() public {
+        _setPathway(DST_EID_OP, 15);
+        MockConfigurableOFT[] memory mocks = _deployAndRegisterMocks(3);
+
+        uint32[] memory eids = new uint32[](1);
+        eids[0] = DST_EID_OP;
+
+        vm.prank(configAdmin);
+        configRegistry.pushToAll(eids);
+
+        for (uint256 i; i < 3; ++i) {
+            assertEq(mocks[i].syncCallCount(), 1); // called exactly once
+            assertEq(mocks[i].lastDstEidsLength(), 1);
+            assertEq(mocks[i].lastDstEids(0), DST_EID_OP); // with the dstEid we pushed
+            assertEq(mocks[i].syncedConfigVersion(), configRegistry.configVersion());
+        }
+    }
+
+    // pushTo triggers syncConfig ONLY on the explicitly listed bridges (here: just mocks[1]).
+    function test_pushTo_callsSyncOnSelectedBridges() public {
+        _setPathway(DST_EID_OP, 15);
+        MockConfigurableOFT[] memory mocks = _deployAndRegisterMocks(3);
+
+        address[] memory targets = new address[](1);
+        targets[0] = address(mocks[1]);
+        uint32[] memory eids = new uint32[](1);
+        eids[0] = DST_EID_OP;
+
+        vm.prank(configAdmin);
+        configRegistry.pushTo(targets, eids);
+
+        assertEq(mocks[0].syncCallCount(), 0);
+        assertEq(mocks[1].syncCallCount(), 1); // only the targeted one
+        assertEq(mocks[2].syncCallCount(), 0);
+    }
+
+    // pushToRange triggers syncConfig ONLY on the [start, start+count) window (here: indices 1,2).
+    function test_pushToRange_paginatesSync() public {
+        _setPathway(DST_EID_OP, 15);
+        MockConfigurableOFT[] memory mocks = _deployAndRegisterMocks(5);
+
+        uint32[] memory eids = new uint32[](1);
+        eids[0] = DST_EID_OP;
+
+        vm.prank(configAdmin);
+        configRegistry.pushToRange(1, 2, eids); // indices 1,2 only
+
+        assertEq(mocks[0].syncCallCount(), 0);
+        assertEq(mocks[1].syncCallCount(), 1);
+        assertEq(mocks[2].syncCallCount(), 1);
+        assertEq(mocks[3].syncCallCount(), 0);
+        assertEq(mocks[4].syncCallCount(), 0);
+    }
+
+    // Only CONFIG_ADMIN_ROLE may trigger a push.
+    function test_pushToAll_reverts_whenNotConfigAdmin() public {
+        uint32[] memory eids = new uint32[](1);
+        eids[0] = DST_EID_OP;
+        vm.prank(alice);
+        vm.expectRevert(IOFTConfigRegistry.OnlyConfigAdmin.selector);
+        configRegistry.pushToAll(eids);
+    }
+
+    // ----------------------------------------------------------------- pause
+
+    // Config edits are blocked while the registry is paused.
+    function test_setPathwayConfig_reverts_whenPaused() public {
+        vm.prank(pauser);
+        configRegistry.pause();
+
+        vm.prank(configAdmin);
+        vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
+        configRegistry.setPathwayConfig(DST_EID_OP, _samplePathway(15));
+    }
+
+    // Bridge registration is blocked while the registry is paused.
+    function test_registerBridge_reverts_whenPaused() public {
+        vm.prank(pauser);
+        configRegistry.pause();
+
+        vm.prank(registrar);
+        vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
+        configRegistry.registerBridge(makeAddr("bridge"));
+    }
+}

--- a/test/oft/OFTConfigRegistry.t.sol
+++ b/test/oft/OFTConfigRegistry.t.sol
@@ -183,7 +183,7 @@ contract OFTConfigRegistryTest is OFTTestSetup {
         for (uint256 i; i < 3; ++i) {
             assertEq(mocks[i].syncCallCount(), 1); // called exactly once
             assertEq(mocks[i].lastDstEidsLength(), 1);
-            assertEq(mocks[i].lastDstEids(0), DST_EID_OP); // with the dstEid we pushed
+            assertEq(mocks[i].lastDstEids(0), DST_EID_OP, "synced with wrong dstEid"); // with the dstEid we pushed
         }
     }
 

--- a/test/oft/OFTConfigRegistry.t.sol
+++ b/test/oft/OFTConfigRegistry.t.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
+import { Vm } from "forge-std/Vm.sol";
+
 import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
 
 import { IOFTConfigRegistry } from "../../src/interfaces/IOFTConfigRegistry.sol";
@@ -118,13 +120,21 @@ contract OFTConfigRegistryTest is OFTTestSetup {
         configRegistry.registerBridge(address(0));
     }
 
-    // Registering the same bridge twice is a no-op (set semantics), not a double-count.
+    // Registering the same bridge twice is a no-op (set semantics), not a double-count,
+    // and the second call emits no BridgeRegistered event.
     function test_registerBridge_isIdempotent() public {
         address bridge = address(new MockConfigurableOFT(address(configRegistry)));
         vm.startPrank(registrar);
         configRegistry.registerBridge(bridge);
+
+        vm.recordLogs();
         configRegistry.registerBridge(bridge); // second add is ignored by the set
         vm.stopPrank();
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        for (uint256 i; i < logs.length; ++i) {
+            assertTrue(logs[i].topics[0] != IOFTConfigRegistry.BridgeRegistered.selector, "no event on duplicate register");
+        }
         assertEq(configRegistry.numBridges(), 1);
     }
 

--- a/test/oft/OFTConfigRegistry.t.sol
+++ b/test/oft/OFTConfigRegistry.t.sol
@@ -169,7 +169,7 @@ contract OFTConfigRegistryTest is OFTTestSetup {
     }
 
     // pushToAll triggers syncConfig on EVERY registered bridge; each mock records that it was
-    // called once, with which dstEids, and the registry version it synced to.
+    // called once, with which dstEids.
     function test_pushToAll_callsSyncOnEveryBridge() public {
         _setPathway(DST_EID_OP, 15);
         MockConfigurableOFT[] memory mocks = _deployAndRegisterMocks(3);
@@ -184,7 +184,6 @@ contract OFTConfigRegistryTest is OFTTestSetup {
             assertEq(mocks[i].syncCallCount(), 1); // called exactly once
             assertEq(mocks[i].lastDstEidsLength(), 1);
             assertEq(mocks[i].lastDstEids(0), DST_EID_OP); // with the dstEid we pushed
-            assertEq(mocks[i].syncedConfigVersion(), configRegistry.configVersion());
         }
     }
 

--- a/test/oft/OFTConfigRegistryRobustness.t.sol
+++ b/test/oft/OFTConfigRegistryRobustness.t.sol
@@ -21,10 +21,6 @@ contract RevertingBridge is IConfigurableOFT {
     function syncConfig(uint32[] calldata) external pure override {
         revert SyncFailed();
     }
-
-    function syncedConfigVersion() external pure override returns (uint256) {
-        return 0;
-    }
 }
 
 /**
@@ -48,10 +44,11 @@ contract OFTConfigRegistryRobustnessTest is OFTTestSetup {
     // ----------------------------------------------------------------- version skew / resync
 
     /**
-     * A bridge synced at v1 can fall behind as the registry advances to v3, then catch up with a
-     * later push — no revert, and syncedConfigVersion lands on the current version.
+     * A bridge synced once can fall behind as the registry advances, then catch up with a later
+     * push — the registry re-invokes syncConfig and the bridge re-pulls, no revert. (The bridge
+     * keeps no version state of its own; sync history is observable via the ConfigSynced event.)
      */
-    function test_versionSkew_resync_advancesToCurrentVersion() public {
+    function test_versionSkew_resync_reinvokesSync() public {
         _setPathway(DST_EID_OP, 15); // v1
         MockConfigurableOFT m = _registerMock();
 
@@ -63,18 +60,19 @@ contract OFTConfigRegistryRobustnessTest is OFTTestSetup {
 
         vm.prank(configAdmin);
         configRegistry.pushTo(targets, eids);
-        assertEq(m.syncedConfigVersion(), 1, "did not sync to v1");
+        assertEq(m.syncCallCount(), 1, "did not sync on first push");
 
-        // registry moves on; the bridge is now stale at v1 while the registry is at v3
+        // registry moves on; the bridge is now stale while the registry is at v3
         _setPathway(DST_EID_OP, 20); // v2
         _setPathway(DST_EID_OP, 25); // v3
         assertEq(configRegistry.configVersion(), 3);
-        assertEq(m.syncedConfigVersion(), 1, "bridge unexpectedly advanced on its own");
+        assertEq(m.syncCallCount(), 1, "bridge re-synced without a push");
 
         // resync catches it up, no revert
         vm.prank(configAdmin);
         configRegistry.pushTo(targets, eids);
-        assertEq(m.syncedConfigVersion(), 3, "resync did not advance to current version");
+        assertEq(m.syncCallCount(), 2, "resync did not re-invoke syncConfig");
+        assertEq(m.lastDstEids(0), DST_EID_OP);
     }
 
     // ----------------------------------------------------------------- pushToAll atomicity

--- a/test/oft/OFTConfigRegistryRobustness.t.sol
+++ b/test/oft/OFTConfigRegistryRobustness.t.sol
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { IConfigurableOFT } from "../../src/interfaces/IConfigurableOFT.sol";
+import { IOFTConfigRegistry } from "../../src/interfaces/IOFTConfigRegistry.sol";
+import { OFTConfigRegistry } from "../../src/oft/OFTConfigRegistry.sol";
+import { RoleRegistry } from "../../src/role-registry/RoleRegistry.sol";
+import { MockConfigurableOFT, OFTTestSetup } from "./OFTTestSetup.t.sol";
+
+/**
+ *  A bridge whose syncConfig always reverts — used to prove pushToAll is all-or-nothing.
+ */
+contract RevertingBridge is IConfigurableOFT {
+    address public immutable configRegistry;
+    error SyncFailed();
+
+    constructor(address r) {
+        configRegistry = r;
+    }
+
+    function syncConfig(uint32[] calldata) external pure override {
+        revert SyncFailed();
+    }
+
+    function syncedConfigVersion() external pure override returns (uint256) {
+        return 0;
+    }
+}
+
+/**
+ * @title OFTConfigRegistryRobustnessTest
+ * @notice Registry-level robustness: version skew/resync, the atomic all-or-nothing semantics of
+ *         pushToAll when a bridge reverts, and the UUPS upgrade gate. Real-endpoint DVN validation
+ *         lives in OFTConfigRegistrySync (it needs the live harness).
+ */
+contract OFTConfigRegistryRobustnessTest is OFTTestSetup {
+    function _setPathway(uint32 dstEid, uint64 confirmations) internal {
+        vm.prank(configAdmin);
+        configRegistry.setPathwayConfig(dstEid, _samplePathway(confirmations));
+    }
+
+    function _registerMock() internal returns (MockConfigurableOFT m) {
+        m = new MockConfigurableOFT(address(configRegistry));
+        vm.prank(registrar);
+        configRegistry.registerBridge(address(m));
+    }
+
+    // ----------------------------------------------------------------- version skew / resync
+
+    /**
+     * A bridge synced at v1 can fall behind as the registry advances to v3, then catch up with a
+     * later push — no revert, and syncedConfigVersion lands on the current version.
+     */
+    function test_versionSkew_resync_advancesToCurrentVersion() public {
+        _setPathway(DST_EID_OP, 15); // v1
+        MockConfigurableOFT m = _registerMock();
+
+        uint32[] memory eids = new uint32[](1);
+        eids[0] = DST_EID_OP;
+
+        address[] memory targets = new address[](1);
+        targets[0] = address(m);
+
+        vm.prank(configAdmin);
+        configRegistry.pushTo(targets, eids);
+        assertEq(m.syncedConfigVersion(), 1, "did not sync to v1");
+
+        // registry moves on; the bridge is now stale at v1 while the registry is at v3
+        _setPathway(DST_EID_OP, 20); // v2
+        _setPathway(DST_EID_OP, 25); // v3
+        assertEq(configRegistry.configVersion(), 3);
+        assertEq(m.syncedConfigVersion(), 1, "bridge unexpectedly advanced on its own");
+
+        // resync catches it up, no revert
+        vm.prank(configAdmin);
+        configRegistry.pushTo(targets, eids);
+        assertEq(m.syncedConfigVersion(), 3, "resync did not advance to current version");
+    }
+
+    // ----------------------------------------------------------------- pushToAll atomicity
+
+    /**
+     * pushToAll iterates every registered bridge in one transaction; if any bridge's syncConfig
+     * reverts, the WHOLE batch reverts and earlier bridges' syncs roll back. Operators must use
+     * pushTo / pushToRange to route around a wedged bridge.
+     */
+    function test_pushToAll_revertsAtomically_whenOneBridgeReverts() public {
+        _setPathway(DST_EID_OP, 15);
+
+        MockConfigurableOFT first = _registerMock(); // index 0 — syncs before the bad one
+        RevertingBridge bad = new RevertingBridge(address(configRegistry));
+        vm.prank(registrar);
+        configRegistry.registerBridge(address(bad)); // index 1 — reverts
+        MockConfigurableOFT third = _registerMock(); // index 2 — never reached
+
+        uint32[] memory eids = new uint32[](1);
+        eids[0] = DST_EID_OP;
+
+        vm.prank(configAdmin);
+        vm.expectRevert(RevertingBridge.SyncFailed.selector);
+        configRegistry.pushToAll(eids);
+
+        // the whole call rolled back: even the bridge that synced first shows no effect
+        assertEq(first.syncCallCount(), 0, "first bridge's sync not rolled back");
+        assertEq(third.syncCallCount(), 0);
+    }
+
+    /**
+     * The escape hatch: pushTo can still configure the healthy bridges individually, skipping the
+     * wedged one.
+     */
+    function test_pushTo_routesAroundRevertingBridge() public {
+        _setPathway(DST_EID_OP, 15);
+        MockConfigurableOFT first = _registerMock();
+        RevertingBridge bad = new RevertingBridge(address(configRegistry));
+        vm.prank(registrar);
+        configRegistry.registerBridge(address(bad));
+
+        address[] memory healthy = new address[](1);
+        healthy[0] = address(first);
+        uint32[] memory eids = new uint32[](1);
+        eids[0] = DST_EID_OP;
+
+        vm.prank(configAdmin);
+        configRegistry.pushTo(healthy, eids); // skips `bad`
+        assertEq(first.syncCallCount(), 1);
+    }
+
+    // ----------------------------------------------------------------- UUPS upgrade gate
+
+    // Only an account with the upgrader role may upgrade the registry implementation.
+    function test_registryUpgrade_reverts_whenNotUpgrader() public {
+        address newImpl = address(new OFTConfigRegistry());
+        vm.prank(alice);
+        vm.expectRevert(RoleRegistry.OnlyUpgrader.selector);
+        configRegistry.upgradeToAndCall(newImpl, "");
+    }
+
+    // The owner can upgrade — the impl slot actually changes — and state survives the upgrade.
+    function test_registryUpgrade_succeeds_forOwner_statePreserved() public {
+        _setPathway(DST_EID_OP, 15);
+        assertEq(configRegistry.configVersion(), 1);
+
+        address oldImpl = _implOf(address(configRegistry));
+        address newImpl = address(new OFTConfigRegistry());
+        assertTrue(newImpl != oldImpl, "test setup: new impl identical to old");
+
+        vm.prank(owner);
+        configRegistry.upgradeToAndCall(newImpl, "");
+
+        // the proxy now points at the new implementation (proves the upgrade actually happened)...
+        assertEq(_implOf(address(configRegistry)), newImpl, "impl slot not updated");
+        // ...and version + pathway persist across the upgrade
+        assertEq(configRegistry.configVersion(), 1);
+        assertEq(configRegistry.getPathwayConfig(DST_EID_OP).confirmations, 15);
+    }
+
+    /// @dev Reads the ERC-1967 implementation slot of a proxy.
+    function _implOf(address proxy) internal view returns (address) {
+        bytes32 EIP1967_IMPL_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+        return address(uint160(uint256(vm.load(proxy, EIP1967_IMPL_SLOT))));
+    }
+}

--- a/test/oft/OFTConfigRegistryRobustness.t.sol
+++ b/test/oft/OFTConfigRegistryRobustness.t.sol
@@ -72,7 +72,7 @@ contract OFTConfigRegistryRobustnessTest is OFTTestSetup {
         vm.prank(configAdmin);
         configRegistry.pushTo(targets, eids);
         assertEq(m.syncCallCount(), 2, "resync did not re-invoke syncConfig");
-        assertEq(m.lastDstEids(0), DST_EID_OP);
+        assertEq(m.lastDstEids(0), DST_EID_OP, "resync pushed wrong dstEid");
     }
 
     // ----------------------------------------------------------------- pushToAll atomicity

--- a/test/oft/OFTConfigRegistrySync.t.sol
+++ b/test/oft/OFTConfigRegistrySync.t.sol
@@ -66,14 +66,12 @@ contract OFTConfigRegistrySyncTest is OFTCrossChainSetup {
     }
 
     // A well-formed pathway with real libs + sorted DVNs is actually applied to the live endpoint —
-    // proven by reading the config back, not just by the local version counter (which syncConfig
-    // would bump even if it never called setConfig).
+    // proven by reading the config back from the endpoint.
     function test_syncConfig_appliesWellFormedConfig() public {
         address[] memory dvns = _sortedDVNs();
         _setPathway(B_EID, _realPathway(15, dvns));
 
-        // BEFORE: not synced; the endpoint serves the harness DEFAULT ULN (1 DVN, conf 100), NOT ours.
-        assertEq(adapter.syncedConfigVersion(), 0, "precondition: already synced");
+        // BEFORE: the endpoint serves the harness DEFAULT ULN (1 DVN, conf 100), NOT ours.
         UlnConfig memory beforeCfg = _ulnOnEndpoint(endpointSetup.sendLibs[0], B_EID);
         assertTrue(beforeCfg.requiredDVNs.length != 2 || beforeCfg.confirmations != 15, "precondition: our config already present");
 
@@ -81,10 +79,7 @@ contract OFTConfigRegistrySyncTest is OFTCrossChainSetup {
         eids[0] = B_EID;
         adapter.syncConfig(eids); // permissionless pull; self-authorized on the endpoint
 
-        // local bookkeeping advanced...
-        assertEq(adapter.syncedConfigVersion(), configRegistry.configVersion());
-
-        // ...AND the config genuinely landed on the endpoint's send + receive rows.
+        // the config genuinely landed on the endpoint's send + receive rows.
         UlnConfig memory sendUln = _ulnOnEndpoint(endpointSetup.sendLibs[0], B_EID);
         assertEq(sendUln.confirmations, 15, "confirmations not applied on send lib");
         assertEq(sendUln.requiredDVNs.length, 2, "DVN count not applied");
@@ -108,8 +103,7 @@ contract OFTConfigRegistrySyncTest is OFTCrossChainSetup {
         vm.expectRevert(); // LZ_ULN_Unsorted (ULN-internal)
         adapter.syncConfig(eids);
 
-        // atomic rollback: nothing synced and the endpoint config is unchanged from before the attempt
-        assertEq(adapter.syncedConfigVersion(), 0, "synced version advanced despite revert");
+        // atomic rollback: the endpoint config is unchanged from before the attempt
         _assertUlnUnchanged(beforeCfg, _ulnOnEndpoint(endpointSetup.sendLibs[0], B_EID));
     }
 
@@ -127,7 +121,6 @@ contract OFTConfigRegistrySyncTest is OFTCrossChainSetup {
         vm.expectRevert();
         adapter.syncConfig(eids);
 
-        assertEq(adapter.syncedConfigVersion(), 0, "synced version advanced despite revert");
         _assertUlnUnchanged(beforeCfg, _ulnOnEndpoint(endpointSetup.sendLibs[0], B_EID));
     }
 
@@ -144,8 +137,6 @@ contract OFTConfigRegistrySyncTest is OFTCrossChainSetup {
         eids[0] = UNCONFIGURED_EID;
         vm.expectRevert();
         adapter.syncConfig(eids);
-
-        assertEq(adapter.syncedConfigVersion(), 0, "synced version advanced despite revert");
     }
 
     // configRegistry is immutable and BOTH production impls (adapter + shadow) reject a zero registry

--- a/test/oft/OFTConfigRegistrySync.t.sol
+++ b/test/oft/OFTConfigRegistrySync.t.sol
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { UlnConfig } from "@layerzerolabs/lz-evm-messagelib-v2/contracts/uln/UlnBase.sol";
+import { ILayerZeroEndpointV2 } from "@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol";
+
+import { IOFTConfigRegistry } from "../../src/interfaces/IOFTConfigRegistry.sol";
+import { OFTCrossChainSetup } from "./OFTCrossChainSetup.t.sol";
+
+/**
+ * @title OFTConfigRegistrySyncTest
+ * @notice Exercises syncConfig against a LIVE LayerZero endpoint, which the
+ *         recording mock could never validate. A well-formed pathway applies cleanly; malformed DVN
+ *         arrays (unsorted, duplicated) are rejected by the real ULN; and syncing an unconfigured
+ *         destination (empty pathway -> zero send library) is rejected rather than silently pushing
+ *         an insecure no-DVN config.
+ *
+ *         Only the mainnet adapter (A_EID -> B_EID) is driven here, so the single shared registry of
+ *         the one-EVM harness doesn't bleed OP-side bridges into these assertions.
+ */
+contract OFTConfigRegistrySyncTest is OFTCrossChainSetup {
+    address internal configAdmin = makeAddr("configAdmin");
+
+    function setUp() public override {
+        super.setUp();
+        _deployPair(8);
+        // cache the role BEFORE the prank: reading it is a call that would otherwise consume the prank
+        bytes32 configAdminRole = configRegistry.CONFIG_ADMIN_ROLE();
+        vm.prank(owner);
+        roleRegistry.grantRole(configAdminRole, configAdmin);
+    }
+
+    // Build a pathway pointing at the harness's REAL send/receive libraries for the adapter's chain.
+    function _realPathway(uint64 confirmations, address[] memory dvns) internal view returns (IOFTConfigRegistry.PathwayConfig memory) {
+        return IOFTConfigRegistry.PathwayConfig({
+            sendLib: endpointSetup.sendLibs[0], // A_EID == 1 -> index 0
+            receiveLib: endpointSetup.receiveLibs[0],
+            confirmations: confirmations,
+            optionalDVNThreshold: 0,
+            requiredDVNs: dvns,
+            optionalDVNs: new address[](0)
+        });
+    }
+
+    function _sortedDVNs() internal returns (address[] memory dvns) {
+        dvns = new address[](2);
+        dvns[0] = makeAddr("dvnA");
+        dvns[1] = makeAddr("dvnB");
+        if (dvns[0] > dvns[1]) (dvns[0], dvns[1]) = (dvns[1], dvns[0]);
+    }
+
+    function _setPathway(uint32 dstEid, IOFTConfigRegistry.PathwayConfig memory cfg) internal {
+        vm.prank(configAdmin);
+        configRegistry.setPathwayConfig(dstEid, cfg);
+    }
+
+    uint32 internal constant UNCONFIGURED_EID = 9999;
+    uint32 internal constant CONFIG_TYPE_ULN = 2;
+
+    // Read the ULN config the adapter has on its OWN endpoint rows for `dstEid` via `lib`.
+    function _ulnOnEndpoint(address lib, uint32 dstEid) internal view returns (UlnConfig memory) {
+        bytes memory raw = ILayerZeroEndpointV2(endpoints[A_EID]).getConfig(address(adapter), lib, dstEid, CONFIG_TYPE_ULN);
+        return abi.decode(raw, (UlnConfig));
+    }
+
+    // A well-formed pathway with real libs + sorted DVNs is actually applied to the live endpoint —
+    // proven by reading the config back, not just by the local version counter (which syncConfig
+    // would bump even if it never called setConfig).
+    function test_syncConfig_appliesWellFormedConfig() public {
+        address[] memory dvns = _sortedDVNs();
+        _setPathway(B_EID, _realPathway(15, dvns));
+
+        // BEFORE: not synced; the endpoint serves the harness DEFAULT ULN (1 DVN, conf 100), NOT ours.
+        assertEq(adapter.syncedConfigVersion(), 0, "precondition: already synced");
+        UlnConfig memory beforeCfg = _ulnOnEndpoint(endpointSetup.sendLibs[0], B_EID);
+        assertTrue(beforeCfg.requiredDVNs.length != 2 || beforeCfg.confirmations != 15, "precondition: our config already present");
+
+        uint32[] memory eids = new uint32[](1);
+        eids[0] = B_EID;
+        adapter.syncConfig(eids); // permissionless pull; self-authorized on the endpoint
+
+        // local bookkeeping advanced...
+        assertEq(adapter.syncedConfigVersion(), configRegistry.configVersion());
+
+        // ...AND the config genuinely landed on the endpoint's send + receive rows.
+        UlnConfig memory sendUln = _ulnOnEndpoint(endpointSetup.sendLibs[0], B_EID);
+        assertEq(sendUln.confirmations, 15, "confirmations not applied on send lib");
+        assertEq(sendUln.requiredDVNs.length, 2, "DVN count not applied");
+        assertEq(sendUln.requiredDVNs[0], dvns[0]);
+        assertEq(sendUln.requiredDVNs[1], dvns[1]);
+
+        UlnConfig memory recvUln = _ulnOnEndpoint(endpointSetup.receiveLibs[0], B_EID);
+        assertEq(recvUln.requiredDVNs.length, 2, "DVN config not applied on receive lib");
+    }
+
+    // Unsorted requiredDVNs are rejected by the real ULN (LZ requires strict ascending order).
+    function test_syncConfig_reverts_onUnsortedDVNs() public {
+        address[] memory dvns = _sortedDVNs();
+        (dvns[0], dvns[1]) = (dvns[1], dvns[0]); // force descending
+        _setPathway(B_EID, _realPathway(15, dvns));
+
+        UlnConfig memory beforeCfg = _ulnOnEndpoint(endpointSetup.sendLibs[0], B_EID);
+
+        uint32[] memory eids = new uint32[](1);
+        eids[0] = B_EID;
+        vm.expectRevert(); // LZ_ULN_Unsorted (ULN-internal)
+        adapter.syncConfig(eids);
+
+        // atomic rollback: nothing synced and the endpoint config is unchanged from before the attempt
+        assertEq(adapter.syncedConfigVersion(), 0, "synced version advanced despite revert");
+        _assertUlnUnchanged(beforeCfg, _ulnOnEndpoint(endpointSetup.sendLibs[0], B_EID));
+    }
+
+    // Duplicate requiredDVNs are rejected by the real ULN.
+    function test_syncConfig_reverts_onDuplicateDVNs() public {
+        address[] memory dvns = new address[](2);
+        dvns[0] = makeAddr("dup");
+        dvns[1] = dvns[0];
+        _setPathway(B_EID, _realPathway(15, dvns));
+
+        UlnConfig memory beforeCfg = _ulnOnEndpoint(endpointSetup.sendLibs[0], B_EID);
+
+        uint32[] memory eids = new uint32[](1);
+        eids[0] = B_EID;
+        vm.expectRevert();
+        adapter.syncConfig(eids);
+
+        assertEq(adapter.syncedConfigVersion(), 0, "synced version advanced despite revert");
+        _assertUlnUnchanged(beforeCfg, _ulnOnEndpoint(endpointSetup.sendLibs[0], B_EID));
+    }
+
+    /// @dev Confirmations + DVN count unchanged — i.e. the attempted (bad) config was not applied.
+    function _assertUlnUnchanged(UlnConfig memory before, UlnConfig memory got) internal pure {
+        assertEq(got.confirmations, before.confirmations, "confirmations changed despite revert");
+        assertEq(got.requiredDVNs.length, before.requiredDVNs.length, "DVN set changed despite revert");
+    }
+
+    // Syncing an unconfigured destination resolves to an empty pathway (zero send lib); the real
+    // endpoint rejects setConfig against the zero library, so no insecure no-DVN config is applied.
+    function test_syncConfig_reverts_onUnconfiguredEid() public {
+        uint32[] memory eids = new uint32[](1);
+        eids[0] = UNCONFIGURED_EID;
+        vm.expectRevert();
+        adapter.syncConfig(eids);
+
+        assertEq(adapter.syncedConfigVersion(), 0, "synced version advanced despite revert");
+    }
+}

--- a/test/oft/OFTConfigRegistrySync.t.sol
+++ b/test/oft/OFTConfigRegistrySync.t.sol
@@ -3,8 +3,10 @@ pragma solidity ^0.8.28;
 
 import { UlnConfig } from "@layerzerolabs/lz-evm-messagelib-v2/contracts/uln/UlnBase.sol";
 import { ILayerZeroEndpointV2 } from "@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol";
+import { OFTUpgradeable } from "@layerzerolabs/oft-evm-upgradeable/contracts/oft/OFTUpgradeable.sol";
 
 import { IOFTConfigRegistry } from "../../src/interfaces/IOFTConfigRegistry.sol";
+import { ConfigurableOFTBase } from "../../src/oft/ConfigurableOFTBase.sol";
 import { OFTCrossChainSetup } from "./OFTCrossChainSetup.t.sol";
 
 /**
@@ -144,5 +146,28 @@ contract OFTConfigRegistrySyncTest is OFTCrossChainSetup {
         adapter.syncConfig(eids);
 
         assertEq(adapter.syncedConfigVersion(), 0, "synced version advanced despite revert");
+    }
+
+    // configRegistry is immutable and BOTH production impls (adapter + shadow) reject a zero registry
+    // at construction, so the RegistryNotSet guard is unreachable in prod. This synthetic impl (zero
+    // registry, guard omitted) exercises it directly: syncConfig must revert before touching the
+    // endpoint. No initialize() is needed — the guard reads the immutable before any storage.
+    function test_syncConfig_reverts_whenRegistryUnset() public {
+        NoGuardConfigurableOFT noReg = new NoGuardConfigurableOFT(endpoints[A_EID]);
+        uint32[] memory eids = new uint32[](1);
+        eids[0] = B_EID;
+        vm.expectRevert(ConfigurableOFTBase.RegistryNotSet.selector);
+        noReg.syncConfig(eids);
+    }
+}
+
+/**
+ * @dev Test-only ConfigurableOFT whose constructor does NOT reject a zero registry. The production
+ *      impls (EtherFiOFTAdapter / EtherFiShadowOFT) both revert `InvalidAddress` on a zero registry,
+ *      which makes {ConfigurableOFTBase.RegistryNotSet} otherwise unreachable; this exposes it.
+ */
+contract NoGuardConfigurableOFT is OFTUpgradeable, ConfigurableOFTBase {
+    constructor(address ep) OFTUpgradeable(ep) ConfigurableOFTBase(address(0)) {
+        _disableInitializers();
     }
 }

--- a/test/oft/OFTConservation.invariant.t.sol
+++ b/test/oft/OFTConservation.invariant.t.sol
@@ -8,39 +8,51 @@ import { IPacketVerifier, OFTConservationHandler } from "./handlers/OFTConservat
 
 /**
  * @title OFTConservationInvariantTest
- * @notice Handler-based stateful invariant. The handler drives randomized bridgeOut/bridgeBack
+ * @notice Handler-based stateful invariant across the supported decimal range. For each of three
+ *         pairs (6-, 8-, and 18-decimal underlyings) a handler drives randomized bridgeOut/bridgeBack
  *         sequences over the live LZ harness (each delivering its packet synchronously), and after
- *         every call the core conservation invariant is re-checked: the underlying locked in the
- *         mainnet adapter must always equal the iTOKEN supply minted on OP (same decimals -> 1:1).
+ *         every call the conservation invariant is re-checked for EVERY pair: the underlying locked
+ *         in the mainnet adapter must always equal the iTOKEN supply minted on OP (same decimals ->
+ *         1:1). Spanning 6/8/18 decimals proves the dust/SD scaling preserves conservation at the
+ *         precision extremes, not just at the WBTC-like 8-decimal midpoint.
  */
 contract OFTConservationInvariantTest is OFTCrossChainSetup {
-    OFTConservationHandler internal handler;
+    OFTConservationHandler[] internal handlers;
 
     function setUp() public override {
         super.setUp();
-        _deployPair(8); // WBTC-like precision; conservation is decimals-agnostic, one pair suffices
 
         address[] memory users = new address[](3);
         users[0] = makeAddr("user0");
         users[1] = makeAddr("user1");
         users[2] = makeAddr("user2");
 
-        handler = new OFTConservationHandler(IPacketVerifier(address(this)), adapter, shadow, underlying, A_EID, B_EID, users);
-
-        // Only fuzz the two bridge actions on the handler.
+        // Only fuzz the two bridge actions on each handler.
         bytes4[] memory selectors = new bytes4[](2);
         selectors[0] = OFTConservationHandler.bridgeOut.selector;
         selectors[1] = OFTConservationHandler.bridgeBack.selector;
-        targetSelector(StdInvariant.FuzzSelector({ addr: address(handler), selectors: selectors }));
-        targetContract(address(handler));
+
+        uint8[3] memory decimalsList = [uint8(6), 8, 18];
+        for (uint256 i; i < decimalsList.length; ++i) {
+            _deployPair(decimalsList[i]); // sets adapter/shadow/underlying to this pair
+            OFTConservationHandler handler =
+                new OFTConservationHandler(IPacketVerifier(address(this)), adapter, shadow, underlying, A_EID, B_EID, users);
+            handlers.push(handler);
+
+            targetSelector(StdInvariant.FuzzSelector({ addr: address(handler), selectors: selectors }));
+            targetContract(address(handler));
+        }
     }
 
-    /// @notice locked underlying (mainnet) == minted iTOKEN supply (OP), at all times.
+    /// @notice For every pair: locked underlying (mainnet) == minted iTOKEN supply (OP), at all times.
     /// forge-config: default.invariant.runs = 64
     /// forge-config: default.invariant.depth = 30
     /// forge-config: default.invariant.fail-on-revert = true
     function invariant_lockedEqualsMinted() public view {
-        assertEq(underlying.balanceOf(address(adapter)), shadow.totalSupply(), "locked underlying != iTOKEN supply");
+        for (uint256 i; i < handlers.length; ++i) {
+            OFTConservationHandler h = handlers[i];
+            assertEq(h.underlying().balanceOf(address(h.adapter())), h.shadow().totalSupply(), "locked underlying != iTOKEN supply");
+        }
     }
 
     /// @notice Guards against a vacuous pass: confirm the fuzzer actually exercised the bridge path.
@@ -48,6 +60,10 @@ contract OFTConservationInvariantTest is OFTCrossChainSetup {
     /// forge-config: default.invariant.depth = 30
     /// forge-config: default.invariant.fail-on-revert = true
     function afterInvariant() public view {
-        assertGt(handler.bridgeOutCount(), 0, "invariant ran zero effective bridgeOut calls");
+        uint256 totalBridgeOut;
+        for (uint256 i; i < handlers.length; ++i) {
+            totalBridgeOut += handlers[i].bridgeOutCount();
+        }
+        assertGt(totalBridgeOut, 0, "invariant ran zero effective bridgeOut calls");
     }
 }

--- a/test/oft/OFTConservation.invariant.t.sol
+++ b/test/oft/OFTConservation.invariant.t.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { StdInvariant } from "forge-std/StdInvariant.sol";
+
+import { OFTCrossChainSetup } from "./OFTCrossChainSetup.t.sol";
+import { IPacketVerifier, OFTConservationHandler } from "./handlers/OFTConservationHandler.sol";
+
+/**
+ * @title OFTConservationInvariantTest
+ * @notice Handler-based stateful invariant. The handler drives randomized bridgeOut/bridgeBack
+ *         sequences over the live LZ harness (each delivering its packet synchronously), and after
+ *         every call the core conservation invariant is re-checked: the underlying locked in the
+ *         mainnet adapter must always equal the iTOKEN supply minted on OP (same decimals -> 1:1).
+ */
+contract OFTConservationInvariantTest is OFTCrossChainSetup {
+    OFTConservationHandler internal handler;
+
+    function setUp() public override {
+        super.setUp();
+        _deployPair(8); // WBTC-like precision; conservation is decimals-agnostic, one pair suffices
+
+        address[] memory users = new address[](3);
+        users[0] = makeAddr("user0");
+        users[1] = makeAddr("user1");
+        users[2] = makeAddr("user2");
+
+        handler = new OFTConservationHandler(IPacketVerifier(address(this)), adapter, shadow, underlying, A_EID, B_EID, users);
+
+        // Only fuzz the two bridge actions on the handler.
+        bytes4[] memory selectors = new bytes4[](2);
+        selectors[0] = OFTConservationHandler.bridgeOut.selector;
+        selectors[1] = OFTConservationHandler.bridgeBack.selector;
+        targetSelector(StdInvariant.FuzzSelector({ addr: address(handler), selectors: selectors }));
+        targetContract(address(handler));
+    }
+
+    /// @notice locked underlying (mainnet) == minted iTOKEN supply (OP), at all times.
+    /// forge-config: default.invariant.runs = 64
+    /// forge-config: default.invariant.depth = 30
+    /// forge-config: default.invariant.fail-on-revert = true
+    function invariant_lockedEqualsMinted() public view {
+        assertEq(underlying.balanceOf(address(adapter)), shadow.totalSupply(), "locked underlying != iTOKEN supply");
+    }
+
+    /// @notice Guards against a vacuous pass: confirm the fuzzer actually exercised the bridge path.
+    /// forge-config: default.invariant.runs = 64
+    /// forge-config: default.invariant.depth = 30
+    /// forge-config: default.invariant.fail-on-revert = true
+    function afterInvariant() public view {
+        assertGt(handler.bridgeOutCount(), 0, "invariant ran zero effective bridgeOut calls");
+    }
+}

--- a/test/oft/OFTCrossChainSetup.t.sol
+++ b/test/oft/OFTCrossChainSetup.t.sol
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { MessagingFee, MessagingReceipt } from "@layerzerolabs/oapp-evm/contracts/oapp/OAppSender.sol";
+import { OptionsBuilder } from "@layerzerolabs/oapp-evm/contracts/oapp/libs/OptionsBuilder.sol";
+import { IOFT, OFTReceipt, SendParam } from "@layerzerolabs/oft-evm/contracts/interfaces/IOFT.sol";
+import { TestHelperOz5 } from "@layerzerolabs/test-devtools-evm-foundry/contracts/TestHelperOz5.sol";
+
+import { UUPSProxy } from "../../src/UUPSProxy.sol";
+import { EtherFiOFTAdapter } from "../../src/oft/EtherFiOFTAdapter.sol";
+import { EtherFiShadowOFT } from "../../src/oft/EtherFiShadowOFT.sol";
+import { OFTAdapterFactory } from "../../src/oft/OFTAdapterFactory.sol";
+import { OFTConfigRegistry } from "../../src/oft/OFTConfigRegistry.sol";
+import { ShadowOFTFactory } from "../../src/oft/ShadowOFTFactory.sol";
+import { RoleRegistry } from "../../src/role-registry/RoleRegistry.sol";
+import { MockERC20 } from "./OFTTestSetup.t.sol";
+
+/**
+ * @title OFTCrossChainSetup
+ * @notice Real LayerZero round-trip harness. Unlike the recording `MockLZEndpoint` in
+ *         {OFTTestSetup}, this wires two live `EndpointV2Mock`s in one EVM via LZ's
+ *         {TestHelperOz5} and delivers packets in-process (`send()` -> `verifyPackets()`),
+ *         so the full lock -> mint -> burn -> unlock path — message encode/decode, peer
+ *         enforcement, SD<->LD truncation in transit — is exercised end to end.
+ *
+ *         Endpoint 1 stands in for mainnet (the lock adapter); endpoint 2 for Optimism
+ *         (the mintable iTOKEN). Both factories/impls live in one EVM but are pinned to
+ *         their respective endpoints via the impl constructor, exactly as on real chains.
+ */
+contract OFTCrossChainSetup is TestHelperOz5 {
+    using OptionsBuilder for bytes;
+
+    // TestHelperOz5 assigns eid = index + 1. Endpoint 1 = "mainnet", endpoint 2 = "OP".
+    uint32 internal constant A_EID = 1; // mainnet (adapter / lock side)
+    uint32 internal constant B_EID = 2; // OP (shadow iTOKEN / mint side)
+
+    uint8 internal constant SHARED_DECIMALS = 6;
+
+    RoleRegistry internal roleRegistry;
+    OFTConfigRegistry internal configRegistry; // one EVM -> one shared registry is fine
+
+    OFTAdapterFactory internal adapterFactory; // pinned to endpoint A
+    ShadowOFTFactory internal shadowFactory; // pinned to endpoint B
+
+    // The active pair under test, set by {_deployPair}.
+    MockERC20 internal underlying;
+    EtherFiOFTAdapter internal adapter;
+    EtherFiShadowOFT internal shadow;
+
+    // actors
+    address internal owner = makeAddr("owner");
+    address internal factoryAdmin = makeAddr("factoryAdmin");
+    address internal delegate = makeAddr("delegate"); // OApp owner / LZ delegate on both ends
+    address internal alice = makeAddr("alice");
+    address internal bob = makeAddr("bob");
+
+    function setUp() public virtual override {
+        // Wire two live LZ endpoints + default DVN/executor/library config between them.
+        super.setUp();
+        setUpEndpoints(2, LibraryType.UltraLightNode);
+
+        vm.startPrank(owner);
+
+        address dataProvider = makeAddr("dataProvider");
+        address roleRegistryImpl = address(new RoleRegistry(dataProvider));
+        roleRegistry = RoleRegistry(address(new UUPSProxy(roleRegistryImpl, abi.encodeWithSelector(RoleRegistry.initialize.selector, owner))));
+
+        address configRegistryImpl = address(new OFTConfigRegistry());
+        configRegistry = OFTConfigRegistry(address(new UUPSProxy(configRegistryImpl, abi.encodeWithSelector(OFTConfigRegistry.initialize.selector, address(roleRegistry)))));
+
+        // Adapter impl/factory pinned to mainnet endpoint; shadow impl/factory to OP endpoint.
+        address adapterImpl = address(new EtherFiOFTAdapter(endpoints[A_EID], address(configRegistry)));
+        address shadowImpl = address(new EtherFiShadowOFT(endpoints[B_EID], address(configRegistry)));
+
+        address adapterFactoryImpl = address(new OFTAdapterFactory());
+        adapterFactory = OFTAdapterFactory(address(new UUPSProxy(adapterFactoryImpl, abi.encodeWithSelector(OFTAdapterFactory.initialize.selector, address(roleRegistry), adapterImpl))));
+        address shadowFactoryImpl = address(new ShadowOFTFactory());
+        shadowFactory = ShadowOFTFactory(address(new UUPSProxy(shadowFactoryImpl, abi.encodeWithSelector(ShadowOFTFactory.initialize.selector, address(roleRegistry), shadowImpl))));
+
+        // Roles: factories auto-register their bridges at deploy, so they need the registrar role.
+        roleRegistry.grantRole(configRegistry.CONFIG_REGISTRAR_ROLE(), address(adapterFactory));
+        roleRegistry.grantRole(configRegistry.CONFIG_REGISTRAR_ROLE(), address(shadowFactory));
+        roleRegistry.grantRole(adapterFactory.OFT_ADAPTER_FACTORY_ADMIN_ROLE(), factoryAdmin);
+        roleRegistry.grantRole(shadowFactory.SHADOW_OFT_FACTORY_ADMIN_ROLE(), factoryAdmin);
+
+        vm.stopPrank();
+
+        // Native gas for paying LZ messaging fees on send().
+        vm.deal(alice, 100 ether);
+        vm.deal(bob, 100 ether);
+    }
+
+    /**
+     * @notice Deploy a fresh adapter+shadow pair for an underlying of `decimals` precision and
+     *         wire them as peers. The registry has no active pathway, so the factory auto-sync
+     *         is a no-op and message routing falls back to TestHelperOz5's default DVN config.
+     */
+    function _deployPair(uint8 decimals) internal {
+        underlying = new MockERC20("Underlying", "UND", decimals);
+
+        vm.startPrank(factoryAdmin);
+        adapter = EtherFiOFTAdapter(adapterFactory.deployAdapter(keccak256(abi.encode("adapter", address(underlying))), address(underlying), delegate));
+        shadow = EtherFiShadowOFT(shadowFactory.deployShadowOFT(keccak256(abi.encode("shadow", address(underlying))), "EtherFi UND", "iUND", decimals, delegate));
+        vm.stopPrank();
+
+        // Peer wiring is owner-gated (delegate is the OApp owner on both ends).
+        vm.startPrank(delegate);
+        adapter.setPeer(B_EID, _b32(address(shadow)));
+        shadow.setPeer(A_EID, _b32(address(adapter)));
+        vm.stopPrank();
+    }
+
+    /**
+     * @notice Lock `amountLD` of underlying in the mainnet adapter and deliver the resulting
+     *         mint on OP. Returns the adapter's OFTReceipt (sent/received, post dust removal).
+     */
+    function _bridgeOut(address user, uint256 amountLD) internal returns (uint256 amountSentLD, uint256 amountReceivedLD) {
+        bytes memory options = OptionsBuilder.newOptions().addExecutorLzReceiveOption(200_000, 0);
+        SendParam memory sp = SendParam(B_EID, _b32(user), amountLD, 0, options, "", "");
+        MessagingFee memory fee = adapter.quoteSend(sp, false);
+
+        vm.startPrank(user);
+        underlying.approve(address(adapter), amountLD);
+        (, OFTReceipt memory r) = adapter.send{ value: fee.nativeFee }(sp, fee, payable(user));
+        vm.stopPrank();
+
+        // Deliver the in-flight packet to the OP shadow (mints iTOKEN).
+        verifyPackets(B_EID, _b32(address(shadow)));
+        return (r.amountSentLD, r.amountReceivedLD);
+    }
+
+    /**
+     * @notice Burn `amountLD` of iTOKEN on OP and deliver the unlock on mainnet to `user`.
+     */
+    function _bridgeBack(address user, uint256 amountLD) internal returns (uint256 amountSentLD, uint256 amountReceivedLD) {
+        bytes memory options = OptionsBuilder.newOptions().addExecutorLzReceiveOption(200_000, 0);
+        SendParam memory sp = SendParam(A_EID, _b32(user), amountLD, 0, options, "", "");
+        MessagingFee memory fee = shadow.quoteSend(sp, false);
+
+        vm.startPrank(user);
+        (, OFTReceipt memory r) = shadow.send{ value: fee.nativeFee }(sp, fee, payable(user));
+        vm.stopPrank();
+
+        verifyPackets(A_EID, _b32(address(adapter)));
+        return (r.amountSentLD, r.amountReceivedLD);
+    }
+
+    /// @dev adapter underlying balance == tokens locked == should equal shadow.totalSupply (decimals match).
+    function _locked() internal view returns (uint256) {
+        return underlying.balanceOf(address(adapter));
+    }
+
+    function _b32(address a) internal pure returns (bytes32) {
+        return bytes32(uint256(uint160(a)));
+    }
+}

--- a/test/oft/OFTDecimals.fuzz.t.sol
+++ b/test/oft/OFTDecimals.fuzz.t.sol
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { IOFT } from "@layerzerolabs/oft-evm/contracts/interfaces/IOFT.sol";
+import { BeaconProxy } from "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
+import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+
+import { EtherFiOFTAdapter } from "../../src/oft/EtherFiOFTAdapter.sol";
+import { MockERC20, OFTTestSetup } from "./OFTTestSetup.t.sol";
+
+/**
+ * Exposes the internal decimal-scaling math (_removeDust / _toSD / _toLD) so the SD<->LD
+ * truncation rules can be fuzzed directly, without driving a cross-chain send. The adapter and
+ * shadow share identical overrides (both read the per-proxy rate from storage), so testing one
+ * covers the math for both; the cross-chain fuzz in OFTRoundTrip proves they agree end to end.
+ */
+contract DecimalMathHarness is EtherFiOFTAdapter {
+    constructor(address ep, address reg) EtherFiOFTAdapter(ep, reg) { }
+
+    function removeDust(uint256 a) external view returns (uint256) {
+        return _removeDust(a);
+    }
+
+    function toSD(uint256 a) external view returns (uint64) {
+        return _toSD(a);
+    }
+
+    function toLD(uint64 a) external view returns (uint256) {
+        return _toLD(a);
+    }
+}
+
+/**
+ * @title OFTDecimalsFuzzTest
+ * @notice Fuzz the decimal/dust math across the supported 6..18-decimal range:
+ *         dust truncation never rounds up, sub-rate amounts collapse to zero, the SD round-trip
+ *         is lossless on clean amounts, and the uint64 SD ceiling reverts rather than silently
+ *         overflowing.
+ */
+contract OFTDecimalsFuzzTest is OFTTestSetup {
+    uint8 internal constant SHARED_DECIMALS = 6;
+
+    // Deploy a math harness whose per-proxy rate is 10**(decimals-6).
+    function _harness(uint8 decimals) internal returns (DecimalMathHarness h) {
+        MockERC20 t = new MockERC20("T", "T", decimals);
+        address impl = address(new DecimalMathHarness(address(endpoint), address(configRegistry)));
+        UpgradeableBeacon beacon = new UpgradeableBeacon(impl, owner);
+        bytes memory initData = abi.encodeWithSelector(EtherFiOFTAdapter.initialize.selector, address(t), delegate);
+        h = DecimalMathHarness(address(new BeaconProxy(address(beacon), initData)));
+    }
+
+    // The conversion rate is exactly 10**(decimals - 6) for every supported precision.
+    function testFuzz_conversionRate_perDecimals(uint8 decimals) public {
+        decimals = uint8(bound(decimals, SHARED_DECIMALS, 18));
+        DecimalMathHarness h = _harness(decimals);
+        assertEq(h.conversionRate(), 10 ** (decimals - SHARED_DECIMALS));
+    }
+
+    // _removeDust floors to a multiple of the rate: result <= input, result is a clean multiple,
+    // and it discards strictly less than one rate unit. Truncation, never rounding up.
+    function testFuzz_removeDust_truncatesDown(uint8 decimals, uint256 amount) public {
+        decimals = uint8(bound(decimals, SHARED_DECIMALS, 18));
+        uint256 rate = 10 ** (decimals - SHARED_DECIMALS);
+        // keep amount under the SD ceiling so _removeDust itself can't be poisoned by overflow elsewhere
+        amount = bound(amount, 0, uint256(type(uint64).max) * rate);
+        DecimalMathHarness h = _harness(decimals);
+
+        uint256 clean = h.removeDust(amount);
+        assertLe(clean, amount, "dust removal increased the amount");
+        assertEq(clean % rate, 0, "result is not a multiple of the rate");
+        assertEq(amount - clean, amount % rate, "discarded more/less than the true dust");
+        assertLt(amount - clean, rate, "discarded a whole rate unit");
+    }
+
+    // Sub-rate amounts (strictly less than one SD unit) collapse to zero in both directions.
+    function testFuzz_subRateAmount_collapsesToZero(uint8 decimals, uint256 amount) public {
+        decimals = uint8(bound(decimals, SHARED_DECIMALS + 1, 18)); // rate > 1 so a sub-rate band exists
+        uint256 rate = 10 ** (decimals - SHARED_DECIMALS);
+        amount = bound(amount, 0, rate - 1);
+        DecimalMathHarness h = _harness(decimals);
+
+        assertEq(h.removeDust(amount), 0);
+        assertEq(h.toSD(amount), 0);
+    }
+
+    // The SD<->LD round-trip is lossless once dust is removed: toLD(toSD(x)) == removeDust(x).
+    function testFuzz_sdRoundTrip_isLosslessAfterDustRemoval(uint8 decimals, uint256 amount) public {
+        decimals = uint8(bound(decimals, SHARED_DECIMALS, 18));
+        uint256 rate = 10 ** (decimals - SHARED_DECIMALS);
+        amount = bound(amount, 0, uint256(type(uint64).max) * rate);
+        DecimalMathHarness h = _harness(decimals);
+
+        uint256 clean = h.removeDust(amount);
+        assertEq(h.toLD(h.toSD(amount)), clean, "SD round-trip lost or created value");
+    }
+
+    // Zero is a fixed point of all three transforms.
+    function test_zero_isFixedPoint() public {
+        DecimalMathHarness h = _harness(18);
+        assertEq(h.removeDust(0), 0);
+        assertEq(h.toSD(0), 0);
+        assertEq(h.toLD(0), 0);
+    }
+
+    // Just above the uint64 SD ceiling, _toSD reverts AmountSDOverflowed instead of wrapping.
+    function test_toSD_revertsAboveUint64Ceiling() public {
+        DecimalMathHarness h = _harness(18); // rate = 1e12
+        uint256 rate = 1e12;
+        // one SD unit past the max representable shared-decimal amount
+        uint256 overflowLD = (uint256(type(uint64).max) + 1) * rate;
+        vm.expectRevert(abi.encodeWithSelector(IOFT.AmountSDOverflowed.selector, uint256(type(uint64).max) + 1));
+        h.toSD(overflowLD);
+    }
+
+    // The largest representable amount (exactly uint64.max SD units) does NOT revert.
+    function test_toSD_maxRepresentable_ok() public {
+        DecimalMathHarness h = _harness(18);
+        uint256 rate = 1e12;
+        uint256 maxLD = uint256(type(uint64).max) * rate;
+        assertEq(h.toSD(maxLD), type(uint64).max);
+        assertEq(h.toLD(type(uint64).max), maxLD);
+    }
+}

--- a/test/oft/OFTFactories.t.sol
+++ b/test/oft/OFTFactories.t.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.28;
 
 import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
 
-import { IConfigurableOFT } from "../../src/interfaces/IConfigurableOFT.sol";
 import { IOFTAdapterFactory } from "../../src/interfaces/IOFTAdapterFactory.sol";
 import { IOFTConfigRegistry } from "../../src/interfaces/IOFTConfigRegistry.sol";
 import { IShadowOFTFactory } from "../../src/interfaces/IShadowOFTFactory.sol";
@@ -43,19 +42,15 @@ contract OFTFactoriesTest is OFTTestSetup {
         (address oapp,, uint32 eid,) = endpoint.configCalls(0);
         assertEq(oapp, adapter); // it configured its own rows (address(this))
         assertEq(eid, DST_EID_OP);
-
-        // recorded the registry version it synced to
-        assertEq(IConfigurableOFT(adapter).syncedConfigVersion(), configRegistry.configVersion());
     }
 
     // With NO pathway configured yet, deploy still registers the bridge, but syncConfig is a
     // harmless no-op (activeDstEids is empty) — a later pushToAll will configure it.
     function test_deployAdapter_autoRegisters_butNoConfigCalls_whenNoPathways() public {
-        address adapter = _deployAdapter(address(token6));
+        _deployAdapter(address(token6));
 
         assertEq(configRegistry.numBridges(), 1); // still registered
         assertEq(endpoint.configCallCount(), 0); // no destinations -> nothing to configure
-        assertEq(IConfigurableOFT(adapter).syncedConfigVersion(), 0);
     }
 
     // Fail-hard: if the factory lacks CONFIG_REGISTRAR_ROLE, the registerBridge call inside deploy
@@ -128,7 +123,6 @@ contract OFTFactoriesTest is OFTTestSetup {
         assertEq(EtherFiShadowOFT(shadow).decimals(), 8); // decimals threaded through to the iTOKEN
         assertEq(configRegistry.numBridges(), 1);
         assertEq(endpoint.configCallCount(), 2); // send + receive lib
-        assertEq(IConfigurableOFT(shadow).syncedConfigVersion(), configRegistry.configVersion());
     }
 
     // Only the factory admin role may deploy a shadow OFT.

--- a/test/oft/OFTFactories.t.sol
+++ b/test/oft/OFTFactories.t.sol
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
+
+import { IConfigurableOFT } from "../../src/interfaces/IConfigurableOFT.sol";
+import { IOFTAdapterFactory } from "../../src/interfaces/IOFTAdapterFactory.sol";
+import { IOFTConfigRegistry } from "../../src/interfaces/IOFTConfigRegistry.sol";
+import { IShadowOFTFactory } from "../../src/interfaces/IShadowOFTFactory.sol";
+import { EtherFiOFTAdapter } from "../../src/oft/EtherFiOFTAdapter.sol";
+import { EtherFiShadowOFT } from "../../src/oft/EtherFiShadowOFT.sol";
+import { OFTTestSetup } from "./OFTTestSetup.t.sol";
+
+contract OFTFactoriesTest is OFTTestSetup {
+    // helper: set the OP pathway config (so activeDstEids is non-empty for auto-sync tests)
+    function _setPathwayOP() internal {
+        vm.prank(configAdmin);
+        configRegistry.setPathwayConfig(DST_EID_OP, _samplePathway(15));
+    }
+
+    // helper: deploy an adapter via the factory as the factory admin
+    function _deployAdapter(address token) internal returns (address) {
+        vm.prank(factoryAdmin);
+        return adapterFactory.deployAdapter(keccak256(abi.encode(token)), token, delegate);
+    }
+
+    // ----------------------------------------------------------------- adapter auto-sync
+
+    // With a pathway already configured, deploying an adapter auto-registers it AND auto-pulls
+    // the DVN config (this is the Step-4 auto-sync feature working end to end).
+    function test_deployAdapter_autoRegistersAndSyncs_whenPathwaySet() public {
+        _setPathwayOP(); // version -> 1, one active dstEid (OP)
+
+        address adapter = _deployAdapter(address(token6));
+
+        // registered in the registry's bridge set
+        assertEq(configRegistry.numBridges(), 1);
+        assertEq(configRegistry.getBridges(0, 10)[0], adapter);
+
+        // pulled config: the bridge configured ITSELF on the endpoint. syncConfig calls setConfig
+        // once for the send lib and once for the receive lib -> 2 recorded calls for one dstEid.
+        assertEq(endpoint.configCallCount(), 2);
+        (address oapp,, uint32 eid,) = endpoint.configCalls(0);
+        assertEq(oapp, adapter); // it configured its own rows (address(this))
+        assertEq(eid, DST_EID_OP);
+
+        // recorded the registry version it synced to
+        assertEq(IConfigurableOFT(adapter).syncedConfigVersion(), configRegistry.configVersion());
+    }
+
+    // With NO pathway configured yet, deploy still registers the bridge, but syncConfig is a
+    // harmless no-op (activeDstEids is empty) — a later pushToAll will configure it.
+    function test_deployAdapter_autoRegisters_butNoConfigCalls_whenNoPathways() public {
+        address adapter = _deployAdapter(address(token6));
+
+        assertEq(configRegistry.numBridges(), 1); // still registered
+        assertEq(endpoint.configCallCount(), 0); // no destinations -> nothing to configure
+        assertEq(IConfigurableOFT(adapter).syncedConfigVersion(), 0);
+    }
+
+    // Fail-hard: if the factory lacks CONFIG_REGISTRAR_ROLE, the registerBridge call inside deploy
+    // reverts and the WHOLE deploy reverts — no half-configured bridge is ever left behind.
+    function test_deployAdapter_failsHard_whenFactoryLacksRegistrarRole() public {
+        // cache the role BEFORE the prank: vm.prank applies to the next call, and reading
+        // configRegistry.CONFIG_REGISTRAR_ROLE() is itself a call that would consume the prank.
+        bytes32 registrarRole = configRegistry.CONFIG_REGISTRAR_ROLE();
+        vm.prank(owner);
+        roleRegistry.revokeRole(registrarRole, address(adapterFactory));
+
+        vm.prank(factoryAdmin);
+        vm.expectRevert(IOFTConfigRegistry.OnlyRegistrar.selector); // bubbles up from registerBridge
+        adapterFactory.deployAdapter(keccak256(abi.encode(address(token6))), address(token6), delegate);
+
+        // the revert rolled everything back: no adapter recorded, no bridge registered
+        assertEq(adapterFactory.numAdaptersDeployed(), 0);
+        assertEq(configRegistry.numBridges(), 0);
+    }
+
+    // deploy records both directions of the underlying<->adapter mapping.
+    function test_deployAdapter_setsMappings() public {
+        address adapter = _deployAdapter(address(token6));
+        assertEq(adapterFactory.adapterOf(address(token6)), adapter);
+        assertEq(adapterFactory.underlyingOf(adapter), address(token6));
+        assertEq(EtherFiOFTAdapter(adapter).token(), address(token6));
+    }
+
+    // Only the factory admin role may deploy.
+    function test_deployAdapter_reverts_whenNotAdmin() public {
+        vm.prank(alice);
+        vm.expectRevert(IOFTAdapterFactory.OnlyAdmin.selector);
+        adapterFactory.deployAdapter(keccak256("x"), address(token6), delegate);
+    }
+
+    // A zero underlying token is rejected.
+    function test_deployAdapter_reverts_onZeroUnderlying() public {
+        vm.prank(factoryAdmin);
+        vm.expectRevert(IOFTAdapterFactory.InvalidUnderlying.selector);
+        adapterFactory.deployAdapter(keccak256("x"), address(0), delegate);
+    }
+
+    // One adapter per underlying: a second deploy for the same token reverts (even with a new salt).
+    function test_deployAdapter_reverts_whenUnderlyingAlreadyHasAdapter() public {
+        _deployAdapter(address(token6));
+        vm.prank(factoryAdmin);
+        vm.expectRevert(IOFTAdapterFactory.AdapterAlreadyExists.selector);
+        adapterFactory.deployAdapter(keccak256("different-salt"), address(token6), delegate);
+    }
+
+    // Deploy is blocked while the factory is paused.
+    function test_deployAdapter_reverts_whenPaused() public {
+        vm.prank(pauser);
+        adapterFactory.pause();
+        vm.prank(factoryAdmin);
+        vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
+        adapterFactory.deployAdapter(keccak256("x"), address(token6), delegate);
+    }
+
+    // ----------------------------------------------------------------- shadow factory
+
+    // Deploying a shadow OFT threads the `decimals` arg into the iTOKEN AND auto-registers/syncs
+    // it (the shadow-side equivalent of the adapter auto-sync test).
+    function test_deployShadowOFT_threadsDecimals_andAutoSyncs() public {
+        _setPathwayOP();
+
+        vm.prank(factoryAdmin);
+        address shadow = shadowFactory.deployShadowOFT(keccak256("iWBTC"), "EtherFi WBTC", "iWBTC", 8, delegate);
+
+        assertEq(EtherFiShadowOFT(shadow).decimals(), 8); // decimals threaded through to the iTOKEN
+        assertEq(configRegistry.numBridges(), 1);
+        assertEq(endpoint.configCallCount(), 2); // send + receive lib
+        assertEq(IConfigurableOFT(shadow).syncedConfigVersion(), configRegistry.configVersion());
+    }
+
+    // Only the factory admin role may deploy a shadow OFT.
+    function test_deployShadowOFT_reverts_whenNotAdmin() public {
+        vm.prank(alice);
+        vm.expectRevert(IShadowOFTFactory.OnlyAdmin.selector);
+        shadowFactory.deployShadowOFT(keccak256("iUSDC"), "EtherFi USDC", "iUSDC", 6, delegate);
+    }
+
+    // The shadow factory dedupes by predicted CREATE3 address, so reusing a salt reverts.
+    function test_deployShadowOFT_reverts_onDuplicateSalt() public {
+        vm.startPrank(factoryAdmin);
+        shadowFactory.deployShadowOFT(keccak256("iUSDC"), "EtherFi USDC", "iUSDC", 6, delegate);
+        vm.expectRevert(IShadowOFTFactory.ShadowOFTAlreadyExists.selector);
+        shadowFactory.deployShadowOFT(keccak256("iUSDC"), "EtherFi USDC", "iUSDC", 6, delegate); // same salt
+        vm.stopPrank();
+    }
+
+    // ----------------------------------------------------------------- pagination (returns empty past end)
+
+    // getDeployedAdapters follows the pagination contract: full list, empty at/after the end, clamp.
+    function test_getDeployedAdapters_returnsEmpty_whenStartPastEnd() public {
+        _deployAdapter(address(token6));
+        _deployAdapter(address(token8));
+        assertEq(adapterFactory.getDeployedAdapters(0, 10).length, 2);
+        assertEq(adapterFactory.getDeployedAdapters(2, 5).length, 0); // start == length -> empty
+        assertEq(adapterFactory.getDeployedAdapters(99, 5).length, 0); // start past end -> empty
+        assertEq(adapterFactory.getDeployedAdapters(1, 10).length, 1); // over-long count clamps to remaining
+    }
+
+    // getDeployedShadowOFTs follows the same pagination contract.
+    function test_getDeployedShadowOFTs_returnsEmpty_whenStartPastEnd() public {
+        vm.startPrank(factoryAdmin);
+        shadowFactory.deployShadowOFT(keccak256("iUSDC"), "EtherFi USDC", "iUSDC", 6, delegate);
+        shadowFactory.deployShadowOFT(keccak256("iWBTC"), "EtherFi WBTC", "iWBTC", 8, delegate);
+        vm.stopPrank();
+        assertEq(shadowFactory.getDeployedShadowOFTs(0, 10).length, 2);
+        assertEq(shadowFactory.getDeployedShadowOFTs(2, 5).length, 0);
+        assertEq(shadowFactory.getDeployedShadowOFTs(99, 5).length, 0);
+        assertEq(shadowFactory.getDeployedShadowOFTs(1, 10).length, 1);
+    }
+}

--- a/test/oft/OFTFactoryMechanics.t.sol
+++ b/test/oft/OFTFactoryMechanics.t.sol
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { CREATE3 } from "solady/utils/CREATE3.sol";
+
+import { UUPSProxy } from "../../src/UUPSProxy.sol";
+import { BeaconFactory } from "../../src/beacon-factory/BeaconFactory.sol";
+import { EtherFiOFTAdapter } from "../../src/oft/EtherFiOFTAdapter.sol";
+import { EtherFiShadowOFT } from "../../src/oft/EtherFiShadowOFT.sol";
+import { OFTAdapterFactory } from "../../src/oft/OFTAdapterFactory.sol";
+import { UpgradeableProxy } from "../../src/utils/UpgradeableProxy.sol";
+import { OFTTestSetup } from "./OFTTestSetup.t.sol";
+
+/**
+ * Beacon-impl V2s: same storage layout, plus a probe so we can confirm a beacon upgrade swaps the
+ * logic seen by EXISTING proxies while their per-proxy storage is preserved.
+ */
+contract EtherFiOFTAdapterV2 is EtherFiOFTAdapter {
+    constructor(address ep, address reg) EtherFiOFTAdapter(ep, reg) { }
+
+    function version() external pure returns (uint256) {
+        return 2;
+    }
+}
+
+contract EtherFiShadowOFTV2 is EtherFiShadowOFT {
+    constructor(address ep, address reg) EtherFiShadowOFT(ep, reg) { }
+
+    function version() external pure returns (uint256) {
+        return 2;
+    }
+}
+
+/**
+ * @title OFTFactoryMechanicsTest
+ * @notice CREATE3 determinism (predicted == deployed, deployer-scoped, salt-collision reverts)
+ *         and beacon upgrade mechanics (existing proxies pick up new logic, per-proxy storage
+ *         survives, upgrade is gated to the RoleRegistry owner).
+ */
+contract OFTFactoryMechanicsTest is OFTTestSetup {
+    function _deployAdapter(bytes32 salt, address token) internal returns (address) {
+        vm.prank(factoryAdmin);
+        return adapterFactory.deployAdapter(salt, token, delegate);
+    }
+
+    // ----------------------------------------------------------------- CREATE3 determinism
+
+    // The deployed adapter lands exactly at the address the factory predicts for its salt.
+    function test_create3_predictedEqualsDeployed() public {
+        bytes32 salt = keccak256("usdc-adapter");
+        address predicted = adapterFactory.getDeterministicAddress(salt);
+        address deployed = _deployAdapter(salt, address(token6));
+        assertEq(deployed, predicted);
+    }
+
+    // CREATE3 addresses are scoped to the deploying factory: the SAME salt on a second factory
+    // instance predicts a DIFFERENT address (so two chains' factories don't have to collide).
+    function test_create3_sameSaltDifferentFactory_differentAddress() public {
+        bytes32 salt = keccak256("shared-salt");
+
+        // a second, independent adapter factory instance
+        vm.startPrank(owner);
+        address factoryImpl = address(new OFTAdapterFactory());
+        OFTAdapterFactory factory2 = OFTAdapterFactory(address(new UUPSProxy(factoryImpl, abi.encodeWithSelector(OFTAdapterFactory.initialize.selector, address(roleRegistry), adapterImpl))));
+        vm.stopPrank();
+
+        assertTrue(adapterFactory.getDeterministicAddress(salt) != factory2.getDeterministicAddress(salt), "CREATE3 address not scoped to deployer");
+    }
+
+    // Reusing a salt within one factory (for a different underlying) collides at the CREATE3 slot
+    // and reverts — no silent overwrite of an existing proxy.
+    function test_create3_saltCollision_reverts() public {
+        bytes32 salt = keccak256("collide");
+        _deployAdapter(salt, address(token6));
+
+        vm.prank(factoryAdmin);
+        vm.expectRevert(CREATE3.DeploymentFailed.selector);
+        adapterFactory.deployAdapter(salt, address(token8), delegate); // same salt, new underlying
+    }
+
+    // ----------------------------------------------------------------- beacon upgrade
+
+    // Upgrading the adapter beacon impl swaps logic for EXISTING proxies while preserving their
+    // per-proxy ERC-7201 storage (underlying + conversion rate).
+    function test_beaconUpgrade_adapter_newLogic_storagePreserved() public {
+        address adapter = _deployAdapter(keccak256("wbtc"), address(token8));
+        assertEq(EtherFiOFTAdapter(adapter).token(), address(token8));
+        assertEq(EtherFiOFTAdapter(adapter).conversionRate(), 100); // 10**(8-6)
+
+        // BEFORE: V1 impl has no version() — the call finds no selector and reverts.
+        (bool okBefore,) = adapter.staticcall(abi.encodeWithSignature("version()"));
+        assertFalse(okBefore, "version() existed before the upgrade - logic did not actually change");
+
+        address implV2 = address(new EtherFiOFTAdapterV2(address(endpoint), address(configRegistry)));
+        vm.prank(owner); // RoleRegistry owner
+        adapterFactory.upgradeBeaconImplementation(implV2);
+
+        // AFTER: the existing proxy now runs V2 logic that did not exist before...
+        (bool okAfter, bytes memory ret) = adapter.staticcall(abi.encodeWithSignature("version()"));
+        assertTrue(okAfter, "version() missing after the upgrade");
+        assertEq(abi.decode(ret, (uint256)), 2);
+        // ...with its storage intact
+        assertEq(EtherFiOFTAdapter(adapter).token(), address(token8));
+        assertEq(EtherFiOFTAdapter(adapter).conversionRate(), 100);
+    }
+
+    function test_beaconUpgrade_shadow_newLogic_storagePreserved() public {
+        vm.prank(factoryAdmin);
+        address shadow = shadowFactory.deployShadowOFT(keccak256("iWBTC"), "EtherFi WBTC", "iWBTC", 8, delegate);
+        assertEq(EtherFiShadowOFT(shadow).decimals(), 8);
+
+        // BEFORE: V1 impl has no version().
+        (bool okBefore,) = shadow.staticcall(abi.encodeWithSignature("version()"));
+        assertFalse(okBefore, "version() existed before the upgrade - logic did not actually change");
+
+        address implV2 = address(new EtherFiShadowOFTV2(address(endpoint), address(configRegistry)));
+        vm.prank(owner);
+        shadowFactory.upgradeBeaconImplementation(implV2);
+
+        // AFTER: V2 logic is live on the existing proxy...
+        (bool okAfter, bytes memory ret) = shadow.staticcall(abi.encodeWithSignature("version()"));
+        assertTrue(okAfter, "version() missing after the upgrade");
+        assertEq(abi.decode(ret, (uint256)), 2);
+        // ...with storage preserved
+        assertEq(EtherFiShadowOFT(shadow).decimals(), 8);
+        assertEq(EtherFiShadowOFT(shadow).conversionRate(), 100);
+    }
+
+    // Only the RoleRegistry owner may upgrade a beacon impl.
+    function test_beaconUpgrade_reverts_whenNotRoleRegistryOwner() public {
+        address implV2 = address(new EtherFiOFTAdapterV2(address(endpoint), address(configRegistry)));
+        vm.prank(alice);
+        vm.expectRevert(UpgradeableProxy.OnlyRoleRegistryOwner.selector);
+        adapterFactory.upgradeBeaconImplementation(implV2);
+    }
+
+    // A zero implementation is rejected.
+    function test_beaconUpgrade_reverts_onZeroImpl() public {
+        vm.prank(owner);
+        vm.expectRevert(BeaconFactory.InvalidInput.selector);
+        adapterFactory.upgradeBeaconImplementation(address(0));
+    }
+}

--- a/test/oft/OFTRoundTrip.t.sol
+++ b/test/oft/OFTRoundTrip.t.sol
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { OFTCrossChainSetup } from "./OFTCrossChainSetup.t.sol";
+
+/**
+ * @title OFTRoundTripTest
+ * @notice End-to-end lock -> mint -> burn -> unlock over the real LZ harness, asserting
+ *         amounts match exactly across 6 / 8 / 18-decimal underlyings and that the lock/mint
+ *         conservation (adapter locked == shadow totalSupply) holds at every step.
+ */
+contract OFTRoundTripTest is OFTCrossChainSetup {
+    // ----------------------------------------------------------------- lock -> mint (outbound)
+
+    function _assertLockMint(uint8 decimals) internal {
+        _deployPair(decimals);
+        uint256 amount = 1234 * (10 ** decimals); // a clean (dust-free) amount
+        underlying.mint(alice, amount);
+
+        assertEq(shadow.totalSupply(), 0);
+        assertEq(_locked(), 0);
+
+        (uint256 sent, uint256 received) = _bridgeOut(alice, amount);
+
+        assertEq(sent, amount, "sent != amount");
+        assertEq(received, amount, "received != amount");
+        assertEq(underlying.balanceOf(alice), 0, "underlying not pulled");
+        assertEq(_locked(), amount, "adapter did not lock full amount");
+        assertEq(shadow.balanceOf(alice), amount, "iTOKEN not minted 1:1");
+        assertEq(shadow.totalSupply(), amount, "supply != minted");
+        assertEq(_locked(), shadow.totalSupply(), "locked != minted");
+    }
+
+    function test_lockMint_6dec() public {
+        _assertLockMint(6);
+    }
+
+    function test_lockMint_8dec() public {
+        _assertLockMint(8);
+    }
+
+    function test_lockMint_18dec() public {
+        _assertLockMint(18);
+    }
+
+    // ----------------------------------------------------------------- full round trip
+
+    function _assertRoundTrip(uint8 decimals) internal {
+        _deployPair(decimals);
+        uint256 amount = 777 * (10 ** decimals);
+        underlying.mint(alice, amount);
+
+        // out: lock on mainnet, mint on OP
+        _bridgeOut(alice, amount);
+        assertEq(_locked(), shadow.totalSupply());
+
+        // back: burn on OP, unlock on mainnet
+        (uint256 sentBack, uint256 receivedBack) = _bridgeBack(alice, amount);
+        assertEq(sentBack, amount);
+        assertEq(receivedBack, amount);
+
+        // user is whole again; nothing left locked or minted
+        assertEq(underlying.balanceOf(alice), amount, "user not made whole");
+        assertEq(shadow.balanceOf(alice), 0, "iTOKEN not burned");
+        assertEq(shadow.totalSupply(), 0, "supply not zero after burn");
+        assertEq(_locked(), 0, "adapter still holds underlying");
+        assertEq(_locked(), shadow.totalSupply());
+    }
+
+    function test_roundTrip_6dec() public {
+        _assertRoundTrip(6);
+    }
+
+    function test_roundTrip_8dec() public {
+        _assertRoundTrip(8);
+    }
+
+    function test_roundTrip_18dec() public {
+        _assertRoundTrip(18);
+    }
+
+    // ----------------------------------------------------------------- fuzz: value conservation
+
+    /**
+     * End-to-end fuzz over (decimals, amount): a full round trip never creates value, the bridged
+     * amount is the input minus dust, sub-rate dust stays with the user, and the user is made whole.
+     * Capped runs — each run deploys a fresh pair on the live endpoints, which is expensive.
+     */
+    /// forge-config: default.fuzz.runs = 200
+    function testFuzz_roundTrip_conservesValue(uint8 decimals, uint256 amount) public {
+        decimals = uint8(bound(decimals, SHARED_DECIMALS, 18));
+        uint256 rate = 10 ** (decimals - SHARED_DECIMALS);
+        // up to 1e9 tokens — well under the uint64 SD ceiling, and mintable
+        amount = bound(amount, 0, 1e9 * (10 ** uint256(decimals)));
+
+        _deployPair(decimals);
+        underlying.mint(alice, amount);
+
+        uint256 expectedBridged = (amount / rate) * rate; // dust removed
+        if (expectedBridged == 0) {
+            // sub-rate: nothing bridgeable. The pure dust math is covered in OFTDecimals.fuzz.
+            return;
+        }
+
+        (uint256 sent, uint256 received) = _bridgeOut(alice, amount);
+        assertEq(sent, expectedBridged, "sent != dust-removed amount");
+        assertEq(received, expectedBridged, "received != sent (value created/destroyed)");
+        assertLe(received, amount, "round-trip created value");
+        assertEq(underlying.balanceOf(alice), amount - expectedBridged, "dust not left with user");
+        assertEq(shadow.totalSupply(), expectedBridged);
+        assertEq(_locked(), shadow.totalSupply());
+
+        (uint256 sentBack, uint256 receivedBack) = _bridgeBack(alice, expectedBridged);
+        assertEq(sentBack, expectedBridged);
+        assertEq(receivedBack, expectedBridged);
+        assertEq(underlying.balanceOf(alice), amount, "user not made whole (dust + principal)");
+        assertEq(_locked(), 0);
+        assertEq(shadow.totalSupply(), 0);
+    }
+
+    // A partial round trip: bridge out, then bridge back only part — conservation still holds.
+    function test_partialBridgeBack_conservationHolds() public {
+        _deployPair(8);
+        uint256 amount = 1000e8;
+        underlying.mint(alice, amount);
+
+        _bridgeOut(alice, amount);
+        assertEq(_locked(), shadow.totalSupply());
+
+        uint256 half = 400e8;
+        _bridgeBack(alice, half);
+
+        assertEq(shadow.balanceOf(alice), amount - half);
+        assertEq(shadow.totalSupply(), amount - half);
+        assertEq(_locked(), amount - half);
+        assertEq(underlying.balanceOf(alice), half);
+        assertEq(_locked(), shadow.totalSupply());
+    }
+}

--- a/test/oft/OFTTestSetup.t.sol
+++ b/test/oft/OFTTestSetup.t.sol
@@ -114,7 +114,6 @@ contract MockFeeOnTransferERC20 is ERC20 {
  */
 contract MockConfigurableOFT is IConfigurableOFT {
     address public immutable configRegistry;
-    uint256 public syncedConfigVersion;
     uint256 public syncCallCount;
     uint32[] public lastDstEids;
 
@@ -128,7 +127,6 @@ contract MockConfigurableOFT is IConfigurableOFT {
         for (uint256 i; i < dstEids.length; ++i) {
             lastDstEids.push(dstEids[i]);
         }
-        syncedConfigVersion = IOFTConfigRegistry(configRegistry).configVersion();
     }
 
     function lastDstEidsLength() external view returns (uint256) {

--- a/test/oft/OFTTestSetup.t.sol
+++ b/test/oft/OFTTestSetup.t.sol
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { SetConfigParam } from "@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessageLibManager.sol";
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { Test } from "forge-std/Test.sol";
+
+import { UUPSProxy } from "../../src/UUPSProxy.sol";
+import { IConfigurableOFT } from "../../src/interfaces/IConfigurableOFT.sol";
+import { IOFTConfigRegistry } from "../../src/interfaces/IOFTConfigRegistry.sol";
+import { EtherFiOFTAdapter } from "../../src/oft/EtherFiOFTAdapter.sol";
+import { EtherFiShadowOFT } from "../../src/oft/EtherFiShadowOFT.sol";
+import { OFTAdapterFactory } from "../../src/oft/OFTAdapterFactory.sol";
+import { OFTConfigRegistry } from "../../src/oft/OFTConfigRegistry.sol";
+import { ShadowOFTFactory } from "../../src/oft/ShadowOFTFactory.sol";
+import { RoleRegistry } from "../../src/role-registry/RoleRegistry.sol";
+
+// --------------------------------------------------------------------------
+// Mocks
+// --------------------------------------------------------------------------
+
+/**
+ *   Minimal LayerZero endpoint stand-in. Our contracts only call `setDelegate` (during initialize)
+ *    and `setConfig` (during syncConfig); this records those so tests can assert the bridge
+ *    configured itself. It does NOT route messages, so it can't drive a full cross-chain round-trip.
+ */
+contract MockLZEndpoint {
+    struct ConfigCall {
+        address oapp;
+        address lib;
+        uint32 eid;
+        bytes config;
+    }
+
+    mapping(address oapp => address) public delegates;
+    ConfigCall[] public configCalls;
+
+    function setDelegate(address _delegate) external {
+        delegates[msg.sender] = _delegate;
+    }
+
+    function setConfig(address _oapp, address _lib, SetConfigParam[] calldata _params) external {
+        for (uint256 i; i < _params.length; ++i) {
+            configCalls.push(ConfigCall(_oapp, _lib, _params[i].eid, _params[i].config));
+        }
+    }
+
+    function configCallCount() external view returns (uint256) {
+        return configCalls.length;
+    }
+}
+
+/**
+ *   ERC-20 with configurable decimals, so one mock stands in for USDC(6) / WBTC(8) / PAXG(18).
+ */
+contract MockERC20 is ERC20 {
+    uint8 private immutable _decimals;
+
+    constructor(string memory name_, string memory symbol_, uint8 decimals_) ERC20(name_, symbol_) {
+        _decimals = decimals_;
+    }
+
+    function decimals() public view override returns (uint8) {
+        return _decimals;
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+/**
+ *   Fee-on-transfer token: skims `feeBps` on every transfer so a lock receives less than was sent
+ *    — exercises the adapter's lossless guard. Mint/burn are NOT taxed so funding stays clean.
+ */
+contract MockFeeOnTransferERC20 is ERC20 {
+    uint8 private immutable _decimals;
+    uint256 public feeBps; // e.g. 10 = 0.10%
+
+    constructor(uint8 decimals_, uint256 feeBps_) ERC20("Fee Token", "FEE") {
+        _decimals = decimals_;
+        feeBps = feeBps_;
+    }
+
+    function decimals() public view override returns (uint8) {
+        return _decimals;
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    /**
+     *   OpenZeppelin's ERC-20 funnels EVERY balance change — mint, burn, and transfer — through this
+     *   single `_update` hook (it's the one place balances actually move). Overriding it is the
+     *   canonical way to build a fee-on-transfer token: on a real transfer we divert `feeBps` of the
+     *   amount to a dead address, so the recipient (here, the adapter) ends up with LESS than was
+     *   sent. Mint/burn (from/to == 0) are left untaxed so test funding stays exact.
+     */
+    function _update(address from, address to, uint256 value) internal override {
+        if (from == address(0) || to == address(0) || feeBps == 0) {
+            super._update(from, to, value); // mint/burn untaxed
+            return;
+        }
+        uint256 fee = (value * feeBps) / 10_000;
+        super._update(from, address(0xdead), fee); // recipient gets less
+        super._update(from, to, value - fee);
+    }
+}
+
+/**
+ *   Fake bridge that records syncConfig calls, so registry push/enumeration can be asserted
+ *   without deploying a real OFT + endpoint.
+ */
+contract MockConfigurableOFT is IConfigurableOFT {
+    address public immutable configRegistry;
+    uint256 public syncedConfigVersion;
+    uint256 public syncCallCount;
+    uint32[] public lastDstEids;
+
+    constructor(address _registry) {
+        configRegistry = _registry;
+    }
+
+    function syncConfig(uint32[] calldata dstEids) external override {
+        syncCallCount += 1;
+        delete lastDstEids;
+        for (uint256 i; i < dstEids.length; ++i) {
+            lastDstEids.push(dstEids[i]);
+        }
+        syncedConfigVersion = IOFTConfigRegistry(configRegistry).configVersion();
+    }
+
+    function lastDstEidsLength() external view returns (uint256) {
+        return lastDstEids.length;
+    }
+}
+
+/**
+ *   --------------------------------------------------------------------------
+ *    Shared setup
+ *   --------------------------------------------------------------------------
+ */
+contract OFTTestSetup is Test {
+    RoleRegistry internal roleRegistry;
+    OFTConfigRegistry internal configRegistry;
+    OFTAdapterFactory internal adapterFactory;
+    ShadowOFTFactory internal shadowFactory;
+    MockLZEndpoint internal endpoint;
+
+    address internal adapterImpl;
+    address internal shadowImpl;
+
+    // actors
+    address internal owner = makeAddr("owner");
+    address internal configAdmin = makeAddr("configAdmin");
+    address internal factoryAdmin = makeAddr("factoryAdmin");
+    address internal registrar = makeAddr("registrar");
+    address internal pauser = makeAddr("pauser");
+    address internal unpauser = makeAddr("unpauser");
+    address internal delegate = makeAddr("delegate");
+    address internal alice = makeAddr("alice");
+
+    // mock tokens
+    MockERC20 internal token6;
+    MockERC20 internal token8;
+    MockERC20 internal token18;
+
+    // LayerZero V2 endpoint IDs (NOT evm chainIds) for the two chains this primitive bridges:
+    // Ethereum mainnet (30101) and Optimism (30111).
+    uint32 internal constant DST_EID_OP = 30_111;
+    uint32 internal constant DST_EID_ETH = 30_101;
+
+    function setUp() public virtual {
+        vm.startPrank(owner);
+
+        // RoleRegistry (dataProvider dependency is unused on the paths we exercise)
+        address dataProvider = makeAddr("dataProvider");
+        address roleRegistryImpl = address(new RoleRegistry(dataProvider));
+        roleRegistry = RoleRegistry(address(new UUPSProxy(roleRegistryImpl, abi.encodeWithSelector(RoleRegistry.initialize.selector, owner))));
+        roleRegistry.grantRole(roleRegistry.PAUSER(), pauser);
+        roleRegistry.grantRole(roleRegistry.UNPAUSER(), unpauser);
+
+        endpoint = new MockLZEndpoint();
+
+        // Config registry
+        address configRegistryImpl = address(new OFTConfigRegistry());
+        configRegistry = OFTConfigRegistry(address(new UUPSProxy(configRegistryImpl, abi.encodeWithSelector(OFTConfigRegistry.initialize.selector, address(roleRegistry)))));
+
+        // Beacon impls (registry + endpoint fixed per chain)
+        adapterImpl = address(new EtherFiOFTAdapter(address(endpoint), address(configRegistry)));
+        shadowImpl = address(new EtherFiShadowOFT(address(endpoint), address(configRegistry)));
+
+        // Factories
+        address adapterFactoryImpl = address(new OFTAdapterFactory());
+        adapterFactory = OFTAdapterFactory(address(new UUPSProxy(adapterFactoryImpl, abi.encodeWithSelector(OFTAdapterFactory.initialize.selector, address(roleRegistry), adapterImpl))));
+        address shadowFactoryImpl = address(new ShadowOFTFactory());
+        shadowFactory = ShadowOFTFactory(address(new UUPSProxy(shadowFactoryImpl, abi.encodeWithSelector(ShadowOFTFactory.initialize.selector, address(roleRegistry), shadowImpl))));
+
+        // Roles
+        roleRegistry.grantRole(configRegistry.CONFIG_ADMIN_ROLE(), configAdmin);
+        roleRegistry.grantRole(configRegistry.CONFIG_REGISTRAR_ROLE(), registrar);
+        // factories auto-register bridges at deploy -> need the registrar role
+        roleRegistry.grantRole(configRegistry.CONFIG_REGISTRAR_ROLE(), address(adapterFactory));
+        roleRegistry.grantRole(configRegistry.CONFIG_REGISTRAR_ROLE(), address(shadowFactory));
+        roleRegistry.grantRole(adapterFactory.OFT_ADAPTER_FACTORY_ADMIN_ROLE(), factoryAdmin);
+        roleRegistry.grantRole(shadowFactory.SHADOW_OFT_FACTORY_ADMIN_ROLE(), factoryAdmin);
+
+        vm.stopPrank();
+
+        token6 = new MockERC20("USD Coin", "USDC", 6);
+        token8 = new MockERC20("Wrapped BTC", "WBTC", 8);
+        token18 = new MockERC20("Pax Gold", "PAXG", 18);
+    }
+
+    // A valid 2-of-2 required-DVN pathway config (mirrors the weETH DVN stack shape).
+    function _samplePathway(uint64 confirmations) internal returns (IOFTConfigRegistry.PathwayConfig memory cfg) {
+        address[] memory required = new address[](2);
+        required[0] = makeAddr("layerZeroDVN");
+        required[1] = makeAddr("nethermindDVN");
+        // requiredDVNs must be sorted ascending / unique per LZ; sort the two.
+        if (required[0] > required[1]) (required[0], required[1]) = (required[1], required[0]);
+
+        cfg = IOFTConfigRegistry.PathwayConfig({ sendLib: makeAddr("sendUln302"), receiveLib: makeAddr("receiveUln302"), confirmations: confirmations, optionalDVNThreshold: 0, requiredDVNs: required, optionalDVNs: new address[](0) });
+    }
+}

--- a/test/oft/OFTWeirdTokens.t.sol
+++ b/test/oft/OFTWeirdTokens.t.sol
@@ -60,6 +60,35 @@ contract OFTWeirdTokensTest is OFTTestSetup {
         h.exposedDebit(alice, amt, 0, DST_EID_OP);
     }
 
+    // Same guard, fuzzed: for ANY amount and fee, an asymmetric-fee token delivers `amt - fee` < amt,
+    // so the lock reverts NonLosslessTransfer(amt, amt - fee). 6-decimal token -> rate 1, no dust.
+    function testFuzz_lock_reverts_onAsymmetricFeeToken(uint256 amt, uint256 feeBps) public {
+        feeBps = bound(feeBps, 1, 1000); // 0.01%..10%
+        amt = bound(amt, 10_000, 1e30); // >= 10_000 so a >=1-bps fee always skims at least 1 wei
+        AsymmetricFeeToken t = new AsymmetricFeeToken(6, feeBps);
+        OFTAdapterHarness h = _harness(address(t));
+        t.mint(alice, amt);
+        vm.prank(alice);
+        t.approve(address(h), amt);
+
+        uint256 fee = (amt * feeBps) / 10_000;
+        vm.expectRevert(abi.encodeWithSelector(EtherFiOFTAdapter.NonLosslessTransfer.selector, amt, amt - fee));
+        h.exposedDebit(alice, amt, 0, DST_EID_OP);
+    }
+
+    // Same guard, fuzzed against a 1-wei negative rebase across magnitudes: received = amt - 1.
+    function testFuzz_lock_reverts_onShrinkingRebaseToken(uint256 amt) public {
+        amt = bound(amt, 1, 1e30);
+        ShrinkOnReceiveToken t = new ShrinkOnReceiveToken();
+        OFTAdapterHarness h = _harness(address(t));
+        t.mint(alice, amt);
+        vm.prank(alice);
+        t.approve(address(h), amt);
+
+        vm.expectRevert(abi.encodeWithSelector(EtherFiOFTAdapter.NonLosslessTransfer.selector, amt, amt - 1));
+        h.exposedDebit(alice, amt, 0, DST_EID_OP);
+    }
+
     // ----------------------------------------------------------------- SafeERC20 tolerance
 
     // USDT-style token whose transferFrom returns no bool: SafeERC20 accepts it, lock succeeds.

--- a/test/oft/OFTWeirdTokens.t.sol
+++ b/test/oft/OFTWeirdTokens.t.sol
@@ -1,0 +1,313 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { IOFT } from "@layerzerolabs/oft-evm/contracts/interfaces/IOFT.sol";
+import { BeaconProxy } from "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
+import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+import { EtherFiOFTAdapter } from "../../src/oft/EtherFiOFTAdapter.sol";
+import { OFTAdapterHarness } from "./EtherFiOFTAdapter.t.sol";
+import { OFTTestSetup } from "./OFTTestSetup.t.sol";
+
+/**
+ * @title OFTWeirdTokensTest
+ * @notice Behavior of the lock adapter against non-standard ERC-20s. The lossless guard
+ *         rejects any token that delivers less than was pulled (fee-on-transfer / shrink-on-lock),
+ *         SafeERC20 tolerates missing/false return values, and the credit (unlock) path inherits
+ *         the underlying's pausable/blacklist failure modes — documented here so the per-asset
+ *         vetting requirement is explicit.
+ */
+contract OFTWeirdTokensTest is OFTTestSetup {
+    using SafeERC20 for *;
+
+    address internal recipient = makeAddr("recipient");
+
+    // Deploy a harness-backed adapter initialized for `tok` so we can reach _debit/_credit.
+    function _harness(address tok) internal returns (OFTAdapterHarness h) {
+        address impl = address(new OFTAdapterHarness(address(endpoint), address(configRegistry)));
+        UpgradeableBeacon beacon = new UpgradeableBeacon(impl, owner);
+        bytes memory initData = abi.encodeWithSelector(EtherFiOFTAdapter.initialize.selector, tok, delegate);
+        h = OFTAdapterHarness(address(new BeaconProxy(address(beacon), initData)));
+    }
+
+    // ----------------------------------------------------------------- lossless guard on lock
+
+    // Asymmetric fee (skims only on transferFrom, i.e. exactly the lock direction) -> lock reverts.
+    function test_lock_reverts_onAsymmetricFeeToken() public {
+        AsymmetricFeeToken t = new AsymmetricFeeToken(6, 25); // 0.25% on transferFrom only
+        OFTAdapterHarness h = _harness(address(t));
+        uint256 amt = 1000e6;
+        t.mint(alice, amt);
+        vm.prank(alice);
+        t.approve(address(h), amt);
+
+        uint256 fee = (amt * 25) / 10_000;
+        vm.expectRevert(abi.encodeWithSelector(EtherFiOFTAdapter.NonLosslessTransfer.selector, amt, amt - fee));
+        h.exposedDebit(alice, amt, 0, DST_EID_OP);
+    }
+
+    // A token that negatively rebases the recipient on receipt delivers < amount -> lock reverts.
+    function test_lock_reverts_onShrinkingRebaseToken() public {
+        ShrinkOnReceiveToken t = new ShrinkOnReceiveToken(); // burns 1 wei from receiver post-credit
+        OFTAdapterHarness h = _harness(address(t));
+        uint256 amt = 1000e6;
+        t.mint(alice, amt);
+        vm.prank(alice);
+        t.approve(address(h), amt);
+
+        vm.expectRevert(abi.encodeWithSelector(EtherFiOFTAdapter.NonLosslessTransfer.selector, amt, amt - 1));
+        h.exposedDebit(alice, amt, 0, DST_EID_OP);
+    }
+
+    // ----------------------------------------------------------------- SafeERC20 tolerance
+
+    // USDT-style token whose transferFrom returns no bool: SafeERC20 accepts it, lock succeeds.
+    function test_lock_succeeds_onMissingReturnToken() public {
+        MissingReturnToken t = new MissingReturnToken();
+        OFTAdapterHarness h = _harness(address(t));
+        uint256 amt = 1000e6;
+        t.mint(alice, amt);
+        vm.prank(alice);
+        t.approve(address(h), amt);
+
+        (uint256 sent, uint256 received) = h.exposedDebit(alice, amt, 0, DST_EID_OP);
+        assertEq(sent, amt);
+        assertEq(received, amt);
+        assertEq(t.balanceOf(address(h)), amt);
+    }
+
+    // A token whose transferFrom returns false: SafeERC20 reverts (no silent failure).
+    function test_lock_reverts_onReturnsFalseToken() public {
+        ReturnsFalseToken t = new ReturnsFalseToken();
+        OFTAdapterHarness h = _harness(address(t));
+        uint256 amt = 1000e6;
+        t.mint(alice, amt);
+        vm.prank(alice);
+        t.approve(address(h), amt);
+
+        vm.expectRevert(abi.encodeWithSelector(SafeERC20.SafeERC20FailedOperation.selector, address(t)));
+        h.exposedDebit(alice, amt, 0, DST_EID_OP);
+    }
+
+    // ----------------------------------------------------------------- unlock (credit) failure modes
+
+    /**
+     * A pausable underlying: while paused, unlock reverts and the locked funds are stuck until the
+     * token unpauses. Documents that the adapter has no override — pausable assets need vetting.
+     */
+    function test_unlock_reverts_whenUnderlyingPaused() public {
+        PausableToken t = new PausableToken();
+        OFTAdapterHarness h = _harness(address(t));
+        t.mint(address(h), 500e6); // simulate previously locked balance
+
+        t.pause();
+        vm.expectRevert(PausableToken.TokenPaused.selector);
+        h.exposedCredit(recipient, 500e6, DST_EID_OP);
+
+        // unpausing restores the unlock
+        t.unpause();
+        uint256 got = h.exposedCredit(recipient, 500e6, DST_EID_OP);
+        assertEq(got, 500e6);
+        assertEq(t.balanceOf(recipient), 500e6);
+    }
+
+    /**
+     * A blacklisting underlying: unlocking to a blacklisted recipient reverts. The funds remain
+     * locked; resolution is a per-asset operational concern, not something the adapter masks.
+     */
+    function test_unlock_reverts_toBlacklistedRecipient() public {
+        BlacklistToken t = new BlacklistToken();
+        OFTAdapterHarness h = _harness(address(t));
+        t.mint(address(h), 500e6);
+
+        t.blacklist(recipient);
+        vm.expectRevert(BlacklistToken.Blacklisted.selector);
+        h.exposedCredit(recipient, 500e6, DST_EID_OP);
+
+        // positive control: lifting the blacklist lets the same unlock through, so the block was
+        // the sole cause (not some unrelated failure).
+        t.unblacklist(recipient);
+        uint256 got = h.exposedCredit(recipient, 500e6, DST_EID_OP);
+        assertEq(got, 500e6);
+        assertEq(t.balanceOf(recipient), 500e6);
+    }
+
+    // ----------------------------------------------------------------- init-time decimals probe
+
+    // An underlying whose decimals() reverts cannot be initialized (the probe propagates).
+    function test_initialize_reverts_whenDecimalsReverts() public {
+        DecimalsRevertToken t = new DecimalsRevertToken();
+        address impl = address(new OFTAdapterHarness(address(endpoint), address(configRegistry)));
+        UpgradeableBeacon beacon = new UpgradeableBeacon(impl, owner);
+        EtherFiOFTAdapter a = EtherFiOFTAdapter(address(new BeaconProxy(address(beacon), "")));
+        vm.expectRevert(DecimalsRevertToken.NoDecimals.selector);
+        a.initialize(address(t), delegate);
+    }
+}
+
+// --------------------------------------------------------------------------
+// Weird-ERC20 mocks (minimal; only the surface the adapter touches)
+// --------------------------------------------------------------------------
+
+abstract contract BaseToken {
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+    uint8 internal _dec;
+
+    function decimals() external view virtual returns (uint8) {
+        return _dec;
+    }
+
+    function mint(address to, uint256 amt) external {
+        balanceOf[to] += amt;
+    }
+
+    function approve(address s, uint256 a) external returns (bool) {
+        allowance[msg.sender][s] = a;
+        return true;
+    }
+}
+
+// Skims a fee ONLY on transferFrom (the lock direction); plain transfer is untaxed.
+contract AsymmetricFeeToken is BaseToken {
+    uint256 public feeBps;
+
+    constructor(uint8 d, uint256 f) {
+        _dec = d;
+        feeBps = f;
+    }
+
+    function transfer(address to, uint256 a) external returns (bool) {
+        balanceOf[msg.sender] -= a;
+        balanceOf[to] += a;
+        return true;
+    }
+
+    function transferFrom(address f, address t, uint256 a) external returns (bool) {
+        allowance[f][msg.sender] -= a;
+        uint256 fee = (a * feeBps) / 10_000;
+        balanceOf[f] -= a;
+        balanceOf[t] += a - fee; // recipient (adapter) gets less
+        return true;
+    }
+}
+
+// Delivers the full amount on transferFrom but immediately burns 1 wei from the receiver,
+// modelling a negative rebase that lands the adapter short.
+contract ShrinkOnReceiveToken is BaseToken {
+    constructor() {
+        _dec = 6;
+    }
+
+    function transferFrom(address f, address t, uint256 a) external returns (bool) {
+        allowance[f][msg.sender] -= a;
+        balanceOf[f] -= a;
+        balanceOf[t] += a;
+        balanceOf[t] -= 1; // rebase down on the receiver
+        return true;
+    }
+}
+
+// transferFrom / transfer return NOTHING (USDT-style). SafeERC20 must still accept it.
+contract MissingReturnToken is BaseToken {
+    constructor() {
+        _dec = 6;
+    }
+
+    function transfer(address to, uint256 a) external {
+        balanceOf[msg.sender] -= a;
+        balanceOf[to] += a;
+    }
+
+    function transferFrom(address f, address t, uint256 a) external {
+        allowance[f][msg.sender] -= a;
+        balanceOf[f] -= a;
+        balanceOf[t] += a;
+    }
+}
+
+// transferFrom returns false instead of reverting; SafeERC20 must convert that to a revert.
+contract ReturnsFalseToken is BaseToken {
+    constructor() {
+        _dec = 6;
+    }
+
+    function transferFrom(address, address, uint256) external pure returns (bool) {
+        return false;
+    }
+}
+
+contract PausableToken is BaseToken {
+    bool public paused;
+
+    error TokenPaused();
+
+    constructor() {
+        _dec = 6;
+    }
+
+    function pause() external {
+        paused = true;
+    }
+
+    function unpause() external {
+        paused = false;
+    }
+
+    function transfer(address to, uint256 a) external returns (bool) {
+        if (paused) revert TokenPaused();
+        balanceOf[msg.sender] -= a;
+        balanceOf[to] += a;
+        return true;
+    }
+
+    function transferFrom(address f, address t, uint256 a) external returns (bool) {
+        if (paused) revert TokenPaused();
+        allowance[f][msg.sender] -= a;
+        balanceOf[f] -= a;
+        balanceOf[t] += a;
+        return true;
+    }
+}
+
+contract BlacklistToken is BaseToken {
+    mapping(address => bool) public blocked;
+
+    error Blacklisted();
+
+    constructor() {
+        _dec = 6;
+    }
+
+    function blacklist(address a) external {
+        blocked[a] = true;
+    }
+
+    function unblacklist(address a) external {
+        blocked[a] = false;
+    }
+
+    function transfer(address to, uint256 a) external returns (bool) {
+        if (blocked[to] || blocked[msg.sender]) revert Blacklisted();
+        balanceOf[msg.sender] -= a;
+        balanceOf[to] += a;
+        return true;
+    }
+
+    function transferFrom(address f, address t, uint256 a) external returns (bool) {
+        if (blocked[t] || blocked[f]) revert Blacklisted();
+        allowance[f][msg.sender] -= a;
+        balanceOf[f] -= a;
+        balanceOf[t] += a;
+        return true;
+    }
+}
+
+contract DecimalsRevertToken is BaseToken {
+    error NoDecimals();
+
+    function decimals() external pure override returns (uint8) {
+        revert NoDecimals();
+    }
+}

--- a/test/oft/handlers/OFTConservationHandler.sol
+++ b/test/oft/handlers/OFTConservationHandler.sol
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { Test } from "forge-std/Test.sol";
+
+import { MessagingFee } from "@layerzerolabs/oapp-evm/contracts/oapp/OAppSender.sol";
+import { OptionsBuilder } from "@layerzerolabs/oapp-evm/contracts/oapp/libs/OptionsBuilder.sol";
+import { SendParam } from "@layerzerolabs/oft-evm/contracts/interfaces/IOFT.sol";
+
+import { EtherFiOFTAdapter } from "../../../src/oft/EtherFiOFTAdapter.sol";
+import { EtherFiShadowOFT } from "../../../src/oft/EtherFiShadowOFT.sol";
+import { MockERC20 } from "../OFTTestSetup.t.sol";
+
+/// @dev Just the in-process delivery hook the handler needs from the TestHelperOz5-based setup.
+interface IPacketVerifier {
+    function verifyPackets(uint32 _dstEid, bytes32 _dstAddress) external;
+}
+
+/**
+ * @title OFTConservationHandler
+ * @notice Stateful-invariant handler that drives randomized bridgeOut / bridgeBack sequences over
+ *         the live LZ harness. Each action performs the `send()` AND the in-process
+ *         `verifyPackets()` delivery synchronously, so by the time control returns to the invariant
+ *         runner the cross-chain hop has fully settled — locked underlying on mainnet must always
+ *         equal the iTOKEN supply on OP.
+ */
+contract OFTConservationHandler is Test {
+    using OptionsBuilder for bytes;
+
+    IPacketVerifier internal immutable helper;
+    EtherFiOFTAdapter internal immutable adapter;
+    EtherFiShadowOFT internal immutable shadow;
+    MockERC20 internal immutable underlying;
+    uint32 internal immutable A_EID;
+    uint32 internal immutable B_EID;
+
+    address[] internal users;
+
+    // ghost counters — let the invariant test assert real sequences ran (not 0 effective calls)
+    uint256 public bridgeOutCount;
+    uint256 public bridgeBackCount;
+    uint256 public totalBridgedOut; // cumulative LD locked across all bridgeOut calls
+
+    constructor(IPacketVerifier _helper, EtherFiOFTAdapter _adapter, EtherFiShadowOFT _shadow, MockERC20 _underlying, uint32 _aEid, uint32 _bEid, address[] memory _users) {
+        helper = _helper;
+        adapter = _adapter;
+        shadow = _shadow;
+        underlying = _underlying;
+        A_EID = _aEid;
+        B_EID = _bEid;
+        users = _users;
+        for (uint256 i; i < _users.length; ++i) {
+            vm.deal(_users[i], 1000 ether); // native for LZ messaging fees
+        }
+    }
+
+    function _user(uint256 seed) internal view returns (address) {
+        return users[seed % users.length];
+    }
+
+    /// @notice Lock a fresh amount on mainnet and deliver the mint on OP.
+    function bridgeOut(uint256 userSeed, uint256 amount) external {
+        address user = _user(userSeed);
+        uint256 rate = adapter.conversionRate();
+        // at least one SD unit (sub-rate would dust-truncate to a zero send), capped to keep
+        // the cumulative supply well under the uint64 SD ceiling.
+        amount = bound(amount, rate, 1_000_000 * (10 ** uint256(underlying.decimals())));
+
+        underlying.mint(user, amount);
+
+        bytes memory options = OptionsBuilder.newOptions().addExecutorLzReceiveOption(200_000, 0);
+        SendParam memory sp = SendParam(B_EID, _b32(user), amount, 0, options, "", "");
+        MessagingFee memory fee = adapter.quoteSend(sp, false);
+
+        vm.startPrank(user);
+        underlying.approve(address(adapter), amount);
+        adapter.send{ value: fee.nativeFee }(sp, fee, payable(user));
+        vm.stopPrank();
+
+        helper.verifyPackets(B_EID, _b32(address(shadow)));
+
+        bridgeOutCount += 1;
+        totalBridgedOut += (amount / rate) * rate;
+    }
+
+    /// @notice Burn some of a user's iTOKEN on OP and deliver the unlock on mainnet.
+    function bridgeBack(uint256 userSeed, uint256 amount) external {
+        address user = _user(userSeed);
+        uint256 bal = shadow.balanceOf(user);
+        if (bal == 0) return; // nothing to send back; not a meaningful action this round
+
+        uint256 rate = shadow.conversionRate();
+        amount = bound(amount, rate, bal);
+
+        bytes memory options = OptionsBuilder.newOptions().addExecutorLzReceiveOption(200_000, 0);
+        SendParam memory sp = SendParam(A_EID, _b32(user), amount, 0, options, "", "");
+        MessagingFee memory fee = shadow.quoteSend(sp, false);
+
+        vm.startPrank(user);
+        shadow.send{ value: fee.nativeFee }(sp, fee, payable(user));
+        vm.stopPrank();
+
+        helper.verifyPackets(A_EID, _b32(address(adapter)));
+
+        bridgeBackCount += 1;
+    }
+
+    function _b32(address a) internal pure returns (bytes32) {
+        return bytes32(uint256(uint160(a)));
+    }
+}

--- a/test/oft/handlers/OFTConservationHandler.sol
+++ b/test/oft/handlers/OFTConservationHandler.sol
@@ -28,9 +28,10 @@ contract OFTConservationHandler is Test {
     using OptionsBuilder for bytes;
 
     IPacketVerifier internal immutable helper;
-    EtherFiOFTAdapter internal immutable adapter;
-    EtherFiShadowOFT internal immutable shadow;
-    MockERC20 internal immutable underlying;
+    // public so a multi-pair invariant can read this handler's pair and assert conservation per pair
+    EtherFiOFTAdapter public immutable adapter;
+    EtherFiShadowOFT public immutable shadow;
+    MockERC20 public immutable underlying;
     uint32 internal immutable A_EID;
     uint32 internal immutable B_EID;
 

--- a/test/oft/vendor/lz-evm-v1-0.7/contracts/interfaces/ILayerZeroUltraLightNodeV2.sol
+++ b/test/oft/vendor/lz-evm-v1-0.7/contracts/interfaces/ILayerZeroUltraLightNodeV2.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity >=0.7.0;
+
+/**
+ * @notice Minimal vendored shim of LayerZero V1's `ILayerZeroUltraLightNodeV2`.
+ *
+ * LayerZero's test tooling (TestHelperOz5 -> DVNMock) imports this V1 interface, but the
+ * lz-evm-v1-0.7 package is not vendored in this repo (we only carry the V2
+ * stack). DVNMock uses exactly two members of it: withdrawNative(...) and
+ * `updateHash.selector`. This shim declares those with the canonical V1 signatures so the
+ * selector matches the real one (`updateHash(uint16,bytes32,uint256,bytes32)` == 0x704316e5),
+ * letting the mock DVN's replay guard behave identically to upstream.
+ *
+ * Scope is deliberately limited to what `DVNMock` references — this is NOT a faithful copy of
+ * the full V1 interface and should not be relied on beyond the test harness.
+ */
+interface ILayerZeroUltraLightNodeV2 {
+    // An Oracle delivers the block data using updateHash(). Declared so its 4-byte selector
+    // (0x704316e5) matches the canonical V1 signature used by DVNMock's replay guard.
+    function updateHash(uint16 _srcChainId, bytes32 _lookupHash, uint256 _confirmations, bytes32 _blockData) external;
+
+    // Workers withdraw their accrued native fees through the ULN.
+    function withdrawNative(address _to, uint256 _amount) external;
+}


### PR DESCRIPTION
Wraps any mainnet ERC-20 onto Optimism and back, so listing a Cash asset becomes **config, not a new bridge integration**. This is the **token side** of COR-699 — the oracle / price-relay side is separate.

### Architecture

Mirror-image setup on each chain. One beacon + one config registry per chain; each listed asset is a cheap proxy.

```
            MAINNET                                          OPTIMISM
 ┌───────────────────────────┐                  ┌───────────────────────────┐
 │ OFTAdapterFactory          │                  │ ShadowOFTFactory           │
 │  1 beacon → N proxies      │                  │  1 beacon → N proxies      │
 └─────────────┬─────────────┘  deploys per asset └─────────────┬─────────────┘
               ▼                                                ▼
 ┌───────────────────────────┐                  ┌───────────────────────────┐
 │ EtherFiOFTAdapter (USDC)   │ ◄──── peers ────► │ EtherFiShadowOFT (iUSDC)   │
 │  locks / unlocks real USDC │                  │  mints / burns 1:1 mirror  │
 └────┬─────────────────┬────┘                  └────┬─────────────────┬─────┘
      │ syncConfig(pull) │ send / receive             │ send / receive   │ syncConfig(pull)
      ▼                  ▼                            ▼                  ▼
 OFTConfigRegistry    LZ Endpoint ◄── DVNs ──► LZ Endpoint    OFTConfigRegistry
 (canonical DVN cfg)        (2-of-2: LayerZero + Nethermind)   (canonical DVN cfg)
```

Bridge flow (and back):

```
 send out (mainnet)            via LayerZero            receive (OP)
 user → adapter._debit   ──►  DVNs verify (2/2)  ──►  iUSDC._credit → user
        lock 100 USDC                                    mint 100 iUSDC

 user → iUSDC._debit     ──►  DVNs verify         ──►  adapter._credit → user
        burn 40 iUSDC                                   unlock 40 USDC
```

### What's here
- **One beacon per chain** serves every asset. The underlying token + its decimals live in per-proxy storage (overriding LayerZero's immutables), so a single implementation handles 6 / 8 / 18-decimal tokens.
- **`OFTConfigRegistry`** - one canonical DVN/library config per chain. Bridges *pull* it via `syncConfig` and configure themselves on the LayerZero endpoint (no delegate needed). Update once, push to all.
- **Factories** deploy a per-asset adapter (mainnet, lock/unlock) or iTOKEN (OP, mint/burn), and **auto-register + sync config at deploy** (fail-hard).
- The lock adapter **rejects fee-on-transfer / lossy tokens**, keeping mirror supply 1:1 with what's locked.

### Tests
47 unit tests against a local mock endpoint (no fork): decimals math, fee-on-transfer guard, init guards, registry config/version/push/pagination, and factory auto-sync.

### Not in this PR (tracked separately)
Cross-chain round-trip integration test, deploy + wire scripts, and Phase 2 (pause + rate limiter).

---
Closes COR-699

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> New cross-chain bridge and custody logic (lock/mint, decimal scaling, LZ DVN config) with large surface area; mistakes could mis-collateralize iTOKENs or misconfigure message security.
> 
> **Overview**
> Adds a **mainnet ↔ Optimism OFT listing stack**: lock adapters on Ethereum, mint/burn iTOKENs on OP, with one beacon implementation per chain for arbitrary underlying decimals (6/8/18).
> 
> **`OFTConfigRegistry`** is the per-chain canonical LayerZero pathway config (DVNs, libraries). Bridges pull it via **`ConfigurableOFTBase.syncConfig`** and apply it on their own endpoint rows. Factories **auto-register** new bridges and **sync** active pathways at deploy (revert if registrar role is missing).
> 
> **`EtherFiOFTAdapter`** moves from skeleton to real lock/unlock: per-proxy underlying + `conversionRate` in ERC-7201 storage, `_debit`/`_credit` with SafeERC20, and **`NonLosslessTransfer`** for fee-on-transfer tokens. **`EtherFiShadowOFT`** takes a `decimals` arg at init and mirrors underlying precision the same way.
> 
> New **forge deploy scripts** (`DeployOFTAdapterSide`, `DeployOFTShadowSide`) wire RoleRegistry, registry, beacon impls, and factories; **remappings** add LZ Foundry test tooling. Factory pagination now returns empty arrays past the end instead of `InvalidStartIndex`. Large **test** coverage: unit, cross-chain round-trip, adversarial, registry sync/robustness, fuzz, and conservation invariants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb5dbf807aaafcd0d0d3baf0c9526aca66777eb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->