### PR TITLE
feat(oft): registry hardening, EOA scripts, and rate limiter

### DIFF
--- a/scripts/CheckOFTConfigSync.s.sol
+++ b/scripts/CheckOFTConfigSync.s.sol
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { UlnConfig } from "@layerzerolabs/lz-evm-messagelib-v2/contracts/uln/UlnBase.sol";
+import { ILayerZeroEndpointV2 } from "@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol";
+import { stdJson } from "forge-std/StdJson.sol";
+import { console } from "forge-std/console.sol";
+
+import { IOFTConfigRegistry } from "../src/interfaces/IOFTConfigRegistry.sol";
+
+import { Utils } from "./utils/Utils.sol";
+
+/// @dev Minimal view of the bridge's endpoint getter (OAppCoreUpgradeable's public immutable).
+interface IBridgeEndpoint {
+    function endpoint() external view returns (address);
+}
+
+/**
+ * @title CheckOFTConfigSync
+ * @author ether.fi
+ * @notice Read-only staleness check: for every registered bridge x active destination, compares
+ *         the ULN config actually applied on the LayerZero endpoint against the registry's
+ *         canonical {IOFTConfigRegistry.getPathwayConfig}. The bridges keep no per-proxy sync
+ *         state (see {ConfigurableOFTBase}), and the registry's `version` is a single global
+ *         counter that bumps on ANY pathway edit — so a version number can't tell you whether a
+ *         specific bridge x dstEid is current. The endpoint rows are the only source of truth.
+ * @dev View-only: no broadcast, no PRIVATE_KEY. Run PER CHAIN (registry, bridges, and endpoint
+ *      are all per-chain). Set REVERT_IF_STALE=true to make the run exit nonzero when anything is
+ *      stale (CI gate); default just logs. Mirrors {ConfigurableOFTBase.syncConfig}: only the ULN
+ *      config (configType 2) on the canonical send/receive libs is validated — library SELECTION
+ *      (setSendLibrary/setReceiveLibrary) is a separate concern and out of scope.
+ *
+ *        forge script scripts/CheckOFTConfigSync.s.sol --rpc-url mainnet
+ *        forge script scripts/CheckOFTConfigSync.s.sol --rpc-url optimism
+ */
+contract CheckOFTConfigSync is Utils {
+    /// @dev LayerZero ULN config type id, matching ConfigurableOFTBase.
+    uint32 constant CONFIG_TYPE_ULN = 2;
+
+    /// @dev Result of evaluating one (bridge, dstEid): whether the endpoint rows read, whether the
+    ///      applied config matches canonical, and the configs themselves for field-level diff logging.
+    struct PathwayEval {
+        bool readOk;
+        bool inSync;
+        UlnConfig want;
+        UlnConfig sendCfg;
+        UlnConfig recvCfg;
+    }
+
+    function run() public view {
+        IOFTConfigRegistry registry = IOFTConfigRegistry(stdJson.readAddress(readDeploymentFile(), ".addresses.OFTConfigRegistry"));
+        uint256 staleCount = check(registry);
+        if (staleCount != 0 && vm.envOr("REVERT_IF_STALE", false)) revert("config drift detected");
+    }
+
+    /// @notice Enumerate every registered bridge x active destination, log each pathway's status,
+    ///         and return the number of stale (or unreadable) entries. Pure read — safe to call
+    ///         from tests against a live-endpoint harness.
+    function check(IOFTConfigRegistry registry) public view returns (uint256) {
+        uint32[] memory dstEids = registry.activeDstEids();
+        address[] memory bridges = registry.getBridges(0, registry.numBridges());
+        uint256 staleCount;
+
+        console.log("OFT config staleness check");
+        console.log("  chainId:    ", block.chainid);
+        console.log("  registry:   ", address(registry));
+        console.log("  version:    ", registry.configVersion());
+        console.log("  bridges:    ", bridges.length);
+        console.log("  active eids:", dstEids.length);
+
+        for (uint256 b; b < bridges.length; ++b) {
+            console.log("");
+            console.log("bridge", bridges[b]);
+
+            for (uint256 e; e < dstEids.length; ++e) {
+                uint32 dstEid = dstEids[e];
+                PathwayEval memory ev = _evaluate(registry, bridges[b], dstEid);
+
+                if (!ev.readOk) {
+                    staleCount++;
+                    console.log("  dstEid", dstEid, "READ FAILED (lib not a registered messagelib?)");
+                } else if (ev.inSync) {
+                    console.log("  dstEid", dstEid, "IN SYNC");
+                } else {
+                    staleCount++;
+                    console.log("  dstEid", dstEid, "STALE");
+                    if (!_eq(ev.want, ev.sendCfg)) _logDiff("    send", ev.want, ev.sendCfg);
+                    if (!_eq(ev.want, ev.recvCfg)) _logDiff("    recv", ev.want, ev.recvCfg);
+                }
+            }
+        }
+
+        console.log("");
+        console.log("stale entries:", staleCount);
+        return staleCount;
+    }
+
+    /// @notice Status of a single (bridge, dstEid): whether the endpoint rows could be read, and
+    ///         whether the applied send+receive ULN config matches the registry's canonical config.
+    function pathwayStatus(IOFTConfigRegistry registry, address bridge, uint32 dstEid) public view returns (bool, bool) {
+        PathwayEval memory ev = _evaluate(registry, bridge, dstEid);
+        return (ev.readOk, ev.inSync);
+    }
+
+    /// @dev Build expected config + read both endpoint rows + compare. Returns the configs too so
+    ///      the caller can log field-level diffs without a second read.
+    function _evaluate(IOFTConfigRegistry registry, address bridge, uint32 dstEid) internal view returns (PathwayEval memory) {
+        IOFTConfigRegistry.PathwayConfig memory c = registry.getPathwayConfig(dstEid);
+        UlnConfig memory want = _expected(c);
+
+        address ep = IBridgeEndpoint(bridge).endpoint();
+        (bool sendRead, UlnConfig memory sendCfg) = _read(ep, bridge, c.sendLib, dstEid);
+        (bool recvRead, UlnConfig memory recvCfg) = _read(ep, bridge, c.receiveLib, dstEid);
+
+        bool readOk = sendRead && recvRead;
+        bool inSync = readOk && _eq(want, sendCfg) && _eq(want, recvCfg);
+        return PathwayEval(readOk, inSync, want, sendCfg, recvCfg);
+    }
+
+    /// @dev Build the UlnConfig the bridge WOULD write, identically to ConfigurableOFTBase.syncConfig.
+    function _expected(IOFTConfigRegistry.PathwayConfig memory c) internal pure returns (UlnConfig memory) {
+        return UlnConfig({ confirmations: c.confirmations, requiredDVNCount: uint8(c.requiredDVNs.length), optionalDVNCount: uint8(c.optionalDVNs.length), optionalDVNThreshold: c.optionalDVNThreshold, requiredDVNs: c.requiredDVNs, optionalDVNs: c.optionalDVNs });
+    }
+
+    /// @dev Read+decode the effective ULN config for (bridge, lib, dstEid). `ok=false` if the lib
+    ///      isn't a registered messagelib (getConfig reverts) rather than aborting the whole sweep.
+    function _read(address ep, address bridge, address lib, uint32 dstEid) internal view returns (bool, UlnConfig memory) {
+        UlnConfig memory cfg;
+        try ILayerZeroEndpointV2(ep).getConfig(bridge, lib, dstEid, CONFIG_TYPE_ULN) returns (bytes memory raw) {
+            return (true, abi.decode(raw, (UlnConfig)));
+        } catch {
+            return (false, cfg);
+        }
+    }
+
+    /// @dev Field-by-field equality. NOTE: getConfig returns the EFFECTIVE config (the bridge's
+    ///      custom config, or the LZ default if it never synced — a never-synced bridge correctly
+    ///      reports STALE). For these pathways every field is set explicitly, so a direct compare is
+    ///      exact; if a pathway ever stores confirmations==0 ("use default" sentinel) it would need
+    ///      special handling here.
+    function _eq(UlnConfig memory a, UlnConfig memory b) internal pure returns (bool) {
+        if (a.confirmations != b.confirmations) return false;
+        if (a.requiredDVNCount != b.requiredDVNCount) return false;
+        if (a.optionalDVNCount != b.optionalDVNCount) return false;
+        if (a.optionalDVNThreshold != b.optionalDVNThreshold) return false;
+        if (a.requiredDVNs.length != b.requiredDVNs.length) return false;
+        if (a.optionalDVNs.length != b.optionalDVNs.length) return false;
+        for (uint256 i; i < a.requiredDVNs.length; ++i) {
+            if (a.requiredDVNs[i] != b.requiredDVNs[i]) return false;
+        }
+        for (uint256 i; i < a.optionalDVNs.length; ++i) {
+            if (a.optionalDVNs[i] != b.optionalDVNs[i]) return false;
+        }
+        return true;
+    }
+
+    function _logDiff(string memory tag, UlnConfig memory want, UlnConfig memory got) internal pure {
+        console.log(string.concat(tag, " confirmations want/got"), want.confirmations, got.confirmations);
+        console.log(string.concat(tag, " requiredDVNs  want/got"), want.requiredDVNCount, got.requiredDVNCount);
+        console.log(string.concat(tag, " optionalDVNs  want/got"), want.optionalDVNCount, got.optionalDVNCount);
+    }
+}

--- a/scripts/ConfigureAndListOFTMainnet.s.sol
+++ b/scripts/ConfigureAndListOFTMainnet.s.sol
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import { stdJson } from "forge-std/StdJson.sol";
+import { console } from "forge-std/console.sol";
+
+import { IOFTConfigRegistry } from "../src/interfaces/IOFTConfigRegistry.sol";
+import { OFTAdapterFactory } from "../src/oft/OFTAdapterFactory.sol";
+import { OFTConfigRegistry } from "../src/oft/OFTConfigRegistry.sol";
+import { RoleRegistry } from "../src/role-registry/RoleRegistry.sol";
+
+import { Utils } from "./utils/Utils.sol";
+
+/**
+ * @title ConfigureAndListOFTMainnet
+ * @author ether.fi
+ * @notice EOA-driven bring-up of the mainnet OFT side: grants the OFT roles, sets the LayerZero
+ *         pathway config for the Optimism destination, and lists the first asset (PEPE) by
+ *         deploying its lock adapter. Reads the infra addresses from deployments.json.
+ * @dev The deployer EOA must own the OFTRoleRegistry (deploy with OFT_OWNER_MAINNET unset so it
+ *      falls back to the deployer). All steps are idempotent: role grants are no-ops if already
+ *      held, and the adapter is only deployed if PEPE is not already listed. Run on mainnet:
+ *
+ *        PRIVATE_KEY=<deployer> forge script scripts/ConfigureAndListOFTMainnet.s.sol --rpc-url mainnet --broadcast
+ */
+contract ConfigureAndListOFTMainnet is Utils {
+    // LayerZero pathway: Ethereum mainnet (EID 30101) -> Optimism (EID 30111).
+    // Libraries/DVN from lz-address-book LayerZeroV2{,DVN}EthereumMainnet.
+    uint32 constant DST_EID = 30_111;
+    address constant SEND_LIB = 0xbB2Ea70C9E858123480642Cf96acbcCE1372dCe1; // SEND_ULN_302
+    address constant RECEIVE_LIB = 0xc02Ab410f0734EFa3F14628780e6e695156024C2; // RECEIVE_ULN_302
+    address constant DVN_LAYERZERO = 0x589dEDbD617e0CBcB916A9223F4d1300c294236b;
+    uint64 constant CONFIRMATIONS = 15;
+
+    // First listed asset: PEPE on Ethereum mainnet (18 decimals).
+    address constant PEPE = 0x6982508145454Ce325dDbE47a25d4ec3d2311933;
+
+    bytes32 constant CONFIG_REGISTRAR_ROLE = keccak256("OFT_CONFIG_REGISTRAR_ROLE");
+    bytes32 constant CONFIG_ADMIN_ROLE = keccak256("OFT_CONFIG_ADMIN_ROLE");
+    bytes32 constant OFT_ADAPTER_FACTORY_ADMIN_ROLE = keccak256("OFT_ADAPTER_FACTORY_ADMIN_ROLE");
+
+    function run() public {
+        require(block.chainid == 1, "run on Ethereum mainnet (chainId 1)");
+
+        uint256 pk = vm.envUint("PRIVATE_KEY");
+        address deployer = vm.addr(pk);
+        // OApp owner that can setPeer/options later. Defaults to the deployer for the EOA flow.
+        address delegate = vm.envOr("OFT_DELEGATE", deployer);
+
+        string memory deployments = readDeploymentFile();
+        RoleRegistry roleRegistry = RoleRegistry(stdJson.readAddress(deployments, ".addresses.OFTRoleRegistry"));
+        OFTConfigRegistry configRegistry = OFTConfigRegistry(stdJson.readAddress(deployments, ".addresses.OFTConfigRegistry"));
+        OFTAdapterFactory factory = OFTAdapterFactory(stdJson.readAddress(deployments, ".addresses.OFTAdapterFactory"));
+
+        require(roleRegistry.owner() == deployer, "deployer must own OFTRoleRegistry (deploy with OFT_OWNER_MAINNET unset for the EOA wiring path)");
+        require(IERC20Metadata(PEPE).decimals() == 18, "unexpected PEPE decimals");
+
+        // CREATE3 salt convention: keccak256(abi.encode("EtherFiOFT", underlyingToken)).
+        bytes32 salt = keccak256(abi.encode("EtherFiOFT", PEPE));
+        address existing = factory.adapterOf(PEPE);
+
+        vm.startBroadcast(pk);
+        // Factory needs CONFIG_REGISTRAR (to auto-register the bridge on deploy); the EOA needs
+        // CONFIG_ADMIN (setPathwayConfig) and the factory-admin role (deployAdapter).
+        roleRegistry.grantRole(CONFIG_REGISTRAR_ROLE, address(factory));
+        roleRegistry.grantRole(CONFIG_ADMIN_ROLE, deployer);
+        roleRegistry.grantRole(OFT_ADAPTER_FACTORY_ADMIN_ROLE, deployer);
+        // Canonical LayerZero config for the OP pathway. Bridges pull this via syncConfig.
+        configRegistry.setPathwayConfig(DST_EID, _pathwayConfig());
+        // List PEPE. Factory auto-registers the bridge and pulls the config just set.
+        address adapter = existing == address(0) ? factory.deployAdapter(salt, PEPE, delegate) : existing;
+        vm.stopBroadcast();
+
+        if (existing != address(0)) console.log("PEPE adapter already listed; skipped deployAdapter");
+        console.log("Configured + listed PEPE on mainnet (chainId", block.chainid, ")");
+        console.log("  delegate (OApp owner):", delegate);
+        console.log("  PEPE adapter:         ", adapter);
+
+        string memory path = string.concat(vm.projectRoot(), "/deployments/", getEnv(), "/", vm.toString(block.chainid), "/deployments.json");
+        vm.writeJson(vm.toString(adapter), path, ".addresses.OFTAdapter_PEPE");
+    }
+
+    /// @dev The canonical pathway config for DST_EID: 1-of-1 LayerZero DVN, no optional DVNs.
+    function _pathwayConfig() internal pure returns (IOFTConfigRegistry.PathwayConfig memory cfg) {
+        address[] memory requiredDVNs = new address[](1);
+        requiredDVNs[0] = DVN_LAYERZERO;
+        cfg = IOFTConfigRegistry.PathwayConfig({ sendLib: SEND_LIB, receiveLib: RECEIVE_LIB, confirmations: CONFIRMATIONS, optionalDVNThreshold: 0, requiredDVNs: requiredDVNs, optionalDVNs: new address[](0) });
+    }
+}

--- a/scripts/ConfigureAndListOFTMainnet.s.sol
+++ b/scripts/ConfigureAndListOFTMainnet.s.sol
@@ -8,6 +8,7 @@ import { console } from "forge-std/console.sol";
 import { IOFTConfigRegistry } from "../src/interfaces/IOFTConfigRegistry.sol";
 import { OFTAdapterFactory } from "../src/oft/OFTAdapterFactory.sol";
 import { OFTConfigRegistry } from "../src/oft/OFTConfigRegistry.sol";
+import { PairwiseRateLimiter } from "../src/oft/PairwiseRateLimiter.sol";
 import { RoleRegistry } from "../src/role-registry/RoleRegistry.sol";
 
 import { Utils } from "./utils/Utils.sol";
@@ -35,6 +36,13 @@ contract ConfigureAndListOFTMainnet is Utils {
 
     // First listed asset: PEPE on Ethereum mainnet (18 decimals).
     address constant PEPE = 0x6982508145454Ce325dDbE47a25d4ec3d2311933;
+
+    // Default per-bridge throughput cap, in WHOLE tokens (scaled to the asset's decimals below, so
+    // the cap means the same thing for a 6-, 8-, or 18-decimal asset). Placeholder — the risk team
+    // sets the real cap; re-tune later via SetOFTRateLimits. The limiter is fail-closed, so a freshly
+    // listed asset must be capped here (or by the delegate) before it can bridge.
+    uint256 constant RATE_LIMIT_TOKENS = 1_000_000;
+    uint256 constant RATE_WINDOW = 1 hours;
 
     bytes32 constant CONFIG_REGISTRAR_ROLE = keccak256("OFT_CONFIG_REGISTRAR_ROLE");
     bytes32 constant CONFIG_ADMIN_ROLE = keccak256("OFT_CONFIG_ADMIN_ROLE");
@@ -70,15 +78,32 @@ contract ConfigureAndListOFTMainnet is Utils {
         configRegistry.setPathwayConfig(DST_EID, _pathwayConfig());
         // List PEPE. Factory auto-registers the bridge and pulls the config just set.
         address adapter = existing == address(0) ? factory.deployAdapter(salt, PEPE, delegate) : existing;
+        // Cap throughput at listing. setRateLimits is owner-gated; in the EOA flow the deployer is
+        // the delegate so it can set them inline. If the delegate is a separate Safe, this is skipped
+        // and the delegate must run SetOFTRateLimits (the bridge stays fail-closed until then).
+        bool setLimitsInline = delegate == deployer;
+        if (setLimitsInline) {
+            // PEPE is 18 decimals (asserted above); scale the whole-token cap to its LD.
+            PairwiseRateLimiter.RateLimitConfig[] memory rlCfg = _rateLimitConfig(IERC20Metadata(PEPE).decimals());
+            PairwiseRateLimiter(adapter).setOutboundRateLimits(rlCfg);
+            PairwiseRateLimiter(adapter).setInboundRateLimits(rlCfg);
+        }
         vm.stopBroadcast();
 
         if (existing != address(0)) console.log("PEPE adapter already listed; skipped deployAdapter");
+        console.log(setLimitsInline ? "  rate limits set (delegate == deployer)" : "  rate limits SKIPPED - delegate must run SetOFTRateLimits");
         console.log("Configured + listed PEPE on mainnet (chainId", block.chainid, ")");
         console.log("  delegate (OApp owner):", delegate);
         console.log("  PEPE adapter:         ", adapter);
 
         string memory path = string.concat(vm.projectRoot(), "/deployments/", getEnv(), "/", vm.toString(block.chainid), "/deployments.json");
         vm.writeJson(vm.toString(adapter), path, ".addresses.OFTAdapter_PEPE");
+    }
+
+    /// @dev Default outbound/inbound throughput cap for the OP pathway, scaled to the asset's decimals.
+    function _rateLimitConfig(uint8 decimals) internal pure returns (PairwiseRateLimiter.RateLimitConfig[] memory c) {
+        c = new PairwiseRateLimiter.RateLimitConfig[](1);
+        c[0] = PairwiseRateLimiter.RateLimitConfig({ peerEid: DST_EID, limit: RATE_LIMIT_TOKENS * (10 ** decimals), window: RATE_WINDOW });
     }
 
     /// @dev The canonical pathway config for DST_EID: 1-of-1 LayerZero DVN, no optional DVNs.

--- a/scripts/ConfigureAndListOFTMainnet.s.sol
+++ b/scripts/ConfigureAndListOFTMainnet.s.sol
@@ -78,6 +78,16 @@ contract ConfigureAndListOFTMainnet is Utils {
         configRegistry.setPathwayConfig(DST_EID, _pathwayConfig());
         // List PEPE. Factory auto-registers the bridge and pulls the config just set.
         address adapter = existing == address(0) ? factory.deployAdapter(salt, PEPE, delegate) : existing;
+        // Fresh deploy: the factory already synced the config above. Re-run on an existing adapter:
+        // push the (possibly updated) pathway config so its endpoint DVN/library rows don't drift
+        // from the registry. syncConfig only accepts the registry, so route through pushTo.
+        if (existing != address(0)) {
+            address[] memory bridges = new address[](1);
+            bridges[0] = adapter;
+            uint32[] memory dstEids = new uint32[](1);
+            dstEids[0] = DST_EID;
+            configRegistry.pushTo(bridges, dstEids);
+        }
         // Cap throughput at listing. setRateLimits is owner-gated; in the EOA flow the deployer is
         // the delegate so it can set them inline. If the delegate is a separate Safe, this is skipped
         // and the delegate must run SetOFTRateLimits (the bridge stays fail-closed until then).

--- a/scripts/ConfigureAndListOFTOptimism.s.sol
+++ b/scripts/ConfigureAndListOFTOptimism.s.sol
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { console } from "forge-std/console.sol";
+import { stdJson } from "forge-std/StdJson.sol";
+
+import { IOFTConfigRegistry } from "../src/interfaces/IOFTConfigRegistry.sol";
+import { OFTConfigRegistry } from "../src/oft/OFTConfigRegistry.sol";
+import { ShadowOFTFactory } from "../src/oft/ShadowOFTFactory.sol";
+import { RoleRegistry } from "../src/role-registry/RoleRegistry.sol";
+
+import { Utils } from "./utils/Utils.sol";
+
+/**
+ * @title ConfigureAndListOFTOptimism
+ * @author ether.fi
+ * @notice EOA-driven bring-up of the Optimism OFT side: grants the OFT roles, sets the LayerZero
+ *         pathway config for the Ethereum destination, and lists the first asset by deploying its
+ *         mintable iTOKEN (iPEPE). Reads the infra addresses from deployments.json.
+ * @dev The deployer EOA must own the OFTRoleRegistry (deploy with OFT_OWNER_OPTIMISM unset so it
+ *      falls back to the deployer). All steps are idempotent: role grants are no-ops if already
+ *      held, and the iTOKEN is only deployed if its deterministic address is not already used.
+ *      Run on Optimism:
+ *
+ *        PRIVATE_KEY=<deployer> forge script scripts/ConfigureAndListOFTOptimism.s.sol --rpc-url optimism --broadcast
+ */
+contract ConfigureAndListOFTOptimism is Utils {
+    // LayerZero pathway: Optimism (EID 30111) -> Ethereum mainnet (EID 30101).
+    // Libraries/DVN from lz-address-book LayerZeroV2{,DVN}OptimismMainnet.
+    uint32 constant DST_EID = 30101;
+    address constant SEND_LIB = 0x1322871e4ab09Bc7f5717189434f97bBD9546e95; // SEND_ULN_302
+    address constant RECEIVE_LIB = 0x3c4962Ff6258dcfCafD23a814237B7d6Eb712063; // RECEIVE_ULN_302
+    address constant DVN_LAYERZERO = 0x6A02D83e8d433304bba74EF1c427913958187142;
+    uint64 constant CONFIRMATIONS = 20;
+
+    // First listed asset mirrors mainnet PEPE (18 decimals). The mainnet token address is only
+    // used to derive the same CREATE3 salt as the mainnet adapter (cross-chain address match is a
+    // non-goal; this just keeps the salt convention consistent).
+    address constant PEPE_MAINNET = 0x6982508145454Ce325dDbE47a25d4ec3d2311933;
+    string constant SHADOW_NAME = "EtherFi Pepe";
+    string constant SHADOW_SYMBOL = "iPEPE";
+    uint8 constant SHADOW_DECIMALS = 18;
+
+    bytes32 constant CONFIG_REGISTRAR_ROLE = keccak256("OFT_CONFIG_REGISTRAR_ROLE");
+    bytes32 constant CONFIG_ADMIN_ROLE = keccak256("OFT_CONFIG_ADMIN_ROLE");
+    bytes32 constant SHADOW_OFT_FACTORY_ADMIN_ROLE = keccak256("SHADOW_OFT_FACTORY_ADMIN_ROLE");
+
+    function run() public {
+        require(block.chainid == 10, "run on Optimism (chainId 10)");
+
+        uint256 pk = vm.envUint("PRIVATE_KEY");
+        address deployer = vm.addr(pk);
+        // OApp owner that can setPeer/options later. Defaults to the deployer for the EOA flow.
+        address delegate = vm.envOr("OFT_DELEGATE", deployer);
+
+        string memory deployments = readDeploymentFile();
+        RoleRegistry roleRegistry = RoleRegistry(stdJson.readAddress(deployments, ".addresses.OFTRoleRegistry"));
+        OFTConfigRegistry configRegistry = OFTConfigRegistry(stdJson.readAddress(deployments, ".addresses.OFTConfigRegistry"));
+        ShadowOFTFactory factory = ShadowOFTFactory(stdJson.readAddress(deployments, ".addresses.ShadowOFTFactory"));
+
+        require(
+            roleRegistry.owner() == deployer,
+            "deployer must own OFTRoleRegistry (deploy with OFT_OWNER_OPTIMISM unset for the EOA wiring path)"
+        );
+
+        // CREATE3 salt convention: keccak256(abi.encode("EtherFiOFT", underlyingToken)).
+        bytes32 salt = keccak256(abi.encode("EtherFiOFT", PEPE_MAINNET));
+        bool alreadyListed = factory.isShadowOFT(factory.getDeterministicAddress(salt));
+
+        vm.startBroadcast(pk);
+        // Factory needs CONFIG_REGISTRAR (to auto-register the bridge on deploy); the EOA needs
+        // CONFIG_ADMIN (setPathwayConfig) and the factory-admin role (deployShadowOFT).
+        roleRegistry.grantRole(CONFIG_REGISTRAR_ROLE, address(factory));
+        roleRegistry.grantRole(CONFIG_ADMIN_ROLE, deployer);
+        roleRegistry.grantRole(SHADOW_OFT_FACTORY_ADMIN_ROLE, deployer);
+        // Canonical LayerZero config for the ETH pathway. Bridges pull this via syncConfig.
+        configRegistry.setPathwayConfig(DST_EID, _pathwayConfig());
+        // List iPEPE. Factory auto-registers the bridge and pulls the config just set.
+        address shadow = _listShadow(factory, salt, delegate, alreadyListed);
+        vm.stopBroadcast();
+
+        if (alreadyListed) console.log("iPEPE already listed; skipped deployShadowOFT");
+        console.log("Configured + listed iPEPE on Optimism (chainId", block.chainid, ")");
+        console.log("  delegate (OApp owner):", delegate);
+        console.log("  iPEPE shadow OFT:     ", shadow);
+
+        string memory path =
+            string.concat(vm.projectRoot(), "/deployments/", getEnv(), "/", vm.toString(block.chainid), "/deployments.json");
+        vm.writeJson(vm.toString(shadow), path, ".addresses.ShadowOFT_iPEPE");
+    }
+
+    /// @dev Deploys the iTOKEN, or returns the existing deterministic address if already listed.
+    function _listShadow(ShadowOFTFactory factory, bytes32 salt, address delegate, bool alreadyListed)
+        internal
+        returns (address)
+    {
+        if (alreadyListed) return factory.getDeterministicAddress(salt);
+        return factory.deployShadowOFT(salt, SHADOW_NAME, SHADOW_SYMBOL, SHADOW_DECIMALS, delegate);
+    }
+
+    /// @dev The canonical pathway config for DST_EID: 1-of-1 LayerZero DVN, no optional DVNs.
+    function _pathwayConfig() internal pure returns (IOFTConfigRegistry.PathwayConfig memory cfg) {
+        address[] memory requiredDVNs = new address[](1);
+        requiredDVNs[0] = DVN_LAYERZERO;
+        cfg = IOFTConfigRegistry.PathwayConfig({
+            sendLib: SEND_LIB,
+            receiveLib: RECEIVE_LIB,
+            confirmations: CONFIRMATIONS,
+            optionalDVNThreshold: 0,
+            requiredDVNs: requiredDVNs,
+            optionalDVNs: new address[](0)
+        });
+    }
+}

--- a/scripts/ConfigureAndListOFTOptimism.s.sol
+++ b/scripts/ConfigureAndListOFTOptimism.s.sol
@@ -85,6 +85,16 @@ contract ConfigureAndListOFTOptimism is Utils {
         configRegistry.setPathwayConfig(DST_EID, _pathwayConfig());
         // List iPEPE. Factory auto-registers the bridge and pulls the config just set.
         address shadow = _listShadow(factory, salt, delegate, alreadyListed);
+        // Fresh deploy: the factory already synced the config above. Re-run on an existing iTOKEN:
+        // push the (possibly updated) pathway config so its endpoint DVN/library rows don't drift
+        // from the registry. syncConfig only accepts the registry, so route through pushTo.
+        if (alreadyListed) {
+            address[] memory bridges = new address[](1);
+            bridges[0] = shadow;
+            uint32[] memory dstEids = new uint32[](1);
+            dstEids[0] = DST_EID;
+            configRegistry.pushTo(bridges, dstEids);
+        }
         // Cap throughput at listing. setRateLimits is owner-gated; in the EOA flow the deployer is
         // the delegate so it can set them inline. If the delegate is a separate Safe, this is skipped
         // and the delegate must run SetOFTRateLimits (the bridge stays fail-closed until then).

--- a/scripts/ConfigureAndListOFTOptimism.s.sol
+++ b/scripts/ConfigureAndListOFTOptimism.s.sol
@@ -6,6 +6,7 @@ import { stdJson } from "forge-std/StdJson.sol";
 
 import { IOFTConfigRegistry } from "../src/interfaces/IOFTConfigRegistry.sol";
 import { OFTConfigRegistry } from "../src/oft/OFTConfigRegistry.sol";
+import { PairwiseRateLimiter } from "../src/oft/PairwiseRateLimiter.sol";
 import { ShadowOFTFactory } from "../src/oft/ShadowOFTFactory.sol";
 import { RoleRegistry } from "../src/role-registry/RoleRegistry.sol";
 
@@ -40,6 +41,13 @@ contract ConfigureAndListOFTOptimism is Utils {
     string constant SHADOW_NAME = "EtherFi Pepe";
     string constant SHADOW_SYMBOL = "iPEPE";
     uint8 constant SHADOW_DECIMALS = 18;
+
+    // Default per-bridge throughput cap, in WHOLE tokens (scaled to the iTOKEN's decimals below, so
+    // the cap means the same thing for a 6-, 8-, or 18-decimal asset). Placeholder — the risk team
+    // sets the real cap; re-tune later via SetOFTRateLimits. The limiter is fail-closed, so a freshly
+    // listed asset must be capped here (or by the delegate) before it can bridge.
+    uint256 constant RATE_LIMIT_TOKENS = 1_000_000;
+    uint256 constant RATE_WINDOW = 1 hours;
 
     bytes32 constant CONFIG_REGISTRAR_ROLE = keccak256("OFT_CONFIG_REGISTRAR_ROLE");
     bytes32 constant CONFIG_ADMIN_ROLE = keccak256("OFT_CONFIG_ADMIN_ROLE");
@@ -77,9 +85,20 @@ contract ConfigureAndListOFTOptimism is Utils {
         configRegistry.setPathwayConfig(DST_EID, _pathwayConfig());
         // List iPEPE. Factory auto-registers the bridge and pulls the config just set.
         address shadow = _listShadow(factory, salt, delegate, alreadyListed);
+        // Cap throughput at listing. setRateLimits is owner-gated; in the EOA flow the deployer is
+        // the delegate so it can set them inline. If the delegate is a separate Safe, this is skipped
+        // and the delegate must run SetOFTRateLimits (the bridge stays fail-closed until then).
+        bool setLimitsInline = delegate == deployer;
+        if (setLimitsInline) {
+            // Scale the whole-token cap to the iTOKEN's decimals (mirrors the mainnet underlying).
+            PairwiseRateLimiter.RateLimitConfig[] memory rlCfg = _rateLimitConfig(SHADOW_DECIMALS);
+            PairwiseRateLimiter(shadow).setOutboundRateLimits(rlCfg);
+            PairwiseRateLimiter(shadow).setInboundRateLimits(rlCfg);
+        }
         vm.stopBroadcast();
 
         if (alreadyListed) console.log("iPEPE already listed; skipped deployShadowOFT");
+        console.log(setLimitsInline ? "  rate limits set (delegate == deployer)" : "  rate limits SKIPPED - delegate must run SetOFTRateLimits");
         console.log("Configured + listed iPEPE on Optimism (chainId", block.chainid, ")");
         console.log("  delegate (OApp owner):", delegate);
         console.log("  iPEPE shadow OFT:     ", shadow);
@@ -96,6 +115,12 @@ contract ConfigureAndListOFTOptimism is Utils {
     {
         if (alreadyListed) return factory.getDeterministicAddress(salt);
         return factory.deployShadowOFT(salt, SHADOW_NAME, SHADOW_SYMBOL, SHADOW_DECIMALS, delegate);
+    }
+
+    /// @dev Default outbound/inbound throughput cap for the ETH pathway, scaled to the iTOKEN's decimals.
+    function _rateLimitConfig(uint8 decimals) internal pure returns (PairwiseRateLimiter.RateLimitConfig[] memory c) {
+        c = new PairwiseRateLimiter.RateLimitConfig[](1);
+        c[0] = PairwiseRateLimiter.RateLimitConfig({ peerEid: DST_EID, limit: RATE_LIMIT_TOKENS * (10 ** decimals), window: RATE_WINDOW });
     }
 
     /// @dev The canonical pathway config for DST_EID: 1-of-1 LayerZero DVN, no optional DVNs.

--- a/scripts/SetOFTRateLimits.s.sol
+++ b/scripts/SetOFTRateLimits.s.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { stdJson } from "forge-std/StdJson.sol";
+import { console } from "forge-std/console.sol";
+
+import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+
+import { EtherFiOFTAdapter } from "../src/oft/EtherFiOFTAdapter.sol";
+import { EtherFiShadowOFT } from "../src/oft/EtherFiShadowOFT.sol";
+import { PairwiseRateLimiter } from "../src/oft/PairwiseRateLimiter.sol";
+
+import { Utils } from "./utils/Utils.sol";
+
+/**
+ * @title SetOFTRateLimits
+ * @author ether.fi
+ * @notice Sets the per-bridge throughput cap (outbound + inbound) for a pathway. Used to (a) lift a
+ *         live bridge out of the fail-closed state right after {UpgradeOFTRateLimiter}, and (b)
+ *         re-tune a cap later without redeploying. Setting limits is gated to the OApp owner
+ *         (the delegate), so PRIVATE_KEY here must be the bridge's delegate.
+ * @dev Chain-aware: on mainnet (1) it caps the adapter's pathway to Optimism (EID 30111); on
+ *      Optimism (10) it caps the shadow's pathway to Ethereum (EID 30101). The bridge proxy and
+ *      the limit/window are env-overridable so this script is reusable across assets:
+ *
+ *        OFT_BRIDGE             bridge proxy address (default: the PEPE / iPEPE bridge from deployments.json)
+ *        OFT_PEER_EID           peer endpoint id     (default: the cross-pathway eid for this chain)
+ *        OFT_RATE_LIMIT_TOKENS  cap in WHOLE tokens, scaled to the asset's decimals (default: placeholder)
+ *        OFT_RATE_WINDOW        window seconds       (default: 1 hour)
+ *
+ *        PRIVATE_KEY=<delegate> forge script scripts/SetOFTRateLimits.s.sol --rpc-url <mainnet|optimism> --broadcast
+ */
+contract SetOFTRateLimits is Utils {
+    uint32 constant ETH_EID = 30_101;
+    uint32 constant OP_EID = 30_111;
+
+    // Placeholder cap in WHOLE tokens — the risk team sets the real number per asset. The script
+    // scales this to the asset's decimals, so it means the same thing for a 6-/8-/18-decimal token.
+    uint256 constant DEFAULT_LIMIT_TOKENS = 1_000_000;
+    uint256 constant DEFAULT_WINDOW = 1 hours;
+
+    function run() public {
+        bool isMainnet = block.chainid == 1;
+        require(isMainnet || block.chainid == 10, "run on Ethereum mainnet (1) or Optimism (10)");
+
+        uint256 pk = vm.envUint("PRIVATE_KEY");
+
+        string memory deployments = readDeploymentFile();
+        string memory defaultBridgeKey = isMainnet ? ".addresses.OFTAdapter_PEPE" : ".addresses.ShadowOFT_iPEPE";
+        address bridge = vm.envOr("OFT_BRIDGE", stdJson.readAddress(deployments, defaultBridgeKey));
+
+        // The peer on the other side of this chain's only pathway.
+        uint32 defaultPeerEid = isMainnet ? OP_EID : ETH_EID;
+        uint32 peerEid = uint32(vm.envOr("OFT_PEER_EID", uint256(defaultPeerEid)));
+
+        // Read the bridge's local decimals so the whole-token cap scales correctly per asset. The
+        // adapter's LD is its underlying's decimals; the shadow iTOKEN exposes decimals() directly.
+        uint8 decimals = isMainnet ? IERC20Metadata(EtherFiOFTAdapter(bridge).token()).decimals() : EtherFiShadowOFT(bridge).decimals();
+        uint256 limitTokens = vm.envOr("OFT_RATE_LIMIT_TOKENS", DEFAULT_LIMIT_TOKENS);
+        uint256 limit = limitTokens * (10 ** decimals);
+        uint256 window = vm.envOr("OFT_RATE_WINDOW", DEFAULT_WINDOW);
+
+        PairwiseRateLimiter.RateLimitConfig[] memory cfg = new PairwiseRateLimiter.RateLimitConfig[](1);
+        cfg[0] = PairwiseRateLimiter.RateLimitConfig({ peerEid: peerEid, limit: limit, window: window });
+
+        vm.startBroadcast(pk);
+        PairwiseRateLimiter(bridge).setOutboundRateLimits(cfg);
+        PairwiseRateLimiter(bridge).setInboundRateLimits(cfg);
+        vm.stopBroadcast();
+
+        console.log("Set OFT rate limits on chainId", block.chainid);
+        console.log("  bridge:        ", bridge);
+        console.log("  peer eid:      ", peerEid);
+        console.log("  limit (tokens):", limitTokens);
+        console.log("  limit (raw LD):", limit);
+        console.log("  window:        ", window);
+    }
+}

--- a/scripts/UpgradeOFTRateLimiter.s.sol
+++ b/scripts/UpgradeOFTRateLimiter.s.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { stdJson } from "forge-std/StdJson.sol";
+import { console } from "forge-std/console.sol";
+
+import { BeaconFactory } from "../src/beacon-factory/BeaconFactory.sol";
+import { EtherFiOFTAdapter } from "../src/oft/EtherFiOFTAdapter.sol";
+import { EtherFiShadowOFT } from "../src/oft/EtherFiShadowOFT.sol";
+import { RoleRegistry } from "../src/role-registry/RoleRegistry.sol";
+
+import { Utils } from "./utils/Utils.sol";
+
+/**
+ * @title UpgradeOFTRateLimiter
+ * @author ether.fi
+ * @notice Ships the {PairwiseRateLimiter} (COR-924) as a beacon upgrade: deploys the new beacon
+ *         implementation for this chain's bridge ({EtherFiOFTAdapter} on mainnet,
+ *         {EtherFiShadowOFT} on Optimism) and points the factory's beacon at it, so every existing
+ *         and future per-asset proxy gains the throughput cap at once.
+ * @dev Run once per chain. The new impl adds only ERC-7201 namespaced storage, so existing proxies
+ *      keep their layout (proven by test_beaconUpgrade_preservesRateLimitState).
+ *
+ *      The limiter is FAIL-CLOSED: after this upgrade, every live pathway is capped at zero until
+ *      {SetOFTRateLimits} sets a limit. Run SetOFTRateLimits in the SAME operation (Safe batch, or
+ *      immediately after in the EOA flow) so no live bridge is bricked.
+ *
+ *      upgradeBeaconImplementation is gated to the RoleRegistry owner. In the EOA bring-up the
+ *      deployer owns it and this broadcasts the upgrade directly; once handed to the protocol Safe,
+ *      this script logs the calldata to submit from the Safe instead. Run:
+ *
+ *        PRIVATE_KEY=<deployer> forge script scripts/UpgradeOFTRateLimiter.s.sol --rpc-url <mainnet|optimism> --broadcast
+ */
+contract UpgradeOFTRateLimiter is Utils {
+    /// @dev LayerZero V2 endpoint — same canonical address on Ethereum mainnet and Optimism.
+    address constant LZ_ENDPOINT = 0x1a44076050125825900e736c501f859c50fE728c;
+
+    function run() public {
+        bool isMainnet = block.chainid == 1;
+        require(isMainnet || block.chainid == 10, "run on Ethereum mainnet (1) or Optimism (10)");
+
+        uint256 pk = vm.envUint("PRIVATE_KEY");
+        address deployer = vm.addr(pk);
+
+        string memory deployments = readDeploymentFile();
+        RoleRegistry roleRegistry = RoleRegistry(stdJson.readAddress(deployments, ".addresses.OFTRoleRegistry"));
+        address configRegistry = stdJson.readAddress(deployments, ".addresses.OFTConfigRegistry");
+        string memory factoryKey = isMainnet ? ".addresses.OFTAdapterFactory" : ".addresses.ShadowOFTFactory";
+        BeaconFactory factory = BeaconFactory(stdJson.readAddress(deployments, factoryKey));
+
+        // Deploy the new beacon implementation for this chain's bridge type.
+        vm.startBroadcast(pk);
+        address newImpl = isMainnet ? address(new EtherFiOFTAdapter(LZ_ENDPOINT, configRegistry)) : address(new EtherFiShadowOFT(LZ_ENDPOINT, configRegistry));
+        vm.stopBroadcast();
+
+        console.log("OFT rate-limiter beacon upgrade on chainId", block.chainid);
+        console.log("  factory:   ", address(factory));
+        console.log("  new impl:  ", newImpl);
+        console.log("  beacon:    ", factory.beacon());
+
+        // Point the beacon at the new impl. Gated to the RoleRegistry owner.
+        if (roleRegistry.owner() == deployer) {
+            vm.broadcast(pk);
+            factory.upgradeBeaconImplementation(newImpl);
+            console.log("  upgraded beacon as RoleRegistry owner (EOA)");
+        } else {
+            console.log("  RoleRegistry owner is a Safe; submit this call FROM the Safe:");
+            console.log("    target:  ", address(factory));
+            console.logBytes(abi.encodeWithSelector(BeaconFactory.upgradeBeaconImplementation.selector, newImpl));
+        }
+
+        // Persist the new impl address (preserves all existing keys).
+        string memory implKey = isMainnet ? ".addresses.EtherFiOFTAdapterImpl" : ".addresses.EtherFiShadowOFTImpl";
+        string memory path = string.concat(vm.projectRoot(), "/deployments/", getEnv(), "/", vm.toString(block.chainid), "/deployments.json");
+        vm.writeJson(vm.toString(newImpl), path, implKey);
+
+        console.log("  NEXT: run SetOFTRateLimits to cap each live pathway (fail-closed until set).");
+    }
+}

--- a/scripts/WireOFTPeers.s.sol
+++ b/scripts/WireOFTPeers.s.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { console } from "forge-std/console.sol";
+import { stdJson } from "forge-std/StdJson.sol";
+
+import { Utils } from "./utils/Utils.sol";
+
+/// @dev Minimal view of the LayerZero OApp peer interface (OAppCore).
+interface ILayerZeroPeer {
+    function setPeer(uint32 eid, bytes32 peer) external;
+    function peers(uint32 eid) external view returns (bytes32);
+    function owner() external view returns (address);
+}
+
+/**
+ * @title WireOFTPeers
+ * @author ether.fi
+ * @notice EOA-driven peer wiring for the PEPE pathway: points each chain's bridge at its
+ *         counterpart so messages route end-to-end. Run once per chain (branches on chainId):
+ *         on mainnet it sets the adapter's OP peer; on Optimism it sets the iTOKEN's ETH peer.
+ * @dev The caller must be the OApp delegate/owner of the local bridge (the delegate set at
+ *      listing time; the deployer EOA in the EOA flow). Reads the local bridge from this chain's
+ *      deployments.json and the remote bridge from the other chain's deployments.json, so list
+ *      the asset on BOTH chains first. Idempotent: skips if the peer is already set. Run:
+ *
+ *        PRIVATE_KEY=<delegate> forge script scripts/WireOFTPeers.s.sol --rpc-url mainnet  --broadcast
+ *        PRIVATE_KEY=<delegate> forge script scripts/WireOFTPeers.s.sol --rpc-url optimism --broadcast
+ */
+contract WireOFTPeers is Utils {
+    uint32 constant ETH_EID = 30101;
+    uint32 constant OP_EID = 30111;
+
+    function run() public {
+        uint256 pk = vm.envUint("PRIVATE_KEY");
+        address deployer = vm.addr(pk);
+
+        // Resolve local/remote bridges and the remote EID from the chain we're running on.
+        string memory localKey;
+        string memory remoteKey;
+        uint256 remoteChainId;
+        uint32 remoteEid;
+        if (block.chainid == 1) {
+            (localKey, remoteKey, remoteChainId, remoteEid) = ("OFTAdapter_PEPE", "ShadowOFT_iPEPE", 10, OP_EID);
+        } else if (block.chainid == 10) {
+            (localKey, remoteKey, remoteChainId, remoteEid) = ("ShadowOFT_iPEPE", "OFTAdapter_PEPE", 1, ETH_EID);
+        } else {
+            revert("run on Ethereum mainnet (1) or Optimism (10)");
+        }
+
+        address localBridge = stdJson.readAddress(readDeploymentFile(), string.concat(".addresses.", localKey));
+        address remoteBridge = stdJson.readAddress(_readRemoteDeployments(remoteChainId), string.concat(".addresses.", remoteKey));
+
+        require(
+            ILayerZeroPeer(localBridge).owner() == deployer,
+            "deployer must be the OApp delegate/owner of the local bridge"
+        );
+
+        bytes32 peer = bytes32(uint256(uint160(remoteBridge)));
+        bool alreadySet = ILayerZeroPeer(localBridge).peers(remoteEid) == peer;
+
+        if (!alreadySet) {
+            vm.startBroadcast(pk);
+            ILayerZeroPeer(localBridge).setPeer(remoteEid, peer);
+            vm.stopBroadcast();
+        }
+
+        if (alreadySet) console.log("Peer already set; nothing to do");
+        console.log("Wired peer on chainId", block.chainid);
+        console.log("  local bridge: ", localBridge);
+        console.log("  remote eid:   ", remoteEid);
+        console.log("  remote bridge:", remoteBridge);
+    }
+
+    /// @dev Reads the deployments.json of another chain (different chainId directory, same ENV).
+    function _readRemoteDeployments(uint256 remoteChainId) internal view returns (string memory) {
+        string memory path =
+            string.concat(vm.projectRoot(), "/deployments/", getEnv(), "/", vm.toString(remoteChainId), "/deployments.json");
+        return vm.readFile(path);
+    }
+}

--- a/src/interfaces/IOFTConfigRegistry.sol
+++ b/src/interfaces/IOFTConfigRegistry.sol
@@ -20,15 +20,24 @@ interface IOFTConfigRegistry {
     }
 
     event PathwayConfigSet(uint32 indexed dstEid, uint256 version);
+    event PathwayRemoved(uint32 indexed dstEid, uint256 version);
     event BridgeRegistered(address indexed bridge);
+    event BridgeDeregistered(address indexed bridge);
     event ConfigPushed(address indexed bridge, uint32[] dstEids);
 
     error InvalidInput();
     error OnlyConfigAdmin();
     error OnlyRegistrar();
+    error DVNsNotSortedOrUnique();
+    error TooManyDVNs();
+    error InvalidOptionalDVNThreshold();
+    error PathwayNotFound();
+    error BridgeNotFound();
 
     /// @notice Set/replace the canonical config for a destination (bumps version)
     function setPathwayConfig(uint32 dstEid, PathwayConfig calldata cfg) external;
+    /// @notice Remove a destination's pathway so it stops propagating (admin only)
+    function removePathway(uint32 dstEid) external;
 
     function getPathwayConfig(uint32 dstEid) external view returns (PathwayConfig memory);
     function configVersion() external view returns (uint256);
@@ -36,9 +45,13 @@ interface IOFTConfigRegistry {
 
     /// @notice Record a bridge so {pushToAll} can enumerate it (registrar only)
     function registerBridge(address bridge) external;
+    /// @notice Drop a bridge from the push set so it stops receiving config (admin only)
+    function deregisterBridge(address bridge) external;
     function getBridges(uint256 start, uint256 n) external view returns (address[] memory);
     function numBridges() external view returns (uint256);
 
+    /// @notice Make a single bridge re-pull config (registrar only; the factory auto-sync path)
+    function syncBridge(address bridge, uint32[] calldata dstEids) external;
     /// @notice Make the given bridges re-pull config (admin only)
     function pushTo(address[] calldata bridges, uint32[] calldata dstEids) external;
     /// @notice Make every registered bridge re-pull config (admin only)

--- a/src/oft/ConfigurableOFTBase.sol
+++ b/src/oft/ConfigurableOFTBase.sol
@@ -32,6 +32,7 @@ abstract contract ConfigurableOFTBase is OFTCoreUpgradeable, IConfigurableOFT {
     uint32 private constant CONFIG_TYPE_ULN = 2;
 
     error RegistryNotSet();
+    error UnauthorizedSync();
 
     event ConfigSynced(uint32[] dstEids);
 
@@ -43,14 +44,19 @@ abstract contract ConfigurableOFTBase is OFTCoreUpgradeable, IConfigurableOFT {
     /**
      * @notice Pulls the canonical config from the registry and applies it to this
      *         bridge's own endpoint rows for each destination.
-     * @dev Self-authorized: `msg.sender == oapp` lets this bridge call `setConfig` on the
-     *      endpoint without a delegate. Emits {ConfigSynced}; the bridge keeps no per-proxy
-     *      sync state, so verify applied config by reading the endpoint rows.
+     * @dev Only the {configRegistry} may invoke this — operators push via the registry
+     *      ({pushTo}/{pushToAll}/{pushToRange}) and factories sync via {syncBridge}. Gating to the
+     *      registry stops a third party from forcing a re-pull that would revert an operator's
+     *      out-of-band hardening or bypass an incident pause. Self-authorized on the endpoint:
+     *      `msg.sender == oapp` lets this bridge call `setConfig` without a delegate. Emits
+     *      {ConfigSynced}; the bridge keeps no per-proxy sync state, so verify applied config by
+     *      reading the endpoint rows.
      * @param dstEids Destination endpoint IDs to (re)configure
      */
     function syncConfig(uint32[] calldata dstEids) external override {
         address reg = configRegistry;
         if (reg == address(0)) revert RegistryNotSet();
+        if (msg.sender != reg) revert UnauthorizedSync();
 
         for (uint256 i; i < dstEids.length;) {
             IOFTConfigRegistry.PathwayConfig memory c = IOFTConfigRegistry(reg).getPathwayConfig(dstEids[i]);

--- a/src/oft/EtherFiOFTAdapter.sol
+++ b/src/oft/EtherFiOFTAdapter.sol
@@ -7,6 +7,7 @@ import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.s
 import { OFTCoreUpgradeable } from "@layerzerolabs/oft-evm-upgradeable/contracts/oft/OFTCoreUpgradeable.sol";
 
 import { ConfigurableOFTBase } from "./ConfigurableOFTBase.sol";
+import { PairwiseRateLimiter } from "./PairwiseRateLimiter.sol";
 
 /**
  * @title EtherFiOFTAdapter
@@ -29,7 +30,7 @@ import { ConfigurableOFTBase } from "./ConfigurableOFTBase.sol";
  *      an auto-generated getter. Internal math is correct; external readers should
  *      use {conversionRate()}.
  */
-contract EtherFiOFTAdapter is ConfigurableOFTBase {
+contract EtherFiOFTAdapter is ConfigurableOFTBase, PairwiseRateLimiter {
     using SafeERC20 for IERC20;
 
     /// @custom:storage-location erc7201:etherfi.storage.EtherFiOFTAdapter
@@ -136,6 +137,9 @@ contract EtherFiOFTAdapter is ConfigurableOFTBase {
     function _debit(address _from, uint256 _amountLD, uint256 _minAmountLD, uint32 _dstEid) internal virtual override returns (uint256, uint256) {
         (uint256 amountSentLD, uint256 amountReceivedLD) = _debitView(_amountLD, _minAmountLD, _dstEid);
 
+        // Meter the dust-removed amount that actually leaves (and is credited on the remote).
+        _checkAndUpdateOutboundRateLimit(_dstEid, amountSentLD);
+
         IERC20 underlying = IERC20(_getStorage().innerToken);
         uint256 balanceBefore = underlying.balanceOf(address(this));
         underlying.safeTransferFrom(_from, address(this), amountSentLD);
@@ -150,13 +154,14 @@ contract EtherFiOFTAdapter is ConfigurableOFTBase {
     function _credit(
         address _to,
         uint256 _amountLD,
-        uint32 /*_srcEid*/
+        uint32 _srcEid
     )
         internal
         virtual
         override
         returns (uint256)
     {
+        _checkAndUpdateInboundRateLimit(_srcEid, _amountLD);
         IERC20(_getStorage().innerToken).safeTransfer(_to, _amountLD);
         return _amountLD;
     }

--- a/src/oft/EtherFiShadowOFT.sol
+++ b/src/oft/EtherFiShadowOFT.sol
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
+import { OFTCoreUpgradeable } from "@layerzerolabs/oft-evm-upgradeable/contracts/oft/OFTCoreUpgradeable.sol";
 import { OFTUpgradeable } from "@layerzerolabs/oft-evm-upgradeable/contracts/oft/OFTUpgradeable.sol";
 
 import { ConfigurableOFTBase } from "./ConfigurableOFTBase.sol";
+import { PairwiseRateLimiter } from "./PairwiseRateLimiter.sol";
 
 /**
  * @title EtherFiShadowOFT
@@ -22,7 +24,7 @@ import { ConfigurableOFTBase } from "./ConfigurableOFTBase.sol";
  *      from storage; before initialization it returns a safe placeholder so the
  *      parent constructor (which reads `decimals()`) does not revert.
  */
-contract EtherFiShadowOFT is OFTUpgradeable, ConfigurableOFTBase {
+contract EtherFiShadowOFT is OFTUpgradeable, ConfigurableOFTBase, PairwiseRateLimiter {
     /// @custom:storage-location erc7201:etherfi.storage.EtherFiShadowOFT
     struct EtherFiShadowOFTStorage {
         /// @notice Local decimals, mirrors the mainnet underlying
@@ -101,6 +103,23 @@ contract EtherFiShadowOFT is OFTUpgradeable, ConfigurableOFTBase {
         // Intentional: floors _amountLD to a multiple of `rate`, discarding dust (matches LayerZero OFTCore).
         // forge-lint: disable-next-line(divide-before-multiply)
         return (_amountLD / rate) * rate;
+    }
+
+    // ---------------------------------------------------------------------
+    // Rate limiting — meter both directions per peer endpoint id
+    // ---------------------------------------------------------------------
+
+    /// @dev Meter the dust-removed sent amount before burning on the outbound path.
+    function _debit(address _from, uint256 _amountLD, uint256 _minAmountLD, uint32 _dstEid) internal virtual override(OFTCoreUpgradeable, OFTUpgradeable) returns (uint256 amountSentLD, uint256 amountReceivedLD) {
+        (amountSentLD, amountReceivedLD) = _debitView(_amountLD, _minAmountLD, _dstEid);
+        _checkAndUpdateOutboundRateLimit(_dstEid, amountSentLD);
+        return super._debit(_from, _amountLD, _minAmountLD, _dstEid);
+    }
+
+    /// @dev Meter the credited amount before minting on the inbound path.
+    function _credit(address _to, uint256 _amountLD, uint32 _srcEid) internal virtual override(OFTCoreUpgradeable, OFTUpgradeable) returns (uint256 amountReceivedLD) {
+        _checkAndUpdateInboundRateLimit(_srcEid, _amountLD);
+        return super._credit(_to, _amountLD, _srcEid);
     }
 
     function _getStorage() private pure returns (EtherFiShadowOFTStorage storage $) {

--- a/src/oft/OFTAdapterFactory.sol
+++ b/src/oft/OFTAdapterFactory.sol
@@ -87,7 +87,8 @@ contract OFTAdapterFactory is IOFTAdapterFactory, BeaconFactory {
         // registry is unreachable (fail-hard: never leave a bridge unregistered).
         address registry = IConfigurableOFT(adapter).configRegistry();
         IOFTConfigRegistry(registry).registerBridge(adapter);
-        IConfigurableOFT(adapter).syncConfig(IOFTConfigRegistry(registry).activeDstEids());
+        // syncConfig only accepts calls from the registry, so route the post-deploy sync through it.
+        IOFTConfigRegistry(registry).syncBridge(adapter, IOFTConfigRegistry(registry).activeDstEids());
         return adapter;
     }
 

--- a/src/oft/OFTConfigRegistry.sol
+++ b/src/oft/OFTConfigRegistry.sol
@@ -37,6 +37,10 @@ contract OFTConfigRegistry is IOFTConfigRegistry, UpgradeableProxy {
     /// @notice Role allowed to register new bridges (the factories)
     bytes32 public constant CONFIG_REGISTRAR_ROLE = keccak256("OFT_CONFIG_REGISTRAR_ROLE");
 
+    /// @dev Max DVNs per side. Mirrors LayerZero {UlnBase}'s MAX_COUNT = (type(uint8).max - 1) / 2,
+    ///      which caps total DVNs (required + optional) so the on-chain config stays within uint8.
+    uint256 private constant MAX_DVN_COUNT = 127;
+
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
         _disableInitializers();
@@ -49,13 +53,17 @@ contract OFTConfigRegistry is IOFTConfigRegistry, UpgradeableProxy {
 
     /**
      * @notice Set/replace the canonical config for a destination (bumps version)
-     * @dev Restricted to CONFIG_ADMIN_ROLE. Reverts on a zero send/receive lib or empty required DVN set.
+     * @dev Restricted to CONFIG_ADMIN_ROLE. Reverts on a zero send/receive lib or empty required DVN set,
+     *      and validates the DVN stack against the same invariants LayerZero's {UlnBase} enforces
+     *      ({_assertConfigValid}) so a malformed config fails fast here instead of being stored, listed,
+     *      and then reverting on every {syncConfig}/{pushTo}/factory auto-deploy for this dstEid.
      * @param dstEid LayerZero destination endpoint id
      * @param cfg Full pathway config (libraries, confirmations, DVN stack)
      */
     function setPathwayConfig(uint32 dstEid, PathwayConfig calldata cfg) external override whenNotPaused {
         if (!roleRegistry().hasRole(CONFIG_ADMIN_ROLE, msg.sender)) revert OnlyConfigAdmin();
         if (cfg.sendLib == address(0) || cfg.receiveLib == address(0) || cfg.requiredDVNs.length == 0) revert InvalidInput();
+        _assertConfigValid(cfg);
 
         OFTConfigRegistryStorage storage $ = _getStorage();
         $.pathway[dstEid] = cfg;
@@ -64,6 +72,26 @@ contract OFTConfigRegistry is IOFTConfigRegistry, UpgradeableProxy {
             $.version += 1;
         }
         emit PathwayConfigSet(dstEid, $.version);
+    }
+
+    /**
+     * @notice Remove a destination's pathway (admin only, bumps version)
+     * @dev Restricted to CONFIG_ADMIN_ROLE. Deletes the stored config and drops the destination from
+     *      {activeDstEids}, so it stops propagating to bridges deployed/synced afterwards. It does NOT
+     *      rewrite config already applied to a bridge's endpoint rows — to neutralize an in-flight
+     *      pathway (e.g. a compromised DVN), the operator must also unset the peer or push a
+     *      restrictive config directly. Reverts if the destination was never configured.
+     * @param dstEid LayerZero destination endpoint id to remove
+     */
+    function removePathway(uint32 dstEid) external override whenNotPaused {
+        if (!roleRegistry().hasRole(CONFIG_ADMIN_ROLE, msg.sender)) revert OnlyConfigAdmin();
+        OFTConfigRegistryStorage storage $ = _getStorage();
+        if (!$.activeDstEidSet.remove(dstEid)) revert PathwayNotFound();
+        delete $.pathway[dstEid];
+        unchecked {
+            $.version += 1;
+        }
+        emit PathwayRemoved(dstEid, $.version);
     }
 
     /**
@@ -112,6 +140,19 @@ contract OFTConfigRegistry is IOFTConfigRegistry, UpgradeableProxy {
     }
 
     /**
+     * @notice Drop a bridge from the push set (admin only)
+     * @dev Restricted to CONFIG_ADMIN_ROLE. After removal the bridge is no longer enumerated by
+     *      {pushToAll}/{pushToRange}, so a deprecated or compromised bridge stops receiving config.
+     *      It does NOT touch config already on the bridge's endpoint rows. Reverts if not registered.
+     * @param bridge The OFT bridge to deregister
+     */
+    function deregisterBridge(address bridge) external override whenNotPaused {
+        if (!roleRegistry().hasRole(CONFIG_ADMIN_ROLE, msg.sender)) revert OnlyConfigAdmin();
+        if (!_getStorage().bridgeSet.remove(bridge)) revert BridgeNotFound();
+        emit BridgeDeregistered(bridge);
+    }
+
+    /**
      * @notice Paginated enumeration of registered bridges
      * @param start Starting index in the bridge set
      * @param n Maximum number of entries to return
@@ -138,6 +179,21 @@ contract OFTConfigRegistry is IOFTConfigRegistry, UpgradeableProxy {
      */
     function numBridges() external view override returns (uint256) {
         return _getStorage().bridgeSet.length();
+    }
+
+    /**
+     * @notice Make a single bridge re-pull config (registrar only)
+     * @dev Restricted to CONFIG_REGISTRAR_ROLE. This is the path the factories use to sync a bridge
+     *      right after deploy: a bridge's {IConfigurableOFT-syncConfig} only accepts calls from this
+     *      registry, so the factory routes its post-deploy sync through here rather than calling the
+     *      bridge directly.
+     * @param bridge Bridge to refresh
+     * @param dstEids Destination endpoint ids to (re)configure on the bridge
+     */
+    function syncBridge(address bridge, uint32[] calldata dstEids) external override whenNotPaused {
+        if (!roleRegistry().hasRole(CONFIG_REGISTRAR_ROLE, msg.sender)) revert OnlyRegistrar();
+        IConfigurableOFT(bridge).syncConfig(dstEids);
+        emit ConfigPushed(bridge, dstEids);
     }
 
     /**
@@ -194,6 +250,37 @@ contract OFTConfigRegistry is IOFTConfigRegistry, UpgradeableProxy {
             address b = $.bridgeSet.at(start + i);
             IConfigurableOFT(b).syncConfig(dstEids);
             emit ConfigPushed(b, dstEids);
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    /**
+     * @dev Reject any config the LayerZero ULN library would reject at apply time. Mirrors
+     *      {UlnBase}._setConfig for the non-DEFAULT/non-NIL case this registry always produces
+     *      (requiredDVNs is non-empty): both DVN lists sorted ascending + deduped, each within
+     *      MAX_DVN_COUNT, and optionalDVNThreshold == 0 iff there are no optional DVNs, else in
+     *      (0, optionalDVNs.length].
+     */
+    function _assertConfigValid(PathwayConfig calldata cfg) private pure {
+        if (cfg.requiredDVNs.length > MAX_DVN_COUNT || cfg.optionalDVNs.length > MAX_DVN_COUNT) revert TooManyDVNs();
+        _assertSortedAndUnique(cfg.requiredDVNs);
+        _assertSortedAndUnique(cfg.optionalDVNs);
+        if (cfg.optionalDVNs.length == 0) {
+            if (cfg.optionalDVNThreshold != 0) revert InvalidOptionalDVNThreshold();
+        } else if (cfg.optionalDVNThreshold == 0 || cfg.optionalDVNThreshold > cfg.optionalDVNs.length) {
+            revert InvalidOptionalDVNThreshold();
+        }
+    }
+
+    /// @dev Strictly-ascending check: each entry must exceed the previous, which also forbids
+    ///      duplicates and a leading address(0) (a zero DVN). Mirrors {UlnBase}._assertNoDuplicates.
+    function _assertSortedAndUnique(address[] calldata dvns) private pure {
+        address last = address(0);
+        for (uint256 i; i < dvns.length;) {
+            if (dvns[i] <= last) revert DVNsNotSortedOrUnique();
+            last = dvns[i];
             unchecked {
                 ++i;
             }

--- a/src/oft/PairwiseRateLimiter.sol
+++ b/src/oft/PairwiseRateLimiter.sol
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { OFTCoreUpgradeable } from "@layerzerolabs/oft-evm-upgradeable/contracts/oft/OFTCoreUpgradeable.sol";
+
+/**
+ * @title PairwiseRateLimiter
+ * @author ether.fi
+ * @notice Per-pathway throughput cap for the OFT bridges. Ported from the weETH
+ *         cross-chain work (`PairwiseRateLimiter`): the upstream LayerZero rate
+ *         limiter only meters outbound messages, this meters BOTH directions with
+ *         an independent limit per peer endpoint id.
+ * @dev Mixed into the beacon OFT impls ({EtherFiOFTAdapter}, {EtherFiShadowOFT}).
+ *      Children call {_checkAndUpdateOutboundRateLimit} in `_debit` (send) and
+ *      {_checkAndUpdateInboundRateLimit} in `_credit` (receive). Capacity replenishes
+ *      linearly over the configured window.
+ *
+ *      Amounts are metered in the asset's LOCAL decimals (LD): every proxy backs a
+ *      single asset with a single `decimalConversionRate`, so the per-bridge limit is
+ *      denominated in that asset's units. `limit`/`window`/`amountInFlight` are
+ *      `uint256` (an 18-decimal cap can exceed `uint64`).
+ *
+ *      Fail-closed: an unconfigured pathway (`limit == 0`) allows zero throughput, so a
+ *      bridge must have its limits explicitly set before it can move value. This matches
+ *      the rest of cash-v3 (spending limits, oracle staleness) where zero means blocked.
+ *      State lives in ERC-7201 namespaced storage so the limiter can be added to an
+ *      existing beacon impl without disturbing any deployed proxy's layout.
+ *
+ *      Inherits {OFTCoreUpgradeable} purely to share the `onlyOwner` (delegate) gate on
+ *      the setters; it is already the common base of the OFT impls, so this adds no new
+ *      inheritance diamond.
+ */
+abstract contract PairwiseRateLimiter is OFTCoreUpgradeable {
+    /**
+     * @notice Rate limit state for a single pathway.
+     * @param amountInFlight The amount counted in the current (decaying) window.
+     * @param lastUpdated Timestamp the rate limit was last checked or updated.
+     * @param limit Maximum amount allowed within a window.
+     * @param window Duration of the rate-limiting window, in seconds.
+     */
+    struct RateLimit {
+        uint256 amountInFlight;
+        uint256 lastUpdated;
+        uint256 limit;
+        uint256 window;
+    }
+
+    /**
+     * @notice Rate limit configuration input.
+     * @param peerEid The peer endpoint id this config applies to.
+     * @param limit Maximum amount allowed within a window.
+     * @param window Duration of the rate-limiting window, in seconds.
+     */
+    struct RateLimitConfig {
+        uint32 peerEid;
+        uint256 limit;
+        uint256 window;
+    }
+
+    /// @custom:storage-location erc7201:etherfi.storage.PairwiseRateLimiter
+    struct PairwiseRateLimiterStorage {
+        /// @notice Outbound (send) limits, keyed by destination endpoint id
+        mapping(uint32 dstEid => RateLimit) outboundRateLimits;
+        /// @notice Inbound (receive) limits, keyed by source endpoint id
+        mapping(uint32 srcEid => RateLimit) inboundRateLimits;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("etherfi.storage.PairwiseRateLimiter")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant PairwiseRateLimiterStorageLocation = 0x7f5b707dd949ce880b63fa3570a51e92d8b382587579a84776075096ec18c500;
+
+    /// @notice Emitted when outbound limits are (re)configured.
+    event OutboundRateLimitsChanged(RateLimitConfig[] rateLimitConfigs);
+    /// @notice Emitted when inbound limits are (re)configured.
+    event InboundRateLimitsChanged(RateLimitConfig[] rateLimitConfigs);
+
+    /// @notice Thrown when a send would exceed the outbound limit for the destination.
+    error OutboundRateLimitExceeded();
+    /// @notice Thrown when a receive would exceed the inbound limit for the source.
+    error InboundRateLimitExceeded();
+
+    // ---------------------------------------------------------------------
+    // Owner-gated configuration (owner == OApp delegate)
+    // ---------------------------------------------------------------------
+
+    /// @notice Sets the outbound (send) limits. Only the OApp owner (delegate) may call.
+    function setOutboundRateLimits(RateLimitConfig[] calldata _rateLimitConfigs) external onlyOwner {
+        _setOutboundRateLimits(_rateLimitConfigs);
+    }
+
+    /// @notice Sets the inbound (receive) limits. Only the OApp owner (delegate) may call.
+    function setInboundRateLimits(RateLimitConfig[] calldata _rateLimitConfigs) external onlyOwner {
+        _setInboundRateLimits(_rateLimitConfigs);
+    }
+
+    // ---------------------------------------------------------------------
+    // Views
+    // ---------------------------------------------------------------------
+
+    /// @notice Returns the raw outbound rate-limit state for a destination endpoint id.
+    function outboundRateLimit(uint32 _dstEid) external view returns (RateLimit memory) {
+        return _getRateLimiterStorage().outboundRateLimits[_dstEid];
+    }
+
+    /// @notice Returns the raw inbound rate-limit state for a source endpoint id.
+    function inboundRateLimit(uint32 _srcEid) external view returns (RateLimit memory) {
+        return _getRateLimiterStorage().inboundRateLimits[_srcEid];
+    }
+
+    /**
+     * @notice Current outbound utilization for a destination endpoint id.
+     * @return outboundAmountInFlight The amount currently counted in the window.
+     * @return amountCanBeSent The amount that can still be sent right now.
+     */
+    function getAmountCanBeSent(uint32 _dstEid) external view virtual returns (uint256 outboundAmountInFlight, uint256 amountCanBeSent) {
+        RateLimit memory rl = _getRateLimiterStorage().outboundRateLimits[_dstEid];
+        return _amountCanBeSent(rl.amountInFlight, rl.lastUpdated, rl.limit, rl.window);
+    }
+
+    /**
+     * @notice Current inbound utilization for a source endpoint id.
+     * @return inboundAmountInFlight The amount currently counted in the window.
+     * @return amountCanBeReceived The amount that can still be received right now.
+     */
+    function getAmountCanBeReceived(uint32 _srcEid) external view virtual returns (uint256 inboundAmountInFlight, uint256 amountCanBeReceived) {
+        RateLimit memory rl = _getRateLimiterStorage().inboundRateLimits[_srcEid];
+        return _amountCanBeSent(rl.amountInFlight, rl.lastUpdated, rl.limit, rl.window);
+    }
+
+    // ---------------------------------------------------------------------
+    // Internal: configuration
+    // ---------------------------------------------------------------------
+
+    /// @dev Checkpoints decay before applying new limit/window; never resets amountInFlight/lastUpdated.
+    function _setOutboundRateLimits(RateLimitConfig[] memory _rateLimitConfigs) internal virtual {
+        PairwiseRateLimiterStorage storage $ = _getRateLimiterStorage();
+        unchecked {
+            for (uint256 i = 0; i < _rateLimitConfigs.length; i++) {
+                RateLimit storage rl = $.outboundRateLimits[_rateLimitConfigs[i].peerEid];
+
+                // Checkpoint the existing in-flight amount so the new window does not retroactively decay it.
+                _checkAndUpdateOutboundRateLimit(_rateLimitConfigs[i].peerEid, 0);
+
+                rl.limit = _rateLimitConfigs[i].limit;
+                rl.window = _rateLimitConfigs[i].window;
+            }
+        }
+        emit OutboundRateLimitsChanged(_rateLimitConfigs);
+    }
+
+    /// @dev Checkpoints decay before applying new limit/window; never resets amountInFlight/lastUpdated.
+    function _setInboundRateLimits(RateLimitConfig[] memory _rateLimitConfigs) internal virtual {
+        PairwiseRateLimiterStorage storage $ = _getRateLimiterStorage();
+        unchecked {
+            for (uint256 i = 0; i < _rateLimitConfigs.length; i++) {
+                RateLimit storage rl = $.inboundRateLimits[_rateLimitConfigs[i].peerEid];
+
+                // Checkpoint the existing in-flight amount so the new window does not retroactively decay it.
+                _checkAndUpdateInboundRateLimit(_rateLimitConfigs[i].peerEid, 0);
+
+                rl.limit = _rateLimitConfigs[i].limit;
+                rl.window = _rateLimitConfigs[i].window;
+            }
+        }
+        emit InboundRateLimitsChanged(_rateLimitConfigs);
+    }
+
+    // ---------------------------------------------------------------------
+    // Internal: decay math + check-and-update (called from _debit / _credit)
+    // ---------------------------------------------------------------------
+
+    /**
+     * @dev Linear-decay accounting for a window.
+     * @return currentAmountInFlight The decayed in-flight amount.
+     * @return amountCanBeSent The remaining capacity in the window.
+     */
+    function _amountCanBeSent(uint256 _amountInFlight, uint256 _lastUpdated, uint256 _limit, uint256 _window) internal view virtual returns (uint256 currentAmountInFlight, uint256 amountCanBeSent) {
+        uint256 timeSinceLastDeposit = block.timestamp - _lastUpdated;
+        if (timeSinceLastDeposit >= _window) {
+            currentAmountInFlight = 0;
+            amountCanBeSent = _limit;
+        } else {
+            // Linear decay of the in-flight amount over the window.
+            uint256 decay = (_limit * timeSinceLastDeposit) / _window;
+            currentAmountInFlight = _amountInFlight <= decay ? 0 : _amountInFlight - decay;
+            // If the limit was lowered below the current in-flight amount, no further capacity is available.
+            amountCanBeSent = _limit <= currentAmountInFlight ? 0 : _limit - currentAmountInFlight;
+        }
+    }
+
+    /**
+     * @dev Verifies `_amount` is within the outbound limit for `_dstEid`, then checkpoints the new
+     *      in-flight amount and timestamp. Reverts {OutboundRateLimitExceeded} on breach. An
+     *      unconfigured pathway (`limit == 0`) has `amountCanBeSent == 0`, so any non-zero send reverts.
+     */
+    function _checkAndUpdateOutboundRateLimit(uint32 _dstEid, uint256 _amount) internal virtual {
+        RateLimit storage rl = _getRateLimiterStorage().outboundRateLimits[_dstEid];
+
+        (uint256 currentAmountInFlight, uint256 amountCanBeSent) = _amountCanBeSent(rl.amountInFlight, rl.lastUpdated, rl.limit, rl.window);
+        if (_amount > amountCanBeSent) revert OutboundRateLimitExceeded();
+
+        rl.amountInFlight = currentAmountInFlight + _amount;
+        rl.lastUpdated = block.timestamp;
+    }
+
+    /**
+     * @dev Verifies `_amount` is within the inbound limit for `_srcEid`, then checkpoints the new
+     *      in-flight amount and timestamp. Reverts {InboundRateLimitExceeded} on breach. An
+     *      unconfigured pathway (`limit == 0`) has zero capacity, so any non-zero receive reverts.
+     */
+    function _checkAndUpdateInboundRateLimit(uint32 _srcEid, uint256 _amount) internal virtual {
+        RateLimit storage rl = _getRateLimiterStorage().inboundRateLimits[_srcEid];
+
+        (uint256 currentAmountInFlight, uint256 amountCanBeReceived) = _amountCanBeSent(rl.amountInFlight, rl.lastUpdated, rl.limit, rl.window);
+        if (_amount > amountCanBeReceived) revert InboundRateLimitExceeded();
+
+        rl.amountInFlight = currentAmountInFlight + _amount;
+        rl.lastUpdated = block.timestamp;
+    }
+
+    function _getRateLimiterStorage() private pure returns (PairwiseRateLimiterStorage storage $) {
+        assembly {
+            $.slot := PairwiseRateLimiterStorageLocation
+        }
+    }
+}

--- a/src/oft/PairwiseRateLimiter.sol
+++ b/src/oft/PairwiseRateLimiter.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.28;
 
 import { OFTCoreUpgradeable } from "@layerzerolabs/oft-evm-upgradeable/contracts/oft/OFTCoreUpgradeable.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 
 /**
  * @title PairwiseRateLimiter
@@ -31,6 +32,8 @@ import { OFTCoreUpgradeable } from "@layerzerolabs/oft-evm-upgradeable/contracts
  *      inheritance diamond.
  */
 abstract contract PairwiseRateLimiter is OFTCoreUpgradeable {
+    using Math for uint256;
+
     /**
      * @notice Rate limit state for a single pathway.
      * @param amountInFlight The amount counted in the current (decaying) window.
@@ -179,8 +182,10 @@ abstract contract PairwiseRateLimiter is OFTCoreUpgradeable {
             currentAmountInFlight = 0;
             amountCanBeSent = _limit;
         } else {
-            // Linear decay of the in-flight amount over the window.
-            uint256 decay = (_limit * timeSinceLastDeposit) / _window;
+            // Linear decay of the in-flight amount over the window. mulDiv carries the product at
+            // full 512-bit precision, so a very large limit (e.g. an "unlimited" type(uint256).max
+            // sentinel) can't overflow the intermediate before the divide.
+            uint256 decay = _limit.mulDiv(timeSinceLastDeposit, _window);
             currentAmountInFlight = _amountInFlight <= decay ? 0 : _amountInFlight - decay;
             // If the limit was lowered below the current in-flight amount, no further capacity is available.
             amountCanBeSent = _limit <= currentAmountInFlight ? 0 : _limit - currentAmountInFlight;

--- a/src/oft/ShadowOFTFactory.sol
+++ b/src/oft/ShadowOFTFactory.sol
@@ -81,7 +81,8 @@ contract ShadowOFTFactory is IShadowOFTFactory, BeaconFactory {
         // registry is unreachable (fail-hard: never leave a bridge unregistered).
         address registry = IConfigurableOFT(shadowOFT).configRegistry();
         IOFTConfigRegistry(registry).registerBridge(shadowOFT);
-        IConfigurableOFT(shadowOFT).syncConfig(IOFTConfigRegistry(registry).activeDstEids());
+        // syncConfig only accepts calls from the registry, so route the post-deploy sync through it.
+        IOFTConfigRegistry(registry).syncBridge(shadowOFT, IOFTConfigRegistry(registry).activeDstEids());
         return shadowOFT;
     }
 

--- a/test/oft/CheckOFTConfigSync.t.sol
+++ b/test/oft/CheckOFTConfigSync.t.sol
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { CheckOFTConfigSync } from "../../scripts/CheckOFTConfigSync.s.sol";
+import { IOFTConfigRegistry } from "../../src/interfaces/IOFTConfigRegistry.sol";
+import { OFTCrossChainSetup } from "./OFTCrossChainSetup.t.sol";
+
+/**
+ * @title CheckOFTConfigSyncTest
+ * @notice Drives the off-chain staleness checker against the LIVE LayerZero endpoint harness:
+ *         a configured-but-not-pushed pathway reads STALE (the endpoint still serves the harness
+ *         default ULN), and the same pathway reads IN SYNC once the registry pushes it. Scoped to
+ *         the mainnet adapter (A_EID -> B_EID) so the one-EVM harness's shared registry doesn't
+ *         bleed the OP-side bridge into the assertions (same scoping rationale as the sync test).
+ */
+contract CheckOFTConfigSyncTest is OFTCrossChainSetup {
+    CheckOFTConfigSync internal checker;
+    address internal configAdmin = makeAddr("configAdmin");
+
+    function setUp() public override {
+        super.setUp();
+        _deployPair(8);
+        checker = new CheckOFTConfigSync();
+        // cache the role BEFORE the prank: reading it is a call that would otherwise consume the prank
+        bytes32 configAdminRole = configRegistry.CONFIG_ADMIN_ROLE();
+        vm.prank(owner);
+        roleRegistry.grantRole(configAdminRole, configAdmin);
+    }
+
+    function _realPathway(uint64 confirmations, address[] memory dvns) internal view returns (IOFTConfigRegistry.PathwayConfig memory) {
+        return IOFTConfigRegistry.PathwayConfig({
+            sendLib: endpointSetup.sendLibs[0], // A_EID == 1 -> index 0
+            receiveLib: endpointSetup.receiveLibs[0],
+            confirmations: confirmations,
+            optionalDVNThreshold: 0,
+            requiredDVNs: dvns,
+            optionalDVNs: new address[](0)
+        });
+    }
+
+    function _sortedDVNs() internal returns (address[] memory) {
+        address[] memory dvns = new address[](2);
+        dvns[0] = makeAddr("dvnA");
+        dvns[1] = makeAddr("dvnB");
+        if (dvns[0] > dvns[1]) (dvns[0], dvns[1]) = (dvns[1], dvns[0]);
+        return dvns;
+    }
+
+    function test_pathwayStatus_staleBeforePush_inSyncAfterPush() public {
+        // Canonical config exists but the adapter has not pulled it yet.
+        vm.prank(configAdmin);
+        configRegistry.setPathwayConfig(B_EID, _realPathway(15, _sortedDVNs()));
+
+        (bool readOk, bool inSync) = checker.pathwayStatus(configRegistry, address(adapter), B_EID);
+        assertTrue(readOk, "endpoint rows should be readable");
+        assertFalse(inSync, "endpoint still serves the harness default ULN -> STALE");
+
+        // Registry pushes the config to the adapter's own endpoint rows.
+        address[] memory targets = new address[](1);
+        targets[0] = address(adapter);
+        uint32[] memory eids = new uint32[](1);
+        eids[0] = B_EID;
+        vm.prank(configAdmin);
+        configRegistry.pushTo(targets, eids);
+
+        (readOk, inSync) = checker.pathwayStatus(configRegistry, address(adapter), B_EID);
+        assertTrue(readOk, "endpoint rows should be readable after push");
+        assertTrue(inSync, "applied config now matches canonical -> IN SYNC");
+    }
+
+    function test_pathwayStatus_staleAgainAfterCanonicalEdit() public {
+        address[] memory targets = new address[](1);
+        targets[0] = address(adapter);
+        uint32[] memory eids = new uint32[](1);
+        eids[0] = B_EID;
+
+        vm.prank(configAdmin);
+        configRegistry.setPathwayConfig(B_EID, _realPathway(15, _sortedDVNs()));
+        vm.prank(configAdmin);
+        configRegistry.pushTo(targets, eids);
+
+        (, bool inSync) = checker.pathwayStatus(configRegistry, address(adapter), B_EID);
+        assertTrue(inSync, "synced");
+
+        // Editing the canonical config (without re-pushing) must surface as STALE.
+        vm.prank(configAdmin);
+        configRegistry.setPathwayConfig(B_EID, _realPathway(30, _sortedDVNs()));
+
+        (, inSync) = checker.pathwayStatus(configRegistry, address(adapter), B_EID);
+        assertFalse(inSync, "canonical changed, bridge not re-pushed -> STALE");
+    }
+}

--- a/test/oft/EtherFiOFTAdapter.t.sol
+++ b/test/oft/EtherFiOFTAdapter.t.sol
@@ -51,6 +51,8 @@ contract EtherFiOFTAdapterTest is OFTTestSetup {
         UpgradeableBeacon beacon = new UpgradeableBeacon(impl, owner);
         bytes memory initData = abi.encodeWithSelector(EtherFiOFTAdapter.initialize.selector, token, delegate);
         h = OFTAdapterHarness(address(new BeaconProxy(address(beacon), initData)));
+        // Lift the fail-closed rate limit so these lock/unlock tests reach the debit/credit hooks.
+        _liftRateLimits(address(h), DST_EID_OP);
     }
 
     // ----------------------------------------------------------------- decimal math

--- a/test/oft/OFTAdversarial.t.sol
+++ b/test/oft/OFTAdversarial.t.sol
@@ -162,6 +162,8 @@ contract OFTAdversarialTest is OFTCrossChainSetup {
         vm.startPrank(delegate);
         evilAdapter.setPeer(B_EID, _b32(address(shadow)));
         vm.stopPrank();
+        // Lift the fail-closed rate limit so the reentrancy path (not the limiter) is what's exercised.
+        _liftRateLimits(address(evilAdapter), B_EID);
 
         uint256 amount = 100e8;
         evil.mint(alice, amount);

--- a/test/oft/OFTConfigRegistry.t.sol
+++ b/test/oft/OFTConfigRegistry.t.sol
@@ -88,6 +88,107 @@ contract OFTConfigRegistryTest is OFTTestSetup {
         configRegistry.setPathwayConfig(DST_EID_OP, cfg);
     }
 
+    // ------------------------------------------- write-time DVN validation (mirrors LZ UlnBase)
+
+    // n sequential addresses (1, 2, ... n): inherently sorted-ascending and unique.
+    function _seqAddrs(uint256 n) internal pure returns (address[] memory a) {
+        a = new address[](n);
+        for (uint256 i; i < n; ++i) {
+            a[i] = address(uint160(i + 1));
+        }
+    }
+
+    // Unsorted requiredDVNs are rejected at write time (LZ requires strict ascending order).
+    function test_setPathwayConfig_reverts_onUnsortedRequiredDVNs() public {
+        IOFTConfigRegistry.PathwayConfig memory cfg = _samplePathway(15);
+        (cfg.requiredDVNs[0], cfg.requiredDVNs[1]) = (cfg.requiredDVNs[1], cfg.requiredDVNs[0]); // force descending
+        vm.prank(configAdmin);
+        vm.expectRevert(IOFTConfigRegistry.DVNsNotSortedOrUnique.selector);
+        configRegistry.setPathwayConfig(DST_EID_OP, cfg);
+    }
+
+    // Duplicate requiredDVNs are rejected (the sorted-strictly-ascending check forbids equals).
+    function test_setPathwayConfig_reverts_onDuplicateRequiredDVNs() public {
+        IOFTConfigRegistry.PathwayConfig memory cfg = _samplePathway(15);
+        cfg.requiredDVNs[1] = cfg.requiredDVNs[0]; // duplicate
+        vm.prank(configAdmin);
+        vm.expectRevert(IOFTConfigRegistry.DVNsNotSortedOrUnique.selector);
+        configRegistry.setPathwayConfig(DST_EID_OP, cfg);
+    }
+
+    // A zero DVN address is rejected (address(0) can't exceed the address(0) sort floor).
+    function test_setPathwayConfig_reverts_onZeroDVNAddress() public {
+        IOFTConfigRegistry.PathwayConfig memory cfg = _samplePathway(15);
+        cfg.requiredDVNs[0] = address(0);
+        vm.prank(configAdmin);
+        vm.expectRevert(IOFTConfigRegistry.DVNsNotSortedOrUnique.selector);
+        configRegistry.setPathwayConfig(DST_EID_OP, cfg);
+    }
+
+    // More than MAX_DVN_COUNT (127) required DVNs is rejected — would overflow the on-chain uint8 count.
+    function test_setPathwayConfig_reverts_onTooManyRequiredDVNs() public {
+        IOFTConfigRegistry.PathwayConfig memory cfg = _samplePathway(15);
+        cfg.requiredDVNs = _seqAddrs(128);
+        vm.prank(configAdmin);
+        vm.expectRevert(IOFTConfigRegistry.TooManyDVNs.selector);
+        configRegistry.setPathwayConfig(DST_EID_OP, cfg);
+    }
+
+    // A non-zero optional threshold with no optional DVNs is rejected (LZ requires threshold == 0 then).
+    function test_setPathwayConfig_reverts_onNonzeroThreshold_whenNoOptionalDVNs() public {
+        IOFTConfigRegistry.PathwayConfig memory cfg = _samplePathway(15); // optionalDVNs empty
+        cfg.optionalDVNThreshold = 1;
+        vm.prank(configAdmin);
+        vm.expectRevert(IOFTConfigRegistry.InvalidOptionalDVNThreshold.selector);
+        configRegistry.setPathwayConfig(DST_EID_OP, cfg);
+    }
+
+    // A zero optional threshold WITH optional DVNs present is rejected (must be in (0, count]).
+    function test_setPathwayConfig_reverts_onZeroThreshold_whenOptionalDVNsPresent() public {
+        IOFTConfigRegistry.PathwayConfig memory cfg = _samplePathway(15);
+        cfg.optionalDVNs = _seqAddrs(2);
+        cfg.optionalDVNThreshold = 0;
+        vm.prank(configAdmin);
+        vm.expectRevert(IOFTConfigRegistry.InvalidOptionalDVNThreshold.selector);
+        configRegistry.setPathwayConfig(DST_EID_OP, cfg);
+    }
+
+    // An optional threshold exceeding the optional DVN count is rejected.
+    function test_setPathwayConfig_reverts_onThresholdAboveOptionalCount() public {
+        IOFTConfigRegistry.PathwayConfig memory cfg = _samplePathway(15);
+        cfg.optionalDVNs = _seqAddrs(2);
+        cfg.optionalDVNThreshold = 3; // > 2
+        vm.prank(configAdmin);
+        vm.expectRevert(IOFTConfigRegistry.InvalidOptionalDVNThreshold.selector);
+        configRegistry.setPathwayConfig(DST_EID_OP, cfg);
+    }
+
+    // Unsorted optional DVNs are rejected too (same invariant as required).
+    function test_setPathwayConfig_reverts_onUnsortedOptionalDVNs() public {
+        IOFTConfigRegistry.PathwayConfig memory cfg = _samplePathway(15);
+        address[] memory opt = _seqAddrs(2);
+        (opt[0], opt[1]) = (opt[1], opt[0]); // descending
+        cfg.optionalDVNs = opt;
+        cfg.optionalDVNThreshold = 1;
+        vm.prank(configAdmin);
+        vm.expectRevert(IOFTConfigRegistry.DVNsNotSortedOrUnique.selector);
+        configRegistry.setPathwayConfig(DST_EID_OP, cfg);
+    }
+
+    // A well-formed config with valid optional DVNs + threshold is accepted and stored.
+    function test_setPathwayConfig_acceptsValidOptionalDVNs() public {
+        IOFTConfigRegistry.PathwayConfig memory cfg = _samplePathway(15);
+        cfg.optionalDVNs = _seqAddrs(2);
+        cfg.optionalDVNThreshold = 1; // in (0, 2]
+        vm.prank(configAdmin);
+        configRegistry.setPathwayConfig(DST_EID_OP, cfg);
+
+        IOFTConfigRegistry.PathwayConfig memory got = configRegistry.getPathwayConfig(DST_EID_OP);
+        assertEq(got.optionalDVNs.length, 2);
+        assertEq(got.optionalDVNThreshold, 1);
+        assertEq(configRegistry.configVersion(), 1);
+    }
+
     // ----------------------------------------------------------------- registerBridge / enumeration
 
     // The registrar can add a bridge; it lands in the enumerable set and emits.
@@ -262,5 +363,93 @@ contract OFTConfigRegistryTest is OFTTestSetup {
         vm.prank(registrar);
         vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
         configRegistry.registerBridge(makeAddr("bridge"));
+    }
+
+    // ----------------------------------------------------------------- removePathway / deregisterBridge
+
+    // Removing a pathway clears its config, drops it from activeDstEids, bumps the version, and emits.
+    function test_removePathway_removesAndBumpsVersion() public {
+        _setPathway(DST_EID_OP, 15); // v1, active = [OP]
+        assertEq(configRegistry.activeDstEids().length, 1);
+
+        vm.expectEmit(true, false, false, true);
+        emit IOFTConfigRegistry.PathwayRemoved(DST_EID_OP, 2);
+        vm.prank(configAdmin);
+        configRegistry.removePathway(DST_EID_OP);
+
+        assertEq(configRegistry.configVersion(), 2);
+        assertEq(configRegistry.activeDstEids().length, 0);
+        assertEq(configRegistry.getPathwayConfig(DST_EID_OP).sendLib, address(0)); // config cleared
+    }
+
+    // Removing a destination that was never configured reverts (fail loud on a likely typo).
+    function test_removePathway_reverts_whenNotFound() public {
+        vm.prank(configAdmin);
+        vm.expectRevert(IOFTConfigRegistry.PathwayNotFound.selector);
+        configRegistry.removePathway(DST_EID_OP);
+    }
+
+    // Only CONFIG_ADMIN_ROLE may remove a pathway.
+    function test_removePathway_reverts_whenNotConfigAdmin() public {
+        _setPathway(DST_EID_OP, 15);
+        vm.prank(alice);
+        vm.expectRevert(IOFTConfigRegistry.OnlyConfigAdmin.selector);
+        configRegistry.removePathway(DST_EID_OP);
+    }
+
+    // Pathway removal is blocked while the registry is paused.
+    function test_removePathway_reverts_whenPaused() public {
+        _setPathway(DST_EID_OP, 15);
+        vm.prank(pauser);
+        configRegistry.pause();
+        vm.prank(configAdmin);
+        vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
+        configRegistry.removePathway(DST_EID_OP);
+    }
+
+    // A removed destination can be re-listed by setting it again — it lands once in activeDstEids.
+    function test_removePathway_thenReAdd_listsOnce() public {
+        _setPathway(DST_EID_OP, 15);
+        vm.prank(configAdmin);
+        configRegistry.removePathway(DST_EID_OP);
+        _setPathway(DST_EID_OP, 20); // re-add with new confirmations
+
+        assertEq(configRegistry.activeDstEids().length, 1);
+        assertEq(configRegistry.activeDstEids()[0], DST_EID_OP);
+        assertEq(configRegistry.getPathwayConfig(DST_EID_OP).confirmations, 20);
+    }
+
+    // The admin can drop a bridge from the push set; it leaves the enumerable set and emits.
+    function test_deregisterBridge_removesAndEmits() public {
+        address bridge = address(new MockConfigurableOFT(address(configRegistry)));
+        vm.prank(registrar);
+        configRegistry.registerBridge(bridge);
+        assertEq(configRegistry.numBridges(), 1);
+
+        vm.expectEmit(true, false, false, false);
+        emit IOFTConfigRegistry.BridgeDeregistered(bridge);
+        vm.prank(configAdmin);
+        configRegistry.deregisterBridge(bridge);
+
+        assertEq(configRegistry.numBridges(), 0);
+        assertEq(configRegistry.getBridges(0, 10).length, 0);
+    }
+
+    // Deregistering a bridge that was never registered reverts.
+    function test_deregisterBridge_reverts_whenNotFound() public {
+        vm.prank(configAdmin);
+        vm.expectRevert(IOFTConfigRegistry.BridgeNotFound.selector);
+        configRegistry.deregisterBridge(makeAddr("ghost"));
+    }
+
+    // Deregistration is an admin action — a registrar (the factory role) cannot deregister.
+    function test_deregisterBridge_reverts_whenNotConfigAdmin() public {
+        address bridge = address(new MockConfigurableOFT(address(configRegistry)));
+        vm.prank(registrar);
+        configRegistry.registerBridge(bridge);
+
+        vm.prank(registrar); // holds REGISTRAR, not CONFIG_ADMIN
+        vm.expectRevert(IOFTConfigRegistry.OnlyConfigAdmin.selector);
+        configRegistry.deregisterBridge(bridge);
     }
 }

--- a/test/oft/OFTConfigRegistrySync.t.sol
+++ b/test/oft/OFTConfigRegistrySync.t.sol
@@ -65,8 +65,20 @@ contract OFTConfigRegistrySyncTest is OFTCrossChainSetup {
         return abi.decode(raw, (UlnConfig));
     }
 
-    // A well-formed pathway with real libs + sorted DVNs is actually applied to the live endpoint —
-    // proven by reading the config back from the endpoint.
+    // helper: push config to the adapter through the registry (the only authorized syncConfig caller)
+    function _push(address[] memory targets, uint32[] memory eids) internal {
+        vm.prank(configAdmin);
+        configRegistry.pushTo(targets, eids);
+    }
+
+    // helper: single-element [adapter] target list
+    function _adapterTarget() internal view returns (address[] memory t) {
+        t = new address[](1);
+        t[0] = address(adapter);
+    }
+
+    // A well-formed pathway with real libs + sorted DVNs is actually applied to the live endpoint
+    // when the registry pushes it — proven by reading the config back from the endpoint.
     function test_syncConfig_appliesWellFormedConfig() public {
         address[] memory dvns = _sortedDVNs();
         _setPathway(B_EID, _realPathway(15, dvns));
@@ -77,7 +89,7 @@ contract OFTConfigRegistrySyncTest is OFTCrossChainSetup {
 
         uint32[] memory eids = new uint32[](1);
         eids[0] = B_EID;
-        adapter.syncConfig(eids); // permissionless pull; self-authorized on the endpoint
+        _push(_adapterTarget(), eids); // registry directs the bridge to apply config
 
         // the config genuinely landed on the endpoint's send + receive rows.
         UlnConfig memory sendUln = _ulnOnEndpoint(endpointSetup.sendLibs[0], B_EID);
@@ -90,44 +102,16 @@ contract OFTConfigRegistrySyncTest is OFTCrossChainSetup {
         assertEq(recvUln.requiredDVNs.length, 2, "DVN config not applied on receive lib");
     }
 
-    // Unsorted requiredDVNs are rejected by the real ULN (LZ requires strict ascending order).
-    function test_syncConfig_reverts_onUnsortedDVNs() public {
-        address[] memory dvns = _sortedDVNs();
-        (dvns[0], dvns[1]) = (dvns[1], dvns[0]); // force descending
-        _setPathway(B_EID, _realPathway(15, dvns));
-
-        UlnConfig memory beforeCfg = _ulnOnEndpoint(endpointSetup.sendLibs[0], B_EID);
-
+    // syncConfig is gated to the registry: a third party can't force a re-pull on the bridge directly.
+    // (Malformed DVN configs are rejected even earlier, at setPathwayConfig write time — see
+    // OFTConfigRegistryTest for that coverage, so the live ULN never receives one.)
+    function test_syncConfig_reverts_whenCallerNotRegistry() public {
+        _setPathway(B_EID, _realPathway(15, _sortedDVNs()));
         uint32[] memory eids = new uint32[](1);
         eids[0] = B_EID;
-        vm.expectRevert(); // LZ_ULN_Unsorted (ULN-internal)
+        vm.prank(alice);
+        vm.expectRevert(ConfigurableOFTBase.UnauthorizedSync.selector);
         adapter.syncConfig(eids);
-
-        // atomic rollback: the endpoint config is unchanged from before the attempt
-        _assertUlnUnchanged(beforeCfg, _ulnOnEndpoint(endpointSetup.sendLibs[0], B_EID));
-    }
-
-    // Duplicate requiredDVNs are rejected by the real ULN.
-    function test_syncConfig_reverts_onDuplicateDVNs() public {
-        address[] memory dvns = new address[](2);
-        dvns[0] = makeAddr("dup");
-        dvns[1] = dvns[0];
-        _setPathway(B_EID, _realPathway(15, dvns));
-
-        UlnConfig memory beforeCfg = _ulnOnEndpoint(endpointSetup.sendLibs[0], B_EID);
-
-        uint32[] memory eids = new uint32[](1);
-        eids[0] = B_EID;
-        vm.expectRevert();
-        adapter.syncConfig(eids);
-
-        _assertUlnUnchanged(beforeCfg, _ulnOnEndpoint(endpointSetup.sendLibs[0], B_EID));
-    }
-
-    /// @dev Confirmations + DVN count unchanged — i.e. the attempted (bad) config was not applied.
-    function _assertUlnUnchanged(UlnConfig memory before, UlnConfig memory got) internal pure {
-        assertEq(got.confirmations, before.confirmations, "confirmations changed despite revert");
-        assertEq(got.requiredDVNs.length, before.requiredDVNs.length, "DVN set changed despite revert");
     }
 
     // Syncing an unconfigured destination resolves to an empty pathway (zero send lib); the real
@@ -136,7 +120,7 @@ contract OFTConfigRegistrySyncTest is OFTCrossChainSetup {
         uint32[] memory eids = new uint32[](1);
         eids[0] = UNCONFIGURED_EID;
         vm.expectRevert();
-        adapter.syncConfig(eids);
+        _push(_adapterTarget(), eids);
     }
 
     // configRegistry is immutable and BOTH production impls (adapter + shadow) reject a zero registry

--- a/test/oft/OFTCrossChainSetup.t.sol
+++ b/test/oft/OFTCrossChainSetup.t.sol
@@ -9,6 +9,7 @@ import { TestHelperOz5 } from "@layerzerolabs/test-devtools-evm-foundry/contract
 import { UUPSProxy } from "../../src/UUPSProxy.sol";
 import { EtherFiOFTAdapter } from "../../src/oft/EtherFiOFTAdapter.sol";
 import { EtherFiShadowOFT } from "../../src/oft/EtherFiShadowOFT.sol";
+import { PairwiseRateLimiter } from "../../src/oft/PairwiseRateLimiter.sol";
 import { OFTAdapterFactory } from "../../src/oft/OFTAdapterFactory.sol";
 import { OFTConfigRegistry } from "../../src/oft/OFTConfigRegistry.sol";
 import { ShadowOFTFactory } from "../../src/oft/ShadowOFTFactory.sol";
@@ -107,6 +108,21 @@ contract OFTCrossChainSetup is TestHelperOz5 {
         vm.startPrank(delegate);
         adapter.setPeer(B_EID, _b32(address(shadow)));
         shadow.setPeer(A_EID, _b32(address(adapter)));
+        vm.stopPrank();
+
+        // The limiter is fail-closed; lift it to effectively-unlimited so the round-trip / conservation
+        // tests exercise the full bridge path. Dedicated rate-limit tests set precise caps instead.
+        _liftRateLimits(address(adapter), B_EID);
+        _liftRateLimits(address(shadow), A_EID);
+    }
+
+    /// @dev Lift the fail-closed rate limit (both directions) for a peer eid on a bridge, as the delegate.
+    function _liftRateLimits(address bridge, uint32 eid) internal {
+        PairwiseRateLimiter.RateLimitConfig[] memory cfg = new PairwiseRateLimiter.RateLimitConfig[](1);
+        cfg[0] = PairwiseRateLimiter.RateLimitConfig({ peerEid: eid, limit: type(uint256).max, window: 1 });
+        vm.startPrank(delegate);
+        PairwiseRateLimiter(bridge).setOutboundRateLimits(cfg);
+        PairwiseRateLimiter(bridge).setInboundRateLimits(cfg);
         vm.stopPrank();
     }
 

--- a/test/oft/OFTFactoryMechanics.t.sol
+++ b/test/oft/OFTFactoryMechanics.t.sol
@@ -8,6 +8,7 @@ import { BeaconFactory } from "../../src/beacon-factory/BeaconFactory.sol";
 import { EtherFiOFTAdapter } from "../../src/oft/EtherFiOFTAdapter.sol";
 import { EtherFiShadowOFT } from "../../src/oft/EtherFiShadowOFT.sol";
 import { OFTAdapterFactory } from "../../src/oft/OFTAdapterFactory.sol";
+import { PairwiseRateLimiter } from "../../src/oft/PairwiseRateLimiter.sol";
 import { UpgradeableProxy } from "../../src/utils/UpgradeableProxy.sol";
 import { OFTTestSetup } from "./OFTTestSetup.t.sol";
 
@@ -124,6 +125,75 @@ contract OFTFactoryMechanicsTest is OFTTestSetup {
         // ...with storage preserved
         assertEq(EtherFiShadowOFT(shadow).decimals(), 8);
         assertEq(EtherFiShadowOFT(shadow).conversionRate(), 100);
+    }
+
+    // The rate-limit state lives in its own ERC-7201 namespaced region, so a beacon upgrade that
+    // swaps logic must leave it intact (the upgrade must not reset or shift configured caps).
+    function test_beaconUpgrade_preservesRateLimitState() public {
+        skip(10_000); // make the lastUpdated checkpoint unambiguously non-zero
+        address adapter = _deployAdapter(keccak256("rl-wbtc"), address(token8));
+
+        PairwiseRateLimiter.RateLimitConfig[] memory cfg = new PairwiseRateLimiter.RateLimitConfig[](1);
+        cfg[0] = PairwiseRateLimiter.RateLimitConfig({ peerEid: DST_EID_OP, limit: 1234e8, window: 2 hours });
+        vm.prank(delegate); // delegate == OApp owner
+        PairwiseRateLimiter(adapter).setOutboundRateLimits(cfg);
+
+        PairwiseRateLimiter.RateLimit memory before = PairwiseRateLimiter(adapter).outboundRateLimit(DST_EID_OP);
+        assertEq(before.limit, 1234e8);
+        assertEq(before.window, 2 hours);
+        assertGt(before.lastUpdated, 0);
+
+        // BEFORE: V1 has no version(), so the call finds no selector and reverts. This proves the
+        // upgrade (not code that was already there) is what makes version() callable afterwards.
+        (bool okBefore,) = adapter.staticcall(abi.encodeWithSignature("version()"));
+        assertFalse(okBefore, "version() existed before the upgrade - logic did not actually change");
+
+        address implV2 = address(new EtherFiOFTAdapterV2(address(endpoint), address(configRegistry)));
+        vm.prank(owner); // RoleRegistry owner
+        adapterFactory.upgradeBeaconImplementation(implV2);
+
+        // V2 logic is live AND the namespaced rate-limit region is byte-for-byte preserved.
+        (bool okAfter,) = adapter.staticcall(abi.encodeWithSignature("version()"));
+        assertTrue(okAfter, "logic did not change");
+        PairwiseRateLimiter.RateLimit memory afterUpg = PairwiseRateLimiter(adapter).outboundRateLimit(DST_EID_OP);
+        assertEq(afterUpg.limit, before.limit, "limit not preserved across upgrade");
+        assertEq(afterUpg.window, before.window, "window not preserved across upgrade");
+        assertEq(afterUpg.lastUpdated, before.lastUpdated, "lastUpdated not preserved across upgrade");
+    }
+
+    // Same guarantee on the shadow (mint/burn) side: a beacon upgrade swaps logic while the
+    // namespaced rate-limit region on existing iTOKEN proxies is preserved.
+    function test_beaconUpgrade_shadow_preservesRateLimitState() public {
+        skip(10_000); // make the lastUpdated checkpoint unambiguously non-zero
+        vm.prank(factoryAdmin);
+        address shadow = shadowFactory.deployShadowOFT(keccak256("rl-iWBTC"), "EtherFi WBTC", "iWBTC", 8, delegate);
+
+        // Cap the inbound (receive-from-Ethereum) pathway.
+        PairwiseRateLimiter.RateLimitConfig[] memory cfg = new PairwiseRateLimiter.RateLimitConfig[](1);
+        cfg[0] = PairwiseRateLimiter.RateLimitConfig({ peerEid: DST_EID_ETH, limit: 1234e8, window: 2 hours });
+        vm.prank(delegate); // delegate == OApp owner
+        PairwiseRateLimiter(shadow).setInboundRateLimits(cfg);
+
+        PairwiseRateLimiter.RateLimit memory before = PairwiseRateLimiter(shadow).inboundRateLimit(DST_EID_ETH);
+        assertEq(before.limit, 1234e8);
+        assertEq(before.window, 2 hours);
+        assertGt(before.lastUpdated, 0);
+
+        // BEFORE: V1 has no version(), so the call reverts — proving the upgrade is what adds it.
+        (bool okBefore,) = shadow.staticcall(abi.encodeWithSignature("version()"));
+        assertFalse(okBefore, "version() existed before the upgrade - logic did not actually change");
+
+        address implV2 = address(new EtherFiShadowOFTV2(address(endpoint), address(configRegistry)));
+        vm.prank(owner); // RoleRegistry owner
+        shadowFactory.upgradeBeaconImplementation(implV2);
+
+        // V2 logic is live AND the namespaced rate-limit region is byte-for-byte preserved.
+        (bool okAfter,) = shadow.staticcall(abi.encodeWithSignature("version()"));
+        assertTrue(okAfter, "logic did not change");
+        PairwiseRateLimiter.RateLimit memory afterUpg = PairwiseRateLimiter(shadow).inboundRateLimit(DST_EID_ETH);
+        assertEq(afterUpg.limit, before.limit, "limit not preserved across upgrade");
+        assertEq(afterUpg.window, before.window, "window not preserved across upgrade");
+        assertEq(afterUpg.lastUpdated, before.lastUpdated, "lastUpdated not preserved across upgrade");
     }
 
     // Only the RoleRegistry owner may upgrade a beacon impl.

--- a/test/oft/OFTRateLimiter.t.sol
+++ b/test/oft/OFTRateLimiter.t.sol
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { BeaconProxy } from "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
+import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+
+import { EtherFiOFTAdapter } from "../../src/oft/EtherFiOFTAdapter.sol";
+import { EtherFiShadowOFT } from "../../src/oft/EtherFiShadowOFT.sol";
+import { PairwiseRateLimiter } from "../../src/oft/PairwiseRateLimiter.sol";
+import { OFTAdapterHarness } from "./EtherFiOFTAdapter.t.sol";
+import { MockERC20, OFTTestSetup } from "./OFTTestSetup.t.sol";
+
+/**
+ * Test harness exposing the internal rate-limit hooks so the decay/checkpoint math can be driven
+ * directly, without routing a full cross-chain send. Built on the shadow impl, but the limiter is
+ * shared so the logic is identical on the adapter.
+ */
+contract ShadowRateHarness is EtherFiShadowOFT {
+    constructor(address ep, address reg) EtherFiShadowOFT(ep, reg) { }
+
+    function checkOutbound(uint32 eid, uint256 amount) external {
+        _checkAndUpdateOutboundRateLimit(eid, amount);
+    }
+
+    function checkInbound(uint32 eid, uint256 amount) external {
+        _checkAndUpdateInboundRateLimit(eid, amount);
+    }
+}
+
+/**
+ * @title OFTRateLimiterTest
+ * @notice Unit coverage for the ported {PairwiseRateLimiter}: fail-closed unset pathways, per-window
+ *         linear decay, limit changes mid-window, outbound/inbound independence, owner-gating, and
+ *         that the adapter meters the dust-removed sent amount (not the raw request).
+ */
+contract OFTRateLimiterTest is OFTTestSetup {
+    ShadowRateHarness internal rl;
+
+    uint256 internal constant LIMIT = 1000 ether;
+    uint256 internal constant WINDOW = 1 hours;
+
+    function setUp() public override {
+        super.setUp();
+        rl = _rateHarness();
+    }
+
+    function _rateHarness() internal returns (ShadowRateHarness h) {
+        address impl = address(new ShadowRateHarness(address(endpoint), address(configRegistry)));
+        UpgradeableBeacon beacon = new UpgradeableBeacon(impl, owner);
+        bytes memory initData = abi.encodeWithSelector(EtherFiShadowOFT.initialize.selector, "EtherFi UND", "iUND", uint8(18), delegate);
+        h = ShadowRateHarness(address(new BeaconProxy(address(beacon), initData)));
+    }
+
+    function _cfg(uint32 eid, uint256 limit, uint256 window) internal pure returns (PairwiseRateLimiter.RateLimitConfig[] memory c) {
+        c = new PairwiseRateLimiter.RateLimitConfig[](1);
+        c[0] = PairwiseRateLimiter.RateLimitConfig({ peerEid: eid, limit: limit, window: window });
+    }
+
+    function _setOutbound(uint32 eid, uint256 limit, uint256 window) internal {
+        vm.prank(delegate);
+        rl.setOutboundRateLimits(_cfg(eid, limit, window));
+    }
+
+    function _setInbound(uint32 eid, uint256 limit, uint256 window) internal {
+        vm.prank(delegate);
+        rl.setInboundRateLimits(_cfg(eid, limit, window));
+    }
+
+    // --------------------------------------------------------------- fail-closed (unset pathway)
+
+    // An unconfigured pathway allows zero throughput in both directions.
+    function test_unsetPathway_blocksOutbound() public {
+        vm.expectRevert(PairwiseRateLimiter.OutboundRateLimitExceeded.selector);
+        rl.checkOutbound(DST_EID_OP, 1);
+    }
+
+    function test_unsetPathway_blocksInbound() public {
+        vm.expectRevert(PairwiseRateLimiter.InboundRateLimitExceeded.selector);
+        rl.checkInbound(DST_EID_OP, 1);
+    }
+
+    // A zero-amount call passes even when unset (used internally to checkpoint decay).
+    function test_unsetPathway_zeroAmountPasses() public {
+        rl.checkOutbound(DST_EID_OP, 0);
+    }
+
+    // --------------------------------------------------------------- basic cap
+
+    function test_outbound_allowsUpToLimit_thenBlocks() public {
+        _setOutbound(DST_EID_OP, LIMIT, WINDOW);
+
+        rl.checkOutbound(DST_EID_OP, 600 ether); // ok
+        (, uint256 canSend) = rl.getAmountCanBeSent(DST_EID_OP);
+        assertEq(canSend, 400 ether, "remaining capacity wrong");
+
+        vm.expectRevert(PairwiseRateLimiter.OutboundRateLimitExceeded.selector);
+        rl.checkOutbound(DST_EID_OP, 600 ether); // would exceed within the same window
+
+        rl.checkOutbound(DST_EID_OP, 400 ether); // exactly the remainder is allowed
+        (, canSend) = rl.getAmountCanBeSent(DST_EID_OP);
+        assertEq(canSend, 0, "should be fully consumed");
+    }
+
+    function test_inbound_allowsUpToLimit_thenBlocks() public {
+        _setInbound(DST_EID_OP, LIMIT, WINDOW);
+
+        rl.checkInbound(DST_EID_OP, LIMIT); // ok, fully consumed
+        vm.expectRevert(PairwiseRateLimiter.InboundRateLimitExceeded.selector);
+        rl.checkInbound(DST_EID_OP, 1);
+    }
+
+    function test_exactlyAtLimit_passes() public {
+        _setOutbound(DST_EID_OP, LIMIT, WINDOW);
+        rl.checkOutbound(DST_EID_OP, LIMIT);
+    }
+
+    // --------------------------------------------------------------- linear decay
+
+    // After half the window, half the consumed capacity has decayed back.
+    function test_decayOverWindow_replenishesLinearly() public {
+        _setOutbound(DST_EID_OP, LIMIT, WINDOW);
+        rl.checkOutbound(DST_EID_OP, LIMIT); // fully consumed
+
+        skip(WINDOW / 2);
+        (uint256 inFlight, uint256 canSend) = rl.getAmountCanBeSent(DST_EID_OP);
+        assertEq(inFlight, LIMIT / 2, "half should remain in flight");
+        assertEq(canSend, LIMIT / 2, "half capacity should have returned");
+    }
+
+    // Once a full window elapses, capacity is fully restored.
+    function test_fullWindowElapsed_fullCapacity() public {
+        _setOutbound(DST_EID_OP, LIMIT, WINDOW);
+        rl.checkOutbound(DST_EID_OP, LIMIT);
+
+        skip(WINDOW);
+        (uint256 inFlight, uint256 canSend) = rl.getAmountCanBeSent(DST_EID_OP);
+        assertEq(inFlight, 0, "in flight should fully decay");
+        assertEq(canSend, LIMIT, "full capacity restored");
+
+        rl.checkOutbound(DST_EID_OP, LIMIT); // can send the full limit again
+    }
+
+    // --------------------------------------------------------------- limit changes mid-window
+
+    // Lowering the limit below the current in-flight amount leaves zero remaining capacity, and
+    // a checkpoint of the existing in-flight amount is preserved (not retroactively decayed).
+    function test_limitLoweredMidWindow_clampsCapacityToZero() public {
+        _setOutbound(DST_EID_OP, LIMIT, WINDOW);
+        rl.checkOutbound(DST_EID_OP, 800 ether);
+
+        _setOutbound(DST_EID_OP, 500 ether, WINDOW); // new limit below in-flight (800)
+        (uint256 inFlight, uint256 canSend) = rl.getAmountCanBeSent(DST_EID_OP);
+        assertEq(inFlight, 800 ether, "in-flight checkpoint should be preserved across the limit change");
+        assertEq(canSend, 0, "no capacity when in-flight exceeds the lowered limit");
+
+        vm.expectRevert(PairwiseRateLimiter.OutboundRateLimitExceeded.selector);
+        rl.checkOutbound(DST_EID_OP, 1);
+    }
+
+    // Raising the limit mid-window immediately grants the extra capacity.
+    function test_limitRaisedMidWindow_grantsExtraCapacity() public {
+        _setOutbound(DST_EID_OP, LIMIT, WINDOW);
+        rl.checkOutbound(DST_EID_OP, LIMIT); // consumed
+
+        _setOutbound(DST_EID_OP, LIMIT * 2, WINDOW);
+        (, uint256 canSend) = rl.getAmountCanBeSent(DST_EID_OP);
+        assertEq(canSend, LIMIT, "raised headroom should be immediately available");
+    }
+
+    // --------------------------------------------------------------- direction independence
+
+    // Outbound and inbound use separate ledgers, even on the same eid.
+    function test_outboundAndInbound_areIndependent() public {
+        _setOutbound(DST_EID_OP, LIMIT, WINDOW);
+        _setInbound(DST_EID_OP, LIMIT, WINDOW);
+
+        rl.checkOutbound(DST_EID_OP, LIMIT); // exhaust outbound
+
+        (, uint256 canReceive) = rl.getAmountCanBeReceived(DST_EID_OP);
+        assertEq(canReceive, LIMIT, "inbound capacity unaffected by outbound usage");
+        rl.checkInbound(DST_EID_OP, LIMIT); // inbound still fully available
+    }
+
+    // Limits on different eids are independent.
+    function test_perEid_independent() public {
+        _setOutbound(DST_EID_OP, LIMIT, WINDOW);
+        _setOutbound(DST_EID_ETH, LIMIT, WINDOW);
+
+        rl.checkOutbound(DST_EID_OP, LIMIT);
+        (, uint256 canSendEth) = rl.getAmountCanBeSent(DST_EID_ETH);
+        assertEq(canSendEth, LIMIT, "other eid capacity unaffected");
+    }
+
+    // --------------------------------------------------------------- access control
+
+    function test_setOutboundRateLimits_onlyOwner() public {
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, alice));
+        rl.setOutboundRateLimits(_cfg(DST_EID_OP, LIMIT, WINDOW));
+    }
+
+    function test_setInboundRateLimits_onlyOwner() public {
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, alice));
+        rl.setInboundRateLimits(_cfg(DST_EID_OP, LIMIT, WINDOW));
+    }
+
+    // --------------------------------------------------------------- metering integration (adapter)
+
+    // The adapter meters the dust-removed sent amount, not the raw request: a sub-rate dust tail
+    // does not inflate the in-flight counter.
+    function test_adapter_metersAmountSentLD_notRaw() public {
+        // PAXG-like 18-decimal underlying => conversion rate 1e12; sub-1e12 wei is dust.
+        OFTAdapterHarness h = _adapterHarness(address(token18));
+        uint256 clean = 1000 * 1e18;
+        uint256 dusty = clean + 500; // 500 wei < rate (1e12) => dropped on the wire
+
+        _setOutboundOn(address(h), DST_EID_OP, type(uint256).max, WINDOW);
+
+        token18.mint(alice, dusty);
+        vm.prank(alice);
+        token18.approve(address(h), dusty);
+
+        (uint256 sent,) = h.exposedDebit(alice, dusty, 0, DST_EID_OP);
+        assertEq(sent, clean, "dust should be removed from the sent amount");
+
+        PairwiseRateLimiter.RateLimit memory state = h.outboundRateLimit(DST_EID_OP);
+        assertEq(state.amountInFlight, clean, "in-flight should track the dust-removed sent amount");
+    }
+
+    // ----------------------------------------------------------------- fuzz
+
+    // For any window-internal split, the cumulative checked amount can never exceed the limit.
+    function testFuzz_cumulativeWithinWindowCappedByLimit(uint256 limit, uint256 a, uint256 b) public {
+        limit = bound(limit, 1, type(uint128).max);
+        a = bound(a, 0, limit);
+        b = bound(b, 0, limit);
+        _setOutbound(DST_EID_OP, limit, WINDOW);
+
+        rl.checkOutbound(DST_EID_OP, a); // a <= limit always ok at window start
+        if (a + b <= limit) {
+            rl.checkOutbound(DST_EID_OP, b);
+        } else {
+            vm.expectRevert(PairwiseRateLimiter.OutboundRateLimitExceeded.selector);
+            rl.checkOutbound(DST_EID_OP, b);
+        }
+    }
+
+    // The cap holds in the asset's local decimals across the supported precision range.
+    function testFuzz_metersInLocalDecimals(uint8 decimalsSeed, uint256 amount) public {
+        MockERC20[3] memory toks = [token6, token8, token18];
+        MockERC20 tok = toks[decimalsSeed % 3];
+        OFTAdapterHarness h = _adapterHarness(address(tok));
+
+        uint256 rate = h.conversionRate();
+        amount = bound(amount, rate, 1_000_000 * (10 ** uint256(tok.decimals())));
+        uint256 expectedSent = (amount / rate) * rate;
+
+        _setOutboundOn(address(h), DST_EID_OP, expectedSent, WINDOW); // limit == exactly the sent amount
+
+        tok.mint(alice, amount);
+        vm.prank(alice);
+        tok.approve(address(h), amount);
+
+        h.exposedDebit(alice, amount, 0, DST_EID_OP); // exactly at the limit -> passes
+        PairwiseRateLimiter.RateLimit memory state = h.outboundRateLimit(DST_EID_OP);
+        assertEq(state.amountInFlight, expectedSent);
+        (, uint256 canSend) = h.getAmountCanBeSent(DST_EID_OP);
+        assertEq(canSend, 0, "limit set to the sent amount should be exactly exhausted");
+    }
+
+    // --------------------------------------------------------------- helpers
+
+    function _adapterHarness(address tok) internal returns (OFTAdapterHarness h) {
+        address impl = address(new OFTAdapterHarness(address(endpoint), address(configRegistry)));
+        UpgradeableBeacon beacon = new UpgradeableBeacon(impl, owner);
+        bytes memory initData = abi.encodeWithSelector(EtherFiOFTAdapter.initialize.selector, tok, delegate);
+        h = OFTAdapterHarness(address(new BeaconProxy(address(beacon), initData)));
+    }
+
+    function _setOutboundOn(address bridge, uint32 eid, uint256 limit, uint256 window) internal {
+        vm.prank(delegate);
+        PairwiseRateLimiter(bridge).setOutboundRateLimits(_cfg(eid, limit, window));
+    }
+}

--- a/test/oft/OFTTestSetup.t.sol
+++ b/test/oft/OFTTestSetup.t.sol
@@ -10,6 +10,7 @@ import { IConfigurableOFT } from "../../src/interfaces/IConfigurableOFT.sol";
 import { IOFTConfigRegistry } from "../../src/interfaces/IOFTConfigRegistry.sol";
 import { EtherFiOFTAdapter } from "../../src/oft/EtherFiOFTAdapter.sol";
 import { EtherFiShadowOFT } from "../../src/oft/EtherFiShadowOFT.sol";
+import { PairwiseRateLimiter } from "../../src/oft/PairwiseRateLimiter.sol";
 import { OFTAdapterFactory } from "../../src/oft/OFTAdapterFactory.sol";
 import { OFTConfigRegistry } from "../../src/oft/OFTConfigRegistry.sol";
 import { ShadowOFTFactory } from "../../src/oft/ShadowOFTFactory.sol";
@@ -209,6 +210,22 @@ contract OFTTestSetup is Test {
         token6 = new MockERC20("USD Coin", "USDC", 6);
         token8 = new MockERC20("Wrapped BTC", "WBTC", 8);
         token18 = new MockERC20("Pax Gold", "PAXG", 18);
+    }
+
+    /**
+     * @dev Lift the fail-closed rate limit on a freshly-deployed bridge for a peer eid so tests that
+     *      are NOT about rate limiting can still exercise the debit/credit (send/receive) hooks. The
+     *      limiter is fail-closed (unset pathway = zero throughput); production listing scripts set a
+     *      real cap, here we set an effectively-unlimited one in both directions. Pranks the delegate
+     *      (the OApp owner). Keep this OUT of dedicated rate-limit tests, which set precise limits.
+     */
+    function _liftRateLimits(address bridge, uint32 eid) internal {
+        PairwiseRateLimiter.RateLimitConfig[] memory cfg = new PairwiseRateLimiter.RateLimitConfig[](1);
+        cfg[0] = PairwiseRateLimiter.RateLimitConfig({ peerEid: eid, limit: type(uint256).max, window: 1 });
+        vm.startPrank(delegate);
+        PairwiseRateLimiter(bridge).setOutboundRateLimits(cfg);
+        PairwiseRateLimiter(bridge).setInboundRateLimits(cfg);
+        vm.stopPrank();
     }
 
     // A valid 2-of-2 required-DVN pathway config (mirrors the weETH DVN stack shape).

--- a/test/oft/OFTWeirdTokens.t.sol
+++ b/test/oft/OFTWeirdTokens.t.sol
@@ -29,6 +29,8 @@ contract OFTWeirdTokensTest is OFTTestSetup {
         UpgradeableBeacon beacon = new UpgradeableBeacon(impl, owner);
         bytes memory initData = abi.encodeWithSelector(EtherFiOFTAdapter.initialize.selector, tok, delegate);
         h = OFTAdapterHarness(address(new BeaconProxy(address(beacon), initData)));
+        // Lift the fail-closed rate limit so the lossless/transfer guards are what these tests observe.
+        _liftRateLimits(address(h), DST_EID_OP);
     }
 
     // ----------------------------------------------------------------- lossless guard on lock


### PR DESCRIPTION
Stacks on #133 (base: `feat/oft-listing-primitive-boilerplate`).

Three commits:

- **Registry hardening** (`f733a7a`) — `removePathway`/`deregisterBridge`, registrar `syncBridge`, DVN-set validation, and `syncConfig` gated to the registry (`UnauthorizedSync`). — COR-909
- **EOA scripts** (`b9820ca`) — `ConfigureAndListOFT{Mainnet,Optimism}` + `WireOFTPeers`. — COR-910
- **Rate limiter** (`2a5f8e0`) — port `PairwiseRateLimiter`: independent per-pathway outbound/inbound caps with linear-decay windows, shipped as a beacon upgrade. ERC-7201 storage (collision-proof), fail-closed, `onlyOwner` setters. Adds `UpgradeOFTRateLimiter` + `SetOFTRateLimits` scripts and default caps in the listing scripts. — COR-924

All 136 OFT tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes cross-chain bridge throughput and LayerZero config sync authorization; beacon upgrades fail-close all pathways until rate limits are set, and mis-ordered ops could brick live bridges.
> 
> **Overview**
> Adds **registry hardening**, **EOA bring-up scripts**, and a **bidirectional `PairwiseRateLimiter`** on OFT bridges.
> 
> **Registry:** `OFTConfigRegistry` gains `removePathway`, `deregisterBridge`, and registrar-only `syncBridge`; pathway DVN stacks are validated at write time (sorted/unique, counts, optional threshold). `ConfigurableOFTBase.syncConfig` is no longer permissionless—only the registry may call it (`UnauthorizedSync`); factories post-deploy sync via `syncBridge`. New view script `CheckOFTConfigSync` compares endpoint ULN rows to canonical config (optional `REVERT_IF_STALE` for CI).
> 
> **Rate limiter:** New `PairwiseRateLimiter` mixin (ERC-7201 storage) on `EtherFiOFTAdapter` and `EtherFiShadowOFT`, metering outbound/inbound per peer EID in `_debit`/`_credit`; **fail-closed** when unset (`limit == 0`). Scripts `UpgradeOFTRateLimiter` (beacon upgrade) and `SetOFTRateLimits` document that upgrades brick bridging until limits are set.
> 
> **Operations:** Idempotent `ConfigureAndListOFT{Mainnet,Optimism}` (roles, pathway, PEPE/iPEPE list, optional inline caps) and `WireOFTPeers` for cross-chain peer wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 366e218280480019d80833f2e2810aa43252ccc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->