### PR TITLE
feat: add pause controls to the OFT bridges (COR-923)

### DIFF
--- a/scripts/PauseOFTBridges.s.sol
+++ b/scripts/PauseOFTBridges.s.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { stdJson } from "forge-std/StdJson.sol";
+import { console } from "forge-std/console.sol";
+
+import { IOFTConfigRegistry } from "../src/interfaces/IOFTConfigRegistry.sol";
+import { ConfigurableOFTBase } from "../src/oft/ConfigurableOFTBase.sol";
+
+import { Utils } from "./utils/Utils.sol";
+
+/**
+ * @title PauseOFTBridges
+ * @author ether.fi
+ * @notice "Pause everything" (COR-923): the on-chain control is per-bridge {ConfigurableOFTBase-pauseBridge}
+ *         gated by the RoleRegistry PAUSER role, so the global switch is a Safe BATCH of those calls —
+ *         the same pattern weETH-cross-chain uses. This script enumerates every registered bridge from
+ *         the {OFTConfigRegistry} and either broadcasts the pause (if the caller holds PAUSER) or logs the
+ *         per-bridge calldata to submit from the PAUSER Safe.
+ * @dev Set OFT_UNPAUSE=true to emit the inverse (unpause) batch — note unpause is gated to UNPAUSER.
+ *      Run once per chain:
+ *        PRIVATE_KEY=<pauser> forge script scripts/PauseOFTBridges.s.sol --rpc-url <mainnet|optimism> --broadcast
+ */
+contract PauseOFTBridges is Utils {
+    function run() public {
+        bool unpause = vm.envOr("OFT_UNPAUSE", false);
+        bool broadcast = vm.envOr("OFT_BROADCAST", false);
+
+        string memory deployments = readDeploymentFile();
+        IOFTConfigRegistry registry = IOFTConfigRegistry(stdJson.readAddress(deployments, ".addresses.OFTConfigRegistry"));
+
+        uint256 n = registry.numBridges();
+        address[] memory bridges = registry.getBridges(0, n);
+        bytes memory data = unpause ? abi.encodeWithSelector(ConfigurableOFTBase.unpauseBridge.selector) : abi.encodeWithSelector(ConfigurableOFTBase.pauseBridge.selector);
+
+        console.log(unpause ? "UNPAUSE" : "PAUSE", "all OFT bridges on chainId", block.chainid);
+        console.log("  registry:", address(registry));
+        console.log("  bridges: ", n);
+
+        if (broadcast) {
+            uint256 pk = vm.envUint("PRIVATE_KEY");
+            for (uint256 i; i < n; ++i) {
+                vm.broadcast(pk);
+                (bool ok,) = bridges[i].call(data);
+                require(ok, "pause call failed (caller lacks PAUSER/UNPAUSER?)");
+                console.log("  toggled", bridges[i]);
+            }
+        } else {
+            // Log the batch to submit from the PAUSER/UNPAUSER Safe (one tx per bridge, same calldata).
+            console.log("  submit this calldata to each target FROM the role-holder Safe:");
+            console.logBytes(data);
+            for (uint256 i; i < n; ++i) {
+                console.log("    target:", bridges[i]);
+            }
+        }
+    }
+}

--- a/scripts/UpgradeOFTPause.s.sol
+++ b/scripts/UpgradeOFTPause.s.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { stdJson } from "forge-std/StdJson.sol";
+import { console } from "forge-std/console.sol";
+
+import { BeaconFactory } from "../src/beacon-factory/BeaconFactory.sol";
+import { EtherFiOFTAdapter } from "../src/oft/EtherFiOFTAdapter.sol";
+import { EtherFiShadowOFT } from "../src/oft/EtherFiShadowOFT.sol";
+import { RoleRegistry } from "../src/role-registry/RoleRegistry.sol";
+
+import { Utils } from "./utils/Utils.sol";
+
+/**
+ * @title UpgradeOFTPause
+ * @author ether.fi
+ * @notice Ships pause controls (COR-923) as a beacon upgrade: deploys the new beacon implementation
+ *         for this chain's bridge ({EtherFiOFTAdapter} on mainnet, {EtherFiShadowOFT} on Optimism)
+ *         and points the factory's beacon at it, so every existing and future per-asset proxy gains
+ *         the `whenNotPaused` gate on `_debit`/`_credit` at once.
+ * @dev Run once per chain. The new impl adds only {PausableUpgradeable}'s own ERC-7201 namespaced
+ *      storage, so existing proxies keep their layout and read as UNPAUSED by default (proven by
+ *      test_beaconUpgrade_preservesPauseState). Unlike the rate-limiter upgrade this is NOT
+ *      fail-closed — bridges come up unpaused, so there is no follow-up config call needed to avoid
+ *      bricking a live bridge.
+ *
+ *      Pause CONTROL lives ON the bridge: {pauseBridge}/{unpauseBridge} are gated by the shared
+ *      RoleRegistry PAUSER/UNPAUSER roles (resolved off the config registry), with no registry in the
+ *      control path. So this beacon upgrade is the ONLY contract change — the OFTConfigRegistry is
+ *      untouched. After it, grant PAUSER/UNPAUSER to the chosen operators/Safe; "pause everything" is
+ *      a Safe batch of {pauseBridge} calls (see {PauseOFTBridges}).
+ *
+ *      upgradeBeaconImplementation is gated to the RoleRegistry owner. In the EOA bring-up the
+ *      deployer owns it and this broadcasts the upgrade directly; once handed to the protocol Safe,
+ *      this script logs the calldata to submit from the Safe instead. Run:
+ *
+ *        PRIVATE_KEY=<deployer> forge script scripts/UpgradeOFTPause.s.sol --rpc-url <mainnet|optimism> --broadcast
+ */
+contract UpgradeOFTPause is Utils {
+    /// @dev LayerZero V2 endpoint — same canonical address on Ethereum mainnet and Optimism.
+    address constant LZ_ENDPOINT = 0x1a44076050125825900e736c501f859c50fE728c;
+
+    function run() public {
+        bool isMainnet = block.chainid == 1;
+        require(isMainnet || block.chainid == 10, "run on Ethereum mainnet (1) or Optimism (10)");
+
+        uint256 pk = vm.envUint("PRIVATE_KEY");
+        address deployer = vm.addr(pk);
+
+        string memory deployments = readDeploymentFile();
+        RoleRegistry roleRegistry = RoleRegistry(stdJson.readAddress(deployments, ".addresses.OFTRoleRegistry"));
+        address configRegistry = stdJson.readAddress(deployments, ".addresses.OFTConfigRegistry");
+        string memory factoryKey = isMainnet ? ".addresses.OFTAdapterFactory" : ".addresses.ShadowOFTFactory";
+        BeaconFactory factory = BeaconFactory(stdJson.readAddress(deployments, factoryKey));
+
+        // Deploy the new beacon implementation for this chain's bridge type.
+        vm.startBroadcast(pk);
+        address newImpl = isMainnet ? address(new EtherFiOFTAdapter(LZ_ENDPOINT, configRegistry)) : address(new EtherFiShadowOFT(LZ_ENDPOINT, configRegistry));
+        vm.stopBroadcast();
+
+        console.log("OFT pause beacon upgrade on chainId", block.chainid);
+        console.log("  factory:   ", address(factory));
+        console.log("  new impl:  ", newImpl);
+        console.log("  beacon:    ", factory.beacon());
+
+        // Point the beacon at the new impl. Gated to the RoleRegistry owner.
+        if (roleRegistry.owner() == deployer) {
+            vm.broadcast(pk);
+            factory.upgradeBeaconImplementation(newImpl);
+            console.log("  upgraded beacon as RoleRegistry owner (EOA)");
+        } else {
+            console.log("  RoleRegistry owner is a Safe; submit this call FROM the Safe:");
+            console.log("    target:  ", address(factory));
+            console.logBytes(abi.encodeWithSelector(BeaconFactory.upgradeBeaconImplementation.selector, newImpl));
+        }
+
+        // Persist the new impl address (preserves all existing keys).
+        string memory implKey = isMainnet ? ".addresses.EtherFiOFTAdapterImpl" : ".addresses.EtherFiShadowOFTImpl";
+        string memory path = string.concat(vm.projectRoot(), "/deployments/", getEnv(), "/", vm.toString(block.chainid), "/deployments.json");
+        vm.writeJson(vm.toString(newImpl), path, implKey);
+
+        console.log("  NEXT: grant PAUSER/UNPAUSER to the operators/Safe. No registry upgrade needed.");
+    }
+}

--- a/src/oft/ConfigurableOFTBase.sol
+++ b/src/oft/ConfigurableOFTBase.sol
@@ -1,12 +1,22 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
+import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
+
 import { UlnConfig } from "@layerzerolabs/lz-evm-messagelib-v2/contracts/uln/UlnBase.sol";
 import { SetConfigParam } from "@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessageLibManager.sol";
 import { OFTCoreUpgradeable } from "@layerzerolabs/oft-evm-upgradeable/contracts/oft/OFTCoreUpgradeable.sol";
 
 import { IConfigurableOFT } from "../interfaces/IConfigurableOFT.sol";
 import { IOFTConfigRegistry } from "../interfaces/IOFTConfigRegistry.sol";
+import { IRoleRegistry } from "../interfaces/IRoleRegistry.sol";
+
+/// @dev Minimal view into the config registry to resolve the shared RoleRegistry that gates pause.
+///      The registry exposes `roleRegistry()` (via UpgradeableProxy); the bridge reads it rather
+///      than carrying its own RoleRegistry reference.
+interface IRoleRegistrySource {
+    function roleRegistry() external view returns (IRoleRegistry);
+}
 
 /**
  * @title ConfigurableOFTBase
@@ -23,8 +33,20 @@ import { IOFTConfigRegistry } from "../interfaces/IOFTConfigRegistry.sol";
  *
  *      Only the DVN/library config (endpoint-side) is synced here. Enforced
  *      options are owner-gated on the OApp and are set separately by the owner.
+ *
+ *      Pause: the bridge inherits {PausableUpgradeable}; children apply
+ *      {whenNotPaused} to `_debit` (send) and `_credit` (receive) so one flag halts
+ *      BOTH directions. {pauseBridge}/{unpauseBridge} live and are gated HERE on the
+ *      bridge (not routed through the registry) so the emergency control has no
+ *      control-path dependency on another mutable contract — matching the weETH OFTs
+ *      and our own {PairwiseRateLimiter}. They are gated by the shared RoleRegistry
+ *      PAUSER/UNPAUSER roles (the same roles the oracle side uses), resolved by reading
+ *      `roleRegistry()` off the immutable {configRegistry}. "Pause everything" is an
+ *      off-chain Safe batch of {pauseBridge} calls. State lives in {PausableUpgradeable}'s
+ *      own ERC-7201 slot, so an existing beacon proxy gains pause without disturbing its
+ *      layout and reads as unpaused by default.
  */
-abstract contract ConfigurableOFTBase is OFTCoreUpgradeable, IConfigurableOFT {
+abstract contract ConfigurableOFTBase is OFTCoreUpgradeable, PausableUpgradeable, IConfigurableOFT {
     /// @notice Shared config registry, fixed at impl deploy (one per chain)
     address public immutable override configRegistry;
 
@@ -39,6 +61,33 @@ abstract contract ConfigurableOFTBase is OFTCoreUpgradeable, IConfigurableOFT {
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(address _configRegistry) {
         configRegistry = _configRegistry;
+    }
+
+    /**
+     * @notice Pause this bridge — halts both send and receive. Callable by a PAUSER.
+     * @dev Gated by the shared RoleRegistry PAUSER role (resolved off {configRegistry}), not the
+     *      OApp delegate, so an incident responder can halt the bridge without the heavier config
+     *      Safe. Idempotent: a redundant pause is a no-op (OZ {_pause} would otherwise revert).
+     *      Emits {Paused} on a real transition. Inbound messages that arrive while paused revert in
+     *      {_credit} and become retryable on the endpoint — held, not lost — until {unpauseBridge}.
+     */
+    function pauseBridge() external {
+        _roleRegistry().onlyPauser(msg.sender);
+        if (!paused()) _pause();
+    }
+
+    /**
+     * @notice Unpause this bridge. Callable by an UNPAUSER (held more tightly than PAUSER).
+     * @dev Idempotent: a redundant unpause is a no-op. Emits {Unpaused} on a real transition.
+     */
+    function unpauseBridge() external {
+        _roleRegistry().onlyUnpauser(msg.sender);
+        if (paused()) _unpause();
+    }
+
+    /// @dev The shared RoleRegistry that gates pause, read off the immutable config registry.
+    function _roleRegistry() private view returns (IRoleRegistry) {
+        return IRoleRegistrySource(configRegistry).roleRegistry();
     }
 
     /**

--- a/src/oft/EtherFiOFTAdapter.sol
+++ b/src/oft/EtherFiOFTAdapter.sol
@@ -72,6 +72,7 @@ contract EtherFiOFTAdapter is ConfigurableOFTBase, PairwiseRateLimiter {
         if (_innerToken == address(0) || _delegate == address(0)) revert InvalidAddress();
         __Ownable_init(_delegate);
         __OFTCore_init(_delegate);
+        __Pausable_init();
 
         uint8 localDecimals = IERC20Metadata(_innerToken).decimals();
         if (localDecimals < sharedDecimals()) revert InvalidLocalDecimals();
@@ -134,7 +135,7 @@ contract EtherFiOFTAdapter is ConfigurableOFTBase, PairwiseRateLimiter {
      *      rather than silently under-collateralizing the shadow supply. Supporting
      *      them (bridging the post-fee amount) is a deliberate per-asset follow-up.
      */
-    function _debit(address _from, uint256 _amountLD, uint256 _minAmountLD, uint32 _dstEid) internal virtual override returns (uint256, uint256) {
+    function _debit(address _from, uint256 _amountLD, uint256 _minAmountLD, uint32 _dstEid) internal virtual override whenNotPaused returns (uint256, uint256) {
         (uint256 amountSentLD, uint256 amountReceivedLD) = _debitView(_amountLD, _minAmountLD, _dstEid);
 
         // Meter the dust-removed amount that actually leaves (and is credited on the remote).
@@ -150,17 +151,10 @@ contract EtherFiOFTAdapter is ConfigurableOFTBase, PairwiseRateLimiter {
 
     /**
      * @dev Unlock and transfer underlying tokens to the recipient on credit.
+     * @dev {whenNotPaused} halts receives when paused — the `lzReceive` reverts and the
+     *      message becomes retryable on the endpoint, so funds stay locked (not lost) until unpause.
      */
-    function _credit(
-        address _to,
-        uint256 _amountLD,
-        uint32 _srcEid
-    )
-        internal
-        virtual
-        override
-        returns (uint256)
-    {
+    function _credit(address _to, uint256 _amountLD, uint32 _srcEid) internal virtual override whenNotPaused returns (uint256) {
         _checkAndUpdateInboundRateLimit(_srcEid, _amountLD);
         IERC20(_getStorage().innerToken).safeTransfer(_to, _amountLD);
         return _amountLD;

--- a/src/oft/EtherFiShadowOFT.sol
+++ b/src/oft/EtherFiShadowOFT.sol
@@ -62,6 +62,7 @@ contract EtherFiShadowOFT is OFTUpgradeable, ConfigurableOFTBase, PairwiseRateLi
 
         __Ownable_init(_delegate);
         __OFT_init(_name, _symbol, _delegate);
+        __Pausable_init();
 
         EtherFiShadowOFTStorage storage $ = _getStorage();
         $.localDecimals = _localDecimals;
@@ -106,18 +107,21 @@ contract EtherFiShadowOFT is OFTUpgradeable, ConfigurableOFTBase, PairwiseRateLi
     }
 
     // ---------------------------------------------------------------------
-    // Rate limiting — meter both directions per peer endpoint id
+    // Pause + rate limiting — meter both directions per peer endpoint id
     // ---------------------------------------------------------------------
 
     /// @dev Meter the dust-removed sent amount before burning on the outbound path.
-    function _debit(address _from, uint256 _amountLD, uint256 _minAmountLD, uint32 _dstEid) internal virtual override(OFTCoreUpgradeable, OFTUpgradeable) returns (uint256 amountSentLD, uint256 amountReceivedLD) {
-        (amountSentLD, amountReceivedLD) = _debitView(_amountLD, _minAmountLD, _dstEid);
+    ///      {whenNotPaused} halts sends when the bridge is paused (reverts the send tx).
+    function _debit(address _from, uint256 _amountLD, uint256 _minAmountLD, uint32 _dstEid) internal virtual override(OFTCoreUpgradeable, OFTUpgradeable) whenNotPaused returns (uint256, uint256) {
+        (uint256 amountSentLD,) = _debitView(_amountLD, _minAmountLD, _dstEid);
         _checkAndUpdateOutboundRateLimit(_dstEid, amountSentLD);
         return super._debit(_from, _amountLD, _minAmountLD, _dstEid);
     }
 
     /// @dev Meter the credited amount before minting on the inbound path.
-    function _credit(address _to, uint256 _amountLD, uint32 _srcEid) internal virtual override(OFTCoreUpgradeable, OFTUpgradeable) returns (uint256 amountReceivedLD) {
+    ///      {whenNotPaused} halts receives when paused — the `lzReceive` reverts and the
+    ///      message becomes retryable on the endpoint, so funds are held (not lost) until unpause.
+    function _credit(address _to, uint256 _amountLD, uint32 _srcEid) internal virtual override(OFTCoreUpgradeable, OFTUpgradeable) whenNotPaused returns (uint256) {
         _checkAndUpdateInboundRateLimit(_srcEid, _amountLD);
         return super._credit(_to, _amountLD, _srcEid);
     }

--- a/test/oft/OFTFactoryMechanics.t.sol
+++ b/test/oft/OFTFactoryMechanics.t.sol
@@ -210,4 +210,30 @@ contract OFTFactoryMechanicsTest is OFTTestSetup {
         vm.expectRevert(BeaconFactory.InvalidInput.selector);
         adapterFactory.upgradeBeaconImplementation(address(0));
     }
+
+    // Pause state lives in PausableUpgradeable's own ERC-7201 region, so a beacon upgrade that
+    // swaps logic must leave a paused proxy paused (the upgrade must not reset the pause flag).
+    function test_beaconUpgrade_preservesPauseState() public {
+        address adapter = _deployAdapter(keccak256("pause-wbtc"), address(token8));
+        assertFalse(EtherFiOFTAdapter(adapter).paused());
+
+        // Pause the bridge directly (PAUSER-gated via the shared RoleRegistry).
+        vm.prank(pauser);
+        EtherFiOFTAdapter(adapter).pauseBridge();
+        assertTrue(EtherFiOFTAdapter(adapter).paused());
+
+        address implV2 = address(new EtherFiOFTAdapterV2(address(endpoint), address(configRegistry)));
+        vm.prank(owner); // RoleRegistry owner
+        adapterFactory.upgradeBeaconImplementation(implV2);
+
+        // V2 logic is live AND the pause flag is preserved across the upgrade.
+        (bool okAfter,) = adapter.staticcall(abi.encodeWithSignature("version()"));
+        assertTrue(okAfter, "logic did not change");
+        assertTrue(EtherFiOFTAdapter(adapter).paused(), "pause flag not preserved across upgrade");
+
+        // And it can still be unpaused after the upgrade.
+        vm.prank(unpauser);
+        EtherFiOFTAdapter(adapter).unpauseBridge();
+        assertFalse(EtherFiOFTAdapter(adapter).paused());
+    }
 }

--- a/test/oft/OFTPause.t.sol
+++ b/test/oft/OFTPause.t.sol
@@ -1,0 +1,290 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { MessagingFee } from "@layerzerolabs/oapp-evm/contracts/oapp/OAppSender.sol";
+import { OptionsBuilder } from "@layerzerolabs/oapp-evm/contracts/oapp/libs/OptionsBuilder.sol";
+import { IOFT, SendParam } from "@layerzerolabs/oft-evm/contracts/interfaces/IOFT.sol";
+import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
+import { BeaconProxy } from "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
+import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+
+import { ConfigurableOFTBase } from "../../src/oft/ConfigurableOFTBase.sol";
+import { EtherFiOFTAdapter } from "../../src/oft/EtherFiOFTAdapter.sol";
+import { EtherFiShadowOFT } from "../../src/oft/EtherFiShadowOFT.sol";
+
+import { OFTAdapterHarness } from "./EtherFiOFTAdapter.t.sol";
+import { OFTCrossChainSetup } from "./OFTCrossChainSetup.t.sol";
+import { OFTTestSetup } from "./OFTTestSetup.t.sol";
+
+/// Shadow harness exposing the internal mint/burn hooks so pause enforcement can be driven directly.
+contract ShadowPauseHarness is EtherFiShadowOFT {
+    constructor(address ep, address reg) EtherFiShadowOFT(ep, reg) { }
+
+    function exposedDebit(address from, uint256 amt, uint256 minAmt, uint32 dstEid) external returns (uint256, uint256) {
+        return _debit(from, amt, minAmt, dstEid);
+    }
+
+    function exposedCredit(address to, uint256 amt, uint32 srcEid) external returns (uint256) {
+        return _credit(to, amt, srcEid);
+    }
+}
+
+/**
+ * @title OFTPauseTest
+ * @notice Per-bridge pause: {pauseBridge}/{unpauseBridge} live ON the bridge, gated by the shared
+ *         RoleRegistry PAUSER/UNPAUSER roles (resolved off the config registry), with NO registry in
+ *         the control path. One flag halts BOTH directions ({whenNotPaused} on `_debit`/`_credit`).
+ *         Enforcement is driven via harnesses that expose the hooks; the live LZ round-trip
+ *         (including inbound retry) is in {OFTPauseE2ETest}.
+ */
+contract OFTPauseTest is OFTTestSetup {
+    function _adapterHarness(address tok) internal returns (OFTAdapterHarness h) {
+        address impl = address(new OFTAdapterHarness(address(endpoint), address(configRegistry)));
+        UpgradeableBeacon beacon = new UpgradeableBeacon(impl, owner);
+        bytes memory initData = abi.encodeWithSelector(EtherFiOFTAdapter.initialize.selector, tok, delegate);
+        h = OFTAdapterHarness(address(new BeaconProxy(address(beacon), initData)));
+        _liftRateLimits(address(h), DST_EID_OP);
+    }
+
+    function _shadowHarness() internal returns (ShadowPauseHarness h) {
+        address impl = address(new ShadowPauseHarness(address(endpoint), address(configRegistry)));
+        UpgradeableBeacon beacon = new UpgradeableBeacon(impl, owner);
+        bytes memory initData = abi.encodeWithSelector(EtherFiShadowOFT.initialize.selector, "EtherFi UND", "iUND", uint8(18), delegate);
+        h = ShadowPauseHarness(address(new BeaconProxy(address(beacon), initData)));
+        _liftRateLimits(address(h), DST_EID_OP);
+    }
+
+    // ----------------------------------------------------------------- toggle + events
+
+    function test_pauseBridge_pausesAndEmits() public {
+        ShadowPauseHarness h = _shadowHarness();
+        assertFalse(h.paused());
+
+        vm.expectEmit(true, true, true, true, address(h));
+        emit PausableUpgradeable.Paused(pauser);
+        vm.prank(pauser);
+        h.pauseBridge();
+
+        assertTrue(h.paused());
+    }
+
+    function test_unpauseBridge_unpauses() public {
+        ShadowPauseHarness h = _shadowHarness();
+        vm.prank(pauser);
+        h.pauseBridge();
+        assertTrue(h.paused());
+
+        vm.prank(unpauser);
+        h.unpauseBridge();
+        assertFalse(h.paused());
+    }
+
+    // Redundant pause/unpause is a no-op (so a Safe-batch "pause everything" can't revert on a
+    // bridge that's already individually paused).
+    function test_pauseBridge_idempotent() public {
+        ShadowPauseHarness h = _shadowHarness();
+        vm.startPrank(pauser);
+        h.pauseBridge();
+        h.pauseBridge(); // no revert
+        vm.stopPrank();
+        assertTrue(h.paused());
+
+        vm.prank(unpauser);
+        h.unpauseBridge();
+        vm.prank(unpauser);
+        h.unpauseBridge(); // no revert
+        assertFalse(h.paused());
+    }
+
+    // ----------------------------------------------------------------- role gating
+
+    function test_pauseBridge_onlyPauser() public {
+        ShadowPauseHarness h = _shadowHarness();
+        vm.prank(alice);
+        vm.expectRevert(); // RoleRegistry onlyPauser reverts for a non-pauser
+        h.pauseBridge();
+    }
+
+    function test_unpauseBridge_onlyUnpauser() public {
+        ShadowPauseHarness h = _shadowHarness();
+        vm.prank(pauser);
+        h.pauseBridge();
+
+        vm.prank(alice);
+        vm.expectRevert();
+        h.unpauseBridge();
+    }
+
+    // "Fast pause, careful unpause": the roles are distinct — a pauser cannot unpause, and vice-versa.
+    function test_pauserCannotUnpause_andUnpauserCannotPause() public {
+        ShadowPauseHarness h = _shadowHarness();
+
+        vm.prank(unpauser);
+        vm.expectRevert();
+        h.pauseBridge();
+
+        vm.prank(pauser);
+        h.pauseBridge();
+
+        vm.prank(pauser);
+        vm.expectRevert();
+        h.unpauseBridge();
+    }
+
+    // ----------------------------------------------------------------- enforcement: adapter
+
+    function test_adapter_debit_revertsWhenPaused() public {
+        OFTAdapterHarness h = _adapterHarness(address(token6));
+        token6.mint(alice, 1000e6);
+        vm.prank(alice);
+        token6.approve(address(h), 1000e6);
+
+        vm.prank(pauser);
+        h.pauseBridge();
+
+        vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
+        h.exposedDebit(alice, 1000e6, 0, DST_EID_OP);
+
+        // unpause -> the same send now succeeds
+        vm.prank(unpauser);
+        h.unpauseBridge();
+        (uint256 sent,) = h.exposedDebit(alice, 1000e6, 0, DST_EID_OP);
+        assertEq(sent, 1000e6);
+    }
+
+    function test_adapter_credit_revertsWhenPaused() public {
+        OFTAdapterHarness h = _adapterHarness(address(token6));
+        token6.mint(address(h), 500e6); // simulate a locked balance to unlock on credit
+
+        vm.prank(pauser);
+        h.pauseBridge();
+
+        vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
+        h.exposedCredit(alice, 500e6, DST_EID_OP);
+
+        vm.prank(unpauser);
+        h.unpauseBridge();
+        assertEq(h.exposedCredit(alice, 500e6, DST_EID_OP), 500e6);
+    }
+
+    // ----------------------------------------------------------------- enforcement: shadow
+
+    function test_shadow_debit_revertsWhenPaused() public {
+        ShadowPauseHarness h = _shadowHarness();
+        vm.prank(pauser);
+        h.pauseBridge();
+
+        // whenNotPaused fires before any burn, so this reverts on pause (not on missing balance).
+        vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
+        h.exposedDebit(alice, 1000e18, 0, DST_EID_OP);
+    }
+
+    function test_shadow_credit_revertsWhenPaused_thenMintsAfterUnpause() public {
+        ShadowPauseHarness h = _shadowHarness();
+        vm.prank(pauser);
+        h.pauseBridge();
+
+        vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
+        h.exposedCredit(alice, 1000e18, DST_EID_OP);
+
+        vm.prank(unpauser);
+        h.unpauseBridge();
+        assertEq(h.exposedCredit(alice, 1000e18, DST_EID_OP), 1000e18);
+        assertEq(h.balanceOf(alice), 1000e18); // minted on the inbound path
+    }
+}
+
+/**
+ * @title OFTPauseE2ETest
+ * @notice End-to-end pause over the live LZ harness: an outbound send reverts up front while paused,
+ *         and an inbound delivery blocked by pause leaves the message RETRYABLE — after unpause the
+ *         same packet delivers and the user is made whole (funds held, not lost).
+ */
+contract OFTPauseE2ETest is OFTCrossChainSetup {
+    using OptionsBuilder for bytes;
+
+    address internal pauser = makeAddr("pauser");
+    address internal unpauser = makeAddr("unpauser");
+
+    function setUp() public override {
+        super.setUp();
+        vm.startPrank(owner);
+        roleRegistry.grantRole(roleRegistry.PAUSER(), pauser);
+        roleRegistry.grantRole(roleRegistry.UNPAUSER(), unpauser);
+        vm.stopPrank();
+    }
+
+    function _send(address bridge, uint32 dstEid, address to, uint256 amt) internal view returns (MessagingFee memory fee, SendParam memory sp) {
+        bytes memory options = OptionsBuilder.newOptions().addExecutorLzReceiveOption(200_000, 0);
+        sp = SendParam(dstEid, _b32(to), amt, 0, options, "", "");
+        fee = IOFT(bridge).quoteSend(sp, false);
+    }
+
+    // Outbound: a paused source bridge reverts the user's send() before any value moves.
+    function test_e2e_outboundPause_revertsSend_thenUnpauseSucceeds() public {
+        _deployPair(18);
+        uint256 amount = 100e18;
+        underlying.mint(alice, amount);
+
+        vm.prank(pauser);
+        adapter.pauseBridge();
+
+        (MessagingFee memory fee, SendParam memory sp) = _send(address(adapter), B_EID, alice, amount);
+        vm.startPrank(alice);
+        underlying.approve(address(adapter), amount);
+        vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
+        adapter.send{ value: fee.nativeFee }(sp, fee, payable(alice));
+        vm.stopPrank();
+
+        // nothing locked, nothing minted
+        assertEq(_locked(), 0);
+        assertEq(shadow.totalSupply(), 0);
+
+        // unpause -> the normal flow goes through
+        vm.prank(unpauser);
+        adapter.unpauseBridge();
+        _bridgeOut(alice, amount);
+        assertEq(_locked(), amount);
+        assertEq(shadow.balanceOf(alice), amount);
+    }
+
+    // Inbound: bridge out, then pause the RECEIVING side before bridging back. The burn on the
+    // source still happens, but delivery on the destination reverts while paused — the packet stays
+    // retryable. After unpause, re-delivering the same packet makes the user whole.
+    function test_e2e_inboundPause_messageRetryable_afterUnpause() public {
+        _deployPair(18);
+        uint256 amount = 100e18;
+        underlying.mint(alice, amount);
+        _bridgeOut(alice, amount); // alice now holds iTOKEN on OP; `amount` locked on mainnet
+
+        // Bridge back: burn iTOKEN on OP (source), deliver unlock on mainnet adapter (receive).
+        // Pause the adapter (the receiving side) first.
+        vm.prank(pauser);
+        adapter.pauseBridge();
+
+        (MessagingFee memory fee, SendParam memory sp) = _send(address(shadow), A_EID, alice, amount);
+        vm.prank(alice);
+        shadow.send{ value: fee.nativeFee }(sp, fee, payable(alice));
+
+        // Burn happened on the source; supply dropped. Funds are mid-flight, not yet unlocked.
+        assertEq(shadow.totalSupply(), 0, "iTOKEN burned on source");
+        assertEq(underlying.balanceOf(alice), 0, "not unlocked yet");
+
+        // Delivery to the paused adapter fails — the message is held (retryable), funds not lost.
+        vm.expectRevert();
+        this.deliver(A_EID, address(adapter));
+
+        // Unpause and retry the SAME packet -> alice is made whole.
+        vm.prank(unpauser);
+        adapter.unpauseBridge();
+        this.deliver(A_EID, address(adapter));
+
+        assertEq(underlying.balanceOf(alice), amount, "user made whole after retry");
+        assertEq(_locked(), 0, "adapter unlocked");
+    }
+
+    /// @dev External wrapper so {test_e2e_inboundPause} can expectRevert on packet delivery.
+    function deliver(uint32 dstEid, address oapp) external {
+        verifyPackets(dstEid, _b32(oapp));
+    }
+}


### PR DESCRIPTION
## What

Adds an emergency **pause** to the OFT bridges (`EtherFiShadowOFT` mint/burn, `EtherFiOFTAdapter` lock/unlock). An operator can stop one bridge — or all of them — in **both directions**. Closes COR-923.

## How

- **Per-bridge, local pause.** `pauseBridge()` / `unpauseBridge()` live on the shared `ConfigurableOFTBase` mixin; `whenNotPaused` sits on **both** `_debit` (send) and `_credit` (receive), so one flag halts both directions.
- **Gated by the shared RoleRegistry PAUSER / UNPAUSER roles** — the same roles the oracle side uses. The bridge resolves them by reading `roleRegistry()` off its immutable `configRegistry` (a getter read, not a control-path dependency). Idempotent, so a "pause everything" batch can't revert on an already-paused bridge.
- **No registry in the control path.** A safety control shouldn't depend on another mutable contract to fire — this matches the weETH-cross-chain OFTs and our own `PairwiseRateLimiter`. The `OFTConfigRegistry` and interfaces are unchanged.
- **"Pause everything"** is an off-chain Safe batch of `pauseBridge()` calls (`scripts/PauseOFTBridges.s.sol`), the same pattern weETH uses.
- **Ships as a beacon upgrade** (`scripts/UpgradeOFTPause.s.sol`) — the only contract change. `PausableUpgradeable` uses its own ERC-7201 slot, so existing proxies gain pause with no layout shift and read as unpaused by default.

## Pause semantics

- **Outbound:** a paused bridge reverts the user's `send` up front.
- **Inbound:** reverts inside `lzReceive`; LayerZero keeps the message **retryable** — funds are held, not lost, and re-deliver after unpause.

## Tests

`test/oft/*` — **149 passed, 0 failed**. New coverage in `test/oft/OFTPause.t.sol`:
- toggle + `Paused` event, idempotency, PAUSER/UNPAUSER gating and role separation
- both-direction enforcement on adapter and shadow
- end-to-end over the live LZ harness: outbound revert, and inbound-pause → retryable → unpause → user made whole
- `OFTFactoryMechanics.t.sol`: pause state survives a beacon upgrade

## Notes

- Out of scope: oracle-side pause is a dormant (unenforced) capability today; left as-is. We keep the PAUSER/UNPAUSER role convention in sync.
- Operational follow-up: decide who holds PAUSER (fast incident responder) vs UNPAUSER (Safe), then grant after the beacon upgrade.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches live cross-chain bridge lock/unlock and mint/burn paths; incorrect pause behavior or upgrade layout could halt or strand user funds (mitigated by tests and default-unpaused upgrade).
> 
> **Overview**
> Adds **emergency pause** to OFT bridges (COR-923): one per-bridge flag stops **both** send (`_debit`) and receive (`_credit`) on `EtherFiOFTAdapter` and `EtherFiShadowOFT`.
> 
> `ConfigurableOFTBase` now inherits `PausableUpgradeable` and exposes **`pauseBridge` / `unpauseBridge`**, gated by RoleRegistry **PAUSER** / **UNPAUSER** (resolved via `roleRegistry()` on the immutable config registry—not through the registry as a control path). Toggles are **idempotent** so a Safe “pause everything” batch won’t revert on already-paused bridges. Initializers call `__Pausable_init()`; existing beacon proxies default to **unpaused** after upgrade.
> 
> **Operational scripts:** `UpgradeOFTPause.s.sol` deploys new beacon impls and upgrades the factory beacon (mainnet adapter / Optimism shadow); `PauseOFTBridges.s.sol` lists all registry bridges and broadcasts or logs calldata for batch pause/unpause.
> 
> **Tests:** `OFTPause.t.sol` (roles, enforcement, LZ e2e including retryable inbound while paused); `OFTFactoryMechanics.t.sol` asserts pause state survives beacon upgrade.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a8f50c9ba8666a3fc6e94f5825ae720cc3708d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->