### PR TITLE
fix(oft): address review feedback on listing primitive

### DIFF
--- a/src/oft/ConfigurableOFTBase.sol
+++ b/src/oft/ConfigurableOFTBase.sol
@@ -34,17 +34,13 @@ interface IRoleRegistrySource {
  *      Only the DVN/library config (endpoint-side) is synced here. Enforced
  *      options are owner-gated on the OApp and are set separately by the owner.
  *
- *      Pause: the bridge inherits {PausableUpgradeable}; children apply
- *      {whenNotPaused} to `_debit` (send) and `_credit` (receive) so one flag halts
- *      BOTH directions. {pauseBridge}/{unpauseBridge} live and are gated HERE on the
- *      bridge (not routed through the registry) so the emergency control has no
- *      control-path dependency on another mutable contract — matching the weETH OFTs
- *      and our own {PairwiseRateLimiter}. They are gated by the shared RoleRegistry
- *      PAUSER/UNPAUSER roles (the same roles the oracle side uses), resolved by reading
- *      `roleRegistry()` off the immutable {configRegistry}. "Pause everything" is an
- *      off-chain Safe batch of {pauseBridge} calls. State lives in {PausableUpgradeable}'s
- *      own ERC-7201 slot, so an existing beacon proxy gains pause without disturbing its
- *      layout and reads as unpaused by default.
+ *      Pause: children apply {whenNotPaused} to `_debit`/`_credit`, so one flag halts
+ *      both directions. {pauseBridge}/{unpauseBridge} live on the bridge (no `pauseAll()`
+ *      on the registry), matching the weETH OFTs and {PairwiseRateLimiter}. Callers are
+ *      gated by the RoleRegistry PAUSER/UNPAUSER roles, resolved via `roleRegistry()` off
+ *      the immutable {configRegistry}; both that registry and the RoleRegistry are
+ *      upgradeable, so pause shares cash-v3's usual trust in the RoleRegistry. State lives
+ *      in {PausableUpgradeable}'s ERC-7201 slot (unpaused by default).
  */
 abstract contract ConfigurableOFTBase is OFTCoreUpgradeable, PausableUpgradeable, IConfigurableOFT {
     /// @notice Shared config registry, fixed at impl deploy (one per chain)
@@ -101,6 +97,7 @@ abstract contract ConfigurableOFTBase is OFTCoreUpgradeable, PausableUpgradeable
      *      {ConfigSynced}; the bridge keeps no per-proxy sync state, so verify applied config by
      *      reading the endpoint rows.
      * @param dstEids Destination endpoint IDs to (re)configure
+     * @custom:throws PathwayNotFound if any dstEid is unconfigured (fails fast before {setConfig})
      */
     function syncConfig(uint32[] calldata dstEids) external override {
         address reg = configRegistry;
@@ -109,6 +106,9 @@ abstract contract ConfigurableOFTBase is OFTCoreUpgradeable, PausableUpgradeable
 
         for (uint256 i; i < dstEids.length;) {
             IOFTConfigRegistry.PathwayConfig memory c = IOFTConfigRegistry(reg).getPathwayConfig(dstEids[i]);
+            // setPathwayConfig guarantees a non-zero sendLib, so address(0) means this dstEid
+            // is unconfigured. Fail fast here with a clear error rather than deep in the ULN.
+            if (c.sendLib == address(0)) revert IOFTConfigRegistry.PathwayNotFound();
 
             UlnConfig memory uln = UlnConfig({ confirmations: c.confirmations, requiredDVNCount: uint8(c.requiredDVNs.length), optionalDVNCount: uint8(c.optionalDVNs.length), optionalDVNThreshold: c.optionalDVNThreshold, requiredDVNs: c.requiredDVNs, optionalDVNs: c.optionalDVNs });
 

--- a/src/oft/EtherFiShadowOFT.sol
+++ b/src/oft/EtherFiShadowOFT.sol
@@ -110,12 +110,13 @@ contract EtherFiShadowOFT is OFTUpgradeable, ConfigurableOFTBase, PairwiseRateLi
     // Pause + rate limiting — meter both directions per peer endpoint id
     // ---------------------------------------------------------------------
 
-    /// @dev Meter the dust-removed sent amount before burning on the outbound path.
+    /// @dev Meter the dust-removed sent amount, then burn it, on the outbound path.
     ///      {whenNotPaused} halts sends when the bridge is paused (reverts the send tx).
     function _debit(address _from, uint256 _amountLD, uint256 _minAmountLD, uint32 _dstEid) internal virtual override(OFTCoreUpgradeable, OFTUpgradeable) whenNotPaused returns (uint256, uint256) {
-        (uint256 amountSentLD,) = _debitView(_amountLD, _minAmountLD, _dstEid);
+        (uint256 amountSentLD, uint256 amountReceivedLD) = _debitView(_amountLD, _minAmountLD, _dstEid);
         _checkAndUpdateOutboundRateLimit(_dstEid, amountSentLD);
-        return super._debit(_from, _amountLD, _minAmountLD, _dstEid);
+        _burn(_from, amountSentLD);
+        return (amountSentLD, amountReceivedLD);
     }
 
     /// @dev Meter the credited amount before minting on the inbound path.

--- a/test/oft/OFTConfigRegistrySync.t.sol
+++ b/test/oft/OFTConfigRegistrySync.t.sol
@@ -114,12 +114,12 @@ contract OFTConfigRegistrySyncTest is OFTCrossChainSetup {
         adapter.syncConfig(eids);
     }
 
-    // Syncing an unconfigured destination resolves to an empty pathway (zero send lib); the real
-    // endpoint rejects setConfig against the zero library, so no insecure no-DVN config is applied.
+    // An unconfigured destination resolves to an empty pathway (zero send lib); syncConfig fails
+    // fast with PathwayNotFound before touching the endpoint, rather than reverting deep in the ULN.
     function test_syncConfig_reverts_onUnconfiguredEid() public {
         uint32[] memory eids = new uint32[](1);
         eids[0] = UNCONFIGURED_EID;
-        vm.expectRevert();
+        vm.expectRevert(IOFTConfigRegistry.PathwayNotFound.selector);
         _push(_adapterTarget(), eids);
     }
 


### PR DESCRIPTION
Follow-up fixes from PR review of the Ethereum→Optimism asset-listing primitive (#133). Targets the listing branch so it lands as part of that PR.

## Changes

**1. `syncConfig` fails fast on an unconfigured pathway** (`ConfigurableOFTBase`)
An unset/removed `dstEid` resolves to an empty pathway (zero `sendLib`), which previously produced `endpoint.setConfig(.., address(0), ..)` — an obscure revert deep in the LayerZero ULN that aborts the whole `pushToAll` batch. Now guarded: `setPathwayConfig` guarantees a non-zero `sendLib`, so `address(0)` means unconfigured and we `revert PathwayNotFound()` cheaply before touching the endpoint. Reuses the registry's existing error selector. Existing test tightened from `expectRevert()` to the specific selector.

**2. `EtherFiShadowOFT._debit` computes `_debitView` once** (gas)
The outbound path called `_debitView` for metering and then again inside `super._debit`, doubling the per-proxy `decimalConversionRate` SLOAD on every send. The burn is now inlined so `_debitView` runs once, matching how `EtherFiOFTAdapter._debit` inlines its lock path.

**3. Corrected pause NatSpec** (`ConfigurableOFTBase`)
The doc claimed the emergency pause had "no control-path dependency on another mutable contract." In fact authorization resolves through the (upgradeable) config registry to the (upgradeable) RoleRegistry. Reworded to state the pause shares cash-v3's usual RoleRegistry trust; the immutable `configRegistry` only fixes the address, not the code behind it. Comment-only.

## Testing
`forge test --match-path "test/oft/*"` — 149 passed, including the `locked == minted` conservation invariant and decimal/rate-limit fuzz suites.

## Note (out of scope, separate area)
The oracle side (`OracleSink.price()`) has a fail-open staleness check — `maxStaleness == 0` skips the check, opposite to the rest of cash-v3 where zero blocks. Flagged to the oracle owner separately; not touched here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches outbound bridge debits and LayerZero config sync; behavior is tighter (clear reverts, same burn semantics) with limited blast radius to OFT listing paths.
> 
> **Overview**
> **`syncConfig`** now reverts with **`PathwayNotFound`** when a destination has no pathway (`sendLib == address(0)`), instead of calling the endpoint with a zero library and failing deep in the ULN—so bulk pushes like **`pushToAll`** fail clearly on the first bad EID. NatSpec documents the new throw; the sync test expects that selector.
> 
> **`EtherFiShadowOFT._debit`** calls **`_debitView`** once, rate-limits on **`amountSentLD`**, then **`_burn`**s inline (aligned with **`EtherFiOFTAdapter`**), avoiding a second **`_debitView`** / **`decimalConversionRate`** SLOAD via **`super._debit`**.
> 
> Pause NatSpec in **`ConfigurableOFTBase`** is corrected: emergency pause still goes through the upgradeable config registry and **RoleRegistry**, not a fully isolated control path—comment-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 074b8f0f8ab150b453897099ce9d392fc523238c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->