### PR TITLE
feat(COR-1007): LINK dev listing scripts

### DIFF
--- a/scripts/AddLinkSupportOptimism.s.sol
+++ b/scripts/AddLinkSupportOptimism.s.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { stdJson } from "forge-std/StdJson.sol";
+import { console } from "forge-std/console.sol";
+
+import { ICashModule } from "../src/interfaces/ICashModule.sol";
+import { IDebtManager } from "../src/interfaces/IDebtManager.sol";
+import { PriceProviderV2 } from "../src/oracle/PriceProviderV2.sol";
+import { Utils } from "./utils/Utils.sol";
+
+/**
+ * @title AddLinkSupportOptimism
+ * @author ether.fi
+ * @notice Makes bridged LINK (iLINK) usable as a Cash asset on Optimism dev so a user can
+ *         HOLD, SPEND and BORROW against it. Three dev-owner calls:
+ *           1. PriceProviderV2.setTokenConfig  - price iLINK from the cross-chain OracleSink.
+ *           2. DebtManager.supportCollateralToken - enable borrowing against iLINK (collateral only).
+ *           3. CashModule.configureWithdrawAssets - whitelist iLINK for hold/spend.
+ * @dev The OracleSink returns a 6-decimal USD price and is keyed by the MAINNET LINK address (the
+ *      relay ships mainnet token addresses), so the oracle calldata is price(LINK_MAINNET) even
+ *      though the Cash token key is iLINK. The broadcaster must hold PRICE_PROVIDER_ADMIN_ROLE,
+ *      DEBT_MANAGER_ADMIN_ROLE and CASH_MODULE_CONTROLLER_ROLE (held by the dev owner from setup).
+ *      Idempotent. Run on Optimism:
+ *
+ *        ENV=dev forge script scripts/AddLinkSupportOptimism.s.sol \
+ *          --rpc-url $OPTIMISM_RPC --account dev-owner --sender <dev-owner-address> --broadcast
+ */
+contract AddLinkSupportOptimism is Utils {
+    /// @notice Native LINK on Ethereum mainnet. Used ONLY as the OracleSink price key.
+    address constant LINK_MAINNET = 0x514910771AF9Ca656af840dff83E8264EcF986CA;
+
+    /// @notice iLINK shadow OFT on Optimism dev (the token Cash users hold). The Cash token key.
+    address constant ILINK_OPTIMISM = 0x0C9446D6A4Fb3a9eA0a8Bc85A4Cb6646e424d36f;
+
+    /// @notice OracleSink on Optimism dev (relayed LINK USD price, 6 decimals). Deployed in the
+    ///         cash-mainnet-asset-listing repo, so pinned here as a dev constant.
+    address constant ORACLE_SINK = 0x83Ba7f354B705C34935437526Cf318c77d9093Aa;
+
+    // DECISION (oracle freshness): max age of a relayed LINK price the PriceProvider will accept.
+    // Measures relay delivery on this chain (keeper poke cadence), not the Chainlink heartbeat.
+    uint24 constant PRICE_MAX_STALENESS = 2 days;
+
+    // DECISION (risk params): LINK collateral terms, 18-decimal ratios. Dev defaults; confirm with
+    // risk before production. ltv < liquidationThreshold.
+    uint80 constant LTV = 50e18; // 50%
+    uint80 constant LIQUIDATION_THRESHOLD = 80e18; // 80%
+    uint96 constant LIQUIDATION_BONUS = 1e18; // 1%
+
+    function run() public {
+        require(block.chainid == 10, "run on Optimism (chainId 10)");
+        // The hardcoded constants are dev iLINK/OracleSink addresses, and the env-read contracts
+        // below must resolve to the dev deployment. getEnv() defaults to "mainnet", and chainId
+        // alone cannot tell dev from prod (both live on chain 10), so fail loudly unless ENV=dev.
+        require(isEqualString(getEnv(), "dev"), "dev only");
+
+        string memory deployments = readDeploymentFile();
+        PriceProviderV2 priceProvider = PriceProviderV2(stdJson.readAddress(deployments, ".addresses.PriceProvider"));
+        IDebtManager debtManager = IDebtManager(stdJson.readAddress(deployments, ".addresses.DebtManager"));
+        ICashModule cashModule = ICashModule(stdJson.readAddress(deployments, ".addresses.CashModule"));
+
+        // 1. Price iLINK from the cross-chain OracleSink (price(LINK_MAINNET) -> 6-decimal USD).
+        address[] memory tokens = new address[](1);
+        tokens[0] = ILINK_OPTIMISM;
+        PriceProviderV2.Config[] memory configs = new PriceProviderV2.Config[](1);
+        // baseAsset address(0): the OracleSink returns USD directly (6 decimals), so no base-asset conversion.
+        configs[0] = PriceProviderV2.Config({ oracle: ORACLE_SINK, priceFunctionCalldata: abi.encodeWithSignature("price(address)", LINK_MAINNET), isChainlinkType: false, oraclePriceDecimals: 6, maxStaleness: PRICE_MAX_STALENESS, dataType: PriceProviderV2.ReturnType.Uint256, isStableToken: false, baseAsset: address(0) });
+
+        // 2. Enable borrowing against iLINK (collateral only; not a borrow token).
+        IDebtManager.CollateralTokenConfig memory collateralConfig = IDebtManager.CollateralTokenConfig({ ltv: LTV, liquidationThreshold: LIQUIDATION_THRESHOLD, liquidationBonus: LIQUIDATION_BONUS });
+
+        // 3. Whitelist iLINK so it can be held + spent.
+        address[] memory withdrawAssets = new address[](1);
+        withdrawAssets[0] = ILINK_OPTIMISM;
+        bool[] memory whitelist = new bool[](1);
+        whitelist[0] = true;
+
+        // Signer comes from the CLI (--account keystore, --ledger, etc.), never an env var or arg.
+        vm.startBroadcast();
+        priceProvider.setTokenConfig(tokens, configs);
+        if (!debtManager.isCollateralToken(ILINK_OPTIMISM)) debtManager.supportCollateralToken(ILINK_OPTIMISM, collateralConfig);
+        cashModule.configureWithdrawAssets(withdrawAssets, whitelist);
+        vm.stopBroadcast();
+
+        console.log("Configured iLINK as a Cash asset on Optimism dev (chainId", block.chainid, ")");
+        console.log("  iLINK:        ", ILINK_OPTIMISM);
+        console.log("  PriceProvider:", address(priceProvider));
+        console.log("  DebtManager:  ", address(debtManager));
+        console.log("  CashModule:   ", address(cashModule));
+
+        // Best-effort read-back. Reverts if the relay has not delivered a fresh price yet (a
+        // keeper/poke issue, not a config error), so do not fail the run on it.
+        try priceProvider.price(ILINK_OPTIMISM) returns (uint256 p) {
+            console.log("  price(iLINK) USD-6:", p);
+        } catch {
+            console.log("  price(iLINK): reverted (relay price stale/undelivered - poke the keeper)");
+        }
+    }
+}

--- a/scripts/AddLinkTopUpEthereum.s.sol
+++ b/scripts/AddLinkTopUpEthereum.s.sol
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { stdJson } from "forge-std/StdJson.sol";
+import { console } from "forge-std/console.sol";
+
+import { TopUpFactory } from "../src/top-up/TopUpFactory.sol";
+import { Utils } from "./utils/Utils.sol";
+
+/**
+ * @title AddLinkTopUpEthereum
+ * @author ether.fi
+ * @notice Registers LINK for top-up bridging from Ethereum to Optimism (the Cash chain)
+ *         via etherfi's OFT adapter, so the top-up relayer can bridge a user's mainnet LINK deposit
+ *         into iLINK on Optimism. Mirrors the weETH `oftBridgeAdapter` top-up config.
+ * @dev `TopUpFactory.setTokenConfig` routes a deposited token through a bridge adapter to a recipient
+ *      on the destination chain. For LINK the adapter is the EtherFiOFTBridgeAdapter, whose
+ *      `additionalData` is `abi.encode(address oftAdapter, uint32 destEid)`. `setTokenConfig` is
+ *      `onlyRoleRegistryOwner`, so the broadcaster must be the dev RoleRegistry owner. Idempotent.
+ *      Run on Ethereum mainnet:
+ *
+ *        ENV=dev forge script scripts/AddLinkTopUpEthereum.s.sol \
+ *          --rpc-url $MAINNET_RPC --account dev-owner --sender <dev-owner-address> --broadcast
+ */
+contract AddLinkTopUpEthereum is Utils {
+    /// @notice Native LINK on Ethereum mainnet (the deposited token users top up with).
+    address constant LINK_MAINNET = 0x514910771AF9Ca656af840dff83E8264EcF986CA;
+
+    /// @notice etherfi LINK OFT adapter on Ethereum dev (lock-on-deposit). Locks LINK and sends the
+    ///         LayerZero message that mints iLINK on Optimism.
+    address constant LINK_OFT_ADAPTER = 0xd7a747f337fFC340d536Eda4da318bDA7De9eaaa;
+
+    /// @notice TopUpDest on Optimism dev (receives bridged iLINK and credits user safes).
+    address constant TOP_UP_DEST_OPTIMISM = 0x06fe42Cf3C63412f1955758ce2798709476a38fd;
+
+    /// @notice Cash chain (Optimism) destination.
+    uint256 constant OPTIMISM_CHAIN_ID = 10;
+    uint32 constant OPTIMISM_EID = 30_111;
+
+    // DECISION (top-up slippage): max slippage the OFT bridge will tolerate, in bps. Matches the
+    // weETH oftBridgeAdapter config. TopUpFactory caps this at 200 bps.
+    uint96 constant MAX_SLIPPAGE_BPS = 50; // 0.5%
+
+    function run() public {
+        require(block.chainid == 1, "run on Ethereum (chainId 1)");
+        // The hardcoded constants are dev OFT/TopUpDest addresses, and the env-read TopUpFactory
+        // below must resolve to the dev deployment. getEnv() defaults to "mainnet", and chainId
+        // alone cannot tell dev from prod (both live on chain 1), so fail loudly unless ENV=dev.
+        require(isEqualString(getEnv(), "dev"), "dev only");
+
+        string memory deployments = readTopUpSourceDeployment();
+        TopUpFactory topUpFactory = TopUpFactory(payable(stdJson.readAddress(deployments, ".addresses.TopUpSourceFactory")));
+        address oftBridgeAdapter = stdJson.readAddress(deployments, ".addresses.EtherFiOFTBridgeAdapter");
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = LINK_MAINNET;
+        uint256[] memory chainIds = new uint256[](1);
+        chainIds[0] = OPTIMISM_CHAIN_ID;
+        TopUpFactory.TokenConfig[] memory configs = new TopUpFactory.TokenConfig[](1);
+        configs[0] = TopUpFactory.TokenConfig({ bridgeAdapter: oftBridgeAdapter, recipientOnDestChain: TOP_UP_DEST_OPTIMISM, maxSlippageInBps: MAX_SLIPPAGE_BPS, additionalData: abi.encode(LINK_OFT_ADAPTER, OPTIMISM_EID) });
+
+        // Signer comes from the CLI (--account keystore, --ledger, etc.), never an env var or arg.
+        vm.startBroadcast();
+        topUpFactory.setTokenConfig(tokens, chainIds, configs);
+        vm.stopBroadcast();
+
+        console.log("Registered LINK top-up (Ethereum -> Optimism) on TopUpFactory");
+        console.log("  TopUpFactory:           ", address(topUpFactory));
+        console.log("  LINK (mainnet):         ", LINK_MAINNET);
+        console.log("  OFT adapter:            ", LINK_OFT_ADAPTER);
+        console.log("  recipient (OP TopUpDest):", TOP_UP_DEST_OPTIMISM);
+        console.log("  dest chainId / EID:     ", OPTIMISM_CHAIN_ID, OPTIMISM_EID);
+    }
+}


### PR DESCRIPTION
Linear: [COR-1007](https://linear.app/ether-fi/issue/COR-1007/list-link-on-dev-cash-febesc)

Two dev-owner forge scripts that list LINK on Cash as the first fast-track ETH -> OP asset:

- `AddLinkSupportOptimism`: prices iLINK off the cross-chain OracleSink, adds it as collateral, whitelists it for hold/spend on Optimism.
- `AddLinkTopUpEthereum`: registers the mainnet -> OP top-up route through the OFT bridge adapter.

Both are `ENV=dev` guarded.

**Don't merge.** LINK is just the test vehicle for the fast-track flow, so these per-asset dev scripts shouldn't land on master. The repeatable version is the `list-fast-track-asset` runbook (etherfi-claude).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 95b25846b9a6aadb7dadaa145187781b971a6fe3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->