### PR TITLE
feat(ramp-volume): RampVolumeEmitter on-chain event for Dune (PAY-234)

### DIFF
--- a/scripts/DeployRampVolumeEmitter.s.sol
+++ b/scripts/DeployRampVolumeEmitter.s.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { stdJson } from "forge-std/StdJson.sol";
+import { console2 } from "forge-std/console2.sol";
+
+import { UUPSProxy } from "../src/UUPSProxy.sol";
+import { RampVolumeEmitter } from "../src/ramp-volume/RampVolumeEmitter.sol";
+import { RoleRegistry } from "../src/role-registry/RoleRegistry.sol";
+import { Utils, ChainConfig } from "./utils/Utils.sol";
+
+/**
+ * @notice Deploys RampVolumeEmitter behind a UUPS proxy and grants the backend relayer
+ *         RAMP_VOLUME_EMITTER_ROLE.
+ * @dev grantRole must be sent by the RoleRegistry owner. On networks where the owner is a
+ *      multisig/governance (prod), drop the grantRole line and grant via scripts/gnosis-txs/.
+ *      Env: PRIVATE_KEY (deployer), RAMP_VOLUME_RELAYER (relayer to authorize), plus ENV +
+ *      chain so readDeploymentFile() resolves the RoleRegistry address.
+ */
+contract DeployRampVolumeEmitter is Utils {
+    function run() public {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        address relayer = vm.envAddress("RAMP_VOLUME_RELAYER");
+
+        string memory deployments = readDeploymentFile();
+        address roleRegistry = stdJson.readAddress(deployments, string.concat(".", "addresses", ".", "RoleRegistry"));
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        bytes memory initData = abi.encodeWithSelector(RampVolumeEmitter.initialize.selector, roleRegistry);
+        address impl = address(new RampVolumeEmitter());
+        address proxy = address(new UUPSProxy(impl, initData));
+
+        RoleRegistry(roleRegistry).grantRole(RampVolumeEmitter(proxy).RAMP_VOLUME_EMITTER_ROLE(), relayer);
+
+        vm.stopBroadcast();
+
+        console2.log("RampVolumeEmitter impl :", impl);
+        console2.log("RampVolumeEmitter proxy:", proxy);
+        console2.log("Relayer granted RAMP_VOLUME_EMITTER_ROLE:", relayer);
+    }
+}

--- a/scripts/DeployRampVolumeEmitter.s.sol
+++ b/scripts/DeployRampVolumeEmitter.s.sol
@@ -7,7 +7,7 @@ import { console2 } from "forge-std/console2.sol";
 import { UUPSProxy } from "../src/UUPSProxy.sol";
 import { RampVolumeEmitter } from "../src/ramp-volume/RampVolumeEmitter.sol";
 import { RoleRegistry } from "../src/role-registry/RoleRegistry.sol";
-import { Utils, ChainConfig } from "./utils/Utils.sol";
+import { ChainConfig, Utils } from "./utils/Utils.sol";
 
 /**
  * @notice Deploys RampVolumeEmitter behind a UUPS proxy and grants the backend relayer

--- a/src/interfaces/IRampVolumeEmitter.sol
+++ b/src/interfaces/IRampVolumeEmitter.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/**
+ * @title IRampVolumeEmitter
+ * @notice Interface for the RampVolumeEmitter contract that emits aggregated
+ *         ether.fi Cash on/off-ramp volumes for off-chain indexing (e.g. Dune).
+ */
+interface IRampVolumeEmitter {
+    /**
+     * @notice A single day-to-date volume datapoint for one (label, token, day) bucket.
+     * @param label Ramp direction as a bytes32 string: bytes32("onramp") | bytes32("offramp").
+     * @param token Token as a bytes32 string: bytes32("USDC") | bytes32("EURC").
+     * @param dayTimestamp UTC-midnight (00:00:00Z) of the attributed day.
+     * @param value Day-to-date cumulative volume, 6-decimals USD.
+     */
+    struct RampVolumeData {
+        bytes32 label;
+        bytes32 token;
+        uint64 dayTimestamp;
+        uint256 value;
+    }
+
+    /**
+     * @notice Emitted for each (label, token, day) bucket pushed on-chain.
+     * @dev Intraday-cumulative: the latest event per (label, token, dayTimestamp) — ordered
+     *      by asOf, then log index — is that day's current total. value is NOT monotonic
+     *      (refunds can shrink it). Restatement re-emits a past dayTimestamp.
+     * @param label Indexed ramp direction (bytes32 string).
+     * @param token Indexed token (bytes32 string).
+     * @param dayTimestamp Indexed UTC-midnight of the attributed day.
+     * @param value Day-to-date cumulative volume, 6-decimals USD.
+     * @param asOf Emission time (block timestamp) for latest-wins ordering.
+     */
+    event RampVolume(bytes32 indexed label, bytes32 indexed token, uint64 indexed dayTimestamp, uint256 value, uint64 asOf);
+
+    /// @notice Emit a single day-to-date volume datapoint.
+    function emitRampVolume(bytes32 label, bytes32 token, uint64 dayTimestamp, uint256 value) external;
+
+    /// @notice Emit all changed (label, token, day) buckets for an hourly run in one tx.
+    function emitRampVolumes(RampVolumeData[] calldata items) external;
+}

--- a/src/ramp-volume/RampVolumeEmitter.sol
+++ b/src/ramp-volume/RampVolumeEmitter.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { UpgradeableProxy } from "../utils/UpgradeableProxy.sol";
+import { IRampVolumeEmitter } from "../interfaces/IRampVolumeEmitter.sol";
+
+/**
+ * @title RampVolumeEmitter
+ * @author ether.fi
+ * @notice Emits aggregated ether.fi Cash on/off-ramp volumes for off-chain indexing (Dune).
+ * @dev Stateless w.r.t. volume: stores no totals and enforces no monotonicity. Volumes are
+ *      day-attributed and intraday-cumulative; "latest event per (label, token, dayTimestamp)
+ *      wins" is a consumer concern. Emission is restricted to RAMP_VOLUME_EMITTER_ROLE
+ *      (the backend relayer). Follows the CashEventEmitter / SettlementDispatcherV2 pattern.
+ */
+contract RampVolumeEmitter is UpgradeableProxy, IRampVolumeEmitter {
+    /// @notice Role authorized to emit RampVolume events (granted to the backend relayer).
+    bytes32 public constant RAMP_VOLUME_EMITTER_ROLE = keccak256("RAMP_VOLUME_EMITTER_ROLE");
+
+    constructor() {
+        _disableInitializers();
+    }
+
+    /**
+     * @notice Initializes the proxy with the role registry.
+     * @param _roleRegistry Address of the role registry contract.
+     */
+    function initialize(address _roleRegistry) external initializer {
+        __UpgradeableProxy_init(_roleRegistry);
+    }
+
+    /// @inheritdoc IRampVolumeEmitter
+    function emitRampVolume(bytes32 label, bytes32 token, uint64 dayTimestamp, uint256 value) external onlyRole(RAMP_VOLUME_EMITTER_ROLE) {
+        emit RampVolume(label, token, dayTimestamp, value, uint64(block.timestamp));
+    }
+
+    /// @inheritdoc IRampVolumeEmitter
+    function emitRampVolumes(RampVolumeData[] calldata items) external onlyRole(RAMP_VOLUME_EMITTER_ROLE) {
+        uint64 asOf = uint64(block.timestamp);
+        uint256 len = items.length;
+        for (uint256 i = 0; i < len;) {
+            RampVolumeData calldata item = items[i];
+            emit RampVolume(item.label, item.token, item.dayTimestamp, item.value, asOf);
+            unchecked {
+                ++i;
+            }
+        }
+    }
+}

--- a/src/ramp-volume/RampVolumeEmitter.sol
+++ b/src/ramp-volume/RampVolumeEmitter.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-import { UpgradeableProxy } from "../utils/UpgradeableProxy.sol";
 import { IRampVolumeEmitter } from "../interfaces/IRampVolumeEmitter.sol";
+import { UpgradeableProxy } from "../utils/UpgradeableProxy.sol";
 
 /**
  * @title RampVolumeEmitter

--- a/test/ramp-volume/RampVolumeEmitter.t.sol
+++ b/test/ramp-volume/RampVolumeEmitter.t.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.8.28;
 import { Test, Vm } from "forge-std/Test.sol";
 
 import { UUPSProxy } from "../../src/UUPSProxy.sol";
-import { RampVolumeEmitter } from "../../src/ramp-volume/RampVolumeEmitter.sol";
 import { IRampVolumeEmitter } from "../../src/interfaces/IRampVolumeEmitter.sol";
+import { RampVolumeEmitter } from "../../src/ramp-volume/RampVolumeEmitter.sol";
 import { RoleRegistry } from "../../src/role-registry/RoleRegistry.sol";
 
 contract RampVolumeEmitterTest is Test {
@@ -22,8 +22,8 @@ contract RampVolumeEmitterTest is Test {
     bytes32 internal constant USDC = bytes32("USDC");
     bytes32 internal constant EURC = bytes32("EURC");
 
-    uint64 internal constant DAY = 1781481600; // 2026-06-15 00:00:00 UTC
-    uint64 internal constant NOW = 1781500000; // some emission time during that day
+    uint64 internal constant DAY = 1_781_481_600; // 2026-06-15 00:00:00 UTC
+    uint64 internal constant NOW = 1_781_500_000; // some emission time during that day
 
     // Mirror of the contract event for vm.expectEmit.
     event RampVolume(bytes32 indexed label, bytes32 indexed token, uint64 indexed dayTimestamp, uint256 value, uint64 asOf);
@@ -48,10 +48,10 @@ contract RampVolumeEmitterTest is Test {
 
     function test_emitRampVolume_byRelayer_emitsEvent() public {
         vm.expectEmit(true, true, true, true, address(emitter));
-        emit RampVolume(ONRAMP, USDC, DAY, 12_345_670000, NOW);
+        emit RampVolume(ONRAMP, USDC, DAY, 12_345_670_000, NOW);
 
         vm.prank(relayer);
-        emitter.emitRampVolume(ONRAMP, USDC, DAY, 12_345_670000);
+        emitter.emitRampVolume(ONRAMP, USDC, DAY, 12_345_670_000);
     }
 
     function test_emitRampVolume_revertsForNonRole() public {

--- a/test/ramp-volume/RampVolumeEmitter.t.sol
+++ b/test/ramp-volume/RampVolumeEmitter.t.sol
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { Test, Vm } from "forge-std/Test.sol";
+
+import { UUPSProxy } from "../../src/UUPSProxy.sol";
+import { RampVolumeEmitter } from "../../src/ramp-volume/RampVolumeEmitter.sol";
+import { IRampVolumeEmitter } from "../../src/interfaces/IRampVolumeEmitter.sol";
+import { RoleRegistry } from "../../src/role-registry/RoleRegistry.sol";
+
+contract RampVolumeEmitterTest is Test {
+    RampVolumeEmitter public emitter;
+    RoleRegistry public roleRegistry;
+
+    address public owner = makeAddr("owner");
+    address public relayer = makeAddr("relayer");
+    address public stranger = makeAddr("stranger");
+    address public dataProviderMock = makeAddr("dataProvider");
+
+    bytes32 internal constant ONRAMP = bytes32("onramp");
+    bytes32 internal constant OFFRAMP = bytes32("offramp");
+    bytes32 internal constant USDC = bytes32("USDC");
+    bytes32 internal constant EURC = bytes32("EURC");
+
+    uint64 internal constant DAY = 1781481600; // 2026-06-15 00:00:00 UTC
+    uint64 internal constant NOW = 1781500000; // some emission time during that day
+
+    // Mirror of the contract event for vm.expectEmit.
+    event RampVolume(bytes32 indexed label, bytes32 indexed token, uint64 indexed dayTimestamp, uint256 value, uint64 asOf);
+
+    function setUp() public {
+        vm.warp(NOW);
+        vm.startPrank(owner);
+
+        address rrImpl = address(new RoleRegistry(dataProviderMock));
+        roleRegistry = RoleRegistry(address(new UUPSProxy(rrImpl, abi.encodeWithSelector(RoleRegistry.initialize.selector, owner))));
+
+        address emitterImpl = address(new RampVolumeEmitter());
+        emitter = RampVolumeEmitter(address(new UUPSProxy(emitterImpl, abi.encodeWithSelector(RampVolumeEmitter.initialize.selector, address(roleRegistry)))));
+
+        roleRegistry.grantRole(emitter.RAMP_VOLUME_EMITTER_ROLE(), relayer);
+        vm.stopPrank();
+    }
+
+    function test_roleConstant_matchesKeccak() public view {
+        assertEq(emitter.RAMP_VOLUME_EMITTER_ROLE(), keccak256("RAMP_VOLUME_EMITTER_ROLE"));
+    }
+
+    function test_emitRampVolume_byRelayer_emitsEvent() public {
+        vm.expectEmit(true, true, true, true, address(emitter));
+        emit RampVolume(ONRAMP, USDC, DAY, 12_345_670000, NOW);
+
+        vm.prank(relayer);
+        emitter.emitRampVolume(ONRAMP, USDC, DAY, 12_345_670000);
+    }
+
+    function test_emitRampVolume_revertsForNonRole() public {
+        vm.expectRevert(abi.encodeWithSignature("Unauthorized()"));
+        vm.prank(stranger);
+        emitter.emitRampVolume(ONRAMP, USDC, DAY, 1);
+    }
+
+    function test_emitRampVolumes_batch_emitsAllEventsWithSharedAsOf() public {
+        IRampVolumeEmitter.RampVolumeData[] memory items = new IRampVolumeEmitter.RampVolumeData[](3);
+        items[0] = IRampVolumeEmitter.RampVolumeData(ONRAMP, USDC, DAY, 100e6);
+        items[1] = IRampVolumeEmitter.RampVolumeData(OFFRAMP, USDC, DAY, 50e6);
+        items[2] = IRampVolumeEmitter.RampVolumeData(ONRAMP, EURC, DAY, 25e6);
+
+        vm.expectEmit(true, true, true, true, address(emitter));
+        emit RampVolume(ONRAMP, USDC, DAY, 100e6, NOW);
+        vm.expectEmit(true, true, true, true, address(emitter));
+        emit RampVolume(OFFRAMP, USDC, DAY, 50e6, NOW);
+        vm.expectEmit(true, true, true, true, address(emitter));
+        emit RampVolume(ONRAMP, EURC, DAY, 25e6, NOW);
+
+        vm.prank(relayer);
+        emitter.emitRampVolumes(items);
+    }
+
+    function test_emitRampVolumes_revertsForNonRole() public {
+        IRampVolumeEmitter.RampVolumeData[] memory items = new IRampVolumeEmitter.RampVolumeData[](1);
+        items[0] = IRampVolumeEmitter.RampVolumeData(ONRAMP, USDC, DAY, 1);
+
+        vm.expectRevert(abi.encodeWithSignature("Unauthorized()"));
+        vm.prank(stranger);
+        emitter.emitRampVolumes(items);
+    }
+
+    function test_emitRampVolumes_emptyArray_noEmitNoRevert() public {
+        IRampVolumeEmitter.RampVolumeData[] memory items = new IRampVolumeEmitter.RampVolumeData[](0);
+
+        vm.recordLogs();
+        vm.prank(relayer);
+        emitter.emitRampVolumes(items);
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(logs.length, 0);
+    }
+
+    function test_restatement_reemitOlderDayWithNewValue() public {
+        // Day already pushed earlier with one value...
+        vm.prank(relayer);
+        emitter.emitRampVolume(ONRAMP, USDC, DAY, 100e6);
+
+        // ...later (next run) the same day is restated with a higher value. The contract is
+        // stateless, so the re-emission just emits again — latest-wins is the consumer's job.
+        vm.warp(NOW + 3600);
+        vm.expectEmit(true, true, true, true, address(emitter));
+        emit RampVolume(ONRAMP, USDC, DAY, 150e6, NOW + 3600);
+
+        vm.prank(relayer);
+        emitter.emitRampVolume(ONRAMP, USDC, DAY, 150e6);
+    }
+
+    function test_refundShrink_valueCanDecrease() public {
+        vm.prank(relayer);
+        emitter.emitRampVolume(ONRAMP, USDC, DAY, 100e6);
+
+        // A refund shrinks the day-to-date total; non-monotonic is allowed (no revert).
+        vm.warp(NOW + 3600);
+        vm.expectEmit(true, true, true, true, address(emitter));
+        emit RampVolume(ONRAMP, USDC, DAY, 80e6, NOW + 3600);
+
+        vm.prank(relayer);
+        emitter.emitRampVolume(ONRAMP, USDC, DAY, 80e6);
+    }
+
+    function test_initialize_revertsOnSecondCall() public {
+        vm.expectRevert(abi.encodeWithSignature("InvalidInitialization()"));
+        emitter.initialize(address(roleRegistry));
+    }
+}


### PR DESCRIPTION
## Summary

Adds `RampVolumeEmitter` — a minimal contract that emits aggregated ether.fi Cash on/off-ramp volumes on-chain so Dune (henrystats) can chart them. Part of [PAY-234](https://linear.app/ether-fi/issue/PAY-234).

- `src/interfaces/IRampVolumeEmitter.sol` — `RampVolume` event + `RampVolumeData` struct + fn sigs
- `src/ramp-volume/RampVolumeEmitter.sol` — `UpgradeableProxy` (UUPS + `RoleRegistry`); single + batch emit gated to `RAMP_VOLUME_EMITTER_ROLE`; **stateless** (no on-chain totals, no monotonicity). Follows the `CashEventEmitter` / `SettlementDispatcherV2` precedent.
- `test/ramp-volume/RampVolumeEmitter.t.sol` — 9 tests
- `scripts/DeployRampVolumeEmitter.s.sol` — deploy proxy + grant the role to the relayer

## Design notes

- **Event semantics** (consumer-side): day-attributed, intraday-cumulative — the latest event per `(label, token, dayTimestamp)`, ordered by `asOf`, is that day's total. Value is **not monotonic** (refunds shrink it); restatement re-emits a past `dayTimestamp`. All of this lives in the consumer; the contract just emits.
- **Access control:** emission restricted to `RAMP_VOLUME_EMITTER_ROLE`, granted to the backend relayer via `RoleRegistry` (rather than a standalone Ownable, to match repo conventions).
- **`asOf`** is set on-chain from `block.timestamp` (the relayer does not pass it).
- **Batch entrypoint** `emitRampVolumes` lets the hourly job push all changed buckets in one tx.
- **Event shape signed off by henrystats (2026-06-16).**

## Test plan

```bash
forge test --match-contract RampVolumeEmitterTest -vv
```

- [x] 9/9 passing (access control, single/batch emit, restatement, refund-shrink, empty batch, init-once, role-hash)
- [x] `forge fmt --check` clean

## Deploy (follow-up, not in this PR)

`forge script scripts/DeployRampVolumeEmitter.s.sol` on **Optimism** with `PRIVATE_KEY` + `RAMP_VOLUME_RELAYER` set; record the proxy address on the Linear issue. Backend feed (PAY-235) and Dune query (PAY-236) are separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New read-only event emitter with no fund movement or changes to existing contracts; risk is mainly correct role assignment at deploy time.
> 
> **Overview**
> Introduces **`RampVolumeEmitter`**, a UUPS upgradeable contract that logs ether.fi Cash on/off-ramp volume buckets for off-chain indexing (e.g. Dune). Emission is limited to **`RAMP_VOLUME_EMITTER_ROLE`** on `RoleRegistry` (intended for the backend relayer).
> 
> The contract is **stateless**: it does not store totals or enforce monotonic values. Single and batch entrypoints (`emitRampVolume` / `emitRampVolumes`) emit indexed `RampVolume` events with label, token, day timestamp, 6-decimal USD value, and on-chain `asOf` from `block.timestamp`. Restatements and refund-driven decreases are allowed; consumers pick the latest event per `(label, token, day)`.
> 
> Also adds **`IRampVolumeEmitter`**, Forge tests (access control, batch, restatement, refund shrink), and **`DeployRampVolumeEmitter.s.sol`** to deploy the proxy and grant the relayer role (with a note to use gnosis txs on prod multisig owners).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a59ddc38730a352548a9b1c299cc1b6f7911f9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->