### PR TITLE
feat: rate adapters for receipt tokens (aave v4)

### DIFF
--- a/src/interfaces/IAaveV4PriceFeed.sol
+++ b/src/interfaces/IAaveV4PriceFeed.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/**
+ * @title IAaveV4PriceFeed
+ * @notice Minimal price-feed interface an asset's price source must implement to be read by the
+ *         Aave v4 AaveOracle. Our receipt-token price adapters (weETH, eBTC, Liquid tokens) implement
+ *         this so those tokens can be priced on the ether.fi Aave instance and used as collateral.
+ * @dev Hand-written MIT mirror of aave-v4 src/spoke/interfaces/IPriceFeed.sol, which is BUSL licensed.
+ *      We declare only the ABI we call rather than vendoring BUSL source, matching this repo's existing
+ *      IAavePoolV3 pattern. Signatures verified against aave/aave-v4.
+ * @author ether.fi
+ */
+interface IAaveV4PriceFeed {
+    /**
+     * @notice The number of decimals used to represent the price
+     * @return The number of decimals
+     */
+    function decimals() external view returns (uint8);
+
+    /**
+     * @notice A human-readable description of the feed
+     * @return The feed description
+     */
+    function description() external view returns (string memory);
+
+    /**
+     * @notice The latest price, expressed with decimals() precision
+     * @return The latest price
+     */
+    function latestAnswer() external view returns (int256);
+}

--- a/src/interfaces/IAaveV4PriceFeed.sol
+++ b/src/interfaces/IAaveV4PriceFeed.sol
@@ -3,30 +3,19 @@ pragma solidity ^0.8.28;
 
 /**
  * @title IAaveV4PriceFeed
- * @notice Minimal price-feed interface an asset's price source must implement to be read by the
- *         Aave v4 AaveOracle. Our receipt-token price adapters (weETH, eBTC, Liquid tokens) implement
- *         this so those tokens can be priced on the ether.fi Aave instance and used as collateral.
- * @dev Hand-written MIT mirror of aave-v4 src/spoke/interfaces/IPriceFeed.sol, which is BUSL licensed.
- *      We declare only the ABI we call rather than vendoring BUSL source, matching this repo's existing
- *      IAavePoolV3 pattern. Signatures verified against aave/aave-v4.
+ * @notice Minimal price-feed interface a price source implements to be read by the Aave v4 AaveOracle.
+ *         Our receipt-token feeds implement it so those tokens can be Aave collateral.
+ * @dev MIT mirror of aave-v4 src/spoke/interfaces/IPriceFeed.sol (BUSL); we declare only the ABI we
+ *      call rather than vendoring BUSL source. Verified against aave/aave-v4.
  * @author ether.fi
  */
 interface IAaveV4PriceFeed {
-    /**
-     * @notice The number of decimals used to represent the price
-     * @return The number of decimals
-     */
+    /// @notice The number of decimals used to represent the price
     function decimals() external view returns (uint8);
 
-    /**
-     * @notice A human-readable description of the feed
-     * @return The feed description
-     */
+    /// @notice A human-readable description of the feed
     function description() external view returns (string memory);
 
-    /**
-     * @notice The latest price, expressed with decimals() precision
-     * @return The latest price
-     */
+    /// @notice The latest price, expressed with decimals() precision
     function latestAnswer() external view returns (int256);
 }

--- a/src/interfaces/IVedaAccountant.sol
+++ b/src/interfaces/IVedaAccountant.sol
@@ -3,23 +3,15 @@ pragma solidity ^0.8.28;
 
 /**
  * @title IVedaAccountant
- * @notice The part of a Veda AccountantWithRateProviders that the price feed reads. getRateSafe
- *         returns the vault exchange rate and reverts when the accountant has paused itself, which
- *         it does after a rate update that is out of bounds or too frequent.
- * @dev Hand-written MIT mirror of Veda's AccountantWithRateProviders (Se7en-Seas/boring-vault).
- *      Declares only what the feed calls. Verified against that source.
+ * @notice The part of a Veda accountant the feed reads. getRateSafe returns the vault rate and
+ *         reverts when the accountant is paused.
+ * @dev MIT mirror of Veda's AccountantWithRateProviders (Se7en-Seas/boring-vault), only what we call.
  * @author ether.fi
  */
 interface IVedaAccountant {
-    /**
-     * @notice The current exchange rate in the base asset, reverting if the accountant is paused
-     * @return The exchange rate in the base asset
-     */
+    /// @notice The exchange rate in the base asset; reverts if the accountant is paused
     function getRateSafe() external view returns (uint256);
 
-    /**
-     * @notice The number of decimals of the exchange rate returned by getRateSafe
-     * @return The exchange rate decimals
-     */
+    /// @notice The decimals of the exchange rate
     function decimals() external view returns (uint8);
 }

--- a/src/interfaces/IVedaAccountant.sol
+++ b/src/interfaces/IVedaAccountant.sol
@@ -9,8 +9,26 @@ pragma solidity ^0.8.28;
  * @author ether.fi
  */
 interface IVedaAccountant {
+    struct AccountantState {
+        address payoutAddress;
+        uint96 highwaterMark;
+        uint128 feesOwedInBase;
+        uint128 totalSharesLastUpdate;
+        uint96 exchangeRate;
+        uint16 allowedExchangeRateChangeUpper;
+        uint16 allowedExchangeRateChangeLower;
+        uint64 lastUpdateTimestamp;
+        bool isPaused;
+        uint24 minimumUpdateDelayInSeconds;
+        uint16 platformFee;
+        uint16 performanceFee;
+    }
+
     /// @notice The exchange rate in the base asset; reverts if the accountant is paused
     function getRateSafe() external view returns (uint256);
+
+    /// @notice The accountant state, including the last exchange-rate update timestamp
+    function accountantState() external view returns (AccountantState memory);
 
     /// @notice The decimals of the exchange rate
     function decimals() external view returns (uint8);

--- a/src/interfaces/IVedaAccountant.sol
+++ b/src/interfaces/IVedaAccountant.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/**
+ * @title IVedaAccountant
+ * @notice The part of a Veda AccountantWithRateProviders that the price feed reads. getRateSafe
+ *         returns the vault exchange rate and reverts when the accountant has paused itself, which
+ *         it does after a rate update that is out of bounds or too frequent.
+ * @dev Hand-written MIT mirror of Veda's AccountantWithRateProviders (Se7en-Seas/boring-vault).
+ *      Declares only what the feed calls. Verified against that source.
+ * @author ether.fi
+ */
+interface IVedaAccountant {
+    /**
+     * @notice The current exchange rate in the base asset, reverting if the accountant is paused
+     * @return The exchange rate in the base asset
+     */
+    function getRateSafe() external view returns (uint256);
+
+    /**
+     * @notice The number of decimals of the exchange rate returned by getRateSafe
+     * @return The exchange rate decimals
+     */
+    function decimals() external view returns (uint8);
+}

--- a/src/oracle/ChainlinkCompositePriceFeed.sol
+++ b/src/oracle/ChainlinkCompositePriceFeed.sol
@@ -68,17 +68,20 @@ contract ChainlinkCompositePriceFeed is IAaveV4PriceFeed {
      * @dev Reverts if either Chainlink feed is stale or non-positive
      */
     function latestAnswer() external view returns (int256) {
-        (, int256 rate,, uint256 rateUpdatedAt,) = rateFeed.latestRoundData();
-        if (rate <= 0) revert InvalidPrice();
-        if (block.timestamp > rateUpdatedAt + rateMaxStaleness) revert StalePrice();
-
-        (, int256 answer,, uint256 updatedAt,) = underlyingUsdFeed.latestRoundData();
-        if (answer <= 0) revert InvalidPrice();
-        if (block.timestamp > updatedAt + underlyingMaxStaleness) revert StalePrice();
+        uint256 rate = _readFeed(rateFeed, rateMaxStaleness);
+        uint256 underlyingPrice = _readFeed(underlyingUsdFeed, underlyingMaxStaleness);
 
         // price = rate * underlyingPrice, normalized from (rateDecimals + underlyingDecimals) to feedDecimals
-        uint256 price = rate.toUint256().mulDiv(answer.toUint256() * 10 ** feedDecimals, 10 ** (rateDecimals + underlyingDecimals));
+        uint256 price = rate.mulDiv(underlyingPrice * 10 ** feedDecimals, 10 ** (rateDecimals + underlyingDecimals));
 
         return price.toInt256();
+    }
+
+    /// @dev Reads a Chainlink feed, reverting if the price is non-positive or older than maxStaleness
+    function _readFeed(IAggregatorV3 feed, uint256 maxStaleness) private view returns (uint256) {
+        (, int256 answer,, uint256 updatedAt,) = feed.latestRoundData();
+        if (answer <= 0) revert InvalidPrice();
+        if (block.timestamp > updatedAt + maxStaleness) revert StalePrice();
+        return answer.toUint256();
     }
 }

--- a/src/oracle/ChainlinkCompositePriceFeed.sol
+++ b/src/oracle/ChainlinkCompositePriceFeed.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+
+import { IAaveV4PriceFeed } from "../interfaces/IAaveV4PriceFeed.sol";
+import { IAggregatorV3 } from "../interfaces/IAggregatorV3.sol";
+
+/**
+ * @title ChainlinkCompositePriceFeed
+ * @notice Prices a token that has a Chainlink rate feed in an underlying asset rather than a direct USD
+ *         feed, for example weETH priced as the weETH/ETH rate times ETH/USD. One instance per token.
+ * @dev Implements the Aave v4 price-feed interface and fails closed: latestAnswer reverts when either
+ *      Chainlink feed is stale or non-positive.
+ * @author ether.fi
+ */
+contract ChainlinkCompositePriceFeed is IAaveV4PriceFeed {
+    using Math for uint256;
+    using SafeCast for uint256;
+    using SafeCast for int256;
+
+    /// @notice The Chainlink feed for the token's rate in the underlying asset, e.g. weETH/ETH
+    IAggregatorV3 public immutable rateFeed;
+    /// @notice The Chainlink feed for the underlying asset's USD price, e.g. ETH/USD
+    IAggregatorV3 public immutable underlyingUsdFeed;
+    /// @notice The decimals of the rate feed
+    uint8 public immutable rateDecimals;
+    /// @notice The decimals of the underlying Chainlink feed
+    uint8 public immutable underlyingDecimals;
+    /// @notice The decimals of the price this feed reports
+    uint8 public immutable feedDecimals;
+    /// @notice The maximum age in seconds for the rate feed before it is rejected
+    uint256 public immutable rateMaxStaleness;
+    /// @notice The maximum age in seconds for the underlying Chainlink price before it is rejected
+    uint256 public immutable underlyingMaxStaleness;
+
+    string private _description;
+
+    /// @notice Thrown when either Chainlink price is older than its staleness limit
+    error StalePrice();
+    /// @notice Thrown when either Chainlink price is zero or negative
+    error InvalidPrice();
+
+    constructor(IAggregatorV3 _rateFeed, IAggregatorV3 _underlyingUsdFeed, uint8 _feedDecimals, uint256 _rateMaxStaleness, uint256 _underlyingMaxStaleness, string memory feedDescription) {
+        rateFeed = _rateFeed;
+        underlyingUsdFeed = _underlyingUsdFeed;
+        rateDecimals = _rateFeed.decimals();
+        underlyingDecimals = _underlyingUsdFeed.decimals();
+        feedDecimals = _feedDecimals;
+        rateMaxStaleness = _rateMaxStaleness;
+        underlyingMaxStaleness = _underlyingMaxStaleness;
+        _description = feedDescription;
+    }
+
+    /// @notice The number of decimals used to represent the price
+    function decimals() external view returns (uint8) {
+        return feedDecimals;
+    }
+
+    /// @notice A human-readable description of the feed
+    function description() external view returns (string memory) {
+        return _description;
+    }
+
+    /**
+     * @notice The token's price, the rate feed times the underlying USD price
+     * @dev Reverts if either Chainlink feed is stale or non-positive
+     */
+    function latestAnswer() external view returns (int256) {
+        (, int256 rate,, uint256 rateUpdatedAt,) = rateFeed.latestRoundData();
+        if (rate <= 0) revert InvalidPrice();
+        if (block.timestamp > rateUpdatedAt + rateMaxStaleness) revert StalePrice();
+
+        (, int256 answer,, uint256 updatedAt,) = underlyingUsdFeed.latestRoundData();
+        if (answer <= 0) revert InvalidPrice();
+        if (block.timestamp > updatedAt + underlyingMaxStaleness) revert StalePrice();
+
+        // price = rate * underlyingPrice, normalized from (rateDecimals + underlyingDecimals) to feedDecimals
+        uint256 price = rate.toUint256().mulDiv(answer.toUint256() * 10 ** feedDecimals, 10 ** (rateDecimals + underlyingDecimals));
+
+        return price.toInt256();
+    }
+}

--- a/src/oracle/VedaAccountantPriceFeed.sol
+++ b/src/oracle/VedaAccountantPriceFeed.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+
+import { IAaveV4PriceFeed } from "../interfaces/IAaveV4PriceFeed.sol";
+import { IAggregatorV3 } from "../interfaces/IAggregatorV3.sol";
+import { IVedaAccountant } from "../interfaces/IVedaAccountant.sol";
+
+/**
+ * @title VedaAccountantPriceFeed
+ * @notice Prices a Veda receipt token (e.g. eBTC, the Liquid tokens, eUSD, sETHFI) for the Aave v4
+ *         oracle. The price is the vault exchange rate times the underlying asset's USD price. The
+ *         rate comes from the vault's Veda accountant and the underlying USD price from a Chainlink
+ *         feed. One instance is deployed per receipt token.
+ * @dev Implements the Aave v4 price-feed interface. The feed fails closed. latestAnswer reverts if
+ *      the accountant is paused (getRateSafe), if the Chainlink price is stale or not positive, or
+ *      if the rate is zero. A max-age check on the rate itself is a planned follow-up, once the
+ *      deployed accountant's state getter is confirmed on a fork.
+ * @author ether.fi
+ */
+contract VedaAccountantPriceFeed is IAaveV4PriceFeed {
+    using Math for uint256;
+    using SafeCast for uint256;
+    using SafeCast for int256;
+
+    /// @notice The Veda accountant that provides the vault exchange rate
+    IVedaAccountant public immutable accountant;
+    /// @notice The Chainlink feed for the underlying asset's USD price, e.g. ETH/USD or BTC/USD
+    IAggregatorV3 public immutable underlyingUsdFeed;
+    /// @notice The decimals of the exchange rate from the accountant
+    uint8 public immutable rateDecimals;
+    /// @notice The decimals of the underlying Chainlink feed
+    uint8 public immutable underlyingDecimals;
+    /// @notice The decimals of the price this feed reports
+    uint8 public immutable feedDecimals;
+    /// @notice The maximum age in seconds for the underlying Chainlink price before it is rejected
+    uint256 public immutable underlyingMaxStaleness;
+
+    string private _description;
+
+    /// @notice Thrown when the underlying Chainlink price is older than underlyingMaxStaleness
+    error StalePrice();
+    /// @notice Thrown when the rate or the underlying price is zero or negative
+    error InvalidPrice();
+
+    constructor(IVedaAccountant _accountant, IAggregatorV3 _underlyingUsdFeed, uint8 _feedDecimals, uint256 _underlyingMaxStaleness, string memory feedDescription) {
+        accountant = _accountant;
+        underlyingUsdFeed = _underlyingUsdFeed;
+        rateDecimals = _accountant.decimals();
+        underlyingDecimals = _underlyingUsdFeed.decimals();
+        feedDecimals = _feedDecimals;
+        underlyingMaxStaleness = _underlyingMaxStaleness;
+        _description = feedDescription;
+    }
+
+    /**
+     * @notice The number of decimals used to represent the price
+     * @return The price decimals this feed reports
+     */
+    function decimals() external view returns (uint8) {
+        return feedDecimals;
+    }
+
+    /**
+     * @notice A human-readable description of the feed
+     * @return The feed description set at deployment
+     */
+    function description() external view returns (string memory) {
+        return _description;
+    }
+
+    /**
+     * @notice The latest price for the token, the vault exchange rate times the underlying USD price
+     * @dev Reverts if the accountant is paused, the underlying price is stale or not positive, or the rate is zero
+     * @return The price expressed with decimals() precision
+     */
+    function latestAnswer() external view returns (int256) {
+        // Exchange rate in the base asset. Reverts if the accountant paused itself on a bad or too-frequent update
+        uint256 rate = accountant.getRateSafe();
+        if (rate == 0) revert InvalidPrice();
+
+        // Underlying asset USD price from Chainlink, with validity and staleness checks.
+        (, int256 answer,, uint256 updatedAt,) = underlyingUsdFeed.latestRoundData();
+        if (answer <= 0) revert InvalidPrice();
+        if (block.timestamp > updatedAt + underlyingMaxStaleness) revert StalePrice();
+
+        // price = rate * underlyingPrice, normalized from (rateDecimals + underlyingDecimals) to feedDecimals
+        uint256 price = rate.mulDiv(answer.toUint256() * 10 ** feedDecimals, 10 ** (rateDecimals + underlyingDecimals));
+
+        return price.toInt256();
+    }
+}

--- a/src/oracle/VedaAccountantPriceFeed.sol
+++ b/src/oracle/VedaAccountantPriceFeed.sol
@@ -13,7 +13,7 @@ import { IVedaAccountant } from "../interfaces/IVedaAccountant.sol";
  * @notice Prices a Veda receipt token (eBTC, the Liquid tokens, eUSD, sETHFI) for the Aave v4 oracle
  *         as the vault rate times the underlying USD price. One instance per token.
  * @dev Implements the Aave v4 price-feed interface and fails closed: latestAnswer reverts on a paused
- *      accountant, a stale or non-positive underlying, or a zero rate.
+ *      or stale accountant, a stale or non-positive underlying, or a zero rate.
  * @author ether.fi
  */
 contract VedaAccountantPriceFeed is IAaveV4PriceFeed {
@@ -31,22 +31,25 @@ contract VedaAccountantPriceFeed is IAaveV4PriceFeed {
     uint8 public immutable underlyingDecimals;
     /// @notice The decimals of the price this feed reports
     uint8 public immutable feedDecimals;
+    /// @notice The maximum age in seconds for the Veda rate before it is rejected
+    uint256 public immutable rateMaxStaleness;
     /// @notice The maximum age in seconds for the underlying Chainlink price before it is rejected
     uint256 public immutable underlyingMaxStaleness;
 
     string private _description;
 
-    /// @notice Thrown when the underlying Chainlink price is older than underlyingMaxStaleness
+    /// @notice Thrown when either price source is older than its staleness limit
     error StalePrice();
     /// @notice Thrown when the rate or the underlying price is zero or negative
     error InvalidPrice();
 
-    constructor(IVedaAccountant _accountant, IAggregatorV3 _underlyingUsdFeed, uint8 _feedDecimals, uint256 _underlyingMaxStaleness, string memory feedDescription) {
+    constructor(IVedaAccountant _accountant, IAggregatorV3 _underlyingUsdFeed, uint8 _feedDecimals, uint256 _rateMaxStaleness, uint256 _underlyingMaxStaleness, string memory feedDescription) {
         accountant = _accountant;
         underlyingUsdFeed = _underlyingUsdFeed;
         rateDecimals = _accountant.decimals();
         underlyingDecimals = _underlyingUsdFeed.decimals();
         feedDecimals = _feedDecimals;
+        rateMaxStaleness = _rateMaxStaleness;
         underlyingMaxStaleness = _underlyingMaxStaleness;
         _description = feedDescription;
     }
@@ -63,9 +66,12 @@ contract VedaAccountantPriceFeed is IAaveV4PriceFeed {
 
     /**
      * @notice The token's price, the vault rate times the underlying USD price
-     * @dev Reverts if the accountant is paused, the underlying is stale or not positive, or the rate is zero
+     * @dev Reverts if the accountant is paused or stale, the underlying is stale or not positive, or the rate is zero
      */
     function latestAnswer() external view returns (int256) {
+        IVedaAccountant.AccountantState memory state = accountant.accountantState();
+        if (block.timestamp > state.lastUpdateTimestamp + rateMaxStaleness) revert StalePrice();
+
         // Vault rate; reverts if the accountant paused itself.
         uint256 rate = accountant.getRateSafe();
         if (rate == 0) revert InvalidPrice();

--- a/src/oracle/VedaAccountantPriceFeed.sol
+++ b/src/oracle/VedaAccountantPriceFeed.sol
@@ -10,14 +10,10 @@ import { IVedaAccountant } from "../interfaces/IVedaAccountant.sol";
 
 /**
  * @title VedaAccountantPriceFeed
- * @notice Prices a Veda receipt token (e.g. eBTC, the Liquid tokens, eUSD, sETHFI) for the Aave v4
- *         oracle. The price is the vault exchange rate times the underlying asset's USD price. The
- *         rate comes from the vault's Veda accountant and the underlying USD price from a Chainlink
- *         feed. One instance is deployed per receipt token.
- * @dev Implements the Aave v4 price-feed interface. The feed fails closed. latestAnswer reverts if
- *      the accountant is paused (getRateSafe), if the Chainlink price is stale or not positive, or
- *      if the rate is zero. A max-age check on the rate itself is a planned follow-up, once the
- *      deployed accountant's state getter is confirmed on a fork.
+ * @notice Prices a Veda receipt token (eBTC, the Liquid tokens, eUSD, sETHFI) for the Aave v4 oracle
+ *         as the vault rate times the underlying USD price. One instance per token.
+ * @dev Implements the Aave v4 price-feed interface and fails closed: latestAnswer reverts on a paused
+ *      accountant, a stale or non-positive underlying, or a zero rate.
  * @author ether.fi
  */
 contract VedaAccountantPriceFeed is IAaveV4PriceFeed {
@@ -55,33 +51,26 @@ contract VedaAccountantPriceFeed is IAaveV4PriceFeed {
         _description = feedDescription;
     }
 
-    /**
-     * @notice The number of decimals used to represent the price
-     * @return The price decimals this feed reports
-     */
+    /// @notice The number of decimals used to represent the price
     function decimals() external view returns (uint8) {
         return feedDecimals;
     }
 
-    /**
-     * @notice A human-readable description of the feed
-     * @return The feed description set at deployment
-     */
+    /// @notice A human-readable description of the feed
     function description() external view returns (string memory) {
         return _description;
     }
 
     /**
-     * @notice The latest price for the token, the vault exchange rate times the underlying USD price
-     * @dev Reverts if the accountant is paused, the underlying price is stale or not positive, or the rate is zero
-     * @return The price expressed with decimals() precision
+     * @notice The token's price, the vault rate times the underlying USD price
+     * @dev Reverts if the accountant is paused, the underlying is stale or not positive, or the rate is zero
      */
     function latestAnswer() external view returns (int256) {
-        // Exchange rate in the base asset. Reverts if the accountant paused itself on a bad or too-frequent update
+        // Vault rate; reverts if the accountant paused itself.
         uint256 rate = accountant.getRateSafe();
         if (rate == 0) revert InvalidPrice();
 
-        // Underlying asset USD price from Chainlink, with validity and staleness checks.
+        // Underlying USD price from Chainlink, checked for validity and staleness.
         (, int256 answer,, uint256 updatedAt,) = underlyingUsdFeed.latestRoundData();
         if (answer <= 0) revert InvalidPrice();
         if (block.timestamp > updatedAt + underlyingMaxStaleness) revert StalePrice();

--- a/test/price-provider/ChainlinkCompositePriceFeed.t.sol
+++ b/test/price-provider/ChainlinkCompositePriceFeed.t.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import { Test } from "forge-std/Test.sol";
+
+import { IAggregatorV3 } from "../../src/interfaces/IAggregatorV3.sol";
+import { ChainlinkCompositePriceFeed } from "../../src/oracle/ChainlinkCompositePriceFeed.sol";
+
+/// @notice Fork tests on Optimism, using the live weETH/ETH rate feed and ETH/USD feed.
+contract ChainlinkCompositePriceFeedTest is Test {
+    using SafeCast for int256;
+
+    // optimism
+    address rateFeed = 0xb4479d436DDa5c1A79bD88D282725615202406E3; // weETH / ETH
+    address ethUsdOracle = 0x13e3Ee699D1909E989722E753853AE30b17e08c5; // ETH / USD
+
+    uint8 constant FEED_DECIMALS = 8;
+    uint256 constant RATE_MAX_STALENESS = 1 days;
+    uint256 constant UNDERLYING_MAX_STALENESS = 1 days;
+
+    ChainlinkCompositePriceFeed feed;
+
+    function setUp() public {
+        vm.createSelectFork(vm.envOr("OPTIMISM_RPC", string("https://mainnet.optimism.io")));
+        feed = new ChainlinkCompositePriceFeed(IAggregatorV3(rateFeed), IAggregatorV3(ethUsdOracle), FEED_DECIMALS, RATE_MAX_STALENESS, UNDERLYING_MAX_STALENESS, "weETH / USD");
+    }
+
+    /// @notice The reported price equals rate x underlying, and lands in a sane USD range.
+    function test_latestAnswer_matchesRateTimesUnderlying() public view {
+        (, int256 rate,,,) = IAggregatorV3(rateFeed).latestRoundData();
+        (, int256 ethUsd,,,) = IAggregatorV3(ethUsdOracle).latestRoundData();
+
+        uint256 expected = rate.toUint256() * ethUsd.toUint256() * (10 ** FEED_DECIMALS) / (10 ** (feed.rateDecimals() + feed.underlyingDecimals()));
+
+        uint256 price = feed.latestAnswer().toUint256();
+        assertEq(price, expected, "price mismatch");
+
+        // Sanity on magnitude, which catches a decimals mistake: weETH should be a few thousand USD,
+        // so well within 100 to 100,000 USD at 8 decimals.
+        assertGt(price, 100 * (10 ** FEED_DECIMALS), "price too low");
+        assertLt(price, 100_000 * (10 ** FEED_DECIMALS), "price too high");
+    }
+
+    function test_decimalsAndDescription() public view {
+        assertEq(feed.decimals(), FEED_DECIMALS);
+        assertEq(feed.description(), "weETH / USD");
+    }
+
+    /// @notice Reverts when the rate feed is older than its staleness limit.
+    function test_reverts_whenRateStale() public {
+        (uint80 roundId, int256 rate, uint256 startedAt,, uint80 answeredInRound) = IAggregatorV3(rateFeed).latestRoundData();
+        uint256 staleUpdatedAt = block.timestamp - RATE_MAX_STALENESS - 1;
+        vm.mockCall(rateFeed, abi.encodeWithSelector(IAggregatorV3.latestRoundData.selector), abi.encode(roundId, rate, startedAt, staleUpdatedAt, answeredInRound));
+        vm.expectRevert(ChainlinkCompositePriceFeed.StalePrice.selector);
+        feed.latestAnswer();
+    }
+
+    /// @notice Reverts when the underlying Chainlink price is older than its staleness limit.
+    function test_reverts_whenUnderlyingStale() public {
+        (uint80 roundId, int256 answer, uint256 startedAt,, uint80 answeredInRound) = IAggregatorV3(ethUsdOracle).latestRoundData();
+        uint256 staleUpdatedAt = block.timestamp - UNDERLYING_MAX_STALENESS - 1;
+        vm.mockCall(ethUsdOracle, abi.encodeWithSelector(IAggregatorV3.latestRoundData.selector), abi.encode(roundId, answer, startedAt, staleUpdatedAt, answeredInRound));
+        vm.expectRevert(ChainlinkCompositePriceFeed.StalePrice.selector);
+        feed.latestAnswer();
+    }
+
+    /// @notice Reverts when the rate feed price is zero or negative.
+    function test_reverts_whenRateNotPositive() public {
+        vm.mockCall(rateFeed, abi.encodeWithSelector(IAggregatorV3.latestRoundData.selector), abi.encode(uint80(1), int256(0), block.timestamp, block.timestamp, uint80(1)));
+        vm.expectRevert(ChainlinkCompositePriceFeed.InvalidPrice.selector);
+        feed.latestAnswer();
+    }
+
+    /// @notice Reverts when the underlying price is zero or negative.
+    function test_reverts_whenUnderlyingNotPositive() public {
+        vm.mockCall(ethUsdOracle, abi.encodeWithSelector(IAggregatorV3.latestRoundData.selector), abi.encode(uint80(1), int256(0), block.timestamp, block.timestamp, uint80(1)));
+        vm.expectRevert(ChainlinkCompositePriceFeed.InvalidPrice.selector);
+        feed.latestAnswer();
+    }
+}

--- a/test/price-provider/VedaAccountantPriceFeed.t.sol
+++ b/test/price-provider/VedaAccountantPriceFeed.t.sol
@@ -4,28 +4,22 @@ pragma solidity ^0.8.28;
 import { Test } from "forge-std/Test.sol";
 
 import { IAggregatorV3 } from "../../src/interfaces/IAggregatorV3.sol";
-import { AccountantWithRateProviders, ILayerZeroTeller } from "../../src/interfaces/ILayerZeroTeller.sol";
 import { IVedaAccountant } from "../../src/interfaces/IVedaAccountant.sol";
 import { VedaAccountantPriceFeed } from "../../src/oracle/VedaAccountantPriceFeed.sol";
 
-/// @notice Fork tests for the Veda price feed, using the mainnet liquidETH vault and ETH/USD feed.
+/// @notice Fork tests on Optimism, using the live liquidETH accountant and ETH/USD feed.
 contract VedaAccountantPriceFeedTest is Test {
-    // mainnet
-    ILayerZeroTeller liquidEthTeller = ILayerZeroTeller(0x9AA79C84b79816ab920bBcE20f8f74557B514734);
-    address ethUsdOracle = 0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419;
+    // optimism
+    IVedaAccountant accountant = IVedaAccountant(0x0d05D94a5F1E76C18fbeB7A13d17C8a314088198); // liquidETH
+    address ethUsdOracle = 0x13e3Ee699D1909E989722E753853AE30b17e08c5; // ETH/USD
 
     uint8 constant FEED_DECIMALS = 8;
     uint256 constant UNDERLYING_MAX_STALENESS = 1 days;
 
-    IVedaAccountant accountant;
     VedaAccountantPriceFeed feed;
 
     function setUp() public {
-        string memory mainnet = vm.envString("MAINNET_RPC");
-        if (bytes(mainnet).length == 0) mainnet = "https://rpc.ankr.com/eth";
-        vm.createSelectFork(mainnet);
-
-        accountant = IVedaAccountant(address(liquidEthTeller.accountant()));
+        vm.createSelectFork(vm.envOr("OPTIMISM_RPC", string("https://mainnet.optimism.io")));
         feed = new VedaAccountantPriceFeed(accountant, IAggregatorV3(ethUsdOracle), FEED_DECIMALS, UNDERLYING_MAX_STALENESS, "liquidETH / USD");
     }
 

--- a/test/price-provider/VedaAccountantPriceFeed.t.sol
+++ b/test/price-provider/VedaAccountantPriceFeed.t.sol
@@ -11,19 +11,21 @@ import { VedaAccountantPriceFeed } from "../../src/oracle/VedaAccountantPriceFee
 /// @notice Fork tests on Optimism, using the live liquidETH accountant and ETH/USD feed.
 contract VedaAccountantPriceFeedTest is Test {
     using SafeCast for int256;
+    using SafeCast for uint256;
 
     // optimism
     IVedaAccountant accountant = IVedaAccountant(0x0d05D94a5F1E76C18fbeB7A13d17C8a314088198); // liquidETH
     address ethUsdOracle = 0x13e3Ee699D1909E989722E753853AE30b17e08c5; // ETH/USD
 
     uint8 constant FEED_DECIMALS = 8;
+    uint256 constant RATE_MAX_STALENESS = 2 days;
     uint256 constant UNDERLYING_MAX_STALENESS = 1 days;
 
     VedaAccountantPriceFeed feed;
 
     function setUp() public {
         vm.createSelectFork(vm.envOr("OPTIMISM_RPC", string("https://mainnet.optimism.io")));
-        feed = new VedaAccountantPriceFeed(accountant, IAggregatorV3(ethUsdOracle), FEED_DECIMALS, UNDERLYING_MAX_STALENESS, "liquidETH / USD");
+        feed = new VedaAccountantPriceFeed(accountant, IAggregatorV3(ethUsdOracle), FEED_DECIMALS, RATE_MAX_STALENESS, UNDERLYING_MAX_STALENESS, "liquidETH / USD");
     }
 
     /// @notice The reported price equals rate x underlying, and lands in a sane USD range.
@@ -50,6 +52,22 @@ contract VedaAccountantPriceFeedTest is Test {
     /// @notice Reverts when the underlying Chainlink price is older than the staleness limit.
     function test_reverts_whenUnderlyingStale() public {
         vm.warp(block.timestamp + UNDERLYING_MAX_STALENESS + 1);
+        vm.expectRevert(VedaAccountantPriceFeed.StalePrice.selector);
+        feed.latestAnswer();
+    }
+
+    /// @notice Reverts when the Veda accountant rate is older than the staleness limit.
+    function test_reverts_whenRateStale() public {
+        uint64 staleLastUpdateTimestamp = (block.timestamp - RATE_MAX_STALENESS - 1).toUint64();
+        IVedaAccountant.AccountantState memory state;
+        state.exchangeRate = 1e18;
+        state.allowedExchangeRateChangeUpper = 10_050;
+        state.allowedExchangeRateChangeLower = 9950;
+        state.lastUpdateTimestamp = staleLastUpdateTimestamp;
+        state.minimumUpdateDelayInSeconds = 6 hours;
+
+        vm.mockCall(address(accountant), abi.encodeWithSelector(IVedaAccountant.accountantState.selector), abi.encode(state));
+
         vm.expectRevert(VedaAccountantPriceFeed.StalePrice.selector);
         feed.latestAnswer();
     }

--- a/test/price-provider/VedaAccountantPriceFeed.t.sol
+++ b/test/price-provider/VedaAccountantPriceFeed.t.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { Test } from "forge-std/Test.sol";
+
+import { IAggregatorV3 } from "../../src/interfaces/IAggregatorV3.sol";
+import { AccountantWithRateProviders, ILayerZeroTeller } from "../../src/interfaces/ILayerZeroTeller.sol";
+import { IVedaAccountant } from "../../src/interfaces/IVedaAccountant.sol";
+import { VedaAccountantPriceFeed } from "../../src/oracle/VedaAccountantPriceFeed.sol";
+
+/// @notice Fork tests for the Veda price feed, using the mainnet liquidETH vault and ETH/USD feed.
+contract VedaAccountantPriceFeedTest is Test {
+    // mainnet
+    ILayerZeroTeller liquidEthTeller = ILayerZeroTeller(0x9AA79C84b79816ab920bBcE20f8f74557B514734);
+    address ethUsdOracle = 0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419;
+
+    uint8 constant FEED_DECIMALS = 8;
+    uint256 constant UNDERLYING_MAX_STALENESS = 1 days;
+
+    IVedaAccountant accountant;
+    VedaAccountantPriceFeed feed;
+
+    function setUp() public {
+        string memory mainnet = vm.envString("MAINNET_RPC");
+        if (bytes(mainnet).length == 0) mainnet = "https://rpc.ankr.com/eth";
+        vm.createSelectFork(mainnet);
+
+        accountant = IVedaAccountant(address(liquidEthTeller.accountant()));
+        feed = new VedaAccountantPriceFeed(accountant, IAggregatorV3(ethUsdOracle), FEED_DECIMALS, UNDERLYING_MAX_STALENESS, "liquidETH / USD");
+    }
+
+    /// @notice The reported price equals rate x underlying, and lands in a sane USD range.
+    function test_latestAnswer_matchesRateTimesUnderlying() public view {
+        uint256 rate = accountant.getRateSafe();
+        (, int256 ethUsd,,,) = IAggregatorV3(ethUsdOracle).latestRoundData();
+
+        uint256 expected = rate * uint256(ethUsd) * (10 ** FEED_DECIMALS) / (10 ** (feed.rateDecimals() + feed.underlyingDecimals()));
+
+        assertEq(uint256(feed.latestAnswer()), expected, "price mismatch");
+
+        // Sanity on magnitude, which catches a decimals mistake: liquidETH should be a few thousand
+        // USD, so well within 100 to 100,000 USD at 8 decimals.
+        assertGt(uint256(feed.latestAnswer()), 100 * (10 ** FEED_DECIMALS), "price too low");
+        assertLt(uint256(feed.latestAnswer()), 100_000 * (10 ** FEED_DECIMALS), "price too high");
+    }
+
+    function test_decimalsAndDescription() public view {
+        assertEq(feed.decimals(), FEED_DECIMALS);
+        assertEq(feed.description(), "liquidETH / USD");
+    }
+
+    /// @notice Reverts when the underlying Chainlink price is older than the staleness limit.
+    function test_reverts_whenUnderlyingStale() public {
+        vm.warp(block.timestamp + UNDERLYING_MAX_STALENESS + 1);
+        vm.expectRevert(VedaAccountantPriceFeed.StalePrice.selector);
+        feed.latestAnswer();
+    }
+
+    /// @notice Reverts when the accountant has paused itself (getRateSafe reverts).
+    function test_reverts_whenAccountantPaused() public {
+        vm.mockCallRevert(address(accountant), abi.encodeWithSelector(IVedaAccountant.getRateSafe.selector), "paused");
+        vm.expectRevert();
+        feed.latestAnswer();
+    }
+
+    /// @notice Reverts when the rate is zero.
+    function test_reverts_whenRateZero() public {
+        vm.mockCall(address(accountant), abi.encodeWithSelector(IVedaAccountant.getRateSafe.selector), abi.encode(uint256(0)));
+        vm.expectRevert(VedaAccountantPriceFeed.InvalidPrice.selector);
+        feed.latestAnswer();
+    }
+
+    /// @notice Reverts when the underlying price is zero or negative.
+    function test_reverts_whenUnderlyingNotPositive() public {
+        vm.mockCall(ethUsdOracle, abi.encodeWithSelector(IAggregatorV3.latestRoundData.selector), abi.encode(uint80(1), int256(0), block.timestamp, block.timestamp, uint80(1)));
+        vm.expectRevert(VedaAccountantPriceFeed.InvalidPrice.selector);
+        feed.latestAnswer();
+    }
+}

--- a/test/price-provider/VedaAccountantPriceFeed.t.sol
+++ b/test/price-provider/VedaAccountantPriceFeed.t.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
+import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import { Test } from "forge-std/Test.sol";
 
 import { IAggregatorV3 } from "../../src/interfaces/IAggregatorV3.sol";
@@ -9,6 +10,8 @@ import { VedaAccountantPriceFeed } from "../../src/oracle/VedaAccountantPriceFee
 
 /// @notice Fork tests on Optimism, using the live liquidETH accountant and ETH/USD feed.
 contract VedaAccountantPriceFeedTest is Test {
+    using SafeCast for int256;
+
     // optimism
     IVedaAccountant accountant = IVedaAccountant(0x0d05D94a5F1E76C18fbeB7A13d17C8a314088198); // liquidETH
     address ethUsdOracle = 0x13e3Ee699D1909E989722E753853AE30b17e08c5; // ETH/USD
@@ -28,14 +31,15 @@ contract VedaAccountantPriceFeedTest is Test {
         uint256 rate = accountant.getRateSafe();
         (, int256 ethUsd,,,) = IAggregatorV3(ethUsdOracle).latestRoundData();
 
-        uint256 expected = rate * uint256(ethUsd) * (10 ** FEED_DECIMALS) / (10 ** (feed.rateDecimals() + feed.underlyingDecimals()));
+        uint256 expected = rate * ethUsd.toUint256() * (10 ** FEED_DECIMALS) / (10 ** (feed.rateDecimals() + feed.underlyingDecimals()));
 
-        assertEq(uint256(feed.latestAnswer()), expected, "price mismatch");
+        uint256 price = feed.latestAnswer().toUint256();
+        assertEq(price, expected, "price mismatch");
 
         // Sanity on magnitude, which catches a decimals mistake: liquidETH should be a few thousand
         // USD, so well within 100 to 100,000 USD at 8 decimals.
-        assertGt(uint256(feed.latestAnswer()), 100 * (10 ** FEED_DECIMALS), "price too low");
-        assertLt(uint256(feed.latestAnswer()), 100_000 * (10 ** FEED_DECIMALS), "price too high");
+        assertGt(price, 100 * (10 ** FEED_DECIMALS), "price too low");
+        assertLt(price, 100_000 * (10 ** FEED_DECIMALS), "price too high");
     }
 
     function test_decimalsAndDescription() public view {


### PR DESCRIPTION
## What it does

Adds two immutable price feeds so Aave v4 can value our receipt tokens as collateral. Each returns a token's USD price through Aave's price-feed interface (`decimals`, `description`, `latestAnswer`) at 8 decimals. We deploy one instance per token.

- `VedaAccountantPriceFeed`: for tokens priced by a Veda accountant (eBTC, LiquidETH, LiquidBTC, LiquidUSD, eUSD). Price is the accountant rate times the underlying USD Chainlink feed.
- `ChainlinkCompositePriceFeed`: for tokens priced by a Chainlink rate feed (weETH). Price is the rate feed times the underlying USD feed, for example weETH/ETH times ETH/USD.

Both fail closed. `latestAnswer` reverts if the underlying is stale or non-positive, or the rate is zero. The Veda feed also reverts if the accountant has paused itself or if its rate has not updated within `rateMaxStaleness`.

## Needs a second eye

- **Rate staleness trade-off.** The Veda feed reverts if the rate is older than `rateMaxStaleness`. If the accountant's updater stalls, that pauses the asset in Aave, liquidations included, until it refreshes or we repoint. Is the window right, and is failing closed what we want here? (Aave risk + us)
- **Immutable, not upgradeable.** No admin; changes are deploy-new-and-repoint via `setReserveSource`. Confirm the Aave side wants immutable. (Jacob / Aave risk)

## Why two adapters and not one

The ticket assumed every receipt token's rate comes from a Veda accountant. It does not. weETH gets its rate from a Chainlink feed, not an accountant, and that rate is in ETH, not USD. So weETH needs the composite adapter. The two adapters have different rate sources and different safety models, so they stay separate instead of being merged behind a flag.

## Why immutable, not upgradeable

The feeds are immutable, set in the constructor, with no admin. An upgradeable feed would mean a key that can silently change how Aave values collateral, which is the highest-value attack surface in the market. We do not lose the ability to change a feed. Aave's `setReserveSource` lets governance repoint a reserve to a new feed, so a fix is to deploy a new feed and repoint, in one controlled action. This also matches what Aave's risk reviewers expect.

## Decimals

The feeds report 8 decimals, which is the USD base unit for an Aave USD market. We confirmed this against the real Aave v4 AaveOracle. It returns `latestAnswer()` with no scaling, and `setReserveSource` checks that the feed's decimals match the market's. So a wrong value fails at registration instead of mispricing quietly.

## Staleness

This follows how PriceProviderV2 prices these assets, with one addition. The underlying Chainlink leg is checked for staleness and a non-positive value. The Veda rate is guarded two ways: `getRateSafe` reverts when the accountant has paused itself, and the feed also rejects the rate if its last update (`accountantState().lastUpdateTimestamp`) is older than `rateMaxStaleness`, since the accountant has no max-age of its own. One consequence for reviewers: if the rate stops updating past that window, the feed reverts, which pauses that asset in Aave until the rate refreshes or the reserve is repointed.

## How we tested

Fork tests on Optimism against the live feeds, 13 in total, 7 for the Veda adapter and 6 for the composite. Each adapter has a happy-path test that checks the price equals rate times underlying and lands in a sane USD range, a decimals and description test, and revert tests for stale, zero, paused, and non-positive inputs. All pass.

## Not in this PR

Deploying the instances and registering them on the instance oracle. That waits on the instance standup (COR-931).

Closes COR-963

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> New collateral pricing for Aave v4; misconfiguration or staleness handling could pause reserves or misvalue collateral during liquidations.
> 
> **Overview**
> Adds **immutable Aave v4 oracle adapters** so ether.fi receipt tokens can be priced as USD collateral: one feed multiplies a **Veda accountant** vault rate by an underlying Chainlink USD leg; the other multiplies two **Chainlink** legs (e.g. weETH/ETH × ETH/USD).
> 
> Both implement `IAaveV4PriceFeed` (`decimals`, `description`, `latestAnswer` at **8 decimals**) and **fail closed**—`latestAnswer` reverts on stale or non-positive inputs; the Veda path also reverts on paused accountant, zero rate, or rate older than `rateMaxStaleness`. New MIT interfaces mirror the minimal Aave and Veda ABIs without vendoring BUSL source.
> 
> **Fork tests on Optimism** cover happy-path math, metadata, and revert cases for each adapter. On-chain deploy and `setReserveSource` registration are out of scope for this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d545151ae9e5bc69a9154cac9a3bbf1a3a94e05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->