### PR TITLE
feat: shared Aave withdraw/action/re-supply sandwich helper

### DIFF
--- a/src/modules/ModuleGatewaySandwich.sol
+++ b/src/modules/ModuleGatewaySandwich.sol
@@ -19,10 +19,13 @@ abstract contract ModuleGatewaySandwich {
     /// @notice The lowest post-withdraw health factor a withdraw may leave the safe at
     uint256 public immutable minHealthFactor;
 
+    /// @notice Thrown when the gateway address is zero
+    error InvalidGateway();
     /// @notice Thrown when a withdraw would leave the safe below minHealthFactor
     error WithdrawBreachesHealth();
 
     constructor(address _gateway, uint256 _minHealthFactor) {
+        if (_gateway == address(0)) revert InvalidGateway();
         gateway = IGateway(_gateway);
         minHealthFactor = _minHealthFactor;
     }

--- a/src/modules/ModuleGatewaySandwich.sol
+++ b/src/modules/ModuleGatewaySandwich.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { IGateway } from "../interfaces/IGateway.sol";
+
+/**
+ * @title ModuleGatewaySandwich
+ * @notice Shared helper for modules that move a safe's assets once those assets live in Aave.
+ *         Auto-supply leaves the asset in the safe's Aave position, not the safe, so a module
+ *         withdraws it back to the safe, runs its action, then re-supplies the output as collateral.
+ * @dev Provides the two bookends and the health guard; the module brackets its own action between
+ *      them. The withdraw guard reverts when the post-withdraw health factor is below minHealthFactor,
+ *      matching Aave's own check that debt-backing collateral cannot be withdrawn (no deferral).
+ * @author ether.fi
+ */
+abstract contract ModuleGatewaySandwich {
+    /// @notice The gateway that performs Aave ops on a safe's behalf
+    IGateway public immutable gateway;
+    /// @notice The lowest post-withdraw health factor a withdraw may leave the safe at
+    uint256 public immutable minHealthFactor;
+
+    /// @notice Thrown when a withdraw would leave the safe below minHealthFactor
+    error WithdrawBreachesHealth();
+
+    constructor(address _gateway, uint256 _minHealthFactor) {
+        gateway = IGateway(_gateway);
+        minHealthFactor = _minHealthFactor;
+    }
+
+    /**
+     * @notice Withdraws an asset from the safe's Aave position back into the safe, then guards health
+     * @param safe The safe whose position is debited
+     * @param asset The asset to withdraw
+     * @param amount The amount to withdraw
+     */
+    function _withdrawFromGateway(address safe, address asset, uint256 amount) internal {
+        gateway.withdraw(safe, asset, amount, safe);
+        if (gateway.getAccountData(safe).healthFactor < minHealthFactor) revert WithdrawBreachesHealth();
+    }
+
+    /**
+     * @notice Supplies an asset from the safe back into Aave and marks it as collateral
+     * @param safe The safe whose position is credited
+     * @param asset The asset to supply
+     * @param amount The amount to supply
+     */
+    function _resupplyToGateway(address safe, address asset, uint256 amount) internal {
+        gateway.supply(safe, asset, amount);
+        gateway.setUsingAsCollateral(safe, asset, true);
+    }
+}

--- a/test/safe/modules/ModuleGatewaySandwich.t.sol
+++ b/test/safe/modules/ModuleGatewaySandwich.t.sol
@@ -38,6 +38,12 @@ contract ModuleGatewaySandwichTest is Test {
         gateway.setAccountData(safe, IGateway.AccountData({ collateralUsd: 0, debtUsd: 0, availableBorrowsUsd: 0, healthFactor: healthFactor }));
     }
 
+    // A zero gateway address is rejected at deployment.
+    function test_constructor_revertsOnZeroGateway() public {
+        vm.expectRevert(ModuleGatewaySandwich.InvalidGateway.selector);
+        new SandwichHarness(address(0), MIN_HEALTH_FACTOR);
+    }
+
     // Withdraws to the safe and passes the guard at exactly minHealthFactor.
     function test_withdraw_routesToSafeAndPassesAtMinHealthFactor() public {
         _setHealthFactor(MIN_HEALTH_FACTOR);
@@ -50,12 +56,14 @@ contract ModuleGatewaySandwichTest is Test {
         assertEq(to, safe);
     }
 
+    // Reverts when the post-withdraw health factor is below the floor.
     function test_withdraw_revertsBelowMinHealthFactor() public {
         _setHealthFactor(MIN_HEALTH_FACTOR - 1);
         vm.expectRevert(ModuleGatewaySandwich.WithdrawBreachesHealth.selector);
         harness.withdrawFromGateway(safe, asset, AMOUNT);
     }
 
+    // Supplies the asset back to Aave and marks it as collateral.
     function test_resupply_suppliesAndSetsCollateral() public {
         harness.resupplyToGateway(safe, asset, AMOUNT);
 

--- a/test/safe/modules/ModuleGatewaySandwich.t.sol
+++ b/test/safe/modules/ModuleGatewaySandwich.t.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { Test } from "forge-std/Test.sol";
+
+import { IGateway } from "../../../src/interfaces/IGateway.sol";
+import { MockGateway } from "../../../src/mocks/MockGateway.sol";
+import { ModuleGatewaySandwich } from "../../../src/modules/ModuleGatewaySandwich.sol";
+
+/// @notice Exposes the base's internal bookends so they can be called directly in tests
+contract SandwichHarness is ModuleGatewaySandwich {
+    constructor(address _gateway, uint256 _minHealthFactor) ModuleGatewaySandwich(_gateway, _minHealthFactor) { }
+
+    function withdrawFromGateway(address safe, address asset, uint256 amount) external {
+        _withdrawFromGateway(safe, asset, amount);
+    }
+
+    function resupplyToGateway(address safe, address asset, uint256 amount) external {
+        _resupplyToGateway(safe, asset, amount);
+    }
+}
+
+contract ModuleGatewaySandwichTest is Test {
+    MockGateway gateway;
+    SandwichHarness harness;
+
+    uint256 constant MIN_HEALTH_FACTOR = 1e18;
+    uint256 constant AMOUNT = 100e6;
+    address safe = makeAddr("safe");
+    address asset = makeAddr("asset");
+
+    function setUp() public {
+        gateway = new MockGateway();
+        harness = new SandwichHarness(address(gateway), MIN_HEALTH_FACTOR);
+    }
+
+    function _setHealthFactor(uint256 healthFactor) internal {
+        gateway.setAccountData(safe, IGateway.AccountData({ collateralUsd: 0, debtUsd: 0, availableBorrowsUsd: 0, healthFactor: healthFactor }));
+    }
+
+    // Withdraws to the safe and passes the guard at exactly minHealthFactor.
+    function test_withdraw_routesToSafeAndPassesAtMinHealthFactor() public {
+        _setHealthFactor(MIN_HEALTH_FACTOR);
+        harness.withdrawFromGateway(safe, asset, AMOUNT);
+
+        (address s, address a, uint256 amount, address to) = gateway.lastWithdraw();
+        assertEq(s, safe);
+        assertEq(a, asset);
+        assertEq(amount, AMOUNT);
+        assertEq(to, safe);
+    }
+
+    function test_withdraw_revertsBelowMinHealthFactor() public {
+        _setHealthFactor(MIN_HEALTH_FACTOR - 1);
+        vm.expectRevert(ModuleGatewaySandwich.WithdrawBreachesHealth.selector);
+        harness.withdrawFromGateway(safe, asset, AMOUNT);
+    }
+
+    function test_resupply_suppliesAndSetsCollateral() public {
+        harness.resupplyToGateway(safe, asset, AMOUNT);
+
+        (address s, address a, uint256 amount, address to) = gateway.lastSupply();
+        assertEq(s, safe);
+        assertEq(a, asset);
+        assertEq(amount, AMOUNT);
+        assertEq(to, address(0));
+        assertTrue(gateway.usingAsCollateral(safe, asset));
+    }
+}


### PR DESCRIPTION
## What it does

Adds `ModuleGatewaySandwich`, a small abstract base that asset-moving modules inherit so they keep working once auto-supply has moved an asset into the safe's Aave position. It provides the two bookends plus a health guard:

- `_withdrawFromGateway`: withdraws the asset from the safe's Aave position back to the safe, then reverts `WithdrawBreachesHealth` if the post-withdraw health factor is below `minHealthFactor`.
- `_resupplyToGateway`: supplies the output back to Aave and marks it as collateral.

A consuming module brackets its own action between the two calls. This PR is only the shared helper and its tests. The module rewrites that consume it are separate tickets: COR-986 (swap), COR-987 (Liquid), COR-988 (LiquidUSD repay).

## Why

Every asset-moving module needs the same withdraw, act, re-supply wrap once collateral lives in Aave. Writing it once avoids three copies of the same bug surface.

## The guard

Aave checks health on every withdraw and does not defer it across a multicall (verified against the live Aave v4 source). So debt-backing collateral cannot be withdrawn mid-action, only free or slack collateral can. The guard makes that explicit with a clean revert. Health factor is on Aave's 1e18 scale.

## Needs a second eye

- Guard is a post-withdraw health check. It is the only price-free guard the current `IGateway` exposes, since `getAccountData` has no per-asset price or LTV. In production Aave reverts the withdraw itself at HF below 1, so the check's value is a clean error plus any safety margin above 1.0 we choose to set. Open question: do we want a margin, and what is the right `minHealthFactor`?
- Gateway is a constructor param, not a `getCashModule`-style getter on the data provider. Keeps the helper self-contained and off the core data provider. Fine to revisit once the gateway is stood up.

## How it was tested

Three unit tests against `MockGateway`: withdraw routes to the safe and passes the guard at the floor, withdraw reverts below the floor, and re-supply supplies and sets collateral. `forge build`, `forge test`, `forge fmt`, and `forge lint` all clean.

Linear COR-985


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches collateral withdraw/supply and health-factor gating for future module flows; logic is isolated and tested but will underpin swap/repay modules later.
> 
> **Overview**
> Introduces **`ModuleGatewaySandwich`**, an abstract base for asset-moving modules once collateral sits in Aave via auto-supply. Modules bracket their logic between two internal helpers: **`_withdrawFromGateway`** (withdraw to the safe through `IGateway`, then revert **`WithdrawBreachesHealth`** if health factor is below **`minHealthFactor`**) and **`_resupplyToGateway`** (supply back and **`setUsingAsCollateral`**).
> 
> The constructor pins an immutable gateway (rejects zero) and health floor. **No consuming modules** are in this PR—only the helper plus **`ModuleGatewaySandwich.t.sol`** tests via a harness and **`MockGateway`** (constructor guard, withdraw routing/guard, re-supply + collateral flag).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 413aa1dd658089120bd697fbcdb5d8e872f2c529. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->