### PR TITLE
feat: rewrite CashLens to read the Aave position

### DIFF
--- a/src/interfaces/IAaveV4PriceFeed.sol
+++ b/src/interfaces/IAaveV4PriceFeed.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/**
+ * @title IAaveV4PriceFeed
+ * @notice Minimal price-feed interface a price source implements to be read by the Aave v4 AaveOracle.
+ *         Our receipt-token feeds implement it so those tokens can be Aave collateral.
+ * @dev MIT mirror of aave-v4 src/spoke/interfaces/IPriceFeed.sol (BUSL); we declare only the ABI we
+ *      call rather than vendoring BUSL source. Verified against aave/aave-v4.
+ * @author ether.fi
+ */
+interface IAaveV4PriceFeed {
+    /// @notice The number of decimals used to represent the price
+    function decimals() external view returns (uint8);
+
+    /// @notice A human-readable description of the feed
+    function description() external view returns (string memory);
+
+    /// @notice The latest price, expressed with decimals() precision
+    function latestAnswer() external view returns (int256);
+}

--- a/src/interfaces/IGateway.sol
+++ b/src/interfaces/IGateway.sol
@@ -13,7 +13,7 @@ pragma solidity ^0.8.28;
  * @author ether.fi
  */
 interface IGateway {
-    /// @notice A safe's Aave position summary, denominated in USD with 8 decimals.
+    /// @notice A safe's Aave position summary, denominated in USD with 6 decimals (matching PriceProvider.DECIMALS).
     struct AccountData {
         uint256 collateralUsd;
         uint256 debtUsd;
@@ -71,4 +71,27 @@ interface IGateway {
      * @return The safe's account data
      */
     function getAccountData(address safe) external view returns (AccountData memory);
+
+    /**
+     * @notice Returns the amount of `asset` that `safe` has supplied to Aave
+     * @param safe The safe to query
+     * @param asset The supplied asset
+     * @return The supplied amount, in asset units
+     */
+    function suppliedOf(address safe, address asset) external view returns (uint256);
+
+    /**
+     * @notice Returns the amount of `asset` debt that `safe` owes Aave
+     * @param safe The safe to query
+     * @param asset The borrowed asset
+     * @return The debt amount, in asset units
+     */
+    function debtOf(address safe, address asset) external view returns (uint256);
+
+    /**
+     * @notice Returns the withdrawable and borrowable liquidity of `asset`'s reserve
+     * @param asset The reserve asset
+     * @return The available liquidity, in asset units
+     */
+    function availableCash(address asset) external view returns (uint256);
 }

--- a/src/interfaces/IGateway.sol
+++ b/src/interfaces/IGateway.sol
@@ -13,10 +13,11 @@ pragma solidity ^0.8.28;
  * @author ether.fi
  */
 interface IGateway {
-    /// @notice A safe's Aave position summary, denominated in USD with 6 decimals (matching PriceProvider.DECIMALS).
+    /// @notice A safe's Aave position summary. USD fields are 6 decimals (matching PriceProvider.DECIMALS); healthFactor is 1e18.
     struct AccountData {
         uint256 collateralUsd;
         uint256 debtUsd;
+        // borrowing headroom: collateral weighted by each reserve's LTV, minus debt
         uint256 availableBorrowsUsd;
         uint256 healthFactor;
     }
@@ -94,4 +95,11 @@ interface IGateway {
      * @return The available liquidity, in asset units
      */
     function availableCash(address asset) external view returns (uint256);
+
+    /**
+     * @notice Returns the loan-to-value of `asset`'s reserve, in the 100e18 = 100% scale (matching DebtManager's CollateralTokenConfig.ltv)
+     * @param asset The reserve asset
+     * @return The LTV, where 100e18 is 100%
+     */
+    function ltv(address asset) external view returns (uint256);
 }

--- a/src/interfaces/IVedaAccountant.sol
+++ b/src/interfaces/IVedaAccountant.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/**
+ * @title IVedaAccountant
+ * @notice The part of a Veda accountant the feed reads. getRateSafe returns the vault rate and
+ *         reverts when the accountant is paused.
+ * @dev MIT mirror of Veda's AccountantWithRateProviders (Se7en-Seas/boring-vault), only what we call.
+ * @author ether.fi
+ */
+interface IVedaAccountant {
+    struct AccountantState {
+        address payoutAddress;
+        uint96 highwaterMark;
+        uint128 feesOwedInBase;
+        uint128 totalSharesLastUpdate;
+        uint96 exchangeRate;
+        uint16 allowedExchangeRateChangeUpper;
+        uint16 allowedExchangeRateChangeLower;
+        uint64 lastUpdateTimestamp;
+        bool isPaused;
+        uint24 minimumUpdateDelayInSeconds;
+        uint16 platformFee;
+        uint16 performanceFee;
+    }
+
+    /// @notice The exchange rate in the base asset; reverts if the accountant is paused
+    function getRateSafe() external view returns (uint256);
+
+    /// @notice The accountant state, including the last exchange-rate update timestamp
+    function accountantState() external view returns (AccountantState memory);
+
+    /// @notice The decimals of the exchange rate
+    function decimals() external view returns (uint8);
+}

--- a/src/mocks/MockGateway.sol
+++ b/src/mocks/MockGateway.sol
@@ -20,6 +20,9 @@ contract MockGateway is IGateway {
 
     mapping(address => AccountData) internal _accountData;
     mapping(address => mapping(address => bool)) public usingAsCollateral;
+    mapping(address safe => mapping(address asset => uint256)) internal _suppliedOf;
+    mapping(address safe => mapping(address asset => uint256)) internal _debtOf;
+    mapping(address asset => uint256) internal _availableCash;
 
     Call public lastSupply;
     Call public lastWithdraw;
@@ -29,6 +32,21 @@ contract MockGateway is IGateway {
     /// @notice Sets the account data a subsequent `getAccountData(safe)` will return
     function setAccountData(address safe, AccountData calldata data) external {
         _accountData[safe] = data;
+    }
+
+    /// @notice Sets the supplied amount a subsequent `suppliedOf(safe, asset)` will return
+    function setSuppliedOf(address safe, address asset, uint256 amount) external {
+        _suppliedOf[safe][asset] = amount;
+    }
+
+    /// @notice Sets the debt a subsequent `debtOf(safe, asset)` will return
+    function setDebtOf(address safe, address asset, uint256 amount) external {
+        _debtOf[safe][asset] = amount;
+    }
+
+    /// @notice Sets the reserve liquidity a subsequent `availableCash(asset)` will return
+    function setAvailableCash(address asset, uint256 amount) external {
+        _availableCash[asset] = amount;
     }
 
     function supply(address safe, address asset, uint256 amount) external {
@@ -54,5 +72,17 @@ contract MockGateway is IGateway {
 
     function getAccountData(address safe) external view returns (AccountData memory) {
         return _accountData[safe];
+    }
+
+    function suppliedOf(address safe, address asset) external view returns (uint256) {
+        return _suppliedOf[safe][asset];
+    }
+
+    function debtOf(address safe, address asset) external view returns (uint256) {
+        return _debtOf[safe][asset];
+    }
+
+    function availableCash(address asset) external view returns (uint256) {
+        return _availableCash[asset];
     }
 }

--- a/src/mocks/MockGateway.sol
+++ b/src/mocks/MockGateway.sol
@@ -23,6 +23,7 @@ contract MockGateway is IGateway {
     mapping(address safe => mapping(address asset => uint256)) internal _suppliedOf;
     mapping(address safe => mapping(address asset => uint256)) internal _debtOf;
     mapping(address asset => uint256) internal _availableCash;
+    mapping(address asset => uint256) internal _ltv;
 
     Call public lastSupply;
     Call public lastWithdraw;
@@ -47,6 +48,11 @@ contract MockGateway is IGateway {
     /// @notice Sets the reserve liquidity a subsequent `availableCash(asset)` will return
     function setAvailableCash(address asset, uint256 amount) external {
         _availableCash[asset] = amount;
+    }
+
+    /// @notice Sets the LTV (100e18 = 100%) a subsequent `ltv(asset)` will return
+    function setLtv(address asset, uint256 ltvValue) external {
+        _ltv[asset] = ltvValue;
     }
 
     function supply(address safe, address asset, uint256 amount) external {
@@ -84,5 +90,9 @@ contract MockGateway is IGateway {
 
     function availableCash(address asset) external view returns (uint256) {
         return _availableCash[asset];
+    }
+
+    function ltv(address asset) external view returns (uint256) {
+        return _ltv[asset];
     }
 }

--- a/src/modules/ModuleGatewaySandwich.sol
+++ b/src/modules/ModuleGatewaySandwich.sol
@@ -8,21 +8,37 @@ import { IGateway } from "../interfaces/IGateway.sol";
  * @notice Shared helper for modules that move a safe's assets once those assets live in Aave.
  *         Auto-supply leaves the asset in the safe's Aave position, not the safe, so a module
  *         withdraws it back to the safe, runs its action, then re-supplies the output as collateral.
- * @dev Provides the two bookends and the health guard; the module brackets its own action between
- *      them. The withdraw guard reverts when the post-withdraw health factor is below minHealthFactor,
- *      matching Aave's own check that debt-backing collateral cannot be withdrawn (no deferral).
+ * @dev Provides the two bookends plus a guardsHealth modifier; the module brackets its own action
+ *      between the bookends and applies guardsHealth to the operation's entry point. Aave enforces its
+ *      own liquidation-threshold floor on the withdraw itself (it reverts if the withdraw alone would
+ *      drop health below that threshold, no deferral). The stricter minHealthFactor buffer is checked
+ *      once by guardsHealth, after the whole operation completes, against the safe's final position, so
+ *      a transient mid-sandwich dip (collateral out, output not yet back) does not false-revert. It runs
+ *      whatever the operation ends with (resupply, repay, borrow, send-out) and even on an early return.
  * @author ether.fi
  */
 abstract contract ModuleGatewaySandwich {
     /// @notice The gateway that performs Aave ops on a safe's behalf
     IGateway public immutable gateway;
-    /// @notice The lowest post-withdraw health factor a withdraw may leave the safe at
+    /// @notice The lowest health factor the operation may leave the safe at once it completes
     uint256 public immutable minHealthFactor;
 
     /// @notice Thrown when the gateway address is zero
     error InvalidGateway();
-    /// @notice Thrown when a withdraw would leave the safe below minHealthFactor
-    error WithdrawBreachesHealth();
+    /// @notice Thrown when the completed operation would leave the safe below minHealthFactor
+    error OperationBreachesHealth();
+
+    /**
+     * @notice Reverts if the operation leaves the safe below minHealthFactor
+     * @dev Apply to a module's operation entry point. The check runs after the function body, against the
+     *      final position, so it covers operations that end by resupplying, repaying, borrowing, or
+     *      sending out, and runs even if the body returns early.
+     * @param safe The safe whose final health is guarded
+     */
+    modifier guardsHealth(address safe) {
+        _;
+        if (gateway.getAccountData(safe).healthFactor < minHealthFactor) revert OperationBreachesHealth();
+    }
 
     constructor(address _gateway, uint256 _minHealthFactor) {
         if (_gateway == address(0)) revert InvalidGateway();
@@ -31,14 +47,15 @@ abstract contract ModuleGatewaySandwich {
     }
 
     /**
-     * @notice Withdraws an asset from the safe's Aave position back into the safe, then guards health
+     * @notice Withdraws an asset from the safe's Aave position back into the safe
+     * @dev Aave reverts if the withdraw alone would breach its liquidation threshold; the stricter
+     *      minHealthFactor buffer is enforced by guardsHealth on the operation, against the final position.
      * @param safe The safe whose position is debited
      * @param asset The asset to withdraw
      * @param amount The amount to withdraw
      */
     function _withdrawFromGateway(address safe, address asset, uint256 amount) internal {
         gateway.withdraw(safe, asset, amount, safe);
-        if (gateway.getAccountData(safe).healthFactor < minHealthFactor) revert WithdrawBreachesHealth();
     }
 
     /**

--- a/src/modules/ModuleGatewaySandwich.sol
+++ b/src/modules/ModuleGatewaySandwich.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { IGateway } from "../interfaces/IGateway.sol";
+
+/**
+ * @title ModuleGatewaySandwich
+ * @notice Shared helper for modules that move a safe's assets once those assets live in Aave.
+ *         Auto-supply leaves the asset in the safe's Aave position, not the safe, so a module
+ *         withdraws it back to the safe, runs its action, then re-supplies the output as collateral.
+ * @dev Provides the two bookends and the health guard; the module brackets its own action between
+ *      them. The withdraw guard reverts when the post-withdraw health factor is below minHealthFactor,
+ *      matching Aave's own check that debt-backing collateral cannot be withdrawn (no deferral).
+ * @author ether.fi
+ */
+abstract contract ModuleGatewaySandwich {
+    /// @notice The gateway that performs Aave ops on a safe's behalf
+    IGateway public immutable gateway;
+    /// @notice The lowest post-withdraw health factor a withdraw may leave the safe at
+    uint256 public immutable minHealthFactor;
+
+    /// @notice Thrown when the gateway address is zero
+    error InvalidGateway();
+    /// @notice Thrown when a withdraw would leave the safe below minHealthFactor
+    error WithdrawBreachesHealth();
+
+    constructor(address _gateway, uint256 _minHealthFactor) {
+        if (_gateway == address(0)) revert InvalidGateway();
+        gateway = IGateway(_gateway);
+        minHealthFactor = _minHealthFactor;
+    }
+
+    /**
+     * @notice Withdraws an asset from the safe's Aave position back into the safe, then guards health
+     * @param safe The safe whose position is debited
+     * @param asset The asset to withdraw
+     * @param amount The amount to withdraw
+     */
+    function _withdrawFromGateway(address safe, address asset, uint256 amount) internal {
+        gateway.withdraw(safe, asset, amount, safe);
+        if (gateway.getAccountData(safe).healthFactor < minHealthFactor) revert WithdrawBreachesHealth();
+    }
+
+    /**
+     * @notice Supplies an asset from the safe back into Aave and marks it as collateral
+     * @param safe The safe whose position is credited
+     * @param asset The asset to supply
+     * @param amount The amount to supply
+     */
+    function _resupplyToGateway(address safe, address asset, uint256 amount) internal {
+        gateway.supply(safe, asset, amount);
+        gateway.setUsingAsCollateral(safe, asset, true);
+    }
+}

--- a/src/modules/cash/CashLens.sol
+++ b/src/modules/cash/CashLens.sol
@@ -215,12 +215,13 @@ contract CashLens is UpgradeableProxy {
                     return (false, "Insufficient token balance for debit mode spending");
                 }
                 uint256 pending = _getPendingWithdrawalAmount(safeData, token);
-                if (_debitSpendableAmount(raw, withdrawable, pending) < needed) {
+                raw = raw > pending ? raw - pending : 0;
+                if (raw + withdrawable < needed) {
                     return (false, "Insufficient effective balance after withdrawal to spend with debit mode");
                 }
             }
 
-            // Only the supplied portion (raw is spent first) consumes the borrowing headroom for later tokens
+            // Only the supplied portion (effective raw is spent first) consumes the borrowing headroom for later tokens
             if (hasDebt) {
                 uint256 usedSupplied = needed > raw ? needed - raw : 0;
                 uint256 used = _headroomConsumed(token, usedSupplied);

--- a/src/modules/cash/CashLens.sol
+++ b/src/modules/cash/CashLens.sol
@@ -210,13 +210,13 @@ contract CashLens is UpgradeableProxy {
             uint256 needed = _fromUsd(token, amountsInUsd[i]);
             uint256 raw = IERC20(token).balanceOf(safe);
             {
-                uint256 withdrawable = _withdrawableSupplied(safe, token, borrowHeadroom, hasDebt);
-                if (raw + withdrawable < needed) {
+                uint256 withdrawableSupplied = _withdrawableSupplied(safe, token, borrowHeadroom, hasDebt);
+                if (raw + withdrawableSupplied < needed) {
                     return (false, "Insufficient token balance for debit mode spending");
                 }
                 uint256 pending = _getPendingWithdrawalAmount(safeData, token);
                 raw = raw > pending ? raw - pending : 0;
-                if (raw + withdrawable < needed) {
+                if (raw + withdrawableSupplied < needed) {
                     return (false, "Insufficient effective balance after withdrawal to spend with debit mode");
                 }
             }
@@ -494,12 +494,12 @@ contract CashLens is UpgradeableProxy {
 
     /// @notice Debit spendable for `token` (token units) given the running borrowing headroom, and the headroom that withdrawal consumes
     function _debitSpendable(address safe, address token, SafeData memory safeData, uint256 borrowHeadroomUsd, bool hasDebt) internal view returns (uint256, uint256) {
-        uint256 withdrawable = _withdrawableSupplied(safe, token, borrowHeadroomUsd, hasDebt);
-        uint256 headroomUsed = hasDebt ? _headroomConsumed(token, withdrawable) : 0;
+        uint256 withdrawableSupplied = _withdrawableSupplied(safe, token, borrowHeadroomUsd, hasDebt);
+        uint256 headroomUsed = hasDebt ? _headroomConsumed(token, withdrawableSupplied) : 0;
 
         uint256 raw = IERC20(token).balanceOf(safe);
         uint256 pending = _getPendingWithdrawalAmount(safeData, token);
-        uint256 spendable = _debitSpendableAmount(raw, withdrawable, pending);
+        uint256 spendable = _debitSpendableAmount(raw, withdrawableSupplied, pending);
 
         return (spendable, headroomUsed);
     }

--- a/src/modules/cash/CashLens.sol
+++ b/src/modules/cash/CashLens.sol
@@ -26,7 +26,7 @@ import { UpgradeableProxy } from "../../utils/UpgradeableProxy.sol";
  *      The debit cap uses LTV, which is stricter than the sandwich's liquidation-threshold health gate
  *      (ModuleGatewaySandwich.minHealthFactor) only while minHealthFactor <= liqThreshold / LTV for every
  *      collateral. Keep that invariant at deploy time, or CashLens can over-report a debit spend that the
- *      sandwich then reverts on withdraw.
+ *      sandwich then reverts on.
  *
  *      A pending withdrawal sits against the loose Safe balance, not the supplied position. CashLens reserves
  *      it from the loose balance and uses the gateway's figures (collateral, maxBorrow, credit/debit headroom)
@@ -179,7 +179,7 @@ contract CashLens is UpgradeableProxy {
     /// @notice Credit mode check: the spend must fit the Aave borrowing capacity and the reserve's liquidity
     function _creditCheck(address safe, address token, uint256 totalSpendingInUsd) internal view returns (bool, string memory) {
         if (!cashModule.getDebtManager().isBorrowToken(token)) {
-            return (false, "Not a supported stable token");
+            return (false, "Not a supported borrow token");
         }
 
         if (gateway.availableCash(token) < _fromUsd(token, totalSpendingInUsd)) {
@@ -204,7 +204,7 @@ contract CashLens is UpgradeableProxy {
         for (uint256 i = 0; i < tokens.length; i++) {
             address token = tokens[i];
             if (!debtManager.isBorrowToken(token)) {
-                return (false, "Not a supported stable token");
+                return (false, "Not a supported borrow token");
             }
 
             uint256 needed = _fromUsd(token, amountsInUsd[i]);
@@ -364,11 +364,28 @@ contract CashLens is UpgradeableProxy {
 
     /**
      * @notice Calculates the maximum amount that can be spent in credit mode
+     * @dev Borrowing power (collateral weighted by LTV, minus debt) bounded by pool liquidity: a credit
+     *      spend draws a single borrow token, so the most liquid borrow token sets the achievable ceiling,
+     *      matching the reserve-liquidity decline in _creditCheck.
      * @param safe Address of the EtherFi Safe
      * @return Maximum amount that can be spent in credit mode (USD, 6 decimals)
      */
     function getMaxSpendCredit(address safe) public view returns (uint256) {
-        return gateway.getAccountData(safe).availableBorrowsUsd;
+        uint256 borrowPower = gateway.getAccountData(safe).availableBorrowsUsd;
+
+        address[] memory borrowTokens = cashModule.getDebtManager().getBorrowTokens();
+        uint256 maxLiquidityUsd = 0;
+        for (uint256 i = 0; i < borrowTokens.length;) {
+            uint256 liquidityUsd = _toUsd(borrowTokens[i], gateway.availableCash(borrowTokens[i]));
+            if (liquidityUsd > maxLiquidityUsd) {
+                maxLiquidityUsd = liquidityUsd;
+            }
+            unchecked {
+                ++i;
+            }
+        }
+
+        return borrowPower < maxLiquidityUsd ? borrowPower : maxLiquidityUsd;
     }
 
     /**

--- a/src/modules/cash/CashLens.sol
+++ b/src/modules/cash/CashLens.sol
@@ -422,7 +422,7 @@ contract CashLens is UpgradeableProxy {
         uint256 balance = IERC20(token).balanceOf(safe);
         uint256 pendingWithdrawalAmount = getPendingWithdrawalAmount(safe, token);
 
-        return balance - pendingWithdrawalAmount;
+        return balance > pendingWithdrawalAmount ? balance - pendingWithdrawalAmount : 0;
     }
 
     /**
@@ -442,7 +442,7 @@ contract CashLens is UpgradeableProxy {
             uint256 balance = IERC20(collateralTokens[i]).balanceOf(safe);
             uint256 pendingWithdrawalAmount = getPendingWithdrawalAmount(safe, collateralTokens[i]);
             if (balance != 0) {
-                balance = balance - pendingWithdrawalAmount;
+                balance = balance > pendingWithdrawalAmount ? balance - pendingWithdrawalAmount : 0;
                 if (balance != 0) {
                     tokenAmounts[m] = IDebtManager.TokenData({ token: collateralTokens[i], amount: balance });
                     unchecked {

--- a/src/modules/cash/CashLens.sol
+++ b/src/modules/cash/CashLens.sol
@@ -22,6 +22,11 @@ import { UpgradeableProxy } from "../../utils/UpgradeableProxy.sol";
  *      borrowing headroom (collateral weighted by LTV, minus debt) so the leftover position keeps
  *      debt within its borrowing power. USD is 6 decimals throughout, matching PriceProvider.DECIMALS;
  *      the gateway returns its USD aggregates in the same scale.
+ *
+ *      The debit cap uses LTV, which is stricter than the sandwich's liquidation-threshold health gate
+ *      (ModuleGatewaySandwich.minHealthFactor) only while minHealthFactor <= liqThreshold / LTV for every
+ *      collateral. Keep that invariant at deploy time, or CashLens can over-report a debit spend that the
+ *      sandwich then reverts on withdraw.
  * @author ether.fi
  */
 contract CashLens is UpgradeableProxy {
@@ -162,13 +167,13 @@ contract CashLens is UpgradeableProxy {
         }
 
         if (mode == Mode.Credit) {
-            return _creditCheck(safe, tokens[0], totalSpendingInUsd);
+            return _creditCheck(safe, tokens[0], totalSpendingInUsd, safeData);
         }
         return _debitCheck(safe, tokens, amountsInUsd, safeData);
     }
 
-    /// @notice Credit mode check: the spend must fit the Aave borrowing capacity and the reserve's liquidity
-    function _creditCheck(address safe, address token, uint256 totalSpendingInUsd) internal view returns (bool, string memory) {
+    /// @notice Credit mode check: the spend must fit the Aave borrowing capacity (net of pending withdrawals) and the reserve's liquidity
+    function _creditCheck(address safe, address token, uint256 totalSpendingInUsd, SafeData memory safeData) internal view returns (bool, string memory) {
         if (!cashModule.getDebtManager().isBorrowToken(token)) {
             return (false, "Not a supported stable token");
         }
@@ -177,7 +182,10 @@ contract CashLens is UpgradeableProxy {
             return (false, "Insufficient liquidity in debt manager to cover the loan");
         }
 
+        // Pending withdrawals will leave the position, so discount their borrowing power up front
+        uint256 pending = _pendingWithdrawalHeadroom(safeData);
         uint256 capacityUsd = gateway.getAccountData(safe).availableBorrowsUsd;
+        capacityUsd = capacityUsd > pending ? capacityUsd - pending : 0;
         if (totalSpendingInUsd > capacityUsd) {
             return (false, "Insufficient borrowing power");
         }
@@ -190,7 +198,8 @@ contract CashLens is UpgradeableProxy {
         IDebtManager debtManager = cashModule.getDebtManager();
         IGateway.AccountData memory account = gateway.getAccountData(safe);
         bool hasDebt = account.debtUsd != 0;
-        uint256 borrowHeadroom = hasDebt ? account.availableBorrowsUsd : 0;
+        // Net of pending withdrawals, which will leave the position and reduce its borrowing power
+        uint256 borrowHeadroom = _netBorrowHeadroom(account, safeData);
 
         for (uint256 i = 0; i < tokens.length; i++) {
             if (!debtManager.isBorrowToken(tokens[i])) {
@@ -203,7 +212,8 @@ contract CashLens is UpgradeableProxy {
             if (available < needed) {
                 return (false, "Insufficient token balance for debit mode spending");
             }
-            if (available - _getPendingWithdrawalAmount(safeData, tokens[i]) < needed) {
+            // available - pending < needed, written as an addition so a pending larger than available declines instead of underflowing
+            if (available < _getPendingWithdrawalAmount(safeData, tokens[i]) + needed) {
                 return (false, "Insufficient effective balance after withdrawal to spend with debit mode");
             }
 
@@ -254,7 +264,8 @@ contract CashLens is UpgradeableProxy {
         data.borrows = _debtBalances(safe, borrowTokens);
         data.totalCollateral = account.collateralUsd;
         data.totalBorrow = account.debtUsd;
-        data.maxBorrow = account.availableBorrowsUsd;
+        // Gross borrowing power (collateral weighted by LTV), matching DebtManager's getMaxBorrowAmount: headroom plus current debt
+        data.maxBorrow = account.availableBorrowsUsd + account.debtUsd;
 
         uint256 len = collateralTokens.length;
         data.tokenPrices = new IDebtManager.TokenData[](len);
@@ -291,7 +302,9 @@ contract CashLens is UpgradeableProxy {
      * @dev Each token's spendable amount is its raw Safe balance plus the withdrawable supplied amount,
      *      minus any pending withdrawal. When the Safe has debt, the withdrawable supplied amount is capped
      *      by the borrowing headroom (collateral weighted by LTV, minus debt), threaded across the
-     *      preference order so each token only spends the headroom the earlier ones left.
+     *      preference order so each token only spends the headroom the earlier ones left. The headroom also
+     *      excludes what pending withdrawals will consume; a token that has both a pending withdrawal and debt
+     *      is treated conservatively, since its pending is netted from both its own amount and the headroom.
      * @param safe Address of the EtherFi Safe
      * @param debtServiceTokenPreference Ordered array of borrow token addresses (stablecoins). Order is
      *                                   preserved in the result.
@@ -316,9 +329,8 @@ contract CashLens is UpgradeableProxy {
         {
             IGateway.AccountData memory account = gateway.getAccountData(safe);
             hasDebt = account.debtUsd != 0;
-            if (hasDebt) {
-                borrowHeadroom = account.availableBorrowsUsd;
-            }
+            // Net of pending withdrawals, which will leave the position and reduce its borrowing power
+            borrowHeadroom = _netBorrowHeadroom(account, safeData);
         }
 
         uint256[] memory spendableAmounts = new uint256[](len);
@@ -352,7 +364,9 @@ contract CashLens is UpgradeableProxy {
      * @return Maximum amount that can be spent in credit mode (USD, 6 decimals)
      */
     function getMaxSpendCredit(address safe) public view returns (uint256) {
-        return gateway.getAccountData(safe).availableBorrowsUsd;
+        uint256 capacity = gateway.getAccountData(safe).availableBorrowsUsd;
+        uint256 pending = _pendingWithdrawalHeadroom(cashModule.getData(safe));
+        return capacity > pending ? capacity - pending : 0;
     }
 
     /**
@@ -458,11 +472,13 @@ contract CashLens is UpgradeableProxy {
 
         if (hasDebt) {
             uint256 ltv = gateway.ltv(token);
-            if (ltv != 0) {
-                uint256 headroomCap = _fromUsd(token, (borrowHeadroomUsd * HUNDRED_PERCENT) / ltv);
-                if (headroomCap < cap) {
-                    cap = headroomCap;
-                }
+            // A zero-LTV reserve has no borrow weight, so a withdrawal against debt cannot be sized safely; stay conservative
+            if (ltv == 0) {
+                return 0;
+            }
+            uint256 headroomCap = _fromUsd(token, (borrowHeadroomUsd * HUNDRED_PERCENT) / ltv);
+            if (headroomCap < cap) {
+                cap = headroomCap;
             }
         }
 
@@ -472,6 +488,30 @@ contract CashLens is UpgradeableProxy {
     /// @notice Borrowing headroom (USD) consumed by withdrawing `amount` of `token`: its USD value weighted by the LTV
     function _headroomConsumed(address token, uint256 amount) internal view returns (uint256) {
         return (_toUsd(token, amount) * gateway.ltv(token)) / HUNDRED_PERCENT;
+    }
+
+    /// @notice Borrowing headroom (USD) available for a new spend: the gateway headroom less what queued withdrawals will consume. Zero without debt, since debit only uses the headroom when there is debt.
+    function _netBorrowHeadroom(IGateway.AccountData memory account, SafeData memory safeData) internal view returns (uint256) {
+        if (account.debtUsd == 0) return 0;
+        uint256 pending = _pendingWithdrawalHeadroom(safeData);
+        return account.availableBorrowsUsd > pending ? account.availableBorrowsUsd - pending : 0;
+    }
+
+    /// @notice Borrowing headroom (USD) tied up by pending withdrawal requests: each pending token's LTV-weighted USD value
+    function _pendingWithdrawalHeadroom(SafeData memory safeData) internal view returns (uint256) {
+        uint256 total = 0;
+        uint256 len = safeData.pendingWithdrawalRequest.tokens.length;
+        for (uint256 i = 0; i < len;) {
+            uint256 amount = safeData.pendingWithdrawalRequest.amounts[i];
+            if (amount != 0) {
+                total += _headroomConsumed(safeData.pendingWithdrawalRequest.tokens[i], amount);
+            }
+            unchecked {
+                ++i;
+            }
+        }
+
+        return total;
     }
 
     /// @notice Debit spendable for `token` (token units) given the running borrowing headroom, and the headroom that withdrawal consumes

--- a/src/modules/cash/CashLens.sol
+++ b/src/modules/cash/CashLens.sol
@@ -183,7 +183,7 @@ contract CashLens is UpgradeableProxy {
         }
 
         if (gateway.availableCash(token) < _fromUsd(token, totalSpendingInUsd)) {
-            return (false, "Insufficient liquidity in debt manager to cover the loan");
+            return (false, "Insufficient liquidity to cover the loan");
         }
 
         // availableBorrowsUsd is the supplied position's capacity; a pending sits against the loose balance, so it is not deducted here

--- a/src/modules/cash/CashLens.sol
+++ b/src/modules/cash/CashLens.sol
@@ -17,9 +17,10 @@ import { UpgradeableProxy } from "../../utils/UpgradeableProxy.sol";
  * @title CashLens
  * @notice Read-only contract providing views into a Safe's cash state
  * @dev Reads the Safe's position from the Aave gateway and the supported-token list from DebtManager.
- *      Phase one covers the no-borrow world: credit capacity comes straight from Aave, debit spendable
- *      is the raw Safe balance plus the withdrawable supplied amount, and there is no underwater math
- *      because no live user has debt yet. USD is 6 decimals throughout, matching PriceProvider.DECIMALS;
+ *      Credit capacity comes straight from Aave. Debit spendable is the raw Safe balance plus the
+ *      withdrawable supplied amount; when the Safe has debt, the withdrawable part is capped by the
+ *      borrowing headroom (collateral weighted by LTV, minus debt) so the leftover position keeps
+ *      debt within its borrowing power. USD is 6 decimals throughout, matching PriceProvider.DECIMALS;
  *      the gateway returns its USD aggregates in the same scale.
  * @author ether.fi
  */
@@ -33,6 +34,9 @@ contract CashLens is UpgradeableProxy {
     IEtherFiDataProvider public immutable dataProvider;
     /// @notice Reference to the Aave gateway that holds the Safe's position
     IGateway public immutable gateway;
+
+    /// @notice Percentage denominator (100e18 = 100%), matching the gateway's ltv scale and DebtManager's CollateralTokenConfig.ltv
+    uint256 internal constant HUNDRED_PERCENT = 100e18;
 
     /// @notice Error thrown when trying to use a token that is not on the collateral whitelist
     error NotACollateralToken();
@@ -181,9 +185,12 @@ contract CashLens is UpgradeableProxy {
         return (true, "");
     }
 
-    /// @notice Debit mode check: each token's spendable amount must cover its share of the spend
+    /// @notice Debit mode check: each token's spendable amount must cover its share of the spend, threading the borrowing headroom across tokens
     function _debitCheck(address safe, address[] memory tokens, uint256[] memory amountsInUsd, SafeData memory safeData) internal view returns (bool, string memory) {
         IDebtManager debtManager = cashModule.getDebtManager();
+        IGateway.AccountData memory account = gateway.getAccountData(safe);
+        bool hasDebt = account.debtUsd != 0;
+        uint256 borrowHeadroom = hasDebt ? account.availableBorrowsUsd : 0;
 
         for (uint256 i = 0; i < tokens.length; i++) {
             if (!debtManager.isBorrowToken(tokens[i])) {
@@ -191,12 +198,20 @@ contract CashLens is UpgradeableProxy {
             }
 
             uint256 needed = _fromUsd(tokens[i], amountsInUsd[i]);
-            uint256 available = IERC20(tokens[i]).balanceOf(safe) + _withdrawable(safe, tokens[i]);
+            uint256 raw = IERC20(tokens[i]).balanceOf(safe);
+            uint256 available = raw + _withdrawableSupplied(safe, tokens[i], borrowHeadroom, hasDebt);
             if (available < needed) {
                 return (false, "Insufficient token balance for debit mode spending");
             }
             if (available - _getPendingWithdrawalAmount(safeData, tokens[i]) < needed) {
                 return (false, "Insufficient effective balance after withdrawal to spend with debit mode");
+            }
+
+            // Only the supplied portion (raw is spent first) consumes the borrowing headroom for later tokens
+            if (hasDebt) {
+                uint256 usedSupplied = needed > raw ? needed - raw : 0;
+                uint256 used = _headroomConsumed(tokens[i], usedSupplied);
+                borrowHeadroom = borrowHeadroom > used ? borrowHeadroom - used : 0;
             }
         }
 
@@ -273,9 +288,10 @@ contract CashLens is UpgradeableProxy {
 
     /**
      * @notice Calculates the maximum amounts that can be spent in debit mode across multiple tokens
-     * @dev Phase one, no-borrow world: each token's spendable amount is its raw Safe balance plus the
-     *      withdrawable supplied amount, minus any pending withdrawal. There is no deficit coverage
-     *      because no live user has debt yet.
+     * @dev Each token's spendable amount is its raw Safe balance plus the withdrawable supplied amount,
+     *      minus any pending withdrawal. When the Safe has debt, the withdrawable supplied amount is capped
+     *      by the borrowing headroom (collateral weighted by LTV, minus debt), threaded across the
+     *      preference order so each token only spends the headroom the earlier ones left.
      * @param safe Address of the EtherFi Safe
      * @param debtServiceTokenPreference Ordered array of borrow token addresses (stablecoins). Order is
      *                                   preserved in the result.
@@ -295,6 +311,16 @@ contract CashLens is UpgradeableProxy {
         IDebtManager debtManager = cashModule.getDebtManager();
         SafeData memory safeData = cashModule.getData(safe);
 
+        bool hasDebt;
+        uint256 borrowHeadroom;
+        {
+            IGateway.AccountData memory account = gateway.getAccountData(safe);
+            hasDebt = account.debtUsd != 0;
+            if (hasDebt) {
+                borrowHeadroom = account.availableBorrowsUsd;
+            }
+        }
+
         uint256[] memory spendableAmounts = new uint256[](len);
         uint256[] memory amountsInUsd = new uint256[](len);
         uint256 totalSpendableInUsd = 0;
@@ -303,7 +329,9 @@ contract CashLens is UpgradeableProxy {
             address token = debtServiceTokenPreference[i];
             if (!debtManager.isBorrowToken(token)) revert NotABorrowToken();
 
-            uint256 spendable = _debitSpendable(safe, token, safeData);
+            (uint256 spendable, uint256 used) = _debitSpendable(safe, token, safeData, borrowHeadroom, hasDebt);
+            borrowHeadroom = borrowHeadroom > used ? borrowHeadroom - used : 0;
+
             spendableAmounts[i] = spendable;
             if (spendable > 0) {
                 amountsInUsd[i] = _toUsd(token, spendable);
@@ -418,19 +446,44 @@ contract CashLens is UpgradeableProxy {
         return tokenAmounts;
     }
 
-    /// @notice Withdrawable supplied amount of a token: the supplied position, capped by the reserve's liquidity
-    function _withdrawable(address safe, address token) internal view returns (uint256) {
+    /**
+     * @notice Supplied amount of `token` withdrawable for a debit spend, in token units
+     * @dev min(supplied, reserve cash). When the Safe has debt, also capped by the borrowing headroom: how much
+     *      of this reserve can be withdrawn before the leftover debt exceeds its borrowing power, via its LTV.
+     */
+    function _withdrawableSupplied(address safe, address token, uint256 borrowHeadroomUsd, bool hasDebt) internal view returns (uint256) {
         uint256 supplied = gateway.suppliedOf(safe, token);
         uint256 cash = gateway.availableCash(token);
-        return supplied < cash ? supplied : cash;
+        uint256 cap = supplied < cash ? supplied : cash;
+
+        if (hasDebt) {
+            uint256 ltv = gateway.ltv(token);
+            if (ltv != 0) {
+                uint256 headroomCap = _fromUsd(token, (borrowHeadroomUsd * HUNDRED_PERCENT) / ltv);
+                if (headroomCap < cap) {
+                    cap = headroomCap;
+                }
+            }
+        }
+
+        return cap;
     }
 
-    /// @notice Debit spendable for a token: raw Safe balance plus the withdrawable supplied amount, minus pending withdrawal
-    function _debitSpendable(address safe, address token, SafeData memory safeData) internal view returns (uint256) {
-        uint256 total = IERC20(token).balanceOf(safe) + _withdrawable(safe, token);
-        uint256 pending = _getPendingWithdrawalAmount(safeData, token);
+    /// @notice Borrowing headroom (USD) consumed by withdrawing `amount` of `token`: its USD value weighted by the LTV
+    function _headroomConsumed(address token, uint256 amount) internal view returns (uint256) {
+        return (_toUsd(token, amount) * gateway.ltv(token)) / HUNDRED_PERCENT;
+    }
 
-        return total > pending ? total - pending : 0;
+    /// @notice Debit spendable for `token` (token units) given the running borrowing headroom, and the headroom that withdrawal consumes
+    function _debitSpendable(address safe, address token, SafeData memory safeData, uint256 borrowHeadroomUsd, bool hasDebt) internal view returns (uint256, uint256) {
+        uint256 withdrawable = _withdrawableSupplied(safe, token, borrowHeadroomUsd, hasDebt);
+        uint256 headroomUsed = hasDebt ? _headroomConsumed(token, withdrawable) : 0;
+
+        uint256 total = IERC20(token).balanceOf(safe) + withdrawable;
+        uint256 pending = _getPendingWithdrawalAmount(safeData, token);
+        uint256 spendable = total > pending ? total - pending : 0;
+
+        return (spendable, headroomUsed);
     }
 
     /// @notice Per-token supplied position in the Safe's Aave account, skipping zero balances

--- a/src/modules/cash/CashLens.sol
+++ b/src/modules/cash/CashLens.sol
@@ -1,40 +1,38 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
-import { EnumerableSetLib } from "solady/utils/EnumerableSetLib.sol";
 import { ArrayDeDupLib } from "../../libraries/ArrayDeDupLib.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 
-import { ICashModule, Mode, SafeCashData, SafeData, WithdrawalRequest, DebitModeMaxSpend } from "../../interfaces/ICashModule.sol";
+import { DebitModeMaxSpend, ICashModule, Mode, SafeCashData, SafeData } from "../../interfaces/ICashModule.sol";
 import { IDebtManager } from "../../interfaces/IDebtManager.sol";
 import { IEtherFiDataProvider } from "../../interfaces/IEtherFiDataProvider.sol";
-import { IEtherFiSafe } from "../../interfaces/IEtherFiSafe.sol";
+import { IGateway } from "../../interfaces/IGateway.sol";
 import { IPriceProvider } from "../../interfaces/IPriceProvider.sol";
 import { SpendingLimit, SpendingLimitLib } from "../../libraries/SpendingLimitLib.sol";
 import { UpgradeableProxy } from "../../utils/UpgradeableProxy.sol";
-import { ArrayDeDupLib } from "../../libraries/ArrayDeDupLib.sol";
 
 /**
  * @title CashLens
- * @notice Read-only contract providing views into the state of the CashModule system
- * @dev Extends UpgradeableProxy to provide upgrade functionality
+ * @notice Read-only contract providing views into a Safe's cash state
+ * @dev Reads the Safe's position from the Aave gateway and the supported-token list from DebtManager.
+ *      Phase one covers the no-borrow world: credit capacity comes straight from Aave, debit spendable
+ *      is the raw Safe balance plus the withdrawable supplied amount, and there is no underwater math
+ *      because no live user has debt yet. USD is 6 decimals throughout, matching PriceProvider.DECIMALS;
+ *      the gateway returns its USD aggregates in the same scale.
  * @author ether.fi
  */
 contract CashLens is UpgradeableProxy {
-    using EnumerableSetLib for EnumerableSetLib.AddressSet;
     using SpendingLimitLib for SpendingLimit;
-    using ArrayDeDupLib for address[];
-    using Math for uint256;
     using ArrayDeDupLib for address[];
 
     /// @notice Reference to the deployed CashModule contract
     ICashModule public immutable cashModule;
     /// @notice Reference to the deployed EtherFiDataProvider contract
     IEtherFiDataProvider public immutable dataProvider;
-
-    /// @notice Constant representing 100% with 18 decimal places
-    uint256 public constant HUNDRED_PERCENT = 100e18;
+    /// @notice Reference to the Aave gateway that holds the Safe's position
+    IGateway public immutable gateway;
 
     /// @notice Error thrown when trying to use a token that is not on the collateral whitelist
     error NotACollateralToken();
@@ -42,13 +40,15 @@ contract CashLens is UpgradeableProxy {
     error NotABorrowToken();
 
     /**
-     * @notice Initializes the CashLens contract with a reference to the CashModule
+     * @notice Initializes the CashLens contract with its dependencies
      * @param _cashModule Address of the deployed CashModule contract
      * @param _dataProvider Address of the deployed EtherFiDataProvider contract
+     * @param _gateway Address of the Aave gateway
      */
-    constructor(address _cashModule, address _dataProvider) {
+    constructor(address _cashModule, address _dataProvider, address _gateway) {
         cashModule = ICashModule(_cashModule);
         dataProvider = IEtherFiDataProvider(_dataProvider);
+        gateway = IGateway(_gateway);
 
         _disableInitializers();
     }
@@ -69,8 +69,7 @@ contract CashLens is UpgradeableProxy {
      * @return Current applicable spending limit
      */
     function applicableSpendingLimit(address safe) external view returns (SpendingLimit memory) {
-        SafeData memory safeData = cashModule.getData(address(safe));
-        return safeData.spendingLimit.getCurrentLimit();
+        return cashModule.getData(safe).spendingLimit.getCurrentLimit();
     }
 
     /**
@@ -83,184 +82,134 @@ contract CashLens is UpgradeableProxy {
      * @return canSpend Boolean indicating if the spending is allowed
      * @return message Error message if spending is not allowed
      */
-    function canSpend(address safe, bytes32 txId, address[] memory tokens,uint256[] memory amountsInUsd) public view returns (bool, string memory) {
+    function canSpend(address safe, bytes32 txId, address[] memory tokens, uint256[] memory amountsInUsd) public view returns (bool, string memory) {
         // Basic validation
         if (tokens.length == 0) return (false, "No tokens provided");
         if (tokens.length != amountsInUsd.length) return (false, "Tokens and amounts arrays length mismatch");
         if (cashModule.transactionCleared(safe, txId)) return (false, "Transaction already cleared");
 
         if (tokens.length > 1) tokens.checkDuplicates();
-        
+
         // Check total spending amount
         uint256 totalSpendingInUsd = 0;
         for (uint256 i = 0; i < amountsInUsd.length; i++) {
             totalSpendingInUsd += amountsInUsd[i];
         }
         if (totalSpendingInUsd == 0) return (false, "Total amount zero in USD");
-        
+
         // Validate mode and spending limits
         return _validateSpending(safe, tokens, amountsInUsd, totalSpendingInUsd);
     }
 
-    function canSpendSingleToken(
-        address safe, 
-        bytes32 txId, 
-        address[] calldata creditModeTokenPreferences, 
-        address[] calldata debitModeTokenPreferences, 
-        uint256 amountInUsd
-    ) public view returns (Mode mode, address token, bool canSpendResult, string memory declineReason) {
+    function canSpendSingleToken(address safe, bytes32 txId, address[] calldata creditModeTokenPreferences, address[] calldata debitModeTokenPreferences, uint256 amountInUsd) public view returns (Mode mode, address token, bool canSpendResult, string memory declineReason) {
         SafeData memory safeData = cashModule.getData(safe);
         if (safeData.incomingModeStartTime != 0) mode = safeData.incomingMode;
         else mode = safeData.mode;
-        
+
         address[] memory tokenPreferences = mode == Mode.Debit ? debitModeTokenPreferences : creditModeTokenPreferences;
-        
+
         if (tokenPreferences.length == 0) return (mode, address(0), false, "No token preferences provided");
         if (amountInUsd == 0) return (mode, tokenPreferences[0], false, "Amount cannot be zero");
         if (cashModule.transactionCleared(safe, txId)) return (mode, tokenPreferences[0], false, "Transaction already cleared");
-        
+
         (token, canSpendResult, declineReason) = _checkTokenPreferences(safe, txId, tokenPreferences, amountInUsd);
-        
+
         return (mode, token, canSpendResult, declineReason);
     }
 
-    function _checkTokenPreferences(
-        address safe,
-        bytes32 txId,
-        address[] memory tokenPreferences,
-        uint256 amountInUsd
-    ) internal view returns (address token, bool canSpendResult, string memory declineReason) {
+    function _checkTokenPreferences(address safe, bytes32 txId, address[] memory tokenPreferences, uint256 amountInUsd) internal view returns (address token, bool canSpendResult, string memory declineReason) {
         uint256[] memory amountsInUsd = new uint256[](1);
         amountsInUsd[0] = amountInUsd;
         address[] memory singleToken = new address[](1);
-        
+
         string memory firstError;
-        
-        for (uint256 i = 0; i < tokenPreferences.length; ) {
+
+        for (uint256 i = 0; i < tokenPreferences.length;) {
             singleToken[0] = tokenPreferences[i];
-            
+
             (bool success, string memory error) = canSpend(safe, txId, singleToken, amountsInUsd);
             if (i == 0) firstError = error;
-            
+
             if (success) return (tokenPreferences[i], true, "");
-            
+
             unchecked {
                 ++i;
             }
         }
-        
+
         return (tokenPreferences[0], false, firstError);
     }
 
-    /**
-     * @notice Validates mode, limits and completes spending checks
-     */
+    /// @notice Validates mode and spending limits, then runs the mode-specific check
     function _validateSpending(address safe, address[] memory tokens, uint256[] memory amountsInUsd, uint256 totalSpendingInUsd) internal view returns (bool, string memory) {
-        IDebtManager debtManager = cashModule.getDebtManager();
         SafeData memory safeData = cashModule.getData(safe);
 
-        Mode mode = safeData.mode; 
+        Mode mode = safeData.mode;
         // Update mode if necessary
         if (safeData.incomingModeStartTime != 0) mode = safeData.incomingMode;
 
         // In Credit mode, only one token is allowed
         if (mode == Mode.Credit && tokens.length > 1) return (false, "Only one token allowed in Credit mode");
-        
+
         // Check spending limit
         (bool withinLimit, string memory limitMessage) = safeData.spendingLimit.canSpend(totalSpendingInUsd);
-        if (!withinLimit) return (false, limitMessage);
-        
-        // Validate tokens
-        return _processTokensAndMode(safe, tokens, amountsInUsd, totalSpendingInUsd, debtManager, safeData, mode);
-    }
-
-    /**
-     * @notice Process tokens and check mode-specific rules
-     */
-    function _processTokensAndMode(address safe, address[] memory tokens, uint256[] memory amountsInUsd, uint256 totalSpendingInUsd, IDebtManager debtManager, SafeData memory safeData, Mode mode) internal view returns (bool, string memory) {
-        // Convert USD to token amounts and validate each token
-        uint256[] memory amounts = new uint256[](tokens.length);
-        
-        for (uint256 i = 0; i < tokens.length; i++) {
-            // Check if token is supported
-            if (!debtManager.isBorrowToken(tokens[i])) {
-                return (false, "Not a supported stable token");
-            }
-            
-            // Convert USD to token amount
-            amounts[i] = debtManager.convertUsdToCollateralToken(tokens[i], amountsInUsd[i]);
-            
-            // In Debit mode, check each token's balance
-            if (mode == Mode.Debit && IERC20(tokens[i]).balanceOf(safe) < amounts[i]) {
-                return (false, "Insufficient token balance for debit mode spending");
-            }
+        if (!withinLimit) {
+            return (false, limitMessage);
         }
-        
-        // Check mode-specific conditions
+
         if (mode == Mode.Credit) {
-            return _creditModeCheck(safe, tokens, amounts, totalSpendingInUsd, debtManager, safeData);
-        } else {
-            return _debitModeCheck(safe, tokens, amounts, debtManager, safeData);
+            return _creditCheck(safe, tokens[0], totalSpendingInUsd);
         }
+        return _debitCheck(safe, tokens, amountsInUsd, safeData);
     }
 
-    /**
-     * @notice Credit mode specific checks
-     */
-    function _creditModeCheck(address safe, address[] memory tokens, uint256[] memory amounts, uint256 totalSpendingInUsd, IDebtManager debtManager, SafeData memory safeData) internal view returns (bool, string memory) {
-        // credit mode should only have 1 token
-        // Check if debt manager has enough liquidity
-        if (IERC20(tokens[0]).balanceOf(address(debtManager)) < amounts[0]) return (false, "Insufficient liquidity in debt manager to cover the loan");
-        
-        // Get collateral balances with pending withdrawals factored in
-        (IDebtManager.TokenData[] memory collateralTokenAmounts, string memory error) = _getCollateralBalanceWithTokensSubtracted(debtManager, safe, safeData, tokens, amounts, Mode.Credit);
-        
-        if (bytes(error).length != 0) return (false, error);
-        
-        return _checkBorrowingPower(safe, collateralTokenAmounts, totalSpendingInUsd, debtManager);
-    }
+    /// @notice Credit mode check: the spend must fit the Aave borrowing capacity and the reserve's liquidity
+    function _creditCheck(address safe, address token, uint256 totalSpendingInUsd) internal view returns (bool, string memory) {
+        if (!cashModule.getDebtManager().isBorrowToken(token)) {
+            return (false, "Not a supported stable token");
+        }
 
-    /**
-     * @notice Debit mode specific checks
-     */
-    function _debitModeCheck(address safe, address[] memory tokens, uint256[] memory amounts, IDebtManager debtManager, SafeData memory safeData) internal view returns (bool, string memory) {
-        // Simulate the spending of multiple tokens
-        (IDebtManager.TokenData[] memory collateralTokenAmounts, string memory error) =  _getCollateralBalanceWithTokensSubtracted(debtManager, safe, safeData, tokens, amounts, Mode.Debit);
-        
-        if (bytes(error).length != 0) return (false, error);
-        
-        // Check if spending would cause collateral ratio issues
-        (uint256 totalMaxBorrow, uint256 totalBorrowings) = debtManager.getBorrowingPowerAndTotalBorrowing(safe, collateralTokenAmounts);
-        
-        if (totalBorrowings > totalMaxBorrow) return (false, "Borrowings greater than max borrow after spending");
-        
+        if (gateway.availableCash(token) < _fromUsd(token, totalSpendingInUsd)) {
+            return (false, "Insufficient liquidity in debt manager to cover the loan");
+        }
+
+        uint256 capacityUsd = gateway.getAccountData(safe).availableBorrowsUsd;
+        if (totalSpendingInUsd > capacityUsd) {
+            return (false, "Insufficient borrowing power");
+        }
+
         return (true, "");
     }
 
-    /**
-     * @notice Check borrowing power for credit mode
-     */
-    function _checkBorrowingPower(address safe, IDebtManager.TokenData[] memory collateralTokenAmounts, uint256 totalSpendingInUsd, IDebtManager debtManager) internal view returns (bool, string memory) {
-        (uint256 totalMaxBorrow, uint256 totalBorrowings) = debtManager.getBorrowingPowerAndTotalBorrowing(safe, collateralTokenAmounts);
-        
-        if (totalBorrowings > totalMaxBorrow) {
-            return (false, "Borrowings greater than max borrow");
+    /// @notice Debit mode check: each token's spendable amount must cover its share of the spend
+    function _debitCheck(address safe, address[] memory tokens, uint256[] memory amountsInUsd, SafeData memory safeData) internal view returns (bool, string memory) {
+        IDebtManager debtManager = cashModule.getDebtManager();
+
+        for (uint256 i = 0; i < tokens.length; i++) {
+            if (!debtManager.isBorrowToken(tokens[i])) {
+                return (false, "Not a supported stable token");
+            }
+
+            uint256 needed = _fromUsd(tokens[i], amountsInUsd[i]);
+            uint256 available = IERC20(tokens[i]).balanceOf(safe) + _withdrawable(safe, tokens[i]);
+            if (available < needed) {
+                return (false, "Insufficient token balance for debit mode spending");
+            }
+            if (available - _getPendingWithdrawalAmount(safeData, tokens[i]) < needed) {
+                return (false, "Insufficient effective balance after withdrawal to spend with debit mode");
+            }
         }
-        
-        if (totalSpendingInUsd > totalMaxBorrow - totalBorrowings) {
-            return (false, "Insufficient borrowing power");
-        }
-        
+
         return (true, "");
     }
 
     /**
      * @notice Gets comprehensive cash data for a Safe
-     * @dev Aggregates data from multiple sources including DebtManager and CashModule
+     * @dev Aggregates the Safe's Aave position (via the gateway) with its CashModule configuration
      * @param safe Address of the EtherFi Safe
      * @param debtServiceTokenPreference Optional ordered array of borrow tokens for debit calculations.
-     *                                   If empty, uses all available borrow tokens from DebtManager.
-     * @return safeCashData Comprehensive data structure containing:
+     *                                   If empty, uses all available borrow tokens.
+     * @return Comprehensive data structure containing:
      *   - mode: Current operating mode (Credit or Debit)
      *   - collateralBalances: Array of collateral token balances
      *   - borrows: Array of borrowed token balances
@@ -275,85 +224,68 @@ contract CashLens is UpgradeableProxy {
      *   - totalCashbackEarnedInUsd: Running total of all cashback earned
      *   - incomingModeStartTime: Timestamp when Credit mode takes effect
      */
-    function getSafeCashData(address safe, address[] memory debtServiceTokenPreference) external view returns (SafeCashData memory safeCashData) {
+    function getSafeCashData(address safe, address[] memory debtServiceTokenPreference) external view returns (SafeCashData memory) {
         IDebtManager debtManager = cashModule.getDebtManager();
         IPriceProvider priceProvider = IPriceProvider(dataProvider.getPriceProvider());
         SafeData memory safeData = cashModule.getData(safe);
+        IGateway.AccountData memory account = gateway.getAccountData(safe);
 
-        (safeCashData.collateralBalances, safeCashData.totalCollateral, safeCashData.borrows, safeCashData.totalBorrow) = debtManager.getUserCurrentState(safe);
+        SafeCashData memory data;
 
-        safeCashData.withdrawalRequest = safeData.pendingWithdrawalRequest;
-        safeCashData.maxBorrow = debtManager.getMaxBorrowAmount(safe, true);
+        address[] memory collateralTokens = debtManager.getCollateralTokens();
+        address[] memory borrowTokens = debtManager.getBorrowTokens();
 
-        address[] memory supportedTokens = debtManager.getCollateralTokens();
-        uint256 len = supportedTokens.length;
-        safeCashData.tokenPrices = new IDebtManager.TokenData[](len);
+        data.collateralBalances = _suppliedBalances(safe, collateralTokens);
+        data.borrows = _debtBalances(safe, borrowTokens);
+        data.totalCollateral = account.collateralUsd;
+        data.totalBorrow = account.debtUsd;
+        data.maxBorrow = account.availableBorrowsUsd;
 
+        uint256 len = collateralTokens.length;
+        data.tokenPrices = new IDebtManager.TokenData[](len);
         for (uint256 i = 0; i < len;) {
-            safeCashData.tokenPrices[i].token = supportedTokens[i];
-            safeCashData.tokenPrices[i].amount = priceProvider.price(supportedTokens[i]);
+            data.tokenPrices[i].token = collateralTokens[i];
+            data.tokenPrices[i].amount = priceProvider.price(collateralTokens[i]);
             unchecked {
                 ++i;
             }
         }
 
-        safeCashData.spendingLimitAllowance = safeData.spendingLimit.maxCanSpend();
-        
-        safeCashData.creditMaxSpend = getMaxSpendCredit(safe);
+        data.withdrawalRequest = safeData.pendingWithdrawalRequest;
+        data.spendingLimitAllowance = safeData.spendingLimit.maxCanSpend();
+        data.creditMaxSpend = getMaxSpendCredit(safe);
 
-        if (debtServiceTokenPreference.length == 0) safeCashData.debitMaxSpend = getMaxSpendDebit(safe, debtManager.getBorrowTokens());
-        else safeCashData.debitMaxSpend = getMaxSpendDebit(safe, debtServiceTokenPreference);
+        if (debtServiceTokenPreference.length == 0) {
+            data.debitMaxSpend = getMaxSpendDebit(safe, borrowTokens);
+        } else {
+            data.debitMaxSpend = getMaxSpendDebit(safe, debtServiceTokenPreference);
+        }
 
-        safeCashData.totalCashbackEarnedInUsd = safeData.totalCashbackEarnedInUsd;
-        safeCashData.incomingModeStartTime = safeData.incomingModeStartTime;
-        safeCashData.mode = safeData.mode;
+        data.totalCashbackEarnedInUsd = safeData.totalCashbackEarnedInUsd;
+        data.incomingModeStartTime = safeData.incomingModeStartTime;
+        data.mode = safeData.mode;
+        if (data.incomingModeStartTime > 0 && block.timestamp > data.incomingModeStartTime) {
+            data.mode = safeData.incomingMode;
+        }
 
-        if (safeCashData.incomingModeStartTime > 0 && block.timestamp > safeCashData.incomingModeStartTime) safeCashData.mode = safeData.incomingMode;
+        return data;
     }
 
     /**
      * @notice Calculates the maximum amounts that can be spent in debit mode across multiple tokens
-     * @dev Analyzes the safe's collateral health to determine spendable amounts for each token while
-     *      maintaining solvency. When underwater (borrowings > max borrow), tokens are consumed in 
-     *      preference order to restore health before allowing spending. The function strictly respects 
-     *      token preference order.
-     * 
-     * @param safe Address of the EtherFi Safe to calculate spending limits for
-     * @param debtServiceTokenPreference Ordered array of borrow token addresses. Order determines 
-     *                                   priority for deficit coverage - earlier tokens are used first.
-     *                                   Must contain only valid borrow tokens (stablecoins).
-     * 
-     * @return DebitModeMaxSpend
-     *  - spendableTokens Array of token addresses (mirrors input debtServiceTokenPreference)
-     *  - spendableAmounts Array of maximum spendable amounts per token in native token units.
-     *                          Accounts for pending withdrawals. Zero for tokens needed as collateral.
-     *  - amountsInUsd Array of spendable amounts converted to USD values. Corresponds 1:1 with
-     *                      spendableAmounts. Zero for tokens reserved for collateral.
-     *  - totalSpendableInUsd Aggregate USD value spendable across all tokens
-     * 
+     * @dev Phase one, no-borrow world: each token's spendable amount is its raw Safe balance plus the
+     *      withdrawable supplied amount, minus any pending withdrawal. There is no deficit coverage
+     *      because no live user has debt yet.
+     * @param safe Address of the EtherFi Safe
+     * @param debtServiceTokenPreference Ordered array of borrow token addresses (stablecoins). Order is
+     *                                   preserved in the result.
+     * @return DebitModeMaxSpend with:
+     *   - spendableTokens: token addresses, mirrors debtServiceTokenPreference
+     *   - spendableAmounts: max spendable per token in native units, after pending withdrawals
+     *   - amountsInUsd: those amounts in USD, 1:1 with spendableAmounts
+     *   - totalSpendableInUsd: aggregate USD value spendable across all tokens
      * @custom:reverts NotABorrowToken if any token in debtServiceTokenPreference is not whitelisted
      * @custom:reverts DuplicateElementFound if debtServiceTokenPreference contains duplicate addresses
-     * 
-     * @custom:example Healthy Position
-     * // Safe: $1000 USDC, $500 USDT, no borrowings
-     * // Returns: spendableAmounts=[1000e6, 500e6], amountsInUsd=[1000e18, 500e18], total=$1500
-     * 
-     * @custom:example Underwater Position  
-     * // Safe: 1 weETH ($3000, 50% LTV), $1000 USDC (80% LTV), $500 USDT (80% LTV), $1700 borrowings
-     * // $1500 borrowing covered by weETH
-     * // Deficit: $200, needs $250 collateral at 80% LTV from USDC (first preference)
-     * // Returns: spendableAmounts=[750e6, 500e6], amountsInUsd=[750e18, 500e18], total=$1250
-     * 
-     * @custom:edge-cases
-     * - Empty token preference array returns empty results
-     * - Zero effective balances after withdrawals are handled correctly  
-     * - Tokens with zero value break the preference chain for subsequent tokens
-     * - If deficit cannot be covered, returns empty arrays and zero total
-     * 
-     * @custom:security 
-     * - Read-only view function with no state modifications
-     * - Conservative calculations ensure safe remains solvent after spending
-     * - Pending withdrawals reduce spendable amounts to prevent double-spending
      */
     function getMaxSpendDebit(address safe, address[] memory debtServiceTokenPreference) public view returns (DebitModeMaxSpend memory) {
         uint256 len = debtServiceTokenPreference.length;
@@ -363,134 +295,36 @@ contract CashLens is UpgradeableProxy {
         IDebtManager debtManager = cashModule.getDebtManager();
         SafeData memory safeData = cashModule.getData(safe);
 
-        // Calculate token values
-        (uint256[] memory effectiveBalances, uint256[] memory tokenValuesInUsd, uint256 totalValueInUsd) = _calculateTokenValues(debtManager, safe, debtServiceTokenPreference, len);
-
-        if (totalValueInUsd == 0) return DebitModeMaxSpend(debtServiceTokenPreference, new uint256[](len), new uint256[](len), 0);
-
-        // Check collateral after theoretical spending all debit tokens
-        (IDebtManager.TokenData[] memory collateralTokenAmounts, string memory error) = _getCollateralBalanceWithTokensSubtracted(debtManager, safe, safeData, debtServiceTokenPreference, effectiveBalances, Mode.Debit);
-
-        if (bytes(error).length != 0) return DebitModeMaxSpend(new address[](0), new uint256[](0), new uint256[](0), 0);
-
-        // Get borrowing power
-        (uint256 totalMaxBorrow, uint256 totalBorrowings) = debtManager.getBorrowingPowerAndTotalBorrowing(safe, collateralTokenAmounts);
-        
-        // Healthy position - can spend all effective balances
-        if (totalBorrowings == 0 || totalMaxBorrow >= totalBorrowings) return DebitModeMaxSpend(debtServiceTokenPreference, effectiveBalances, tokenValuesInUsd, totalValueInUsd);
-        
-        // Underwater position - need to calculate deficit coverage
-        return _processUnderwaterPosition(debtServiceTokenPreference, tokenValuesInUsd, effectiveBalances, debtManager, totalBorrowings - totalMaxBorrow);
-    }
-
-    function _calculateTokenValues(IDebtManager debtManager,address safe,address[] memory tokens,uint256 len) internal view returns (uint256[] memory effectiveBalances,uint256[] memory tokenValuesInUsd,uint256 totalValueInUsd) {
-        effectiveBalances = new uint256[](len);
-        tokenValuesInUsd = new uint256[](len);
+        uint256[] memory spendableAmounts = new uint256[](len);
+        uint256[] memory amountsInUsd = new uint256[](len);
+        uint256 totalSpendableInUsd = 0;
 
         for (uint256 i = 0; i < len;) {
-            address token = tokens[i];
+            address token = debtServiceTokenPreference[i];
             if (!debtManager.isBorrowToken(token)) revert NotABorrowToken();
-            
-            effectiveBalances[i] = IERC20(token).balanceOf(safe) - getPendingWithdrawalAmount(safe, token);
-            
-            if (effectiveBalances[i] > 0) {  
-                tokenValuesInUsd[i] = debtManager.convertCollateralTokenToUsd(token, effectiveBalances[i]);
-                totalValueInUsd += tokenValuesInUsd[i];
+
+            uint256 spendable = _debitSpendable(safe, token, safeData);
+            spendableAmounts[i] = spendable;
+            if (spendable > 0) {
+                amountsInUsd[i] = _toUsd(token, spendable);
+                totalSpendableInUsd += amountsInUsd[i];
             }
-            
-            unchecked { ++i; }
-        }
-    }
 
-    function _processUnderwaterPosition(address[] memory tokens,uint256[] memory tokenValuesInUsd,uint256[] memory effectiveBalances,IDebtManager debtManager,uint256 deficit) internal view returns (DebitModeMaxSpend memory) {
-        uint256 len = tokens.length;
-        
-        // Cover deficit and calculate spendable amounts
-        (uint256[] memory spendableAmounts, uint256[] memory spendableUsdValues, uint256 remainingDeficit, uint256 lastProcessedIndex) = _coverDeficitAndCalculateSpendable(tokens, tokenValuesInUsd, debtManager, deficit);
-        
-        // If deficit remains uncovered, can't spend anything
-        if (remainingDeficit > 0) return DebitModeMaxSpend(new address[](0), new uint256[](0), new uint256[](0), 0);
-        
-        // Add remaining tokens and calculate total
-        uint256 totalSpendableUsd = _addRemainingTokens(spendableAmounts,spendableUsdValues,effectiveBalances,tokenValuesInUsd,lastProcessedIndex,len);
-        
-        return DebitModeMaxSpend(tokens, spendableAmounts, spendableUsdValues, totalSpendableUsd);
-    }
-
-    function _coverDeficitAndCalculateSpendable(address[] memory tokens,uint256[] memory tokenValuesInUsd,IDebtManager debtManager,uint256 deficit) internal view returns (uint256[] memory spendableAmounts,uint256[] memory spendableUsdValues,uint256 remainingDeficit,uint256 lastProcessedIndex) {
-        uint256 len = tokens.length;
-        spendableAmounts = new uint256[](len);
-        spendableUsdValues = new uint256[](len);
-        remainingDeficit = deficit;
-        
-        for (uint256 i = 0; i < len && remainingDeficit > 0;) {
-            uint256 tokenValue = tokenValuesInUsd[i];
-            
-            if (tokenValue > 0) {
-                (uint256 spendableAmount, uint256 spendableUsd, uint256 deficitCovered) = _processTokenForDeficit(tokens[i], tokenValue, remainingDeficit, debtManager);
-                
-                spendableAmounts[i] = spendableAmount;
-                spendableUsdValues[i] = spendableUsd;
-                remainingDeficit -= deficitCovered;
-                lastProcessedIndex = i;
-                
-                if (remainingDeficit == 0) break;
+            unchecked {
+                ++i;
             }
-            
-            unchecked { ++i; }
         }
-    }
 
-    function _processTokenForDeficit(address token,uint256 tokenValue,uint256 remainingDeficit,IDebtManager debtManager) internal view returns (uint256 spendableAmount,uint256 spendableUsd,uint256 deficitCovered) {
-        uint80 ltv = debtManager.collateralTokenConfig(token).ltv;
-        uint256 borrowingPower = tokenValue.mulDiv(ltv, HUNDRED_PERCENT, Math.Rounding.Floor);
-        
-        if (borrowingPower >= remainingDeficit) {
-            // This token can cover the remaining deficit
-            uint256 collateralNeeded = remainingDeficit.mulDiv(HUNDRED_PERCENT, ltv, Math.Rounding.Ceil);
-            spendableUsd = tokenValue - collateralNeeded;
-            spendableAmount = debtManager.convertUsdToCollateralToken(token, spendableUsd);
-            deficitCovered = remainingDeficit;
-        } else {
-            // This token can't cover deficit alone - use it all for collateral
-            spendableAmount = 0;
-            spendableUsd = 0;
-            deficitCovered = borrowingPower;
-        }
-    }
-
-    function _addRemainingTokens(uint256[] memory spendableAmounts,uint256[] memory spendableUsdValues,uint256[] memory effectiveBalances,uint256[] memory tokenValuesInUsd,uint256 lastProcessedIndex,uint256 len) internal pure returns (uint256 totalSpendableUsd) {
-        // Sum up what we can spend from deficit coverage
-        for (uint256 i = 0; i <= lastProcessedIndex;) {
-            totalSpendableUsd += spendableUsdValues[i];
-            unchecked { ++i; }
-        }
-        
-        // Add remaining tokens that weren't needed for deficit
-        for (uint256 i = lastProcessedIndex + 1; i < len;) {
-            if (tokenValuesInUsd[i] > 0) {
-                spendableAmounts[i] = effectiveBalances[i];
-                spendableUsdValues[i] = tokenValuesInUsd[i];
-                totalSpendableUsd += tokenValuesInUsd[i];
-            }
-            unchecked { ++i; }
-        }
+        return DebitModeMaxSpend(debtServiceTokenPreference, spendableAmounts, amountsInUsd, totalSpendableInUsd);
     }
 
     /**
      * @notice Calculates the maximum amount that can be spent in credit mode
      * @param safe Address of the EtherFi Safe
-     * @return returnAmtInCreditModeUsd Maximum amount that can be spent in credit mode (USD)
+     * @return Maximum amount that can be spent in credit mode (USD, 6 decimals)
      */
-    function getMaxSpendCredit(address safe) public view returns (uint256 returnAmtInCreditModeUsd) {
-        // Get debt manager and safe data once to avoid multiple calls
-        IDebtManager debtManager = cashModule.getDebtManager();
-        SafeData memory safeData = cashModule.getData(safe);
-
-        bool isValidCredit;
-
-        (returnAmtInCreditModeUsd, isValidCredit) = _calculateCreditModeAmount(debtManager, safe, safeData);
-        if (!isValidCredit) return 0;
+    function getMaxSpendCredit(address safe) public view returns (uint256) {
+        return gateway.getAccountData(safe).availableBorrowsUsd;
     }
 
     /**
@@ -530,7 +364,8 @@ contract CashLens is UpgradeableProxy {
 
     /**
      * @notice Gets the effective collateral amount for a specific token
-     * @dev Returns balance minus pending withdrawals
+     * @dev Returns the raw Safe balance minus pending withdrawals. DebtManager reads this during its
+     *      retirement window, so it stays on the raw balance until the Aave cutover.
      * @param safe Address of the safe
      * @param token Address of the collateral token to check
      * @return Effective collateral amount
@@ -548,7 +383,8 @@ contract CashLens is UpgradeableProxy {
 
     /**
      * @notice Gets all effective collateral balances for a safe
-     * @dev Returns array of token addresses and their effective amounts (balance minus pending withdrawals)
+     * @dev Returns the raw Safe balances minus pending withdrawals. DebtManager reads this during its
+     *      retirement window, so it stays on the raw balance until the Aave cutover.
      * @param safe Address of the safe
      * @return Array of token data with token addresses and effective amounts
      */
@@ -582,87 +418,29 @@ contract CashLens is UpgradeableProxy {
         return tokenAmounts;
     }
 
-    /**
-     * @notice Calculate the amount that can be spent in credit mode
-     * @dev Internal helper that handles credit mode calculations
-     * @param debtManager The debt manager instance
-     * @param safe The address of the safe
-     * @param safeData The safe data
-     * @return creditModeAmount The amount that can be spent in credit mode
-     * @return isValid Whether the calculation was successful
-     */
-    function _calculateCreditModeAmount(IDebtManager debtManager, address safe, SafeData memory safeData) internal view returns (uint256 creditModeAmount, bool isValid) {
-        (IDebtManager.TokenData[] memory collateralTokenAmounts, string memory error) = _getCollateralBalanceWithTokensSubtracted(debtManager, safe, safeData, new address[](0), new uint256[](0), Mode.Credit);
-
-        // Check for errors - short circuit to save gas
-        if (bytes(error).length != 0 || collateralTokenAmounts.length == 0) {
-            return (0, false);
-        }
-
-        // Get borrowing power and total borrowing
-        (uint256 totalMaxBorrow, uint256 totalBorrowings) = debtManager.getBorrowingPowerAndTotalBorrowing(safe, collateralTokenAmounts);
-
-        // Check if borrowings exceed max borrow
-        if (totalBorrowings > totalMaxBorrow) {
-            return (0, false);
-        }
-
-        // Calculate credit mode amount 
-        return (totalMaxBorrow - totalBorrowings, true);
+    /// @notice Withdrawable supplied amount of a token: the supplied position, capped by the reserve's liquidity
+    function _withdrawable(address safe, address token) internal view returns (uint256) {
+        uint256 supplied = gateway.suppliedOf(safe, token);
+        uint256 cash = gateway.availableCash(token);
+        return supplied < cash ? supplied : cash;
     }
 
-    /**
-     * @notice Gets collateral balances with multiple token amounts subtracted
-     * @dev Internal helper for simulating multi-token debit spending
-     * @param debtManager Reference to the debt manager contract
-     * @param safe Address of the EtherFi Safe
-     * @param safeData Safe data structure containing withdrawal requests
-     * @param tokens Array of addresses of tokens to subtract
-     * @param amounts Array of amounts to subtract (must match tokens array)
-     * @return tokenAmounts Array of token data with updated balances
-     * @return error Error message if calculation fails
-     */
-    function _getCollateralBalanceWithTokensSubtracted(
-        IDebtManager debtManager,
-        address safe,
-        SafeData memory safeData,
-        address[] memory tokens,
-        uint256[] memory amounts,
-        Mode mode
-    ) internal view returns (IDebtManager.TokenData[] memory, string memory) {
-        address[] memory collateralTokens = debtManager.getCollateralTokens();
-        uint256 len = collateralTokens.length;
-        
-        IDebtManager.TokenData[] memory tokenAmounts = new IDebtManager.TokenData[](collateralTokens.length);
+    /// @notice Debit spendable for a token: raw Safe balance plus the withdrawable supplied amount, minus pending withdrawal
+    function _debitSpendable(address safe, address token, SafeData memory safeData) internal view returns (uint256) {
+        uint256 total = IERC20(token).balanceOf(safe) + _withdrawable(safe, token);
+        uint256 pending = _getPendingWithdrawalAmount(safeData, token);
+
+        return total > pending ? total - pending : 0;
+    }
+
+    /// @notice Per-token supplied position in the Safe's Aave account, skipping zero balances
+    function _suppliedBalances(address safe, address[] memory tokens) internal view returns (IDebtManager.TokenData[] memory) {
+        IDebtManager.TokenData[] memory out = new IDebtManager.TokenData[](tokens.length);
         uint256 m = 0;
-        
-        for (uint256 i = 0; i < len;) {
-            uint256 balance = IERC20(collateralTokens[i]).balanceOf(safe);
-            uint256 pendingWithdrawalAmount = _getPendingWithdrawalAmount(safeData, collateralTokens[i]);
-            
-            if (balance != 0) {
-                balance = balance - pendingWithdrawalAmount;
-
-                if (mode == Mode.Debit) {
-    
-                    // Check if this token is in the tokens array
-                    for (uint256 j = 0; j < tokens.length; j++) {
-                        if (collateralTokens[i] == tokens[j]) {
-                            if (balance < amounts[j]) {
-                                return (
-                                    new IDebtManager.TokenData[](0), 
-                                    "Insufficient effective balance after withdrawal to spend with debit mode"
-                                );
-                            }
-            
-                            balance = balance - amounts[j];
-                            break;
-                        }
-                    }
-                }
-                
-                tokenAmounts[m] = IDebtManager.TokenData({ token: collateralTokens[i], amount: balance });
-
+        for (uint256 i = 0; i < tokens.length;) {
+            uint256 amount = gateway.suppliedOf(safe, tokens[i]);
+            if (amount != 0) {
+                out[m] = IDebtManager.TokenData({ token: tokens[i], amount: amount });
                 unchecked {
                     ++m;
                 }
@@ -671,11 +449,45 @@ contract CashLens is UpgradeableProxy {
                 ++i;
             }
         }
-        
+
         assembly ("memory-safe") {
-            mstore(tokenAmounts, m)
+            mstore(out, m)
         }
-        
-        return (tokenAmounts, "");
+
+        return out;
+    }
+
+    /// @notice Per-token debt in the Safe's Aave account, skipping zero balances
+    function _debtBalances(address safe, address[] memory tokens) internal view returns (IDebtManager.TokenData[] memory) {
+        IDebtManager.TokenData[] memory out = new IDebtManager.TokenData[](tokens.length);
+        uint256 m = 0;
+        for (uint256 i = 0; i < tokens.length;) {
+            uint256 amount = gateway.debtOf(safe, tokens[i]);
+            if (amount != 0) {
+                out[m] = IDebtManager.TokenData({ token: tokens[i], amount: amount });
+                unchecked {
+                    ++m;
+                }
+            }
+            unchecked {
+                ++i;
+            }
+        }
+
+        assembly ("memory-safe") {
+            mstore(out, m)
+        }
+
+        return out;
+    }
+
+    /// @notice Converts a token amount to USD (6 decimals), mirroring DebtManager's conversion
+    function _toUsd(address token, uint256 amount) internal view returns (uint256) {
+        return (amount * IPriceProvider(dataProvider.getPriceProvider()).price(token)) / (10 ** IERC20Metadata(token).decimals());
+    }
+
+    /// @notice Converts a USD amount (6 decimals) to token units, mirroring DebtManager's conversion
+    function _fromUsd(address token, uint256 usd) internal view returns (uint256) {
+        return (usd * (10 ** IERC20Metadata(token).decimals())) / IPriceProvider(dataProvider.getPriceProvider()).price(token);
     }
 }

--- a/src/modules/cash/CashLens.sol
+++ b/src/modules/cash/CashLens.sol
@@ -27,6 +27,10 @@ import { UpgradeableProxy } from "../../utils/UpgradeableProxy.sol";
  *      (ModuleGatewaySandwich.minHealthFactor) only while minHealthFactor <= liqThreshold / LTV for every
  *      collateral. Keep that invariant at deploy time, or CashLens can over-report a debit spend that the
  *      sandwich then reverts on withdraw.
+ *
+ *      A pending withdrawal sits against the loose Safe balance, not the supplied position. CashLens reserves
+ *      it from the loose balance and uses the gateway's figures (collateral, maxBorrow, credit/debit headroom)
+ *      for the supplied position as-is.
  * @author ether.fi
  */
 contract CashLens is UpgradeableProxy {
@@ -167,13 +171,13 @@ contract CashLens is UpgradeableProxy {
         }
 
         if (mode == Mode.Credit) {
-            return _creditCheck(safe, tokens[0], totalSpendingInUsd, safeData);
+            return _creditCheck(safe, tokens[0], totalSpendingInUsd);
         }
         return _debitCheck(safe, tokens, amountsInUsd, safeData);
     }
 
-    /// @notice Credit mode check: the spend must fit the Aave borrowing capacity (net of pending withdrawals) and the reserve's liquidity
-    function _creditCheck(address safe, address token, uint256 totalSpendingInUsd, SafeData memory safeData) internal view returns (bool, string memory) {
+    /// @notice Credit mode check: the spend must fit the Aave borrowing capacity and the reserve's liquidity
+    function _creditCheck(address safe, address token, uint256 totalSpendingInUsd) internal view returns (bool, string memory) {
         if (!cashModule.getDebtManager().isBorrowToken(token)) {
             return (false, "Not a supported stable token");
         }
@@ -182,11 +186,8 @@ contract CashLens is UpgradeableProxy {
             return (false, "Insufficient liquidity in debt manager to cover the loan");
         }
 
-        // Pending withdrawals will leave the position, so discount their borrowing power up front
-        uint256 pending = _pendingWithdrawalHeadroom(safeData);
-        uint256 capacityUsd = gateway.getAccountData(safe).availableBorrowsUsd;
-        capacityUsd = capacityUsd > pending ? capacityUsd - pending : 0;
-        if (totalSpendingInUsd > capacityUsd) {
+        // availableBorrowsUsd is the supplied position's capacity; a pending sits against the loose balance, so it is not deducted here
+        if (totalSpendingInUsd > gateway.getAccountData(safe).availableBorrowsUsd) {
             return (false, "Insufficient borrowing power");
         }
 
@@ -198,29 +199,31 @@ contract CashLens is UpgradeableProxy {
         IDebtManager debtManager = cashModule.getDebtManager();
         IGateway.AccountData memory account = gateway.getAccountData(safe);
         bool hasDebt = account.debtUsd != 0;
-        // Net of pending withdrawals, which will leave the position and reduce its borrowing power
-        uint256 borrowHeadroom = _netBorrowHeadroom(account, safeData);
+        uint256 borrowHeadroom = hasDebt ? account.availableBorrowsUsd : 0;
 
         for (uint256 i = 0; i < tokens.length; i++) {
-            if (!debtManager.isBorrowToken(tokens[i])) {
+            address token = tokens[i];
+            if (!debtManager.isBorrowToken(token)) {
                 return (false, "Not a supported stable token");
             }
 
-            uint256 needed = _fromUsd(tokens[i], amountsInUsd[i]);
-            uint256 raw = IERC20(tokens[i]).balanceOf(safe);
-            uint256 available = raw + _withdrawableSupplied(safe, tokens[i], borrowHeadroom, hasDebt);
-            if (available < needed) {
-                return (false, "Insufficient token balance for debit mode spending");
-            }
-            // available - pending < needed, written as an addition so a pending larger than available declines instead of underflowing
-            if (available < _getPendingWithdrawalAmount(safeData, tokens[i]) + needed) {
-                return (false, "Insufficient effective balance after withdrawal to spend with debit mode");
+            uint256 needed = _fromUsd(token, amountsInUsd[i]);
+            uint256 raw = IERC20(token).balanceOf(safe);
+            {
+                uint256 withdrawable = _withdrawableSupplied(safe, token, borrowHeadroom, hasDebt);
+                if (raw + withdrawable < needed) {
+                    return (false, "Insufficient token balance for debit mode spending");
+                }
+                uint256 pending = _getPendingWithdrawalAmount(safeData, token);
+                if (_debitSpendableAmount(raw, withdrawable, pending) < needed) {
+                    return (false, "Insufficient effective balance after withdrawal to spend with debit mode");
+                }
             }
 
             // Only the supplied portion (raw is spent first) consumes the borrowing headroom for later tokens
             if (hasDebt) {
                 uint256 usedSupplied = needed > raw ? needed - raw : 0;
-                uint256 used = _headroomConsumed(tokens[i], usedSupplied);
+                uint256 used = _headroomConsumed(token, usedSupplied);
                 borrowHeadroom = borrowHeadroom > used ? borrowHeadroom - used : 0;
             }
         }
@@ -264,7 +267,7 @@ contract CashLens is UpgradeableProxy {
         data.borrows = _debtBalances(safe, borrowTokens);
         data.totalCollateral = account.collateralUsd;
         data.totalBorrow = account.debtUsd;
-        // Gross borrowing power (collateral weighted by LTV), matching DebtManager's getMaxBorrowAmount: headroom plus current debt
+        // Gross borrowing power (collateral weighted by LTV): the gateway headroom plus current debt
         data.maxBorrow = account.availableBorrowsUsd + account.debtUsd;
 
         uint256 len = collateralTokens.length;
@@ -299,12 +302,11 @@ contract CashLens is UpgradeableProxy {
 
     /**
      * @notice Calculates the maximum amounts that can be spent in debit mode across multiple tokens
-     * @dev Each token's spendable amount is its raw Safe balance plus the withdrawable supplied amount,
-     *      minus any pending withdrawal. When the Safe has debt, the withdrawable supplied amount is capped
-     *      by the borrowing headroom (collateral weighted by LTV, minus debt), threaded across the
-     *      preference order so each token only spends the headroom the earlier ones left. The headroom also
-     *      excludes what pending withdrawals will consume; a token that has both a pending withdrawal and debt
-     *      is treated conservatively, since its pending is netted from both its own amount and the headroom.
+     * @dev Each token's spendable amount is its loose Safe balance (less any pending withdrawal it has
+     *      reserved) plus the withdrawable supplied amount. When the Safe has debt, the withdrawable supplied
+     *      amount is capped by the borrowing headroom (collateral weighted by LTV, minus debt), threaded
+     *      across the preference order so each token only spends the headroom the earlier ones left. Pending
+     *      withdrawals are reserved from the raw Safe balance only; the supplied side is used as-is.
      * @param safe Address of the EtherFi Safe
      * @param debtServiceTokenPreference Ordered array of borrow token addresses (stablecoins). Order is
      *                                   preserved in the result.
@@ -329,8 +331,9 @@ contract CashLens is UpgradeableProxy {
         {
             IGateway.AccountData memory account = gateway.getAccountData(safe);
             hasDebt = account.debtUsd != 0;
-            // Net of pending withdrawals, which will leave the position and reduce its borrowing power
-            borrowHeadroom = _netBorrowHeadroom(account, safeData);
+            if (hasDebt) {
+                borrowHeadroom = account.availableBorrowsUsd;
+            }
         }
 
         uint256[] memory spendableAmounts = new uint256[](len);
@@ -364,9 +367,7 @@ contract CashLens is UpgradeableProxy {
      * @return Maximum amount that can be spent in credit mode (USD, 6 decimals)
      */
     function getMaxSpendCredit(address safe) public view returns (uint256) {
-        uint256 capacity = gateway.getAccountData(safe).availableBorrowsUsd;
-        uint256 pending = _pendingWithdrawalHeadroom(cashModule.getData(safe));
-        return capacity > pending ? capacity - pending : 0;
+        return gateway.getAccountData(safe).availableBorrowsUsd;
     }
 
     /**
@@ -490,40 +491,26 @@ contract CashLens is UpgradeableProxy {
         return (_toUsd(token, amount) * gateway.ltv(token)) / HUNDRED_PERCENT;
     }
 
-    /// @notice Borrowing headroom (USD) available for a new spend: the gateway headroom less what queued withdrawals will consume. Zero without debt, since debit only uses the headroom when there is debt.
-    function _netBorrowHeadroom(IGateway.AccountData memory account, SafeData memory safeData) internal view returns (uint256) {
-        if (account.debtUsd == 0) return 0;
-        uint256 pending = _pendingWithdrawalHeadroom(safeData);
-        return account.availableBorrowsUsd > pending ? account.availableBorrowsUsd - pending : 0;
-    }
-
-    /// @notice Borrowing headroom (USD) tied up by pending withdrawal requests: each pending token's LTV-weighted USD value
-    function _pendingWithdrawalHeadroom(SafeData memory safeData) internal view returns (uint256) {
-        uint256 total = 0;
-        uint256 len = safeData.pendingWithdrawalRequest.tokens.length;
-        for (uint256 i = 0; i < len;) {
-            uint256 amount = safeData.pendingWithdrawalRequest.amounts[i];
-            if (amount != 0) {
-                total += _headroomConsumed(safeData.pendingWithdrawalRequest.tokens[i], amount);
-            }
-            unchecked {
-                ++i;
-            }
-        }
-
-        return total;
-    }
-
     /// @notice Debit spendable for `token` (token units) given the running borrowing headroom, and the headroom that withdrawal consumes
     function _debitSpendable(address safe, address token, SafeData memory safeData, uint256 borrowHeadroomUsd, bool hasDebt) internal view returns (uint256, uint256) {
         uint256 withdrawable = _withdrawableSupplied(safe, token, borrowHeadroomUsd, hasDebt);
         uint256 headroomUsed = hasDebt ? _headroomConsumed(token, withdrawable) : 0;
 
-        uint256 total = IERC20(token).balanceOf(safe) + withdrawable;
+        uint256 raw = IERC20(token).balanceOf(safe);
         uint256 pending = _getPendingWithdrawalAmount(safeData, token);
-        uint256 spendable = total > pending ? total - pending : 0;
+        uint256 spendable = _debitSpendableAmount(raw, withdrawable, pending);
 
         return (spendable, headroomUsed);
+    }
+
+    /**
+     * @notice Spendable amount of one debit token: its loose Safe balance less the pending withdrawal it has reserved, plus the withdrawable supplied amount.
+     * @dev A pending withdrawal sits against the loose Safe balance, so it is reserved from `raw` only;
+     *      `withdrawableSupplied` (the supplied side) is unaffected.
+     */
+    function _debitSpendableAmount(uint256 raw, uint256 withdrawableSupplied, uint256 pending) internal pure returns (uint256) {
+        uint256 rawAfterPending = raw > pending ? raw - pending : 0;
+        return rawAfterPending + withdrawableSupplied;
     }
 
     /// @notice Per-token supplied position in the Safe's Aave account, skipping zero balances

--- a/src/oracle/ChainlinkCompositePriceFeed.sol
+++ b/src/oracle/ChainlinkCompositePriceFeed.sol
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+
+import { IAaveV4PriceFeed } from "../interfaces/IAaveV4PriceFeed.sol";
+import { IAggregatorV3 } from "../interfaces/IAggregatorV3.sol";
+
+/**
+ * @title ChainlinkCompositePriceFeed
+ * @notice Prices a token that has a Chainlink rate feed in an underlying asset rather than a direct USD
+ *         feed, for example weETH priced as the weETH/ETH rate times ETH/USD. One instance per token.
+ * @dev Implements the Aave v4 price-feed interface and fails closed: latestAnswer reverts when either
+ *      Chainlink feed is stale or non-positive.
+ * @author ether.fi
+ */
+contract ChainlinkCompositePriceFeed is IAaveV4PriceFeed {
+    using Math for uint256;
+    using SafeCast for uint256;
+    using SafeCast for int256;
+
+    /// @notice The Chainlink feed for the token's rate in the underlying asset, e.g. weETH/ETH
+    IAggregatorV3 public immutable rateFeed;
+    /// @notice The Chainlink feed for the underlying asset's USD price, e.g. ETH/USD
+    IAggregatorV3 public immutable underlyingUsdFeed;
+    /// @notice The decimals of the rate feed
+    uint8 public immutable rateDecimals;
+    /// @notice The decimals of the underlying Chainlink feed
+    uint8 public immutable underlyingDecimals;
+    /// @notice The decimals of the price this feed reports
+    uint8 public immutable feedDecimals;
+    /// @notice The maximum age in seconds for the rate feed before it is rejected
+    uint256 public immutable rateMaxStaleness;
+    /// @notice The maximum age in seconds for the underlying Chainlink price before it is rejected
+    uint256 public immutable underlyingMaxStaleness;
+
+    string private _description;
+
+    /// @notice Thrown when either Chainlink price is older than its staleness limit
+    error StalePrice();
+    /// @notice Thrown when either Chainlink price is zero or negative
+    error InvalidPrice();
+
+    constructor(IAggregatorV3 _rateFeed, IAggregatorV3 _underlyingUsdFeed, uint8 _feedDecimals, uint256 _rateMaxStaleness, uint256 _underlyingMaxStaleness, string memory feedDescription) {
+        rateFeed = _rateFeed;
+        underlyingUsdFeed = _underlyingUsdFeed;
+        rateDecimals = _rateFeed.decimals();
+        underlyingDecimals = _underlyingUsdFeed.decimals();
+        feedDecimals = _feedDecimals;
+        rateMaxStaleness = _rateMaxStaleness;
+        underlyingMaxStaleness = _underlyingMaxStaleness;
+        _description = feedDescription;
+    }
+
+    /// @notice The number of decimals used to represent the price
+    function decimals() external view returns (uint8) {
+        return feedDecimals;
+    }
+
+    /// @notice A human-readable description of the feed
+    function description() external view returns (string memory) {
+        return _description;
+    }
+
+    /**
+     * @notice The token's price, the rate feed times the underlying USD price
+     * @dev Reverts if either Chainlink feed is stale or non-positive
+     */
+    function latestAnswer() external view returns (int256) {
+        uint256 rate = _readFeed(rateFeed, rateMaxStaleness);
+        uint256 underlyingPrice = _readFeed(underlyingUsdFeed, underlyingMaxStaleness);
+
+        // price = rate * underlyingPrice, normalized from (rateDecimals + underlyingDecimals) to feedDecimals
+        uint256 price = rate.mulDiv(underlyingPrice * 10 ** feedDecimals, 10 ** (rateDecimals + underlyingDecimals));
+
+        return price.toInt256();
+    }
+
+    /// @dev Reads a Chainlink feed, reverting if the price is non-positive or older than maxStaleness
+    function _readFeed(IAggregatorV3 feed, uint256 maxStaleness) private view returns (uint256) {
+        (, int256 answer,, uint256 updatedAt,) = feed.latestRoundData();
+        if (answer <= 0) revert InvalidPrice();
+        if (block.timestamp > updatedAt + maxStaleness) revert StalePrice();
+        return answer.toUint256();
+    }
+}

--- a/src/oracle/VedaAccountantPriceFeed.sol
+++ b/src/oracle/VedaAccountantPriceFeed.sol
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+
+import { IAaveV4PriceFeed } from "../interfaces/IAaveV4PriceFeed.sol";
+import { IAggregatorV3 } from "../interfaces/IAggregatorV3.sol";
+import { IVedaAccountant } from "../interfaces/IVedaAccountant.sol";
+
+/**
+ * @title VedaAccountantPriceFeed
+ * @notice Prices a Veda receipt token (eBTC, the Liquid tokens, eUSD, sETHFI) for the Aave v4 oracle
+ *         as the vault rate times the underlying USD price. One instance per token.
+ * @dev Implements the Aave v4 price-feed interface and fails closed: latestAnswer reverts on a paused
+ *      or stale accountant, a stale or non-positive underlying, or a zero rate.
+ * @author ether.fi
+ */
+contract VedaAccountantPriceFeed is IAaveV4PriceFeed {
+    using Math for uint256;
+    using SafeCast for uint256;
+    using SafeCast for int256;
+
+    /// @notice The Veda accountant that provides the vault exchange rate
+    IVedaAccountant public immutable accountant;
+    /// @notice The Chainlink feed for the underlying asset's USD price, e.g. ETH/USD or BTC/USD
+    IAggregatorV3 public immutable underlyingUsdFeed;
+    /// @notice The decimals of the exchange rate from the accountant
+    uint8 public immutable rateDecimals;
+    /// @notice The decimals of the underlying Chainlink feed
+    uint8 public immutable underlyingDecimals;
+    /// @notice The decimals of the price this feed reports
+    uint8 public immutable feedDecimals;
+    /// @notice The maximum age in seconds for the Veda rate before it is rejected
+    uint256 public immutable rateMaxStaleness;
+    /// @notice The maximum age in seconds for the underlying Chainlink price before it is rejected
+    uint256 public immutable underlyingMaxStaleness;
+
+    string private _description;
+
+    /// @notice Thrown when either price source is older than its staleness limit
+    error StalePrice();
+    /// @notice Thrown when the rate or the underlying price is zero or negative
+    error InvalidPrice();
+
+    constructor(IVedaAccountant _accountant, IAggregatorV3 _underlyingUsdFeed, uint8 _feedDecimals, uint256 _rateMaxStaleness, uint256 _underlyingMaxStaleness, string memory feedDescription) {
+        accountant = _accountant;
+        underlyingUsdFeed = _underlyingUsdFeed;
+        rateDecimals = _accountant.decimals();
+        underlyingDecimals = _underlyingUsdFeed.decimals();
+        feedDecimals = _feedDecimals;
+        rateMaxStaleness = _rateMaxStaleness;
+        underlyingMaxStaleness = _underlyingMaxStaleness;
+        _description = feedDescription;
+    }
+
+    /// @notice The number of decimals used to represent the price
+    function decimals() external view returns (uint8) {
+        return feedDecimals;
+    }
+
+    /// @notice A human-readable description of the feed
+    function description() external view returns (string memory) {
+        return _description;
+    }
+
+    /**
+     * @notice The token's price, the vault rate times the underlying USD price
+     * @dev Reverts if the accountant is paused or stale, the underlying is stale or not positive, or the rate is zero
+     */
+    function latestAnswer() external view returns (int256) {
+        IVedaAccountant.AccountantState memory state = accountant.accountantState();
+        if (block.timestamp > state.lastUpdateTimestamp + rateMaxStaleness) revert StalePrice();
+
+        // Vault rate; reverts if the accountant paused itself.
+        uint256 rate = accountant.getRateSafe();
+        if (rate == 0) revert InvalidPrice();
+
+        // Underlying USD price from Chainlink, checked for validity and staleness.
+        (, int256 answer,, uint256 updatedAt,) = underlyingUsdFeed.latestRoundData();
+        if (answer <= 0) revert InvalidPrice();
+        if (block.timestamp > updatedAt + underlyingMaxStaleness) revert StalePrice();
+
+        // price = rate * underlyingPrice, normalized from (rateDecimals + underlyingDecimals) to feedDecimals
+        uint256 price = rate.mulDiv(answer.toUint256() * 10 ** feedDecimals, 10 ** (rateDecimals + underlyingDecimals));
+
+        return price.toInt256();
+    }
+}

--- a/test/price-provider/ChainlinkCompositePriceFeed.t.sol
+++ b/test/price-provider/ChainlinkCompositePriceFeed.t.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import { Test } from "forge-std/Test.sol";
+
+import { IAggregatorV3 } from "../../src/interfaces/IAggregatorV3.sol";
+import { ChainlinkCompositePriceFeed } from "../../src/oracle/ChainlinkCompositePriceFeed.sol";
+
+/// @notice Fork tests on Optimism, using the live weETH/ETH rate feed and ETH/USD feed.
+contract ChainlinkCompositePriceFeedTest is Test {
+    using SafeCast for int256;
+
+    // optimism
+    address rateFeed = 0xb4479d436DDa5c1A79bD88D282725615202406E3; // weETH / ETH
+    address ethUsdOracle = 0x13e3Ee699D1909E989722E753853AE30b17e08c5; // ETH / USD
+
+    uint8 constant FEED_DECIMALS = 8;
+    uint256 constant RATE_MAX_STALENESS = 1 days;
+    uint256 constant UNDERLYING_MAX_STALENESS = 1 days;
+
+    ChainlinkCompositePriceFeed feed;
+
+    function setUp() public {
+        vm.createSelectFork(vm.envOr("OPTIMISM_RPC", string("https://mainnet.optimism.io")));
+        feed = new ChainlinkCompositePriceFeed(IAggregatorV3(rateFeed), IAggregatorV3(ethUsdOracle), FEED_DECIMALS, RATE_MAX_STALENESS, UNDERLYING_MAX_STALENESS, "weETH / USD");
+    }
+
+    /// @notice The reported price equals rate x underlying, and lands in a sane USD range.
+    function test_latestAnswer_matchesRateTimesUnderlying() public view {
+        (, int256 rate,,,) = IAggregatorV3(rateFeed).latestRoundData();
+        (, int256 ethUsd,,,) = IAggregatorV3(ethUsdOracle).latestRoundData();
+
+        uint256 expected = rate.toUint256() * ethUsd.toUint256() * (10 ** FEED_DECIMALS) / (10 ** (feed.rateDecimals() + feed.underlyingDecimals()));
+
+        uint256 price = feed.latestAnswer().toUint256();
+        assertEq(price, expected, "price mismatch");
+
+        // Sanity on magnitude, which catches a decimals mistake: weETH should be a few thousand USD,
+        // so well within 100 to 100,000 USD at 8 decimals.
+        assertGt(price, 100 * (10 ** FEED_DECIMALS), "price too low");
+        assertLt(price, 100_000 * (10 ** FEED_DECIMALS), "price too high");
+    }
+
+    function test_decimalsAndDescription() public view {
+        assertEq(feed.decimals(), FEED_DECIMALS);
+        assertEq(feed.description(), "weETH / USD");
+    }
+
+    /// @notice Reverts when the rate feed is older than its staleness limit.
+    function test_reverts_whenRateStale() public {
+        (uint80 roundId, int256 rate, uint256 startedAt,, uint80 answeredInRound) = IAggregatorV3(rateFeed).latestRoundData();
+        uint256 staleUpdatedAt = block.timestamp - RATE_MAX_STALENESS - 1;
+        vm.mockCall(rateFeed, abi.encodeWithSelector(IAggregatorV3.latestRoundData.selector), abi.encode(roundId, rate, startedAt, staleUpdatedAt, answeredInRound));
+        vm.expectRevert(ChainlinkCompositePriceFeed.StalePrice.selector);
+        feed.latestAnswer();
+    }
+
+    /// @notice Reverts when the underlying Chainlink price is older than its staleness limit.
+    function test_reverts_whenUnderlyingStale() public {
+        (uint80 roundId, int256 answer, uint256 startedAt,, uint80 answeredInRound) = IAggregatorV3(ethUsdOracle).latestRoundData();
+        uint256 staleUpdatedAt = block.timestamp - UNDERLYING_MAX_STALENESS - 1;
+        vm.mockCall(ethUsdOracle, abi.encodeWithSelector(IAggregatorV3.latestRoundData.selector), abi.encode(roundId, answer, startedAt, staleUpdatedAt, answeredInRound));
+        vm.expectRevert(ChainlinkCompositePriceFeed.StalePrice.selector);
+        feed.latestAnswer();
+    }
+
+    /// @notice Reverts when the rate feed price is zero or negative.
+    function test_reverts_whenRateNotPositive() public {
+        vm.mockCall(rateFeed, abi.encodeWithSelector(IAggregatorV3.latestRoundData.selector), abi.encode(uint80(1), int256(0), block.timestamp, block.timestamp, uint80(1)));
+        vm.expectRevert(ChainlinkCompositePriceFeed.InvalidPrice.selector);
+        feed.latestAnswer();
+    }
+
+    /// @notice Reverts when the underlying price is zero or negative.
+    function test_reverts_whenUnderlyingNotPositive() public {
+        vm.mockCall(ethUsdOracle, abi.encodeWithSelector(IAggregatorV3.latestRoundData.selector), abi.encode(uint80(1), int256(0), block.timestamp, block.timestamp, uint80(1)));
+        vm.expectRevert(ChainlinkCompositePriceFeed.InvalidPrice.selector);
+        feed.latestAnswer();
+    }
+}

--- a/test/price-provider/VedaAccountantPriceFeed.t.sol
+++ b/test/price-provider/VedaAccountantPriceFeed.t.sol
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import { Test } from "forge-std/Test.sol";
+
+import { IAggregatorV3 } from "../../src/interfaces/IAggregatorV3.sol";
+import { IVedaAccountant } from "../../src/interfaces/IVedaAccountant.sol";
+import { VedaAccountantPriceFeed } from "../../src/oracle/VedaAccountantPriceFeed.sol";
+
+/// @notice Fork tests on Optimism, using the live liquidETH accountant and ETH/USD feed.
+contract VedaAccountantPriceFeedTest is Test {
+    using SafeCast for int256;
+    using SafeCast for uint256;
+
+    // optimism
+    IVedaAccountant accountant = IVedaAccountant(0x0d05D94a5F1E76C18fbeB7A13d17C8a314088198); // liquidETH
+    address ethUsdOracle = 0x13e3Ee699D1909E989722E753853AE30b17e08c5; // ETH/USD
+
+    uint8 constant FEED_DECIMALS = 8;
+    uint256 constant RATE_MAX_STALENESS = 2 days;
+    uint256 constant UNDERLYING_MAX_STALENESS = 1 days;
+
+    VedaAccountantPriceFeed feed;
+
+    function setUp() public {
+        vm.createSelectFork(vm.envOr("OPTIMISM_RPC", string("https://mainnet.optimism.io")));
+        feed = new VedaAccountantPriceFeed(accountant, IAggregatorV3(ethUsdOracle), FEED_DECIMALS, RATE_MAX_STALENESS, UNDERLYING_MAX_STALENESS, "liquidETH / USD");
+    }
+
+    /// @notice The reported price equals rate x underlying, and lands in a sane USD range.
+    function test_latestAnswer_matchesRateTimesUnderlying() public view {
+        uint256 rate = accountant.getRateSafe();
+        (, int256 ethUsd,,,) = IAggregatorV3(ethUsdOracle).latestRoundData();
+
+        uint256 expected = rate * ethUsd.toUint256() * (10 ** FEED_DECIMALS) / (10 ** (feed.rateDecimals() + feed.underlyingDecimals()));
+
+        uint256 price = feed.latestAnswer().toUint256();
+        assertEq(price, expected, "price mismatch");
+
+        // Sanity on magnitude, which catches a decimals mistake: liquidETH should be a few thousand
+        // USD, so well within 100 to 100,000 USD at 8 decimals.
+        assertGt(price, 100 * (10 ** FEED_DECIMALS), "price too low");
+        assertLt(price, 100_000 * (10 ** FEED_DECIMALS), "price too high");
+    }
+
+    function test_decimalsAndDescription() public view {
+        assertEq(feed.decimals(), FEED_DECIMALS);
+        assertEq(feed.description(), "liquidETH / USD");
+    }
+
+    /// @notice Reverts when the underlying Chainlink price is older than the staleness limit.
+    function test_reverts_whenUnderlyingStale() public {
+        vm.warp(block.timestamp + UNDERLYING_MAX_STALENESS + 1);
+        vm.expectRevert(VedaAccountantPriceFeed.StalePrice.selector);
+        feed.latestAnswer();
+    }
+
+    /// @notice Reverts when the Veda accountant rate is older than the staleness limit.
+    function test_reverts_whenRateStale() public {
+        uint64 staleLastUpdateTimestamp = (block.timestamp - RATE_MAX_STALENESS - 1).toUint64();
+        IVedaAccountant.AccountantState memory state;
+        state.exchangeRate = 1e18;
+        state.allowedExchangeRateChangeUpper = 10_050;
+        state.allowedExchangeRateChangeLower = 9950;
+        state.lastUpdateTimestamp = staleLastUpdateTimestamp;
+        state.minimumUpdateDelayInSeconds = 6 hours;
+
+        vm.mockCall(address(accountant), abi.encodeWithSelector(IVedaAccountant.accountantState.selector), abi.encode(state));
+
+        vm.expectRevert(VedaAccountantPriceFeed.StalePrice.selector);
+        feed.latestAnswer();
+    }
+
+    /// @notice Reverts when the accountant has paused itself (getRateSafe reverts).
+    function test_reverts_whenAccountantPaused() public {
+        vm.mockCallRevert(address(accountant), abi.encodeWithSelector(IVedaAccountant.getRateSafe.selector), "paused");
+        vm.expectRevert();
+        feed.latestAnswer();
+    }
+
+    /// @notice Reverts when the rate is zero.
+    function test_reverts_whenRateZero() public {
+        vm.mockCall(address(accountant), abi.encodeWithSelector(IVedaAccountant.getRateSafe.selector), abi.encode(uint256(0)));
+        vm.expectRevert(VedaAccountantPriceFeed.InvalidPrice.selector);
+        feed.latestAnswer();
+    }
+
+    /// @notice Reverts when the underlying price is zero or negative.
+    function test_reverts_whenUnderlyingNotPositive() public {
+        vm.mockCall(ethUsdOracle, abi.encodeWithSelector(IAggregatorV3.latestRoundData.selector), abi.encode(uint80(1), int256(0), block.timestamp, block.timestamp, uint80(1)));
+        vm.expectRevert(VedaAccountantPriceFeed.InvalidPrice.selector);
+        feed.latestAnswer();
+    }
+}

--- a/test/safe/SafeTestSetup.t.sol
+++ b/test/safe/SafeTestSetup.t.sol
@@ -31,6 +31,7 @@ import { DebtManagerAdmin } from "../../src/debt-manager/DebtManagerAdmin.sol";
 import { CashbackDispatcher } from "../../src/cashback-dispatcher/CashbackDispatcher.sol";
 import { PriceProvider, IAggregatorV3 } from "../../src/oracle/PriceProvider.sol";
 import { SettlementDispatcherV2 } from "../../src/settlement-dispatcher/SettlementDispatcherV2.sol";
+import { MockGateway } from "../../src/mocks/MockGateway.sol";
 import { Utils, ChainConfig } from "../utils/Utils.sol";
 
 contract SafeTestSetup is Utils {
@@ -46,6 +47,7 @@ contract SafeTestSetup is Utils {
     SettlementDispatcherV2 settlementDispatcherRain;
     SettlementDispatcherV2 settlementDispatcherReap;
     IDebtManager debtManager;
+    MockGateway gateway;
     address debtManagerAdminImpl;
     CashbackDispatcher cashbackDispatcher;
     ICashEventEmitter cashEventEmitter;
@@ -177,7 +179,8 @@ contract SafeTestSetup is Utils {
         address hookImpl = address(new EtherFiHook(address(dataProvider)));
         hook = EtherFiHook(address(new UUPSProxy(hookImpl, abi.encodeWithSelector(EtherFiHook.initialize.selector, address(roleRegistry)))));
 
-        address cashLensImpl = address(new CashLens(address(cashModule), address(dataProvider)));
+        gateway = new MockGateway();
+        address cashLensImpl = address(new CashLens(address(cashModule), address(dataProvider), address(gateway)));
         cashLens = CashLens(address(new UUPSProxy(cashLensImpl, abi.encodeWithSelector(CashLens.initialize.selector, address(roleRegistry)))));
 
         dataProvider.initialize(EtherFiDataProvider.InitParams(address(roleRegistry), address(cashModule), address(cashLens), modules, defaultModules, address(hook), address(safeFactory), address(priceProvider), etherFiRecoverySigner, thirdPartyRecoverySigner, refundWallet));

--- a/test/safe/modules/ModuleGatewaySandwich.t.sol
+++ b/test/safe/modules/ModuleGatewaySandwich.t.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { Test } from "forge-std/Test.sol";
+
+import { IGateway } from "../../../src/interfaces/IGateway.sol";
+import { MockGateway } from "../../../src/mocks/MockGateway.sol";
+import { ModuleGatewaySandwich } from "../../../src/modules/ModuleGatewaySandwich.sol";
+
+/// @notice Exposes the base's internal bookends so they can be called directly in tests
+contract SandwichHarness is ModuleGatewaySandwich {
+    constructor(address _gateway, uint256 _minHealthFactor) ModuleGatewaySandwich(_gateway, _minHealthFactor) { }
+
+    function withdrawFromGateway(address safe, address asset, uint256 amount) external {
+        _withdrawFromGateway(safe, asset, amount);
+    }
+
+    function resupplyToGateway(address safe, address asset, uint256 amount) external {
+        _resupplyToGateway(safe, asset, amount);
+    }
+}
+
+contract ModuleGatewaySandwichTest is Test {
+    MockGateway gateway;
+    SandwichHarness harness;
+
+    uint256 constant MIN_HEALTH_FACTOR = 1e18;
+    uint256 constant AMOUNT = 100e6;
+    address safe = makeAddr("safe");
+    address asset = makeAddr("asset");
+
+    function setUp() public {
+        gateway = new MockGateway();
+        harness = new SandwichHarness(address(gateway), MIN_HEALTH_FACTOR);
+    }
+
+    function _setHealthFactor(uint256 healthFactor) internal {
+        gateway.setAccountData(safe, IGateway.AccountData({ collateralUsd: 0, debtUsd: 0, availableBorrowsUsd: 0, healthFactor: healthFactor }));
+    }
+
+    // A zero gateway address is rejected at deployment.
+    function test_constructor_revertsOnZeroGateway() public {
+        vm.expectRevert(ModuleGatewaySandwich.InvalidGateway.selector);
+        new SandwichHarness(address(0), MIN_HEALTH_FACTOR);
+    }
+
+    // Withdraws to the safe and passes the guard at exactly minHealthFactor.
+    function test_withdraw_routesToSafeAndPassesAtMinHealthFactor() public {
+        _setHealthFactor(MIN_HEALTH_FACTOR);
+        harness.withdrawFromGateway(safe, asset, AMOUNT);
+
+        (address s, address a, uint256 amount, address to) = gateway.lastWithdraw();
+        assertEq(s, safe);
+        assertEq(a, asset);
+        assertEq(amount, AMOUNT);
+        assertEq(to, safe);
+    }
+
+    // Reverts when the post-withdraw health factor is below the floor.
+    function test_withdraw_revertsBelowMinHealthFactor() public {
+        _setHealthFactor(MIN_HEALTH_FACTOR - 1);
+        vm.expectRevert(ModuleGatewaySandwich.WithdrawBreachesHealth.selector);
+        harness.withdrawFromGateway(safe, asset, AMOUNT);
+    }
+
+    // Supplies the asset back to Aave and marks it as collateral.
+    function test_resupply_suppliesAndSetsCollateral() public {
+        harness.resupplyToGateway(safe, asset, AMOUNT);
+
+        (address s, address a, uint256 amount, address to) = gateway.lastSupply();
+        assertEq(s, safe);
+        assertEq(a, asset);
+        assertEq(amount, AMOUNT);
+        assertEq(to, address(0));
+        assertTrue(gateway.usingAsCollateral(safe, asset));
+    }
+}

--- a/test/safe/modules/ModuleGatewaySandwich.t.sol
+++ b/test/safe/modules/ModuleGatewaySandwich.t.sol
@@ -18,6 +18,12 @@ contract SandwichHarness is ModuleGatewaySandwich {
     function resupplyToGateway(address safe, address asset, uint256 amount) external {
         _resupplyToGateway(safe, asset, amount);
     }
+
+    /// @notice A guarded withdraw-resupply operation, mirroring how a module brackets its action
+    function runSandwich(address safe, address asset, uint256 amount) external guardsHealth(safe) {
+        _withdrawFromGateway(safe, asset, amount);
+        _resupplyToGateway(safe, asset, amount);
+    }
 }
 
 contract ModuleGatewaySandwichTest is Test {
@@ -44,9 +50,8 @@ contract ModuleGatewaySandwichTest is Test {
         new SandwichHarness(address(0), MIN_HEALTH_FACTOR);
     }
 
-    // Withdraws to the safe and passes the guard at exactly minHealthFactor.
-    function test_withdraw_routesToSafeAndPassesAtMinHealthFactor() public {
-        _setHealthFactor(MIN_HEALTH_FACTOR);
+    // The withdraw bookend routes to the safe and does not guard health; Aave guards the withdraw itself.
+    function test_withdraw_routesToSafe() public {
         harness.withdrawFromGateway(safe, asset, AMOUNT);
 
         (address s, address a, uint256 amount, address to) = gateway.lastWithdraw();
@@ -56,14 +61,7 @@ contract ModuleGatewaySandwichTest is Test {
         assertEq(to, safe);
     }
 
-    // Reverts when the post-withdraw health factor is below the floor.
-    function test_withdraw_revertsBelowMinHealthFactor() public {
-        _setHealthFactor(MIN_HEALTH_FACTOR - 1);
-        vm.expectRevert(ModuleGatewaySandwich.WithdrawBreachesHealth.selector);
-        harness.withdrawFromGateway(safe, asset, AMOUNT);
-    }
-
-    // Supplies the asset back to Aave and marks it as collateral.
+    // The resupply bookend supplies the asset back to Aave and marks it as collateral, with no health guard of its own.
     function test_resupply_suppliesAndSetsCollateral() public {
         harness.resupplyToGateway(safe, asset, AMOUNT);
 
@@ -73,5 +71,23 @@ contract ModuleGatewaySandwichTest is Test {
         assertEq(amount, AMOUNT);
         assertEq(to, address(0));
         assertTrue(gateway.usingAsCollateral(safe, asset));
+    }
+
+    // The guarded operation runs both bookends and passes at exactly minHealthFactor.
+    function test_guardedOperation_passesAtMinHealthFactor() public {
+        _setHealthFactor(MIN_HEALTH_FACTOR);
+        harness.runSandwich(safe, asset, AMOUNT);
+
+        (address ws,,, address wto) = gateway.lastWithdraw();
+        assertEq(ws, safe);
+        assertEq(wto, safe);
+        assertTrue(gateway.usingAsCollateral(safe, asset));
+    }
+
+    // The guard reverts when the completed operation leaves the safe's health factor below the floor.
+    function test_guardedOperation_revertsBelowMinHealthFactor() public {
+        _setHealthFactor(MIN_HEALTH_FACTOR - 1);
+        vm.expectRevert(ModuleGatewaySandwich.OperationBreachesHealth.selector);
+        harness.runSandwich(safe, asset, AMOUNT);
     }
 }

--- a/test/safe/modules/cash/CanSpend.t.sol
+++ b/test/safe/modules/cash/CanSpend.t.sol
@@ -84,6 +84,22 @@ contract CashLensCanSpendTest is CashModuleTestSetup {
         assertEq(reason, "");
     }
 
+    function test_canSpend_succeeds_inDebitMode_whenSuppliedToAave() public {
+        // Scenario 2: the stable is supplied to Aave, not held raw. Debit still works via the withdrawable amount.
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 100e6;
+
+        deal(address(usdc), address(safe), 0);
+        gateway.setSuppliedOf(address(safe), address(usdc), 100e6);
+        gateway.setAvailableCash(address(usdc), type(uint128).max);
+
+        (bool canSpend, string memory reason) = cashLens.canSpend(address(safe), txId, tokens, amounts);
+        assertEq(canSpend, true);
+        assertEq(reason, "");
+    }
+
     function test_canSpend_succeeds_inCreditMode_whenCollateralAvailable() public {
         _setMode(Mode.Credit);
         vm.warp(cashModule.incomingModeStartTime(address(safe)) + 1);
@@ -95,6 +111,7 @@ contract CashLensCanSpendTest is CashModuleTestSetup {
 
         deal(address(weETH), address(safe), 1 ether);
         deal(address(usdc), address(debtManager), amounts[0]);
+        _mirrorPositionToGateway(address(safe));
         (bool canSpend, string memory reason) = cashLens.canSpend(address(safe), txId, tokens, amounts);
         assertEq(canSpend, true);
         assertEq(reason, "");
@@ -169,6 +186,7 @@ contract CashLensCanSpendTest is CashModuleTestSetup {
 
         amounts[0] = balToTransfer;
 
+        _mirrorPositionToGateway(address(safe));
         (bool canSpend, string memory reason) = cashLens.canSpend(address(safe), txId, tokens, amounts);
         assertEq(canSpend, true);
         assertEq(reason, "");
@@ -210,6 +228,7 @@ contract CashLensCanSpendTest is CashModuleTestSetup {
         // if we want to borrow 82 USDC, it should fail
         amounts[0] = 82e6;
 
+        _mirrorPositionToGateway(address(safe));
         (bool canSpend, string memory reason) = cashLens.canSpend(address(safe), txId, tokens, amounts);
         assertEq(canSpend, false);
         assertEq(reason, "Insufficient borrowing power");
@@ -223,6 +242,7 @@ contract CashLensCanSpendTest is CashModuleTestSetup {
         uint256[] memory amounts = new uint256[](1);
         amounts[0] = 50e6;
 
+        _mirrorPositionToGateway(address(safe));
         (bool canSpend, string memory reason) = cashLens.canSpend(address(safe), txId, tokens, amounts);
         assertEq(canSpend, false);
         assertEq(reason, "Insufficient borrowing power");
@@ -717,9 +737,10 @@ contract CashLensCanSpendTest is CashModuleTestSetup {
         debitPrefs[0] = address(usdc);
         
         uint256 amountInUsd = 500e6; // 500 USD
-        
+
+        _mirrorPositionToGateway(address(safe));
         (Mode mode, address token, bool canSpend, string memory message) = cashLens.canSpendSingleToken(address(safe), txId, creditPrefs, debitPrefs, amountInUsd);
-        
+
         assertEq(uint8(mode), uint8(Mode.Credit), "Should return credit mode");
         assertEq(token, address(usdc), "Should return USDC");
         assertTrue(canSpend, "Should be able to spend in credit mode");
@@ -853,9 +874,10 @@ contract CashLensCanSpendTest is CashModuleTestSetup {
         debitPrefs[0] = address(usdc);
         
         uint256 amountInUsd = 500e6;
-        
+
+        _mirrorPositionToGateway(address(safe));
         (Mode mode, address token, bool canSpend, string memory message) = cashLens.canSpendSingleToken(address(safe), txId, creditPrefs, debitPrefs, amountInUsd);
-        
+
         assertEq(uint8(mode), uint8(Mode.Credit), "Should return credit mode");
         assertEq(token, address(usdc), "Should return USDC");
         assertFalse(canSpend, "Should not be able to spend without collateral");

--- a/test/safe/modules/cash/CanSpend.t.sol
+++ b/test/safe/modules/cash/CanSpend.t.sol
@@ -142,7 +142,7 @@ contract CashLensCanSpendTest is CashModuleTestSetup {
         deal(address(usdc), address(debtManager), amounts[0] - 1);
         (bool canSpend, string memory reason) = cashLens.canSpend(address(safe), txId, tokens, amounts);
         assertEq(canSpend, false);
-        assertEq(reason, "Insufficient liquidity in debt manager to cover the loan");
+        assertEq(reason, "Insufficient liquidity to cover the loan");
     }
 
     function test_canSpend_succeeds_inDebitMode_whenWithdrawalIsLowerThanAmountRequested() public {

--- a/test/safe/modules/cash/CanSpend.t.sol
+++ b/test/safe/modules/cash/CanSpend.t.sol
@@ -14,7 +14,7 @@ import { IDebtManager } from "../../../../src/interfaces/IDebtManager.sol";
 contract CashLensCanSpendTest is CashModuleTestSetup {
     using MessageHashUtils for bytes32;
 
-    IERC20 public liquidUsdScroll = IERC20(0x08c6F91e2B681FaF5e17227F2a44C307b3C1364C);
+    IERC20 public liquidUsd = IERC20(0x08c6F91e2B681FaF5e17227F2a44C307b3C1364C);
 
     function setUp() public override {
         super.setUp();
@@ -34,7 +34,7 @@ contract CashLensCanSpendTest is CashModuleTestSetup {
         });
 
         address[] memory tokens = new address[](1);
-        tokens[0] = address(liquidUsdScroll);
+        tokens[0] = address(liquidUsd);
 
         PriceProvider.Config[] memory tokensConfig = new PriceProvider.Config[](1);
         tokensConfig[0] = liquidUsdConfig;
@@ -47,10 +47,10 @@ contract CashLensCanSpendTest is CashModuleTestSetup {
         collateralTokenConfig[0].liquidationThreshold = liquidationThreshold;
         collateralTokenConfig[0].liquidationBonus = liquidationBonus;
 
-        debtManager.supportCollateralToken(address(liquidUsdScroll), collateralTokenConfig[0]);        
+        debtManager.supportCollateralToken(address(liquidUsd), collateralTokenConfig[0]);        
 
-        minShares = uint128(10 * 10 ** IERC20Metadata(address(liquidUsdScroll)).decimals());
-        debtManager.supportBorrowToken(address(liquidUsdScroll), borrowApyPerSecond, minShares);
+        minShares = uint128(10 * 10 ** IERC20Metadata(address(liquidUsd)).decimals());
+        debtManager.supportBorrowToken(address(liquidUsd), borrowApyPerSecond, minShares);
         
         CashbackTokens[] memory cashbackTokens = new CashbackTokens[](1);
         CashbackTokens memory scr = CashbackTokens({
@@ -683,14 +683,14 @@ contract CashLensCanSpendTest is CashModuleTestSetup {
     
     function test_canSpendSingleToken_debitMode_firstTokenWorks() public {
         deal(address(usdc), address(safe), 1000e6);
-        deal(address(liquidUsdScroll), address(safe), 1000e18);
+        deal(address(liquidUsd), address(safe), 1000e18);
         
         address[] memory creditPrefs = new address[](1);
         creditPrefs[0] = address(usdc);
         
         address[] memory debitPrefs = new address[](2);
         debitPrefs[0] = address(usdc);
-        debitPrefs[1] = address(liquidUsdScroll);
+        debitPrefs[1] = address(liquidUsd);
         
         uint256 amountInUsd = 500e6; // 500 USD
         
@@ -704,21 +704,21 @@ contract CashLensCanSpendTest is CashModuleTestSetup {
 
     function test_canSpendSingleToken_debitMode_fallbackToSecondToken() public {
         // Setup: safe only has LiquidUSD
-        deal(address(liquidUsdScroll), address(safe), 1000e18);
+        deal(address(liquidUsd), address(safe), 1000e18);
         
         address[] memory creditPrefs = new address[](1);
         creditPrefs[0] = address(usdc);
         
         address[] memory debitPrefs = new address[](2);
         debitPrefs[0] = address(usdc); // No balance
-        debitPrefs[1] = address(liquidUsdScroll); // Has balance
+        debitPrefs[1] = address(liquidUsd); // Has balance
         
         uint256 amountInUsd = 500e6; // 500 USD
         
         (Mode mode, address token, bool canSpend, string memory message) = cashLens.canSpendSingleToken(address(safe), txId, creditPrefs, debitPrefs, amountInUsd);
         
         assertEq(uint8(mode), uint8(Mode.Debit), "Should return debit mode");
-        assertEq(token, address(liquidUsdScroll), "Should return second preference token");
+        assertEq(token, address(liquidUsd), "Should return second preference token");
         assertTrue(canSpend, "Should be able to spend with second token");
         assertEq(message, "", "Should have no error message");
     }
@@ -755,7 +755,7 @@ contract CashLensCanSpendTest is CashModuleTestSetup {
         
         address[] memory debitPrefs = new address[](2);
         debitPrefs[0] = address(usdc);
-        debitPrefs[1] = address(liquidUsdScroll);
+        debitPrefs[1] = address(liquidUsd);
         
         uint256 amountInUsd = 500e6; 
         
@@ -833,7 +833,7 @@ contract CashLensCanSpendTest is CashModuleTestSetup {
     function test_canSpendSingleToken_withPendingWithdrawals() public {
         // Setup balances
         deal(address(usdc), address(safe), 1000e6);
-        deal(address(liquidUsdScroll), address(safe), 1000e18);
+        deal(address(liquidUsd), address(safe), 1000e18);
         
         // Request withdrawal that affects USDC
         address[] memory withdrawTokens = new address[](1);
@@ -847,14 +847,14 @@ contract CashLensCanSpendTest is CashModuleTestSetup {
         
         address[] memory debitPrefs = new address[](2);
         debitPrefs[0] = address(usdc); // Will fail due to withdrawal
-        debitPrefs[1] = address(liquidUsdScroll); // Should work
+        debitPrefs[1] = address(liquidUsd); // Should work
         
         uint256 amountInUsd = 500e6; // More than remaining USDC
         
         (Mode mode, address token, bool canSpend, string memory message) = cashLens.canSpendSingleToken(address(safe), txId, creditPrefs, debitPrefs, amountInUsd);
         
         assertEq(uint8(mode), uint8(Mode.Debit), "Should return debit mode");
-        assertEq(token, address(liquidUsdScroll), "Should fallback to LiquidUSD");
+        assertEq(token, address(liquidUsd), "Should fallback to LiquidUSD");
         assertTrue(canSpend, "Should be able to spend with second token");
         assertEq(message, "", "Should have no error message");
     }

--- a/test/safe/modules/cash/CanSpend.t.sol
+++ b/test/safe/modules/cash/CanSpend.t.sol
@@ -640,7 +640,7 @@ contract CashLensCanSpendTest is CashModuleTestSetup {
         (bool canSpend, string memory message) = cashLens.canSpend(address(safe), txId, tokens, amountsInUsd);
         
         assertFalse(canSpend, "Should not allow spending a non-borrow token");
-        assertEq(message, "Not a supported stable token", "Error message should match");
+        assertEq(message, "Not a supported borrow token", "Error message should match");
     }
 
     function test_canSpend_alreadyCleared() public {

--- a/test/safe/modules/cash/CashLens.t.sol
+++ b/test/safe/modules/cash/CashLens.t.sol
@@ -18,7 +18,7 @@ import { ILayerZeroTeller, AccountantWithRateProviders } from "../../../../src/i
 contract CashLensTest is CashModuleTestSetup {
     using MessageHashUtils for bytes32;
 
-    IERC20 public liquidUsdScroll = IERC20(0x08c6F91e2B681FaF5e17227F2a44C307b3C1364C);
+    IERC20 public liquidUsd = IERC20(0x08c6F91e2B681FaF5e17227F2a44C307b3C1364C);
     ILayerZeroTeller public liquidUsdTeller = ILayerZeroTeller(0x4DE413a26fC24c3FC27Cc983be70aA9c5C299387);
 
     function setUp() public override {
@@ -41,7 +41,7 @@ contract CashLensTest is CashModuleTestSetup {
         });
 
         address[] memory tokens = new address[](1);
-        tokens[0] = address(liquidUsdScroll);
+        tokens[0] = address(liquidUsd);
 
         PriceProvider.Config[] memory tokensConfig = new PriceProvider.Config[](1);
         tokensConfig[0] = liquidUsdConfig;
@@ -54,10 +54,10 @@ contract CashLensTest is CashModuleTestSetup {
         collateralTokenConfig[0].liquidationThreshold = liquidationThreshold;
         collateralTokenConfig[0].liquidationBonus = liquidationBonus;
 
-        debtManager.supportCollateralToken(address(liquidUsdScroll), collateralTokenConfig[0]);        
+        debtManager.supportCollateralToken(address(liquidUsd), collateralTokenConfig[0]);        
 
-        minShares = uint128(10 * 10 ** IERC20Metadata(address(liquidUsdScroll)).decimals());
-        debtManager.supportBorrowToken(address(liquidUsdScroll), borrowApyPerSecond, minShares);
+        minShares = uint128(10 * 10 ** IERC20Metadata(address(liquidUsd)).decimals());
+        debtManager.supportBorrowToken(address(liquidUsd), borrowApyPerSecond, minShares);
 
         // Add some collateral to safe for tests
         deal(address(weETH), address(safe), 10 ether);

--- a/test/safe/modules/cash/CashLens.t.sol
+++ b/test/safe/modules/cash/CashLens.t.sol
@@ -163,10 +163,12 @@ contract CashLensTest is CashModuleTestSetup {
         assertEq(data.withdrawalRequest.tokens[0], address(usdc), "Withdrawal token should be USDC");
         assertEq(data.withdrawalRequest.amounts[0], 5000e6, "Withdrawal amount should be 5000 USDC");
         
-        // Verify total values
-        assertGt(data.totalCollateral, 0, "Total collateral should be positive");
+        // Verify total values stay aligned with the old DebtManager-facing effective state.
+        (, uint256 expectedTotalCollateral,,) = debtManager.getUserCurrentState(address(safe));
+        uint256 expectedMaxBorrow = debtManager.getMaxBorrowAmount(address(safe), true);
+        assertEq(data.totalCollateral, expectedTotalCollateral, "Total collateral should exclude pending withdrawals");
         assertEq(data.totalBorrow, 0, "Total borrow should be zero initially");
-        assertGt(data.maxBorrow, 0, "Max borrow should be positive");
+        assertEq(data.maxBorrow, expectedMaxBorrow, "Max borrow should exclude pending withdrawals");
     }
 
     function test_getSafeCashData_inCreditMode() public {

--- a/test/safe/modules/cash/CashLens.t.sol
+++ b/test/safe/modules/cash/CashLens.t.sol
@@ -145,8 +145,9 @@ contract CashLensTest is CashModuleTestSetup {
         _requestWithdrawal(tokens, amounts, withdrawRecipient);
         
         // Get safe cash data
+        _mirrorPositionToGateway(address(safe));
         SafeCashData memory data = cashLens.getSafeCashData(address(safe), new address[](0));
-        
+
         // Verify basic data
         assertEq(uint8(data.mode), uint8(Mode.Debit), "Initial mode should be Debit");
         assertEq(data.incomingModeStartTime, 0, "No incoming mode change");
@@ -229,8 +230,9 @@ contract CashLensTest is CashModuleTestSetup {
         // Spend in credit mode to create a borrow
         vm.prank(etherFiWallet);
         cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
-        
+
         // Get safe cash data
+        _mirrorPositionToGateway(address(safe));
         SafeCashData memory data = cashLens.getSafeCashData(address(safe), new address[](0));
         
         // Verify borrows

--- a/test/safe/modules/cash/CashLensMaxSpend.t.sol
+++ b/test/safe/modules/cash/CashLensMaxSpend.t.sol
@@ -146,6 +146,8 @@ contract CashLensMaxSpendTest is CashModuleTestSetup {
     }
 
     function test_getMaxSpendDebit_underwaterPosition_USDCFirst() public {
+        // Underwater debit (debt-driven restriction) is phase two; phase one has no live debt.
+        vm.skip(true);
         // Create debt by borrowing in credit mode
         _setMode(Mode.Credit);
         vm.warp(cashModule.incomingModeStartTime(address(safe)) + 1);
@@ -198,6 +200,8 @@ contract CashLensMaxSpendTest is CashModuleTestSetup {
     }
 
     function test_getMaxSpendDebit_underwaterPosition_liquidUSDFirst() public {
+        // Underwater debit (debt-driven restriction) is phase two; phase one has no live debt.
+        vm.skip(true);
         // Create debt
         _setMode(Mode.Credit);
         vm.warp(cashModule.incomingModeStartTime(address(safe)) + 1);
@@ -303,6 +307,8 @@ contract CashLensMaxSpendTest is CashModuleTestSetup {
     }
 
     function test_getMaxSpendDebit_cannotCoverDeficit() public {        
+        // Underwater debit (debt-driven restriction) is phase two; phase one has no live debt.
+        vm.skip(true);
         // Create large debt
         _setMode(Mode.Credit);
         vm.warp(cashModule.incomingModeStartTime(address(safe)) + 1);
@@ -367,13 +373,56 @@ contract CashLensMaxSpendTest is CashModuleTestSetup {
         assertEq(result.totalSpendableInUsd, 0, "Total should be zero");
     }
 
+    // ================ Phase-one supplied-position Tests ================
+
+    function test_getMaxSpendDebit_suppliedOnly_noRawBalance() public {
+        // Scenario 2: the stable lives in Aave, not the safe. Debit spends the withdrawable supplied amount.
+        deal(address(usdc), address(safe), 0);
+        gateway.setSuppliedOf(address(safe), address(usdc), 1000e6);
+        gateway.setAvailableCash(address(usdc), type(uint128).max);
+
+        address[] memory tokenPreference = new address[](1);
+        tokenPreference[0] = address(usdc);
+
+        DebitModeMaxSpend memory result = cashLens.getMaxSpendDebit(address(safe), tokenPreference);
+        assertEq(result.spendableAmounts[0], 1000e6, "Should spend the withdrawable supplied amount");
+        assertGt(result.totalSpendableInUsd, 0, "Total should be positive");
+    }
+
+    function test_getMaxSpendDebit_withdrawableCappedByReserveCash() public {
+        // The supplied amount is only spendable up to the reserve's available liquidity.
+        deal(address(usdc), address(safe), 0);
+        gateway.setSuppliedOf(address(safe), address(usdc), 1000e6);
+        gateway.setAvailableCash(address(usdc), 400e6);
+
+        address[] memory tokenPreference = new address[](1);
+        tokenPreference[0] = address(usdc);
+
+        DebitModeMaxSpend memory result = cashLens.getMaxSpendDebit(address(safe), tokenPreference);
+        assertEq(result.spendableAmounts[0], 400e6, "Should cap at reserve liquidity");
+    }
+
+    function test_getMaxSpendDebit_rawPlusSupplied() public {
+        // Mixed: a raw safe balance plus a supplied position. Debit spends the sum.
+        deal(address(usdc), address(safe), 300e6);
+        gateway.setSuppliedOf(address(safe), address(usdc), 700e6);
+        gateway.setAvailableCash(address(usdc), type(uint128).max);
+
+        address[] memory tokenPreference = new address[](1);
+        tokenPreference[0] = address(usdc);
+
+        DebitModeMaxSpend memory result = cashLens.getMaxSpendDebit(address(safe), tokenPreference);
+        assertEq(result.spendableAmounts[0], 1000e6, "Should spend raw plus withdrawable supplied");
+    }
+
     // ================ Updated getSafeCashData Tests ================
 
-    function test_getSafeCashData_withTokenPreference_USDC_liquidUSD() public view {
+    function test_getSafeCashData_withTokenPreference_USDC_liquidUSD() public {
         address[] memory tokenPreference = new address[](2);
         tokenPreference[0] = address(usdc);
         tokenPreference[1] = address(liquidUsdScroll);
-        
+
+        _mirrorPositionToGateway(address(safe));
         SafeCashData memory data = cashLens.getSafeCashData(address(safe), tokenPreference);
         
         // Verify debitMaxSpend uses the preference
@@ -453,7 +502,8 @@ contract CashLensMaxSpendTest is CashModuleTestSetup {
 
     // ================ getMaxSpendCredit Tests ================
 
-    function test_getMaxSpendCredit_withUSDC_liquidUSD_collateral() public view {
+    function test_getMaxSpendCredit_withUSDC_liquidUSD_collateral() public {
+        _mirrorPositionToGateway(address(safe));
         uint256 creditMaxSpend = cashLens.getMaxSpendCredit(address(safe));
         
         // Calculate expected based on collateral

--- a/test/safe/modules/cash/CashLensMaxSpend.t.sol
+++ b/test/safe/modules/cash/CashLensMaxSpend.t.sol
@@ -140,6 +140,12 @@ contract CashLensMaxSpendTest is CashModuleTestSetup {
         assertApproxEqRel(result.totalSpendableInUsd, usdcBal + liquidAmtInUsd, 1, "Total should be sum of both");
     }
 
+    /// @notice Sets the gateway account aggregate, deriving availableBorrowsUsd = collateralUsd x ltv - debtUsd (floored at 0). CashLens does not read healthFactor.
+    function _setGatewayAccount(uint256 collateralUsd, uint256 debtUsd, uint256 ltv) internal {
+        uint256 maxBorrowUsd = (collateralUsd * ltv) / HUNDRED_PERCENT;
+        gateway.setAccountData(address(safe), IGateway.AccountData({ collateralUsd: collateralUsd, debtUsd: debtUsd, availableBorrowsUsd: maxBorrowUsd > debtUsd ? maxBorrowUsd - debtUsd : 0, healthFactor: 1e18 }));
+    }
+
     /// @notice Sets a gateway debt position: both stables supplied with ample reserve cash, a uniform LTV, a debt, and zero raw safe balance. The borrowing headroom is derived as collateral x LTV - debt (stables valued at $1)
     function _setDebtPosition(uint256 suppliedUsdc, uint256 suppliedLiquid, uint256 ltvValue, uint256 debtUsd) internal {
         deal(address(usdc), address(safe), 0);
@@ -151,10 +157,7 @@ contract CashLensMaxSpendTest is CashModuleTestSetup {
         gateway.setLtv(address(usdc), ltvValue);
         gateway.setLtv(address(liquidUsd), ltvValue);
 
-        uint256 collateralUsd = suppliedUsdc + suppliedLiquid;
-        uint256 maxBorrowUsd = (collateralUsd * ltvValue) / HUNDRED_PERCENT;
-        uint256 availableBorrowsUsd = maxBorrowUsd > debtUsd ? maxBorrowUsd - debtUsd : 0;
-        gateway.setAccountData(address(safe), IGateway.AccountData({ collateralUsd: collateralUsd, debtUsd: debtUsd, availableBorrowsUsd: availableBorrowsUsd, healthFactor: 1e18 }));
+        _setGatewayAccount(suppliedUsdc + suppliedLiquid, debtUsd, ltvValue);
     }
 
     /// With debt, USDC first takes the whole borrowing headroom and liquidUSD gets none.
@@ -276,7 +279,7 @@ contract CashLensMaxSpendTest is CashModuleTestSetup {
         gateway.setSuppliedOf(address(safe), address(usdc), 1000e6);
         gateway.setAvailableCash(address(usdc), type(uint128).max);
         gateway.setLtv(address(usdc), 50e18);
-        gateway.setAccountData(address(safe), IGateway.AccountData({ collateralUsd: 1000e6, debtUsd: 400e6, availableBorrowsUsd: 100e6, healthFactor: 1e18 }));
+        _setGatewayAccount(1000e6, 400e6, 50e18);
 
         address[] memory tokenPreference = new address[](1);
         tokenPreference[0] = address(usdc);
@@ -464,8 +467,8 @@ contract CashLensMaxSpendTest is CashModuleTestSetup {
 
     /// maxBorrow stays gross (collateral x LTV, debt not subtracted) like DebtManager, while creditMaxSpend is the net headroom.
     function test_getSafeCashData_maxBorrowIsGrossWithDebt() public {
-        // $2000 collateral at 50% LTV with $800 debt: gross borrow power $1000, net headroom $200.
-        _setDebtPosition(1000e6, 1000e6, 50e18, 800e6);
+        // $2000 USDC collateral at 50% LTV with $800 debt: gross borrow power $1000, net headroom $200.
+        _setDebtPosition(2000e6, 0, 50e18, 800e6);
 
         address[] memory emptyPreference = new address[](0);
         SafeCashData memory data = cashLens.getSafeCashData(address(safe), emptyPreference);
@@ -477,26 +480,7 @@ contract CashLensMaxSpendTest is CashModuleTestSetup {
         assertGt(data.maxBorrow, data.creditMaxSpend, "gross exceeds net once there is debt");
     }
 
-    /// A pending withdrawal lowers credit capacity by the withdrawing collateral's LTV-weighted value.
-    function test_getMaxSpendCredit_reducedByPendingWithdrawal() public {
-        _mirrorPositionToGateway(address(safe));
-        uint256 creditBefore = cashLens.getMaxSpendCredit(address(safe));
-
-        uint256 withdrawAmount = 10_000e6;
-        address[] memory tokens = new address[](1);
-        tokens[0] = address(usdc);
-        uint256[] memory amounts = new uint256[](1);
-        amounts[0] = withdrawAmount;
-        _requestWithdrawal(tokens, amounts, withdrawRecipient);
-
-        uint256 creditAfter = cashLens.getMaxSpendCredit(address(safe));
-
-        // USDC is $1 (6dp), so the headroom freed up by the pending withdrawal is withdrawAmount x LTV.
-        uint256 expectedDrop = (withdrawAmount * ltv) / HUNDRED_PERCENT;
-        assertEq(creditBefore - creditAfter, expectedDrop, "credit drops by the pending withdrawal's LTV-weighted value");
-    }
-
-    /// A pending withdrawal on one token reduces the borrowing headroom available to spend another token under debt.
+    /// A pending withdrawal on one token reduces another token's debit spendable: once it leaves Aave, the gateway reports less shared borrowing power.
     function test_getMaxSpendDebit_pendingWithdrawalReducesOtherTokenHeadroom() public {
         // Debt position: USDC + liquidUSD supplied at 50% LTV with $600 headroom; liquidUSD has raw balance for the request.
         deal(address(usdc), address(safe), 0);
@@ -506,23 +490,49 @@ contract CashLensMaxSpendTest is CashModuleTestSetup {
         gateway.setAvailableCash(address(usdc), type(uint128).max);
         gateway.setLtv(address(usdc), 50e18);
         gateway.setLtv(address(liquidUsd), 50e18);
-        gateway.setAccountData(address(safe), IGateway.AccountData({ collateralUsd: 2000e6, debtUsd: 400e6, availableBorrowsUsd: 600e6, healthFactor: 1e18 }));
+        _setGatewayAccount(2000e6, 400e6, 50e18);
 
         address[] memory tokenPreference = new address[](1);
         tokenPreference[0] = address(usdc);
 
         uint256 withoutPending = cashLens.getMaxSpendDebit(address(safe), tokenPreference).spendableAmounts[0];
+        assertEq(withoutPending, 1000e6, "USDC spendable capped by its supply, headroom ample");
 
-        // Queue a liquidUSD withdrawal; it consumes part of the shared borrowing headroom.
+        // Queue a $1000 liquidUSD withdrawal. It is pulled from Aave, so the gateway now holds $1000 less liquidUSD and $500 less borrowing power.
         address[] memory wTokens = new address[](1);
         wTokens[0] = address(liquidUsd);
         uint256[] memory wAmounts = new uint256[](1);
         wAmounts[0] = 1000e6;
         _requestWithdrawal(wTokens, wAmounts, withdrawRecipient);
+        gateway.setSuppliedOf(address(safe), address(liquidUsd), 0);
+        _setGatewayAccount(1000e6, 400e6, 50e18);
 
         uint256 withPending = cashLens.getMaxSpendDebit(address(safe), tokenPreference).spendableAmounts[0];
+        // Headroom is now $100 -> $100 / 50% = $200 of USDC withdrawable.
+        assertEq(withPending, 200e6, "a pending liquidUSD withdrawal lowers USDC's spendable via the shared headroom");
+    }
 
-        assertLt(withPending, withoutPending, "a pending liquidUSD withdrawal lowers USDC's spendable via the shared headroom");
+    /// With debt, a same-token pending withdrawal is reserved from the loose balance only: it zeroes the raw portion, while the supplied side stays capped by the borrowing headroom and is untouched by the pending.
+    function test_getMaxSpendDebit_sameTokenPendingWithDebtChargesHeadroomOnce() public {
+        // $900 is supplied to Aave; the $100 sits loose in the safe as a pending withdrawal, earmarked to leave.
+        deal(address(usdc), address(safe), 100e6);
+        gateway.setSuppliedOf(address(safe), address(usdc), 900e6);
+        gateway.setAvailableCash(address(usdc), type(uint128).max);
+        gateway.setLtv(address(usdc), 50e18);
+        _setGatewayAccount(900e6, 200e6, 50e18);
+
+        address[] memory wTokens = new address[](1);
+        wTokens[0] = address(usdc);
+        uint256[] memory wAmounts = new uint256[](1);
+        wAmounts[0] = 100e6;
+        _requestWithdrawal(wTokens, wAmounts, withdrawRecipient);
+
+        address[] memory tokenPreference = new address[](1);
+        tokenPreference[0] = address(usdc);
+
+        DebitModeMaxSpend memory result = cashLens.getMaxSpendDebit(address(safe), tokenPreference);
+        // Aave allows $250 / 50% = $500 of supplied withdrawal; the raw $100 is fully reserved by the pending, so total is $500.
+        assertEq(result.spendableAmounts[0], 500e6, "pending reserved from raw only; supplied side capped by headroom");
     }
 
     /// Debit canSpend declines (does not revert) when a pending withdrawal exceeds the currently available balance.
@@ -552,7 +562,7 @@ contract CashLensMaxSpendTest is CashModuleTestSetup {
         gateway.setSuppliedOf(address(safe), address(usdc), 1000e6);
         gateway.setAvailableCash(address(usdc), type(uint128).max);
         gateway.setLtv(address(usdc), 0);
-        gateway.setAccountData(address(safe), IGateway.AccountData({ collateralUsd: 1000e6, debtUsd: 200e6, availableBorrowsUsd: 100e6, healthFactor: 1e18 }));
+        _setGatewayAccount(1000e6, 200e6, 30e18);
 
         address[] memory tokenPreference = new address[](1);
         tokenPreference[0] = address(usdc);

--- a/test/safe/modules/cash/CashLensMaxSpend.t.sol
+++ b/test/safe/modules/cash/CashLensMaxSpend.t.sol
@@ -465,6 +465,17 @@ contract CashLensMaxSpendTest is CashModuleTestSetup {
         assertGt(creditMaxSpend, 0, "Should have positive credit limit with collateral");
     }
 
+    /// Credit max spend is capped by the borrow token's pool liquidity, not just the borrowing power.
+    function test_getMaxSpendCredit_cappedByPoolLiquidity() public {
+        // $2000 collateral at 50% LTV, no debt: borrowing power $1000.
+        _setGatewayAccount(2000e6, 0, 50e18);
+
+        // The reserve only has $400 of USDC to lend, below the $1000 borrowing power.
+        gateway.setAvailableCash(address(usdc), 400e6);
+
+        assertEq(cashLens.getMaxSpendCredit(address(safe)), 400e6, "credit max spend capped by reserve liquidity, not borrowing power");
+    }
+
     /// maxBorrow stays gross (collateral x LTV, debt not subtracted) like DebtManager, while creditMaxSpend is the net headroom.
     function test_getSafeCashData_maxBorrowIsGrossWithDebt() public {
         // $2000 USDC collateral at 50% LTV with $800 debt: gross borrow power $1000, net headroom $200.

--- a/test/safe/modules/cash/CashLensMaxSpend.t.sol
+++ b/test/safe/modules/cash/CashLensMaxSpend.t.sol
@@ -556,6 +556,49 @@ contract CashLensMaxSpendTest is CashModuleTestSetup {
         assertEq(reason, "Insufficient effective balance after withdrawal to spend with debit mode", "declines with a reason instead of reverting");
     }
 
+    /// Pending withdrawals reserve raw balance before calculating how much supplied collateral a debit spend consumes.
+    function test_canSpendDebit_pendingRawConsumesSuppliedHeadroomForLaterTokens() public {
+        // $1,200 collateral at 50% LTV gives $600 max borrow; $500 debt leaves $100 headroom,
+        // so only $200 of supplied collateral can be spent across all debit tokens.
+        deal(address(usdc), address(safe), 500e6);
+        deal(address(liquidUsd), address(safe), 0);
+
+        // The Safe has $500 raw USDC, but $400 of it will be reserved by the pending withdrawal below.
+        // That leaves only $100 effective raw USDC for spending.
+        //
+        // The requested USDC spend is $300, so it must use:
+        //   $100 effective raw USDC + $200 supplied USDC withdrawn from Aave.
+        //
+        // With 50% LTV, withdrawing that $200 supplied USDC consumes all $100 of shared headroom.
+        gateway.setSuppliedOf(address(safe), address(usdc), 200e6);
+        gateway.setSuppliedOf(address(safe), address(liquidUsd), 1000e6);
+        gateway.setAvailableCash(address(usdc), type(uint128).max);
+        gateway.setAvailableCash(address(liquidUsd), type(uint128).max);
+        gateway.setLtv(address(usdc), 50e18);
+        gateway.setLtv(address(liquidUsd), 50e18);
+        gateway.setAccountData(address(safe), IGateway.AccountData({ collateralUsd: 1200e6, debtUsd: 500e6, availableBorrowsUsd: 100e6, healthFactor: 144e16 }));
+
+        address[] memory withdrawTokens = new address[](1);
+        withdrawTokens[0] = address(usdc);
+        uint256[] memory withdrawAmounts = new uint256[](1);
+        withdrawAmounts[0] = 400e6;
+        _requestWithdrawal(withdrawTokens, withdrawAmounts, withdrawRecipient);
+
+        // The second leg asks for $50 liquidUSD. It should fail because the first USDC leg
+        // already consumed the entire shared Aave headroom after accounting for the pending withdrawal.
+        address[] memory spendTokens = new address[](2);
+        spendTokens[0] = address(usdc);
+        spendTokens[1] = address(liquidUsd);
+        uint256[] memory amountsInUsd = new uint256[](2);
+        amountsInUsd[0] = 300e6;
+        amountsInUsd[1] = 50e6;
+
+        (bool ok, string memory reason) = cashLens.canSpend(address(safe), keccak256("pending-headroom"), spendTokens, amountsInUsd);
+
+        assertFalse(ok, "USDC should consume the full shared headroom after reserving its pending withdrawal");
+        assertEq(reason, "Insufficient token balance for debit mode spending", "later token should not reuse consumed headroom");
+    }
+
     /// With debt, a zero-LTV reserve cannot back a safe withdrawal, so only the raw balance is spendable.
     function test_getMaxSpendDebit_zeroLtvWithDebt() public {
         deal(address(usdc), address(safe), 300e6);

--- a/test/safe/modules/cash/CashLensMaxSpend.t.sol
+++ b/test/safe/modules/cash/CashLensMaxSpend.t.sol
@@ -613,4 +613,71 @@ contract CashLensMaxSpendTest is CashModuleTestSetup {
         DebitModeMaxSpend memory result = cashLens.getMaxSpendDebit(address(safe), tokenPreference);
         assertEq(result.spendableAmounts[0], 300e6, "Only the raw balance is spendable when LTV is zero and there is debt");
     }
+
+    // ================ Mixed-LTV / multi-collateral debt Tests ================
+
+    /// With debt, each token consumes the shared borrowing headroom at its OWN LTV: USDC (80%) bills 80% of what it spends, and the headroom it leaves caps liquidUSD (50%) at liquidUSD's own rate, not USDC's.
+    function test_getMaxSpendDebit_mixedLtv_perTokenThreading() public {
+        // Supplied: 200 USDC @ 80% LTV and 2000 liquidUSD @ 50% LTV, ample reserve cash, nothing loose.
+        // Borrowing headroom is $460. USDC first is face-bound at its 200 supply and bills 200 x 80% = $160,
+        // leaving $300. liquidUSD is then headroom-bound: $300 / 50% = $600 of face (well under its 2000 supply).
+        // A bug that reused one LTV for both tokens would yield $300/0.8 = $375 (USDC's LTV) or, if USDC also
+        // billed at 50%, $360 left -> $720; pinning $600 catches either.
+        deal(address(usdc), address(safe), 0);
+        deal(address(liquidUsd), address(safe), 0);
+        gateway.setSuppliedOf(address(safe), address(usdc), 200e6);
+        gateway.setSuppliedOf(address(safe), address(liquidUsd), 2000e6);
+        gateway.setAvailableCash(address(usdc), type(uint128).max);
+        gateway.setAvailableCash(address(liquidUsd), type(uint128).max);
+        gateway.setLtv(address(usdc), 80e18);
+        gateway.setLtv(address(liquidUsd), 50e18);
+        gateway.setAccountData(address(safe), IGateway.AccountData({ collateralUsd: 2200e6, debtUsd: 700e6, availableBorrowsUsd: 460e6, healthFactor: 1e18 }));
+
+        address[] memory tokenPreference = new address[](2);
+        tokenPreference[0] = address(usdc);
+        tokenPreference[1] = address(liquidUsd);
+
+        DebitModeMaxSpend memory result = cashLens.getMaxSpendDebit(address(safe), tokenPreference);
+
+        assertEq(result.spendableAmounts[0], 200e6, "USDC is face-bound at its 200 supply");
+        // $600 of liquidUSD face, converted through liquidUSD's own price exactly as CashLens does.
+        uint256 expectedLiquid = (600e6 * 10 ** IERC20Metadata(address(liquidUsd)).decimals()) / priceProvider.price(address(liquidUsd));
+        assertEq(result.spendableAmounts[1], expectedLiquid, "liquidUSD is headroom-bound at its own 50% LTV, not USDC's 80%");
+    }
+
+    /// Mixed collateral with a non-stable carrying the borrowing power: with debt, both supplied stables stay fully spendable, credit is the un-haircut headroom, and maxBorrow stays gross.
+    function test_getMaxSpendDebit_mixedCollateral_weEthCarriesPower() public {
+        // Integration-doc shape (Alice): weETH + USDC + EURC supplied with $4,000 borrowed. weETH carries most of
+        // the borrowing power, so the headroom never binds and both stables are face-bound. liquidUSD stands in for
+        // EURC. The gateway aggregates are injected to the doc's figures: borrow power $11,406, debt $4,000,
+        // availableBorrows $7,406, collateral $13,340.
+        deal(address(usdc), address(safe), 0);
+        deal(address(liquidUsd), address(safe), 0);
+        gateway.setSuppliedOf(address(safe), address(weETH), weETHBal);
+        gateway.setSuppliedOf(address(safe), address(usdc), 5000e6);
+        gateway.setSuppliedOf(address(safe), address(liquidUsd), 2000e6);
+        gateway.setDebtOf(address(safe), address(usdc), 4000e6);
+        gateway.setAvailableCash(address(usdc), type(uint128).max);
+        gateway.setAvailableCash(address(liquidUsd), type(uint128).max);
+        gateway.setLtv(address(usdc), 90e18);
+        gateway.setLtv(address(liquidUsd), 90e18);
+        gateway.setAccountData(address(safe), IGateway.AccountData({ collateralUsd: 13_340e6, debtUsd: 4000e6, availableBorrowsUsd: 7406e6, healthFactor: 1e18 }));
+
+        address[] memory tokenPreference = new address[](2);
+        tokenPreference[0] = address(usdc);
+        tokenPreference[1] = address(liquidUsd);
+
+        DebitModeMaxSpend memory debit = cashLens.getMaxSpendDebit(address(safe), tokenPreference);
+        assertEq(debit.spendableAmounts[0], 5000e6, "USDC fully spendable: the headroom never binds");
+        assertEq(debit.spendableAmounts[1], 2000e6, "liquidUSD fully spendable: the headroom never binds");
+
+        // The doc's 10% volatility haircut ($6,665) is applied in cash-be, not on-chain; CashLens returns the raw headroom.
+        assertEq(cashLens.getMaxSpendCredit(address(safe)), 7406e6, "credit max spend is the un-haircut availableBorrowsUsd");
+
+        SafeCashData memory data = cashLens.getSafeCashData(address(safe), tokenPreference);
+        assertEq(data.totalBorrow, 4000e6, "totalBorrow is the debt");
+        assertEq(data.maxBorrow, 11_406e6, "maxBorrow is gross power: availableBorrowsUsd + debt");
+        assertEq(data.creditMaxSpend, 7406e6, "creditMaxSpend is the net headroom");
+        assertEq(data.totalCollateral, 13_340e6, "totalCollateral mirrors the gateway aggregate");
+    }
 }

--- a/test/safe/modules/cash/CashLensMaxSpend.t.sol
+++ b/test/safe/modules/cash/CashLensMaxSpend.t.sol
@@ -1,29 +1,30 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
 import { IERC20Metadata } from "@openzeppelin/contracts/interfaces/IERC20Metadata.sol";
+import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
-import { Mode, SafeCashData, BinSponsor, SafeData, DebitModeMaxSpend, Cashback, CashbackTokens } from "../../../../src/interfaces/ICashModule.sol";
-import { IEtherFiSafeFactory } from "../../../../src/interfaces/IEtherFiSafeFactory.sol";
-import { CashLens } from "../../../../src/modules/cash/CashLens.sol";
+import { BinSponsor, Cashback, CashbackTokens, DebitModeMaxSpend, Mode, SafeCashData, SafeData } from "../../../../src/interfaces/ICashModule.sol";
 import { IDebtManager } from "../../../../src/interfaces/IDebtManager.sol";
-import { CashModuleTestSetup } from "./CashModuleTestSetup.t.sol";
-import { SpendingLimit } from "../../../../src/libraries/SpendingLimitLib.sol";
-import { PriceProvider, IAggregatorV3 } from "../../../../src/oracle/PriceProvider.sol"; 
-import { ILayerZeroTeller, AccountantWithRateProviders } from "../../../../src/interfaces/ILayerZeroTeller.sol";
+import { IEtherFiSafeFactory } from "../../../../src/interfaces/IEtherFiSafeFactory.sol";
+import { IGateway } from "../../../../src/interfaces/IGateway.sol";
+import { AccountantWithRateProviders, ILayerZeroTeller } from "../../../../src/interfaces/ILayerZeroTeller.sol";
 import { ArrayDeDupLib } from "../../../../src/libraries/ArrayDeDupLib.sol";
+import { SpendingLimit } from "../../../../src/libraries/SpendingLimitLib.sol";
+import { CashLens } from "../../../../src/modules/cash/CashLens.sol";
+import { IAggregatorV3, PriceProvider } from "../../../../src/oracle/PriceProvider.sol";
+import { CashModuleTestSetup } from "./CashModuleTestSetup.t.sol";
 
 contract CashLensMaxSpendTest is CashModuleTestSetup {
     using MessageHashUtils for bytes32;
 
-    IERC20 public liquidUsdScroll = IERC20(0x08c6F91e2B681FaF5e17227F2a44C307b3C1364C);
+    IERC20 public liquidUsd = IERC20(0x08c6F91e2B681FaF5e17227F2a44C307b3C1364C);
     ILayerZeroTeller public liquidUsdTeller = ILayerZeroTeller(0x4DE413a26fC24c3FC27Cc983be70aA9c5C299387);
-    
+
     uint256 weETHBal = 10 ether;
-    uint256 usdcBal = 50000e6;
-    uint256 liquidUsdBal = 30000e6;
+    uint256 usdcBal = 50_000e6;
+    uint256 liquidUsdBal = 30_000e6;
     uint256 liquidUsdBorrowPower;
     uint256 usdcBorrowPower;
     uint256 weEthBorrowPower;
@@ -37,20 +38,10 @@ contract CashLensMaxSpendTest is CashModuleTestSetup {
         // Setup liquidUSD price config
         AccountantWithRateProviders liquidUsdAccountant = liquidUsdTeller.accountant();
 
-        PriceProvider.Config memory liquidUsdConfig = PriceProvider.Config({
-            oracle: address(liquidUsdAccountant),
-            priceFunctionCalldata: abi.encodeWithSelector(AccountantWithRateProviders.getRate.selector),
-            isChainlinkType: false,
-            oraclePriceDecimals: liquidUsdAccountant.decimals(),
-            maxStaleness: 2 days,
-            dataType: PriceProvider.ReturnType.Uint256,
-            isBaseTokenEth: false,
-            isStableToken: true,
-            isBaseTokenBtc: false
-        });
+        PriceProvider.Config memory liquidUsdConfig = PriceProvider.Config({ oracle: address(liquidUsdAccountant), priceFunctionCalldata: abi.encodeWithSelector(AccountantWithRateProviders.getRate.selector), isChainlinkType: false, oraclePriceDecimals: liquidUsdAccountant.decimals(), maxStaleness: 2 days, dataType: PriceProvider.ReturnType.Uint256, isBaseTokenEth: false, isStableToken: true, isBaseTokenBtc: false });
 
         address[] memory tokens = new address[](1);
-        tokens[0] = address(liquidUsdScroll);
+        tokens[0] = address(liquidUsd);
 
         PriceProvider.Config[] memory tokensConfig = new PriceProvider.Config[](1);
         tokensConfig[0] = liquidUsdConfig;
@@ -63,14 +54,14 @@ contract CashLensMaxSpendTest is CashModuleTestSetup {
         collateralTokenConfig[0].liquidationThreshold = liquidationThreshold;
         collateralTokenConfig[0].liquidationBonus = liquidationBonus;
 
-        debtManager.supportCollateralToken(address(liquidUsdScroll), collateralTokenConfig[0]);        
+        debtManager.supportCollateralToken(address(liquidUsd), collateralTokenConfig[0]);
 
-        minShares = uint128(10 * 10 ** IERC20Metadata(address(liquidUsdScroll)).decimals());
-        debtManager.supportBorrowToken(address(liquidUsdScroll), borrowApyPerSecond, minShares);
+        minShares = uint128(10 * 10 ** IERC20Metadata(address(liquidUsd)).decimals());
+        debtManager.supportBorrowToken(address(liquidUsd), borrowApyPerSecond, minShares);
 
         // Add liquidUSD to withdraw whitelist
         address[] memory withdrawTokens = new address[](1);
-        withdrawTokens[0] = address(liquidUsdScroll);
+        withdrawTokens[0] = address(liquidUsd);
         bool[] memory whitelist = new bool[](1);
         whitelist[0] = true;
         cashModule.configureWithdrawAssets(withdrawTokens, whitelist);
@@ -78,14 +69,14 @@ contract CashLensMaxSpendTest is CashModuleTestSetup {
         // Add collateral to safe
         deal(address(weETH), address(safe), weETHBal);
         deal(address(usdc), address(safe), usdcBal);
-        deal(address(liquidUsdScroll), address(safe), liquidUsdBal); 
-        
+        deal(address(liquidUsd), address(safe), liquidUsdBal);
+
         // Ensure debt manager has sufficient liquidity
-        deal(address(usdc), address(debtManager), 100000e6);
-        deal(address(liquidUsdScroll), address(debtManager), 100000e6);
+        deal(address(usdc), address(debtManager), 100_000e6);
+        deal(address(liquidUsd), address(debtManager), 100_000e6);
 
         uint256 weEthInUsd = debtManager.convertCollateralTokenToUsd(address(weETH), weETHBal);
-        liquidAmtInUsd = debtManager.convertCollateralTokenToUsd(address(liquidUsdScroll), liquidUsdBal);     
+        liquidAmtInUsd = debtManager.convertCollateralTokenToUsd(address(liquidUsd), liquidUsdBal);
         weEthBorrowPower = (weEthInUsd * ltv) / HUNDRED_PERCENT;
         usdcBorrowPower = (usdcBal * ltv) / HUNDRED_PERCENT;
         liquidUsdBorrowPower = (liquidAmtInUsd * ltv) / HUNDRED_PERCENT;
@@ -95,23 +86,25 @@ contract CashLensMaxSpendTest is CashModuleTestSetup {
 
     // ================ getMaxSpendDebit Tests ================
 
+    /// An empty token preference returns an empty, all-zero result.
     function test_getMaxSpendDebit_emptyTokenPreference() public view {
         address[] memory emptyPreference = new address[](0);
-        
+
         DebitModeMaxSpend memory result = cashLens.getMaxSpendDebit(address(safe), emptyPreference);
-        
+
         assertEq(result.spendableTokens.length, 0, "Should return empty tokens array");
         assertEq(result.spendableAmounts.length, 0, "Should return empty amounts array");
         assertEq(result.amountsInUsd.length, 0, "Should return empty USD amounts array");
         assertEq(result.totalSpendableInUsd, 0, "Should return zero total");
     }
 
+    /// No debt: a supplied USDC position is fully spendable.
     function test_getMaxSpendDebit_singleToken_USDC_healthyPosition() public view {
         address[] memory tokenPreference = new address[](1);
         tokenPreference[0] = address(usdc);
-        
+
         DebitModeMaxSpend memory result = cashLens.getMaxSpendDebit(address(safe), tokenPreference);
-        
+
         assertEq(result.spendableTokens.length, 1, "Should return one token");
         assertEq(result.spendableTokens[0], address(usdc), "Token should be USDC");
         assertEq(result.spendableAmounts[0], usdcBal, "Should be able to spend all USDC");
@@ -119,146 +112,96 @@ contract CashLensMaxSpendTest is CashModuleTestSetup {
         assertEq(result.totalSpendableInUsd, usdcBal, "Total should match USDC value");
     }
 
+    /// No debt: a supplied liquidUSD position is fully spendable, priced by its rate.
     function test_getMaxSpendDebit_singleToken_liquidUSD_healthyPosition() public view {
         address[] memory tokenPreference = new address[](1);
-        tokenPreference[0] = address(liquidUsdScroll);
-        
+        tokenPreference[0] = address(liquidUsd);
+
         DebitModeMaxSpend memory result = cashLens.getMaxSpendDebit(address(safe), tokenPreference);
-        
+
         assertEq(result.spendableTokens.length, 1, "Should return one token");
-        assertEq(result.spendableTokens[0], address(liquidUsdScroll), "Token should be liquidUSD");
+        assertEq(result.spendableTokens[0], address(liquidUsd), "Token should be liquidUSD");
         assertEq(result.spendableAmounts[0], liquidUsdBal, "Should be able to spend all liquidUSD");
         assertApproxEqRel(result.amountsInUsd[0], liquidAmtInUsd, 1, "USD value should match approximately"); // Allow 1% deviation for rate
         assertApproxEqRel(result.totalSpendableInUsd, liquidAmtInUsd, 1, "Total should match liquidUSD value");
     }
 
+    /// No debt: both supplied stables are fully spendable and sum together.
     function test_getMaxSpendDebit_bothTokens_healthyPosition() public view {
         address[] memory tokenPreference = new address[](2);
         tokenPreference[0] = address(usdc);
-        tokenPreference[1] = address(liquidUsdScroll);
-        
+        tokenPreference[1] = address(liquidUsd);
+
         DebitModeMaxSpend memory result = cashLens.getMaxSpendDebit(address(safe), tokenPreference);
-        
+
         assertEq(result.spendableTokens.length, 2, "Should return two tokens");
         assertEq(result.spendableAmounts[0], usdcBal, "Should be able to spend all USDC");
         assertEq(result.spendableAmounts[1], liquidUsdBal, "Should be able to spend all liquidUSD");
         assertApproxEqRel(result.totalSpendableInUsd, usdcBal + liquidAmtInUsd, 1, "Total should be sum of both");
     }
 
-    function test_getMaxSpendDebit_underwaterPosition_USDCFirst() public {
-        // Underwater debit (debt-driven restriction) is phase two; phase one has no live debt.
-        vm.skip(true);
-        // Create debt by borrowing in credit mode
-        _setMode(Mode.Credit);
-        vm.warp(cashModule.incomingModeStartTime(address(safe)) + 1);
-        
-        _updateSpendingLimit(1000_000e6, 1000_000e6);
-        
-        // Borrow large % of collateral value to create underwater position
-        uint256 borrowAmount = weEthBorrowPower + usdcBorrowPower - 1e6;
-        address[] memory spendTokens = new address[](1);
-        spendTokens[0] = address(usdc);
-        uint256[] memory spendAmounts = new uint256[](1);
-        spendAmounts[0] = borrowAmount;
+    /// @notice Sets a gateway debt position: both stables supplied with ample reserve cash, a uniform LTV, a debt, and zero raw safe balance. The borrowing headroom is derived as collateral x LTV - debt (stables valued at $1)
+    function _setDebtPosition(uint256 suppliedUsdc, uint256 suppliedLiquid, uint256 ltvValue, uint256 debtUsd) internal {
+        deal(address(usdc), address(safe), 0);
+        deal(address(liquidUsd), address(safe), 0);
+        gateway.setSuppliedOf(address(safe), address(usdc), suppliedUsdc);
+        gateway.setSuppliedOf(address(safe), address(liquidUsd), suppliedLiquid);
+        gateway.setAvailableCash(address(usdc), type(uint128).max);
+        gateway.setAvailableCash(address(liquidUsd), type(uint128).max);
+        gateway.setLtv(address(usdc), ltvValue);
+        gateway.setLtv(address(liquidUsd), ltvValue);
 
-        Cashback[] memory cashbacks = new Cashback[](1);
-        CashbackTokens[] memory cashbackTokens = new CashbackTokens[](1);
+        uint256 collateralUsd = suppliedUsdc + suppliedLiquid;
+        uint256 maxBorrowUsd = (collateralUsd * ltvValue) / HUNDRED_PERCENT;
+        uint256 availableBorrowsUsd = maxBorrowUsd > debtUsd ? maxBorrowUsd - debtUsd : 0;
+        gateway.setAccountData(address(safe), IGateway.AccountData({ collateralUsd: collateralUsd, debtUsd: debtUsd, availableBorrowsUsd: availableBorrowsUsd, healthFactor: 1e18 }));
+    }
 
-        CashbackTokens memory scr = CashbackTokens({
-            token: address(cashbackToken),
-            amountInUsd: 1e6,
-            cashbackType: 0
-        });
+    /// With debt, USDC first takes the whole borrowing headroom and liquidUSD gets none.
+    function test_getMaxSpendDebit_withDebt_USDCFirst() public {
+        // With debt, the borrowing headroom caps supplied withdrawal. Supplied $1000 each at 50% LTV,
+        // debt $800, so headroom = $2000 x 50% - $800 = $200. Headroom is borrowing power, not collateral:
+        // dividing by the 50% LTV, $200 of headroom frees $400 of collateral (withdrawing it lowers borrowing
+        // power by exactly $200). USDC is first, so it takes the whole $400 and liquidUSD gets none.
+        _setDebtPosition(1000e6, 1000e6, 50e18, 800e6);
 
-        cashbackTokens[0] = scr;
-
-        Cashback memory scrCashback = Cashback({
-            to: address(safe),
-            cashbackTokens: cashbackTokens
-        });
-
-        cashbacks[0] = scrCashback;
-        
-        vm.prank(etherFiWallet);
-        cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
-        
-        // Switch back to debit mode
-        _setMode(Mode.Debit);
-        vm.warp(block.timestamp + 1);
-        
-        // Check max spend with USDC first preference
         address[] memory tokenPreference = new address[](2);
         tokenPreference[0] = address(usdc);
-        tokenPreference[1] = address(liquidUsdScroll);
-        
+        tokenPreference[1] = address(liquidUsd);
+
         DebitModeMaxSpend memory result = cashLens.getMaxSpendDebit(address(safe), tokenPreference);
-        
-        // With debt, USDC should be used first to cover deficit
-        assertLt(result.spendableAmounts[0], usdcBal, "USDC spend should be restricted");
-        assertEq(result.spendableAmounts[1], liquidUsdBal, "liquidUSD should be fully spendable after USDC covers deficit");
-        assertGt(result.totalSpendableInUsd, 0, "Should still be able to spend something");
+        assertEq(result.spendableAmounts[0], 400e6, "USDC takes the full headroom");
+        assertEq(result.spendableAmounts[1], 0, "liquidUSD gets none after the headroom is exhausted");
+        assertEq(result.totalSpendableInUsd, 400e6, "Total bounded by the headroom");
     }
 
-    function test_getMaxSpendDebit_underwaterPosition_liquidUSDFirst() public {
-        // Underwater debit (debt-driven restriction) is phase two; phase one has no live debt.
-        vm.skip(true);
-        // Create debt
-        _setMode(Mode.Credit);
-        vm.warp(cashModule.incomingModeStartTime(address(safe)) + 1);
-        _updateSpendingLimit(1000_000e6, 1000_000e6);
-        
-        uint256 borrowAmount = weEthBorrowPower + liquidUsdBorrowPower - 1e6;
-        address[] memory spendTokens = new address[](1);
-        spendTokens[0] = address(usdc);
-        uint256[] memory spendAmounts = new uint256[](1);
-        spendAmounts[0] = borrowAmount;
+    /// Same position, liquidUSD first: order flips which token the headroom goes to.
+    function test_getMaxSpendDebit_withDebt_liquidUSDFirst() public {
+        _setDebtPosition(1000e6, 1000e6, 50e18, 800e6);
 
-        Cashback[] memory cashbacks = new Cashback[](1);
-        CashbackTokens[] memory cashbackTokens = new CashbackTokens[](1);
-
-        CashbackTokens memory scr = CashbackTokens({
-            token: address(cashbackToken),
-            amountInUsd: 1e6,
-            cashbackType: 0
-        });
-
-        cashbackTokens[0] = scr;
-
-        Cashback memory scrCashback = Cashback({
-            to: address(safe),
-            cashbackTokens: cashbackTokens
-        });
-
-        cashbacks[0] = scrCashback;
-        
-        vm.prank(etherFiWallet);
-        cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
-        
-        // Check max spend with liquidUSD first preference
         address[] memory tokenPreference = new address[](2);
-        tokenPreference[0] = address(liquidUsdScroll);
+        tokenPreference[0] = address(liquidUsd);
         tokenPreference[1] = address(usdc);
-        
+
         DebitModeMaxSpend memory result = cashLens.getMaxSpendDebit(address(safe), tokenPreference);
-        
-        // With debt, liquidUSD should be used first to cover deficit
-        assertLt(result.spendableAmounts[0], liquidUsdBal, "liquidUSD spend should be restricted");
-        assertEq(result.spendableAmounts[1], usdcBal, "USDC should be fully spendable after liquidUSD covers deficit");
-        assertGt(result.totalSpendableInUsd, 0, "Should still be able to spend something");
+        // approx, not assertEq: liquidUSD's price is a rate (not 1:1), so the _toUsd/_fromUsd round trip floors a few units short of exact. USDC-first is exact because USDC is 1:1.
+        assertApproxEqAbs(result.totalSpendableInUsd, 400e6, 1e6, "debt caps total debit at the $400 the headroom allows");
+        assertApproxEqAbs(result.amountsInUsd[1], 0, 1e6, "liquidUSD first leaves USDC no headroom");
     }
 
+    /// A pending USDC withdrawal reduces USDC's spendable; liquidUSD is unaffected.
     function test_getMaxSpendDebit_withPendingWithdrawals_USDC() public {
         // Create withdrawal request for USDC
         address[] memory tokens = new address[](1);
         tokens[0] = address(usdc);
         uint256[] memory amounts = new uint256[](1);
-        amounts[0] = 20000e6;
+        amounts[0] = 20_000e6;
         _requestWithdrawal(tokens, amounts, withdrawRecipient);
-        
+
         address[] memory tokenPreference = new address[](2);
         tokenPreference[0] = address(usdc);
-        tokenPreference[1] = address(liquidUsdScroll);
-        
+        tokenPreference[1] = address(liquidUsd);
+
         DebitModeMaxSpend memory result = cashLens.getMaxSpendDebit(address(safe), tokenPreference);
         uint256 effectiveUsdcBal = usdcBal - amounts[0];
         assertEq(result.spendableAmounts[0], effectiveUsdcBal, "USDC should only spend effective balance");
@@ -266,117 +209,117 @@ contract CashLensMaxSpendTest is CashModuleTestSetup {
         assertApproxEqRel(result.totalSpendableInUsd, effectiveUsdcBal + liquidAmtInUsd, 1, "Total should reflect reduced USDC");
     }
 
+    /// A pending liquidUSD withdrawal reduces liquidUSD's spendable; USDC is unaffected.
     function test_getMaxSpendDebit_withPendingWithdrawals_liquidUSD() public {
         // Create withdrawal request for liquidUSD
         address[] memory tokens = new address[](1);
-        tokens[0] = address(liquidUsdScroll);
+        tokens[0] = address(liquidUsd);
         uint256[] memory amounts = new uint256[](1);
-        amounts[0] = 15000e6;
+        amounts[0] = 15_000e6;
         _requestWithdrawal(tokens, amounts, withdrawRecipient);
-        
+
         address[] memory tokenPreference = new address[](2);
         tokenPreference[0] = address(usdc);
-        tokenPreference[1] = address(liquidUsdScroll);
-        
+        tokenPreference[1] = address(liquidUsd);
+
         DebitModeMaxSpend memory result = cashLens.getMaxSpendDebit(address(safe), tokenPreference);
         uint256 effectiveLiquidUsdBal = liquidUsdBal - amounts[0];
-        uint256 liquidUsdAmtInUsd = debtManager.convertCollateralTokenToUsd(address(liquidUsdScroll), effectiveLiquidUsdBal);
+        uint256 liquidUsdAmtInUsd = debtManager.convertCollateralTokenToUsd(address(liquidUsd), effectiveLiquidUsdBal);
 
         assertEq(result.spendableAmounts[0], usdcBal, "USDC should be unaffected");
         assertEq(result.spendableAmounts[1], effectiveLiquidUsdBal, "liquidUSD should only spend effective balance");
         assertApproxEqRel(result.totalSpendableInUsd, usdcBal + liquidUsdAmtInUsd, 1, "Total should reflect reduced liquidUSD");
     }
 
+    /// Duplicate tokens in the preference revert.
     function test_getMaxSpendDebit_duplicateTokens() public {
         address[] memory tokenPreference = new address[](2);
         tokenPreference[0] = address(usdc);
         tokenPreference[1] = address(usdc);
-        
+
         vm.expectRevert(ArrayDeDupLib.DuplicateElementFound.selector);
         cashLens.getMaxSpendDebit(address(safe), tokenPreference);
     }
 
+    /// A non-borrow token in the preference reverts.
     function test_getMaxSpendDebit_notBorrowToken() public {
         address nonBorrowToken = makeAddr("nonBorrowToken");
-        
+
         address[] memory tokenPreference = new address[](1);
         tokenPreference[0] = nonBorrowToken;
-        
+
         vm.expectRevert(CashLens.NotABorrowToken.selector);
         cashLens.getMaxSpendDebit(address(safe), tokenPreference);
     }
 
-    function test_getMaxSpendDebit_cannotCoverDeficit() public {        
-        // Underwater debit (debt-driven restriction) is phase two; phase one has no live debt.
-        vm.skip(true);
-        // Create large debt
-        _setMode(Mode.Credit);
-        vm.warp(cashModule.incomingModeStartTime(address(safe)) + 1);
-        
-        uint256 borrowAmount = 10000e6;
-        address[] memory spendTokens = new address[](1);
-        spendTokens[0] = address(usdc);
-        uint256[] memory spendAmounts = new uint256[](1);
-        spendAmounts[0] = borrowAmount;
+    /// Debt at the borrowing limit leaves zero headroom, so nothing supplied is spendable.
+    function test_getMaxSpendDebit_cannotCoverDeficit() public {
+        // Debt has consumed all borrowing power, so the headroom is zero and no supplied collateral can be
+        // withdrawn. With no raw balance, nothing is spendable.
+        _setDebtPosition(1000e6, 1000e6, 50e18, 1200e6);
 
-        Cashback[] memory cashbacks = new Cashback[](1);
-        CashbackTokens[] memory cashbackTokens = new CashbackTokens[](1);
-
-        CashbackTokens memory scr = CashbackTokens({
-            token: address(cashbackToken),
-            amountInUsd: 1e6,
-            cashbackType: 0
-        });
-
-        cashbackTokens[0] = scr;
-
-        Cashback memory scrCashback = Cashback({
-            to: address(safe),
-            cashbackTokens: cashbackTokens
-        });
-
-        cashbacks[0] = scrCashback;
-        
-        vm.prank(etherFiWallet);
-        cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
-
-        // Remove most collateral
-        deal(address(usdc), address(safe), 500e6);
-        deal(address(liquidUsdScroll), address(safe), 500e6);
-        deal(address(weETH), address(safe), 0);
-        
-        // Try to get max spend - should return empty as deficit cannot be covered
         address[] memory tokenPreference = new address[](2);
         tokenPreference[0] = address(usdc);
-        tokenPreference[1] = address(liquidUsdScroll);
-        
+        tokenPreference[1] = address(liquidUsd);
+
         DebitModeMaxSpend memory result = cashLens.getMaxSpendDebit(address(safe), tokenPreference);
-        
-        assertEq(result.spendableTokens.length, 0, "Should return empty when deficit cannot be covered");
+        assertEq(result.spendableAmounts[0], 0, "No USDC spendable when the headroom is zero");
+        assertEq(result.spendableAmounts[1], 0, "No liquidUSD spendable when the headroom is zero");
         assertEq(result.totalSpendableInUsd, 0, "Total should be zero");
     }
 
+    /// Raw safe balance is spendable on top of the headroom-capped supplied amount.
+    function test_getMaxSpendDebit_rawBalanceDoesNotConsumeHeadroom() public {
+        // Raw safe balance is spendable on top of the headroom-capped supplied amount and does not consume headroom.
+        // supplied $1000 USDC at 50% LTV, debt $400, borrow headroom $100 -> $200 supplied withdrawable; plus $500 raw.
+        deal(address(usdc), address(safe), 500e6);
+        gateway.setSuppliedOf(address(safe), address(usdc), 1000e6);
+        gateway.setAvailableCash(address(usdc), type(uint128).max);
+        gateway.setLtv(address(usdc), 50e18);
+        gateway.setAccountData(address(safe), IGateway.AccountData({ collateralUsd: 1000e6, debtUsd: 400e6, availableBorrowsUsd: 100e6, healthFactor: 1e18 }));
+
+        address[] memory tokenPreference = new address[](1);
+        tokenPreference[0] = address(usdc);
+
+        DebitModeMaxSpend memory result = cashLens.getMaxSpendDebit(address(safe), tokenPreference);
+        assertEq(result.spendableAmounts[0], 700e6, "Raw $500 plus headroom-capped supplied $200");
+    }
+
+    /// With debt, supplied withdrawal is capped at the LTV borrowing headroom.
+    function test_getMaxSpendDebit_debtCapsAtBorrowHeadroom() public {
+        // With debt, the supplied withdrawal is capped by the LTV borrowing headroom (availableBorrowsUsd).
+        // Supplied $1000 USDC at 50% LTV, debt $200 -> borrow headroom $300 -> $600 of supplied withdrawable.
+        _setDebtPosition(1000e6, 0, 50e18, 200e6);
+
+        address[] memory tokenPreference = new address[](1);
+        tokenPreference[0] = address(usdc);
+
+        DebitModeMaxSpend memory result = cashLens.getMaxSpendDebit(address(safe), tokenPreference);
+        assertEq(result.spendableAmounts[0], 600e6, "Debit capped at the LTV borrowing headroom");
+    }
+
+    /// A pending withdrawal of the entire balance leaves nothing spendable.
     function test_getMaxSpendDebit_zeroEffectiveBalance() public {
         // Create withdrawal request for all USDC
         address[] memory tokens = new address[](1);
         tokens[0] = address(usdc);
         uint256[] memory amounts = new uint256[](1);
-        amounts[0] = 50000e6;
+        amounts[0] = 50_000e6;
         _requestWithdrawal(tokens, amounts, withdrawRecipient);
-        
+
         address[] memory tokenPreference = new address[](1);
         tokenPreference[0] = address(usdc);
-        
+
         DebitModeMaxSpend memory result = cashLens.getMaxSpendDebit(address(safe), tokenPreference);
-        
+
         assertEq(result.spendableAmounts[0], 0, "Should have zero spendable with full withdrawal");
         assertEq(result.totalSpendableInUsd, 0, "Total should be zero");
     }
 
     // ================ Phase-one supplied-position Tests ================
 
+    /// Scenario 2, no debt and nothing raw: debit spends the withdrawable supplied position.
     function test_getMaxSpendDebit_suppliedOnly_noRawBalance() public {
-        // Scenario 2: the stable lives in Aave, not the safe. Debit spends the withdrawable supplied amount.
         deal(address(usdc), address(safe), 0);
         gateway.setSuppliedOf(address(safe), address(usdc), 1000e6);
         gateway.setAvailableCash(address(usdc), type(uint128).max);
@@ -389,8 +332,8 @@ contract CashLensMaxSpendTest is CashModuleTestSetup {
         assertGt(result.totalSpendableInUsd, 0, "Total should be positive");
     }
 
+    /// The withdrawable supplied amount is capped by the reserve's available liquidity.
     function test_getMaxSpendDebit_withdrawableCappedByReserveCash() public {
-        // The supplied amount is only spendable up to the reserve's available liquidity.
         deal(address(usdc), address(safe), 0);
         gateway.setSuppliedOf(address(safe), address(usdc), 1000e6);
         gateway.setAvailableCash(address(usdc), 400e6);
@@ -402,8 +345,8 @@ contract CashLensMaxSpendTest is CashModuleTestSetup {
         assertEq(result.spendableAmounts[0], 400e6, "Should cap at reserve liquidity");
     }
 
+    /// Mixed raw balance plus supplied position: debit spends the sum.
     function test_getMaxSpendDebit_rawPlusSupplied() public {
-        // Mixed: a raw safe balance plus a supplied position. Debit spends the sum.
         deal(address(usdc), address(safe), 300e6);
         gateway.setSuppliedOf(address(safe), address(usdc), 700e6);
         gateway.setAvailableCash(address(usdc), type(uint128).max);
@@ -417,83 +360,88 @@ contract CashLensMaxSpendTest is CashModuleTestSetup {
 
     // ================ Updated getSafeCashData Tests ================
 
+    /// getSafeCashData honors the token preference order and populates the position fields.
     function test_getSafeCashData_withTokenPreference_USDC_liquidUSD() public {
         address[] memory tokenPreference = new address[](2);
         tokenPreference[0] = address(usdc);
-        tokenPreference[1] = address(liquidUsdScroll);
+        tokenPreference[1] = address(liquidUsd);
 
         _mirrorPositionToGateway(address(safe));
         SafeCashData memory data = cashLens.getSafeCashData(address(safe), tokenPreference);
-        
+
         // Verify debitMaxSpend uses the preference
         assertEq(data.debitMaxSpend.spendableTokens.length, 2, "Should have two tokens in preference order");
         assertEq(data.debitMaxSpend.spendableTokens[0], address(usdc), "First token should be USDC");
-        assertEq(data.debitMaxSpend.spendableTokens[1], address(liquidUsdScroll), "Second token should be liquidUSD");
+        assertEq(data.debitMaxSpend.spendableTokens[1], address(liquidUsd), "Second token should be liquidUSD");
         assertGt(data.debitMaxSpend.totalSpendableInUsd, 0, "Should have spendable amount");
-        
+
         // Verify other data is still populated correctly
         assertGt(data.totalCollateral, 0, "Should have collateral value");
         assertEq(data.totalBorrow, 0, "Should have no borrows initially");
     }
 
+    /// getSafeCashData reflects a reversed token preference order.
     function test_getSafeCashData_withTokenPreference_liquidUSD_USDC() public view {
         address[] memory tokenPreference = new address[](2);
-        tokenPreference[0] = address(liquidUsdScroll);
+        tokenPreference[0] = address(liquidUsd);
         tokenPreference[1] = address(usdc);
-        
+
         SafeCashData memory data = cashLens.getSafeCashData(address(safe), tokenPreference);
-        
+
         // Verify debitMaxSpend uses the preference
-        assertEq(data.debitMaxSpend.spendableTokens[0], address(liquidUsdScroll), "First token should be liquidUSD");
+        assertEq(data.debitMaxSpend.spendableTokens[0], address(liquidUsd), "First token should be liquidUSD");
         assertEq(data.debitMaxSpend.spendableTokens[1], address(usdc), "Second token should be USDC");
     }
 
+    /// An empty preference falls back to all borrow tokens.
     function test_getSafeCashData_emptyTokenPreference() public view {
         address[] memory emptyPreference = new address[](0);
-        
+
         SafeCashData memory data = cashLens.getSafeCashData(address(safe), emptyPreference);
-        
+
         // Should use all borrow tokens when preference is empty
         assertGt(data.debitMaxSpend.spendableTokens.length, 0, "Should have default borrow tokens");
         assertGt(data.debitMaxSpend.totalSpendableInUsd, 0, "Should have spendable amount");
-        
+
         // Check that it includes both USDC and liquidUSD
         bool hasUSDC = false;
         bool hasLiquidUSD = false;
-        for (uint i = 0; i < data.debitMaxSpend.spendableTokens.length; i++) {
+        for (uint256 i = 0; i < data.debitMaxSpend.spendableTokens.length; i++) {
             if (data.debitMaxSpend.spendableTokens[i] == address(usdc)) hasUSDC = true;
-            if (data.debitMaxSpend.spendableTokens[i] == address(liquidUsdScroll)) hasLiquidUSD = true;
+            if (data.debitMaxSpend.spendableTokens[i] == address(liquidUsd)) hasLiquidUSD = true;
         }
         assertTrue(hasUSDC && hasLiquidUSD, "Should include both USDC and liquidUSD");
     }
 
+    /// A single-token preference returns just that token's spendable.
     function test_getSafeCashData_singleTokenPreference() public view {
         address[] memory tokenPreference = new address[](1);
-        tokenPreference[0] = address(liquidUsdScroll);
-        
+        tokenPreference[0] = address(liquidUsd);
+
         SafeCashData memory data = cashLens.getSafeCashData(address(safe), tokenPreference);
-        
+
         assertEq(data.debitMaxSpend.spendableTokens.length, 1, "Should have only liquidUSD");
-        assertEq(data.debitMaxSpend.spendableTokens[0], address(liquidUsdScroll), "Token should be liquidUSD");
+        assertEq(data.debitMaxSpend.spendableTokens[0], address(liquidUsd), "Token should be liquidUSD");
         assertApproxEqRel(data.debitMaxSpend.totalSpendableInUsd, liquidAmtInUsd, 1, "Should match liquidUSD value");
     }
 
+    /// debitMaxSpend in getSafeCashData matches a direct getMaxSpendDebit call.
     function test_getSafeCashData_consistencyWithDirectCall() public view {
         address[] memory tokenPreference = new address[](2);
         tokenPreference[0] = address(usdc);
-        tokenPreference[1] = address(liquidUsdScroll);
-        
+        tokenPreference[1] = address(liquidUsd);
+
         // Get data through getSafeCashData
         SafeCashData memory data = cashLens.getSafeCashData(address(safe), tokenPreference);
-        
+
         // Get data through direct getMaxSpendDebit call
         DebitModeMaxSpend memory directResult = cashLens.getMaxSpendDebit(address(safe), tokenPreference);
-        
+
         // Compare results
         assertEq(data.debitMaxSpend.totalSpendableInUsd, directResult.totalSpendableInUsd, "Total USD should match");
         assertEq(data.debitMaxSpend.spendableTokens.length, directResult.spendableTokens.length, "Token count should match");
-        
-        for (uint i = 0; i < data.debitMaxSpend.spendableTokens.length; i++) {
+
+        for (uint256 i = 0; i < data.debitMaxSpend.spendableTokens.length; i++) {
             assertEq(data.debitMaxSpend.spendableTokens[i], directResult.spendableTokens[i], "Tokens should match");
             assertEq(data.debitMaxSpend.spendableAmounts[i], directResult.spendableAmounts[i], "Amounts should match");
             assertEq(data.debitMaxSpend.amountsInUsd[i], directResult.amountsInUsd[i], "USD amounts should match");
@@ -502,13 +450,14 @@ contract CashLensMaxSpendTest is CashModuleTestSetup {
 
     // ================ getMaxSpendCredit Tests ================
 
+    /// Credit max spend equals the gateway's borrowing power.
     function test_getMaxSpendCredit_withUSDC_liquidUSD_collateral() public {
         _mirrorPositionToGateway(address(safe));
         uint256 creditMaxSpend = cashLens.getMaxSpendCredit(address(safe));
-        
+
         // Calculate expected based on collateral
         uint256 expectedMaxBorrow = debtManager.getMaxBorrowAmount(address(safe), true);
-        
+
         assertEq(creditMaxSpend, expectedMaxBorrow, "Credit max spend should match max borrow");
         assertGt(creditMaxSpend, 0, "Should have positive credit limit with collateral");
     }

--- a/test/safe/modules/cash/CashLensMaxSpend.t.sol
+++ b/test/safe/modules/cash/CashLensMaxSpend.t.sol
@@ -461,4 +461,103 @@ contract CashLensMaxSpendTest is CashModuleTestSetup {
         assertEq(creditMaxSpend, expectedMaxBorrow, "Credit max spend should match max borrow");
         assertGt(creditMaxSpend, 0, "Should have positive credit limit with collateral");
     }
+
+    /// maxBorrow stays gross (collateral x LTV, debt not subtracted) like DebtManager, while creditMaxSpend is the net headroom.
+    function test_getSafeCashData_maxBorrowIsGrossWithDebt() public {
+        // $2000 collateral at 50% LTV with $800 debt: gross borrow power $1000, net headroom $200.
+        _setDebtPosition(1000e6, 1000e6, 50e18, 800e6);
+
+        address[] memory emptyPreference = new address[](0);
+        SafeCashData memory data = cashLens.getSafeCashData(address(safe), emptyPreference);
+
+        assertEq(data.totalBorrow, 800e6, "totalBorrow is the debt");
+        assertEq(data.maxBorrow, 1000e6, "maxBorrow is gross collateral x LTV, debt not subtracted");
+        assertEq(data.creditMaxSpend, 200e6, "creditMaxSpend is the net headroom");
+        assertEq(data.maxBorrow, data.totalBorrow + data.creditMaxSpend, "gross == debt + net headroom");
+        assertGt(data.maxBorrow, data.creditMaxSpend, "gross exceeds net once there is debt");
+    }
+
+    /// A pending withdrawal lowers credit capacity by the withdrawing collateral's LTV-weighted value.
+    function test_getMaxSpendCredit_reducedByPendingWithdrawal() public {
+        _mirrorPositionToGateway(address(safe));
+        uint256 creditBefore = cashLens.getMaxSpendCredit(address(safe));
+
+        uint256 withdrawAmount = 10_000e6;
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = withdrawAmount;
+        _requestWithdrawal(tokens, amounts, withdrawRecipient);
+
+        uint256 creditAfter = cashLens.getMaxSpendCredit(address(safe));
+
+        // USDC is $1 (6dp), so the headroom freed up by the pending withdrawal is withdrawAmount x LTV.
+        uint256 expectedDrop = (withdrawAmount * ltv) / HUNDRED_PERCENT;
+        assertEq(creditBefore - creditAfter, expectedDrop, "credit drops by the pending withdrawal's LTV-weighted value");
+    }
+
+    /// A pending withdrawal on one token reduces the borrowing headroom available to spend another token under debt.
+    function test_getMaxSpendDebit_pendingWithdrawalReducesOtherTokenHeadroom() public {
+        // Debt position: USDC + liquidUSD supplied at 50% LTV with $600 headroom; liquidUSD has raw balance for the request.
+        deal(address(usdc), address(safe), 0);
+        deal(address(liquidUsd), address(safe), 2000e6);
+        gateway.setSuppliedOf(address(safe), address(usdc), 1000e6);
+        gateway.setSuppliedOf(address(safe), address(liquidUsd), 1000e6);
+        gateway.setAvailableCash(address(usdc), type(uint128).max);
+        gateway.setLtv(address(usdc), 50e18);
+        gateway.setLtv(address(liquidUsd), 50e18);
+        gateway.setAccountData(address(safe), IGateway.AccountData({ collateralUsd: 2000e6, debtUsd: 400e6, availableBorrowsUsd: 600e6, healthFactor: 1e18 }));
+
+        address[] memory tokenPreference = new address[](1);
+        tokenPreference[0] = address(usdc);
+
+        uint256 withoutPending = cashLens.getMaxSpendDebit(address(safe), tokenPreference).spendableAmounts[0];
+
+        // Queue a liquidUSD withdrawal; it consumes part of the shared borrowing headroom.
+        address[] memory wTokens = new address[](1);
+        wTokens[0] = address(liquidUsd);
+        uint256[] memory wAmounts = new uint256[](1);
+        wAmounts[0] = 1000e6;
+        _requestWithdrawal(wTokens, wAmounts, withdrawRecipient);
+
+        uint256 withPending = cashLens.getMaxSpendDebit(address(safe), tokenPreference).spendableAmounts[0];
+
+        assertLt(withPending, withoutPending, "a pending liquidUSD withdrawal lowers USDC's spendable via the shared headroom");
+    }
+
+    /// Debit canSpend declines (does not revert) when a pending withdrawal exceeds the currently available balance.
+    function test_canSpendDebit_pendingExceedsAvailable_declinesNotReverts() public {
+        // Queue a withdrawal for the full USDC balance, then drop the raw balance below it with no supplied position,
+        // so available (raw + withdrawable) is less than the pending amount.
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = usdcBal;
+        _requestWithdrawal(tokens, amounts, withdrawRecipient);
+
+        deal(address(usdc), address(safe), 100e6);
+        gateway.setSuppliedOf(address(safe), address(usdc), 0);
+
+        uint256[] memory amountsInUsd = new uint256[](1);
+        amountsInUsd[0] = 1e6;
+
+        (bool ok, string memory reason) = cashLens.canSpend(address(safe), keccak256("p3"), tokens, amountsInUsd);
+        assertFalse(ok, "should decline");
+        assertEq(reason, "Insufficient effective balance after withdrawal to spend with debit mode", "declines with a reason instead of reverting");
+    }
+
+    /// With debt, a zero-LTV reserve cannot back a safe withdrawal, so only the raw balance is spendable.
+    function test_getMaxSpendDebit_zeroLtvWithDebt() public {
+        deal(address(usdc), address(safe), 300e6);
+        gateway.setSuppliedOf(address(safe), address(usdc), 1000e6);
+        gateway.setAvailableCash(address(usdc), type(uint128).max);
+        gateway.setLtv(address(usdc), 0);
+        gateway.setAccountData(address(safe), IGateway.AccountData({ collateralUsd: 1000e6, debtUsd: 200e6, availableBorrowsUsd: 100e6, healthFactor: 1e18 }));
+
+        address[] memory tokenPreference = new address[](1);
+        tokenPreference[0] = address(usdc);
+
+        DebitModeMaxSpend memory result = cashLens.getMaxSpendDebit(address(safe), tokenPreference);
+        assertEq(result.spendableAmounts[0], 300e6, "Only the raw balance is spendable when LTV is zero and there is debt");
+    }
 }

--- a/test/safe/modules/cash/CashModuleTestSetup.t.sol
+++ b/test/safe/modules/cash/CashModuleTestSetup.t.sol
@@ -13,6 +13,7 @@ import { DebtManagerCore, DebtManagerStorageContract } from "../../../../src/deb
 import { ICashModule } from "../../../../src/interfaces/ICashModule.sol";
 import { Mode, SafeTiers, Cashback, CashbackTokens } from "../../../../src/interfaces/ICashModule.sol";
 import { IDebtManager } from "../../../../src/interfaces/IDebtManager.sol";
+import { IGateway } from "../../../../src/interfaces/IGateway.sol";
 import { IPriceProvider } from "../../../../src/interfaces/IPriceProvider.sol";
 import { CashVerificationLib } from "../../../../src/libraries/CashVerificationLib.sol";
 import { SpendingLimit } from "../../../../src/libraries/SpendingLimitLib.sol";
@@ -153,5 +154,33 @@ contract CashModuleTestSetup is SafeTestSetup {
         vm.expectEmit(true, true, true, true);
         emit CashEventEmitter.SpendingLimitChanged(address(safe), oldLimit, newLimit);
         cashModule.updateSpendingLimit(address(safe), dailyLimit, monthlyLimit, owner1, signature);
+    }
+
+    /// @notice Mirrors the safe's DebtManager-derived position into the mock gateway so CashLens (which now reads the gateway) resolves the same position
+    function _mirrorPositionToGateway(address _safe) internal {
+        (IDebtManager.TokenData[] memory collaterals, uint256 totalCollateralUsd, IDebtManager.TokenData[] memory borrows, uint256 totalBorrowUsd) = debtManager.getUserCurrentState(_safe);
+
+        for (uint256 i = 0; i < collaterals.length; i++) {
+            gateway.setSuppliedOf(_safe, collaterals[i].token, collaterals[i].amount);
+        }
+        for (uint256 i = 0; i < borrows.length; i++) {
+            gateway.setDebtOf(_safe, borrows[i].token, borrows[i].amount);
+        }
+
+        address[] memory borrowTokens = debtManager.getBorrowTokens();
+        for (uint256 i = 0; i < borrowTokens.length; i++) {
+            gateway.setAvailableCash(borrowTokens[i], type(uint128).max);
+        }
+
+        uint256 maxBorrowUsd = debtManager.getMaxBorrowAmount(_safe, true);
+        gateway.setAccountData(
+            _safe,
+            IGateway.AccountData({
+                collateralUsd: totalCollateralUsd,
+                debtUsd: totalBorrowUsd,
+                availableBorrowsUsd: maxBorrowUsd > totalBorrowUsd ? maxBorrowUsd - totalBorrowUsd : 0,
+                healthFactor: type(uint256).max
+            })
+        );
     }
 }

--- a/test/safe/modules/cash/CashModuleTestSetup.t.sol
+++ b/test/safe/modules/cash/CashModuleTestSetup.t.sol
@@ -162,6 +162,7 @@ contract CashModuleTestSetup is SafeTestSetup {
 
         for (uint256 i = 0; i < collaterals.length; i++) {
             gateway.setSuppliedOf(_safe, collaterals[i].token, collaterals[i].amount);
+            gateway.setLtv(collaterals[i].token, debtManager.collateralTokenConfig(collaterals[i].token).ltv);
         }
         for (uint256 i = 0; i < borrows.length; i++) {
             gateway.setDebtOf(_safe, borrows[i].token, borrows[i].amount);

--- a/test/safe/modules/cash/CashModuleTestSetup.t.sol
+++ b/test/safe/modules/cash/CashModuleTestSetup.t.sol
@@ -11,7 +11,7 @@ import { CashbackDispatcher } from "../../../../src/cashback-dispatcher/Cashback
 import { DebtManagerAdmin } from "../../../../src/debt-manager/DebtManagerAdmin.sol";
 import { DebtManagerCore, DebtManagerStorageContract } from "../../../../src/debt-manager/DebtManagerCore.sol";
 import { ICashModule } from "../../../../src/interfaces/ICashModule.sol";
-import { Mode, SafeTiers, Cashback, CashbackTokens } from "../../../../src/interfaces/ICashModule.sol";
+import { Cashback, CashbackTokens, Mode, SafeTiers } from "../../../../src/interfaces/ICashModule.sol";
 import { IDebtManager } from "../../../../src/interfaces/IDebtManager.sol";
 import { IGateway } from "../../../../src/interfaces/IGateway.sol";
 import { IPriceProvider } from "../../../../src/interfaces/IPriceProvider.sol";
@@ -46,7 +46,7 @@ contract CashModuleTestSetup is SafeTestSetup {
         bool[] memory shouldWhitelist = new bool[](1);
         shouldWhitelist[0] = true;
 
-        _configureModules(modules, shouldWhitelist, setupData);        
+        _configureModules(modules, shouldWhitelist, setupData);
 
         vm.stopPrank();
     }
@@ -156,14 +156,35 @@ contract CashModuleTestSetup is SafeTestSetup {
         cashModule.updateSpendingLimit(address(safe), dailyLimit, monthlyLimit, owner1, signature);
     }
 
-    /// @notice Mirrors the safe's DebtManager-derived position into the mock gateway so CashLens (which now reads the gateway) resolves the same position
+    /**
+     * @notice Recreates the safe's DebtManager-era position on the mock gateway as an Aave position, so the
+     *         legacy DebtManager-based test setup can drive CashLens's Aave reads.
+     * @dev Mirrors the whole position: supplies all collateral (an Aave borrow needs collateral backing, so
+     *      nothing backing debt can sit loose), carries the DebtManager debt over, and keeps only a pending
+     *      withdrawal loose via supplied = balance - pending, modeling it as withdrawn from Aave at request time.
+     */
     function _mirrorPositionToGateway(address _safe) internal {
-        (IDebtManager.TokenData[] memory collaterals, uint256 totalCollateralUsd, IDebtManager.TokenData[] memory borrows, uint256 totalBorrowUsd) = debtManager.getUserCurrentState(_safe);
+        address[] memory collateralTokens = debtManager.getCollateralTokens();
+        uint256 totalCollateralUsd = 0;
+        uint256 maxBorrowUsd = 0;
 
-        for (uint256 i = 0; i < collaterals.length; i++) {
-            gateway.setSuppliedOf(_safe, collaterals[i].token, collaterals[i].amount);
-            gateway.setLtv(collaterals[i].token, debtManager.collateralTokenConfig(collaterals[i].token).ltv);
+        for (uint256 i = 0; i < collateralTokens.length; i++) {
+            IDebtManager.CollateralTokenConfig memory config = debtManager.collateralTokenConfig(collateralTokens[i]);
+            uint256 balance = IERC20(collateralTokens[i]).balanceOf(_safe);
+            uint256 pending = cashLens.getPendingWithdrawalAmount(_safe, collateralTokens[i]);
+            uint256 supplied = balance > pending ? balance - pending : 0;
+
+            gateway.setSuppliedOf(_safe, collateralTokens[i], supplied);
+            gateway.setLtv(collateralTokens[i], config.ltv);
+
+            if (supplied != 0) {
+                uint256 suppliedUsd = debtManager.convertCollateralTokenToUsd(collateralTokens[i], supplied);
+                totalCollateralUsd += suppliedUsd;
+                maxBorrowUsd += (suppliedUsd * config.ltv) / 100e18;
+            }
         }
+
+        (,, IDebtManager.TokenData[] memory borrows, uint256 totalBorrowUsd) = debtManager.getUserCurrentState(_safe);
         for (uint256 i = 0; i < borrows.length; i++) {
             gateway.setDebtOf(_safe, borrows[i].token, borrows[i].amount);
         }
@@ -173,15 +194,6 @@ contract CashModuleTestSetup is SafeTestSetup {
             gateway.setAvailableCash(borrowTokens[i], type(uint128).max);
         }
 
-        uint256 maxBorrowUsd = debtManager.getMaxBorrowAmount(_safe, true);
-        gateway.setAccountData(
-            _safe,
-            IGateway.AccountData({
-                collateralUsd: totalCollateralUsd,
-                debtUsd: totalBorrowUsd,
-                availableBorrowsUsd: maxBorrowUsd > totalBorrowUsd ? maxBorrowUsd - totalBorrowUsd : 0,
-                healthFactor: type(uint256).max
-            })
-        );
+        gateway.setAccountData(_safe, IGateway.AccountData({ collateralUsd: totalCollateralUsd, debtUsd: totalBorrowUsd, availableBorrowsUsd: maxBorrowUsd > totalBorrowUsd ? maxBorrowUsd - totalBorrowUsd : 0, healthFactor: type(uint256).max }));
     }
 }

--- a/test/upgrade-bytecode-verification/VerifyOPMainnet.t.sol
+++ b/test/upgrade-bytecode-verification/VerifyOPMainnet.t.sol
@@ -193,7 +193,10 @@ contract VerifyOPMainnetBytecode is ContractCodeChecker, Utils {
     }
 
     function test_verifyBytecode_CashLens() public {
-        address local = address(new CashLens(cashModuleProxy, dataProviderProxy));
+        // CashLens is rewritten for Lend (reads the Aave gateway, takes a gateway constructor arg), so its
+        // bytecode no longer matches the deployed pre-Lend version. Re-enable after the Lend deployment.
+        vm.skip(true);
+        address local = address(new CashLens(cashModuleProxy, dataProviderProxy, address(0)));
         _verify("CashLens", cashLensImpl, local);
     }
 


### PR DESCRIPTION
## What this does

Repoints CashLens to read a safe's position from the Aave gateway (`IGateway`) instead of DebtManager plus raw Safe balances. External signatures and the `SafeCashData` / `DebitModeMaxSpend` structs stay byte-identical, since ~15 cash-be methods and 3 controllers depend on `getSafeCashData`.

- Collateral and borrows come from the gateway (`suppliedOf` / `debtOf`).
- Credit capacity and reserve liquidity from `getAccountData` / `availableCash`.
- `maxBorrow` is gross borrowing power (`availableBorrowsUsd + debtUsd`), kept distinct from `creditMaxSpend` (net headroom), matching DebtManager's `getMaxBorrowAmount`.
- Debit spendable = loose balance + withdrawable supplied (capped by reserve cash and, with debt, by the LTV borrowing headroom). A pending withdrawal is reserved from the loose balance only.
- Debit `canSpend` declines (does not revert) when a pending withdrawal exceeds the available balance.
- A zero-LTV reserve is treated as not withdrawable against debt.

It uses LTV, stricter than Aave's liquidation threshold, so it is a safe under-estimate of what a withdraw allows. USD is 6 decimals and LTV is 100e18 = 100%, matching the old DebtManager conventions.

## Withdrawal flow (COR-958, decided)

A pending withdrawal is netted from the loose Safe balance only. The gateway figures (collateral, maxBorrow, credit and debit headroom) are read as-is. COR-958 is now decided and does exactly what this code assumes: a withdrawal pulls the funds out of Aave into the Safe at request time, then queues the existing delayed withdrawal, which the cron processes with the existing off-chain holds check. So a pending withdrawal lives in the loose balance, the gateway already reflects the reduced position, and this netting is exact. An earlier variant that subtracted the pending from every gateway figure was reverted, because it under-reported spendable when wallet and Aave balances coexist.

Decision and reasoning: https://linear.app/ether-fi/issue/COR-958/reconcile-the-cash-withdrawal-flow-with-aave-time-lock-vs-immediate (write-up in `docs/adr/0002-cash-withdrawals-on-aave.md`).

## Open questions (want a second eye)

- **DebtManager still partly coupled.** `getUserCollateralForToken` / `getUserTotalCollateral` and token lists still return raw Safe balances during the retirement window, so they can disagree with `collateralBalances` (supplied). Confirm the retirement order before merge.
- **Sandwich guard coupling.** CashLens's LTV cap stays stricter than the sandwich helper's withdraw guard only while `minHealthFactor <= liqThreshold / LTV`. Keep it in range or CashLens over-reports.
- **Gateway normalization.** The live gateway must normalize Aave's native units (Ray, bps, 8-dec) to the seam units (6-dec USD, 100e18 LTV, 1e18 HF). Confirm with the gateway track.
- **Stale decline string** "Insufficient liquidity in debt manager..." kept as-is in case cash-be matches on it.

## Testing

`forge build`, `forge fmt`, `forge lint` on changed files. On the Optimism fork (`TEST_CHAIN=10`): CashLens, CashLensMaxSpend, CanSpend pass (80 tests).

## Out of scope

COR-979 (CashModule write path), COR-981 (EtherFiHook), COR-982 (liquidation removal).

Closes COR-980

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Rewrites on-chain spend and borrow-headroom logic that gates card spending; incorrect gateway normalization or LTV/headroom threading could approve spends that later revert or misstate limits.
> 
> **Overview**
> **CashLens** now takes an immutable **`IGateway`** and treats Aave as the source of truth for collateral, debt, credit headroom, and pool liquidity instead of **DebtManager** balances and borrowing-power math. **`canSpend`**, **`getMaxSpendDebit`**, **`getMaxSpendCredit`**, and **`getSafeCashData`** were rewritten: debit spendable is loose Safe balance (minus pending withdrawals on the loose side only) plus withdrawable supplied, capped by reserve cash and—when there is debt—by LTV-weighted borrowing headroom threaded across tokens; credit checks **`availableBorrowsUsd`** and **`availableCash`**. External return shapes stay the same; **`maxBorrow`** stays gross (**`availableBorrowsUsd + debtUsd`**). A few collateral helpers still read raw Safe balances for the DebtManager retirement window.
> 
> **`IGateway`** gains **`suppliedOf`**, **`debtOf`**, **`availableCash`**, and **`ltv`**; **`MockGateway`** and tests (**`_mirrorPositionToGateway`**, expanded max-spend / can-spend cases) follow. New **`ModuleGatewaySandwich`** brackets module actions with gateway withdraw/resupply and a post-op **`minHealthFactor`** guard.
> 
> Adds **`IAaveV4PriceFeed`**, **`IVedaAccountant`**, and fail-closed **`ChainlinkCompositePriceFeed`** / **`VedaAccountantPriceFeed`** for Aave v4 collateral oracles, with Optimism fork tests. OP bytecode verification for **CashLens** is skipped until the Lend deployment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39276820353cac429f3151ec0b65e265c0253eea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

