### PR TITLE
refactor: update requestAsyncWithdraw to accept multiple signers and signatures

### DIFF
--- a/scripts/DeployFraxModule.s.sol
+++ b/scripts/DeployFraxModule.s.sol
@@ -7,14 +7,14 @@ import { EtherFiDataProvider } from "../src/data-provider/EtherFiDataProvider.so
 import { ICashModule } from "../src/interfaces/ICashModule.sol";
 import { IDebtManager } from "../src/interfaces/IDebtManager.sol";
 import { FraxModule } from "../src/modules/frax/FraxModule.sol";
-import { IAggregatorV3, PriceProvider } from "../src/oracle/PriceProvider.sol";
+import { IAggregatorV3, PriceProviderV2 as PriceProvider } from "../src/oracle/PriceProviderV2.sol";
 import { Utils } from "./utils/Utils.sol";
 
 contract DeployFraxModule is Utils {
-    address fraxusd = 0x397F939C3b91A74C321ea7129396492bA9Cdce82;
-    address custodian = 0x05bF905356fbeA7E59500f904b908402dB7A53DD;
-    address fraxUsdPriceOracle = 0x7be4f8b373853b74CDf48FE817bC2eB2272eBe45;
-    address remoteHop = 0xF6f45CCB5E85D1400067ee66F9e168f83e86124E;
+    address fraxusd = 0x80Eede496655FB9047dd39d9f418d5483ED600df;
+    address custodian = 0x8C81eda18b8F1cF5AdB4f2dcDb010D0B707fd940;
+    address fraxUsdPriceOracle = 0x8BF42811876e1B692d0E70F61b80e1fbc68Ef1bf;
+    address remoteHop = 0x31D982ebd82Ad900358984bd049207A4c2468640;
 
     IDebtManager debtManager;
     PriceProvider priceProvider;
@@ -57,9 +57,8 @@ contract DeployFraxModule is Utils {
             oraclePriceDecimals: IAggregatorV3(fraxUsdPriceOracle).decimals(),
             maxStaleness: 2 days,
             dataType: PriceProvider.ReturnType.Int256,
-            isBaseTokenEth: false,
-            isStableToken: true, //Stable coin
-            isBaseTokenBtc: false
+            isStableToken: true,
+            baseAsset: address(0)
         });
         PriceProvider.Config[] memory fraxUsdConfigs = new PriceProvider.Config[](1);
         fraxUsdConfigs[0] = fraxUsdConfig;
@@ -76,9 +75,9 @@ contract DeployFraxModule is Utils {
         uint64 borrowApy = 1; // ~0%
         uint128 minShares = type(uint128).max; // Since we dont want to use it in borrow mode
 
-        //debt manager set collateral and borrow config
-        debtManager.supportCollateralToken(address(fraxusd), collateralConfig);
-        debtManager.supportBorrowToken(address(fraxusd), borrowApy, minShares);
+        //debt manager set collateral and borrow config (idempotent)
+        if (!debtManager.isCollateralToken(fraxusd)) debtManager.supportCollateralToken(fraxusd, collateralConfig);
+        if (!debtManager.isBorrowToken(fraxusd)) debtManager.supportBorrowToken(fraxusd, borrowApy, minShares);
 
         address[] memory withdrawableAssets = new address[](1);
         withdrawableAssets[0] = address(fraxusd);

--- a/src/modules/frax/FraxModule.sol
+++ b/src/modules/frax/FraxModule.sol
@@ -283,12 +283,13 @@ contract FraxModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardTransient,
      * @param safe Address for user safe
      * @param _recipient Recipient address from Frax api
      * @param _withdrawAmount Amount to withdraw asynchronously
-     * @param signer The address that signed the transaction
-     * @param signature The signature authorizing this transaction
+     * @param signers Array of addresses of safe owners that signed the transaction
+     * @param signatures Array of signatures from the signers
+     * @dev Requires the Safe's owner quorum because funds exit to an arbitrary recipient
      */
-    function requestAsyncWithdraw(address safe, address _recipient, uint256 _withdrawAmount, address signer, bytes calldata signature) external payable onlyEtherFiSafe(safe) onlySafeAdmin(safe, signer) {
+    function requestAsyncWithdraw(address safe, address _recipient, uint256 _withdrawAmount, address[] calldata signers, bytes[] calldata signatures) external payable onlyEtherFiSafe(safe) {
         bytes32 digestHash = _getRequestAsyncWithdrawDigestHash(safe, _recipient, _withdrawAmount);
-        _verifyAdminSig(digestHash, signer, signature);
+        if (!IEtherFiSafe(safe).checkSignatures(digestHash, signers, signatures)) revert InvalidSignatures();
         _requestAsyncWithdraw(safe, _recipient, _withdrawAmount);
     }
 

--- a/src/modules/frax/FraxModule.sol
+++ b/src/modules/frax/FraxModule.sol
@@ -358,7 +358,7 @@ contract FraxModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardTransient,
      * @return The digest hash for signature verification
      */
     function _getRequestAsyncWithdrawDigestHash(address safe, address _recipient, uint256 _withdrawAmount) internal returns (bytes32) {
-        return keccak256(abi.encodePacked(REQUEST_ASYNC_WITHDRAW_SIG, block.chainid, address(this), _useNonce(safe), safe, abi.encode(fraxusd, _recipient, _withdrawAmount))).toEthSignedMessageHash();
+        return keccak256(abi.encodePacked(REQUEST_ASYNC_WITHDRAW_SIG, block.chainid, address(this), IEtherFiSafe(safe).useNonce(), safe, abi.encode(fraxusd, _recipient, _withdrawAmount))).toEthSignedMessageHash();
     }
 
     /**

--- a/test/safe/modules/frax/FraxModule.t.sol
+++ b/test/safe/modules/frax/FraxModule.t.sol
@@ -152,7 +152,7 @@ contract FraxModuleTest is SafeTestSetup {
                     fraxModule.REQUEST_ASYNC_WITHDRAW_SIG(),
                     block.chainid,
                     address(fraxModule),
-                    fraxModule.getNonce(address(safe)), //nonce
+                    safe.nonce(), //nonce
                     safe,
                     abi.encode(fraxusd, depositAddress, amountToWithdraw)
                 )
@@ -450,7 +450,7 @@ contract FraxModuleTest is SafeTestSetup {
         // deal less amount than required
         deal(address(fraxusd), address(safe), amount - 1);
 
-        bytes32 digestHash = keccak256(abi.encodePacked(fraxModule.REQUEST_ASYNC_WITHDRAW_SIG(), block.chainid, address(fraxModule), fraxModule.getNonce(address(safe)), safe, abi.encode(fraxusd, depositAddress, amount))).toEthSignedMessageHash();
+        bytes32 digestHash = keccak256(abi.encodePacked(fraxModule.REQUEST_ASYNC_WITHDRAW_SIG(), block.chainid, address(fraxModule), safe.nonce(), safe, abi.encode(fraxusd, depositAddress, amount))).toEthSignedMessageHash();
 
         (address[] memory signers, bytes[] memory signatures) = _signRequestAsync(digestHash);
 
@@ -462,7 +462,7 @@ contract FraxModuleTest is SafeTestSetup {
         uint256 amount = 1000 * 10 ** 18;
         deal(address(fraxusd), address(safe), amount);
 
-        bytes32 digestHash = keccak256(abi.encodePacked(fraxModule.REQUEST_ASYNC_WITHDRAW_SIG(), block.chainid, address(fraxModule), fraxModule.getNonce(address(safe)), safe, abi.encode(fraxusd, address(0), amount))).toEthSignedMessageHash();
+        bytes32 digestHash = keccak256(abi.encodePacked(fraxModule.REQUEST_ASYNC_WITHDRAW_SIG(), block.chainid, address(fraxModule), safe.nonce(), safe, abi.encode(fraxusd, address(0), amount))).toEthSignedMessageHash();
 
         (address[] memory signers, bytes[] memory signatures) = _signRequestAsync(digestHash);
 
@@ -471,7 +471,7 @@ contract FraxModuleTest is SafeTestSetup {
         fraxModule.requestAsyncWithdraw(address(safe), address(0), amount, signers, signatures);
 
         // Test with zero amount
-        bytes32 digestHash1 = keccak256(abi.encodePacked(fraxModule.REQUEST_ASYNC_WITHDRAW_SIG(), block.chainid, address(fraxModule), fraxModule.getNonce(address(safe)), safe, abi.encode(fraxusd, depositAddress, 0))).toEthSignedMessageHash();
+        bytes32 digestHash1 = keccak256(abi.encodePacked(fraxModule.REQUEST_ASYNC_WITHDRAW_SIG(), block.chainid, address(fraxModule), safe.nonce(), safe, abi.encode(fraxusd, depositAddress, 0))).toEthSignedMessageHash();
 
         (address[] memory signers1, bytes[] memory signatures1) = _signRequestAsync(digestHash1);
 
@@ -484,7 +484,7 @@ contract FraxModuleTest is SafeTestSetup {
         uint256 amount = 1000 * 10 ** 18 + 1; // Not a multiple of DUST_THRESHOLD (1e12)
         deal(address(fraxusd), address(safe), amount);
 
-        bytes32 digestHash = keccak256(abi.encodePacked(fraxModule.REQUEST_ASYNC_WITHDRAW_SIG(), block.chainid, address(fraxModule), fraxModule.getNonce(address(safe)), safe, abi.encode(fraxusd, depositAddress, amount))).toEthSignedMessageHash();
+        bytes32 digestHash = keccak256(abi.encodePacked(fraxModule.REQUEST_ASYNC_WITHDRAW_SIG(), block.chainid, address(fraxModule), safe.nonce(), safe, abi.encode(fraxusd, depositAddress, amount))).toEthSignedMessageHash();
 
         (address[] memory signers, bytes[] memory signatures) = _signRequestAsync(digestHash);
 
@@ -497,7 +497,7 @@ contract FraxModuleTest is SafeTestSetup {
         uint256 amount = 1000 * 10 ** 18; // 1000 * 1e18 = 1000 * 1e6 * 1e12, which is a multiple of 1e12
         deal(address(fraxusd), address(safe), amount);
 
-        bytes32 digestHash = keccak256(abi.encodePacked(fraxModule.REQUEST_ASYNC_WITHDRAW_SIG(), block.chainid, address(fraxModule), fraxModule.getNonce(address(safe)), safe, abi.encode(fraxusd, depositAddress, amount))).toEthSignedMessageHash();
+        bytes32 digestHash = keccak256(abi.encodePacked(fraxModule.REQUEST_ASYNC_WITHDRAW_SIG(), block.chainid, address(fraxModule), safe.nonce(), safe, abi.encode(fraxusd, depositAddress, amount))).toEthSignedMessageHash();
 
         (address[] memory signers, bytes[] memory signatures) = _signRequestAsync(digestHash);
 
@@ -588,7 +588,7 @@ contract FraxModuleTest is SafeTestSetup {
     }
 
     function _requestAsyncWithdrawal(uint256 amount) internal {
-        bytes32 digestHash = keccak256(abi.encodePacked(fraxModule.REQUEST_ASYNC_WITHDRAW_SIG(), block.chainid, address(fraxModule), fraxModule.getNonce(address(safe)), safe, abi.encode(fraxusd, depositAddress, amount))).toEthSignedMessageHash();
+        bytes32 digestHash = keccak256(abi.encodePacked(fraxModule.REQUEST_ASYNC_WITHDRAW_SIG(), block.chainid, address(fraxModule), safe.nonce(), safe, abi.encode(fraxusd, depositAddress, amount))).toEthSignedMessageHash();
 
         (address[] memory signers, bytes[] memory signatures) = _signRequestAsync(digestHash);
 
@@ -612,7 +612,7 @@ contract FraxModuleTest is SafeTestSetup {
         uint256 amount = 1000 * 10 ** 18;
         deal(address(fraxusd), address(safe), amount);
 
-        bytes32 digestHash = keccak256(abi.encodePacked(fraxModule.REQUEST_ASYNC_WITHDRAW_SIG(), block.chainid, address(fraxModule), fraxModule.getNonce(address(safe)), safe, abi.encode(fraxusd, depositAddress, amount))).toEthSignedMessageHash();
+        bytes32 digestHash = keccak256(abi.encodePacked(fraxModule.REQUEST_ASYNC_WITHDRAW_SIG(), block.chainid, address(fraxModule), safe.nonce(), safe, abi.encode(fraxusd, depositAddress, amount))).toEthSignedMessageHash();
 
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Pk, digestHash);
         address[] memory signers = new address[](1);

--- a/test/safe/modules/frax/FraxModule.t.sol
+++ b/test/safe/modules/frax/FraxModule.t.sol
@@ -160,16 +160,14 @@ contract FraxModuleTest is SafeTestSetup {
 
         MessagingFee memory fee = fraxModule.quoteAsyncWithdraw(depositAddress, amountToWithdraw);
 
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Pk, digestHash);
-
-        bytes memory signature = abi.encodePacked(r, s, v);
+        (address[] memory signers, bytes[] memory signatures) = _signRequestAsync(digestHash);
 
         uint256 fraxUsdBalBefore = fraxusd.balanceOf(address(safe));
 
         vm.expectEmit(true, true, true, true);
         emit FraxModule.AsyncWithdrawalRequested(address(safe), amountToWithdraw, fraxModule.ETHEREUM_EID(), depositAddress);
 
-        fraxModule.requestAsyncWithdraw(address(safe), depositAddress, amountToWithdraw, owner1, signature);
+        fraxModule.requestAsyncWithdraw(address(safe), depositAddress, amountToWithdraw, signers, signatures);
 
         (uint64 withdrawalDelay,,) = cashModule.getDelays();
         vm.warp(block.timestamp + withdrawalDelay);
@@ -227,8 +225,7 @@ contract FraxModuleTest is SafeTestSetup {
 
         MessagingFee memory fee = fraxModule.quoteAsyncWithdraw(depositAddress, amount);
 
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Pk, digestHash);
-        bytes memory signature = abi.encodePacked(r, s, v);
+        (address[] memory signers, bytes[] memory signatures) = _signRequestAsync(digestHash);
 
         uint256 liquidAssetBalBefore = fraxusd.balanceOf(address(safe));
 
@@ -236,7 +233,7 @@ contract FraxModuleTest is SafeTestSetup {
         emit FraxModule.AsyncWithdrawalRequested(address(safe), amount, fraxModule.ETHEREUM_EID(), depositAddress);
         vm.expectEmit(true, true, true, true);
         emit FraxModule.AsyncWithdrawalExecuted(address(safe), amount, fraxModule.ETHEREUM_EID(), depositAddress);
-        fraxModule.requestAsyncWithdraw{ value: fee.nativeFee }(address(safe), depositAddress, amount, owner1, signature);
+        fraxModule.requestAsyncWithdraw{ value: fee.nativeFee }(address(safe), depositAddress, amount, signers, signatures);
 
         uint256 liquidAssetBalAfter = fraxusd.balanceOf(address(safe));
         assertEq(liquidAssetBalAfter, liquidAssetBalBefore - amount);
@@ -455,11 +452,10 @@ contract FraxModuleTest is SafeTestSetup {
 
         bytes32 digestHash = keccak256(abi.encodePacked(fraxModule.REQUEST_ASYNC_WITHDRAW_SIG(), block.chainid, address(fraxModule), fraxModule.getNonce(address(safe)), safe, abi.encode(fraxusd, depositAddress, amount))).toEthSignedMessageHash();
 
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Pk, digestHash);
-        bytes memory signature = abi.encodePacked(r, s, v);
+        (address[] memory signers, bytes[] memory signatures) = _signRequestAsync(digestHash);
 
         vm.expectRevert(ICashModule.InsufficientBalance.selector);
-        fraxModule.requestAsyncWithdraw(address(safe), depositAddress, amount, owner1, signature);
+        fraxModule.requestAsyncWithdraw(address(safe), depositAddress, amount, signers, signatures);
     }
 
     function test_requestAsyncWithdrawal_invalidInput() public {
@@ -468,22 +464,20 @@ contract FraxModuleTest is SafeTestSetup {
 
         bytes32 digestHash = keccak256(abi.encodePacked(fraxModule.REQUEST_ASYNC_WITHDRAW_SIG(), block.chainid, address(fraxModule), fraxModule.getNonce(address(safe)), safe, abi.encode(fraxusd, address(0), amount))).toEthSignedMessageHash();
 
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Pk, digestHash);
-        bytes memory signature = abi.encodePacked(r, s, v);
+        (address[] memory signers, bytes[] memory signatures) = _signRequestAsync(digestHash);
 
         vm.expectRevert(ModuleBase.InvalidInput.selector);
         //Test with zero address for depositAddress
-        fraxModule.requestAsyncWithdraw(address(safe), address(0), amount, owner1, signature);
+        fraxModule.requestAsyncWithdraw(address(safe), address(0), amount, signers, signatures);
 
         // Test with zero amount
         bytes32 digestHash1 = keccak256(abi.encodePacked(fraxModule.REQUEST_ASYNC_WITHDRAW_SIG(), block.chainid, address(fraxModule), fraxModule.getNonce(address(safe)), safe, abi.encode(fraxusd, depositAddress, 0))).toEthSignedMessageHash();
 
-        (uint8 v1, bytes32 r1, bytes32 s1) = vm.sign(owner1Pk, digestHash1);
-        bytes memory signature1 = abi.encodePacked(r1, s1, v1);
+        (address[] memory signers1, bytes[] memory signatures1) = _signRequestAsync(digestHash1);
 
         vm.expectRevert(ModuleBase.InvalidInput.selector);
         //Test with zero address for depositAddress
-        fraxModule.requestAsyncWithdraw(address(safe), depositAddress, 0, owner1, signature1);
+        fraxModule.requestAsyncWithdraw(address(safe), depositAddress, 0, signers1, signatures1);
     }
 
     function test_requestAsyncWithdrawal_revertsWithAmountContainingDust() public {
@@ -492,11 +486,10 @@ contract FraxModuleTest is SafeTestSetup {
 
         bytes32 digestHash = keccak256(abi.encodePacked(fraxModule.REQUEST_ASYNC_WITHDRAW_SIG(), block.chainid, address(fraxModule), fraxModule.getNonce(address(safe)), safe, abi.encode(fraxusd, depositAddress, amount))).toEthSignedMessageHash();
 
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Pk, digestHash);
-        bytes memory signature = abi.encodePacked(r, s, v);
+        (address[] memory signers, bytes[] memory signatures) = _signRequestAsync(digestHash);
 
         vm.expectRevert(FraxModule.AmountContainsDust.selector);
-        fraxModule.requestAsyncWithdraw(address(safe), depositAddress, amount, owner1, signature);
+        fraxModule.requestAsyncWithdraw(address(safe), depositAddress, amount, signers, signatures);
     }
 
     function test_requestAsyncWithdrawal_succeedsWithValidDustAmount() public {
@@ -506,12 +499,11 @@ contract FraxModuleTest is SafeTestSetup {
 
         bytes32 digestHash = keccak256(abi.encodePacked(fraxModule.REQUEST_ASYNC_WITHDRAW_SIG(), block.chainid, address(fraxModule), fraxModule.getNonce(address(safe)), safe, abi.encode(fraxusd, depositAddress, amount))).toEthSignedMessageHash();
 
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Pk, digestHash);
-        bytes memory signature = abi.encodePacked(r, s, v);
+        (address[] memory signers, bytes[] memory signatures) = _signRequestAsync(digestHash);
 
         vm.expectEmit(true, true, true, true);
         emit FraxModule.AsyncWithdrawalRequested(address(safe), amount, fraxModule.ETHEREUM_EID(), depositAddress);
-        fraxModule.requestAsyncWithdraw(address(safe), depositAddress, amount, owner1, signature);
+        fraxModule.requestAsyncWithdraw(address(safe), depositAddress, amount, signers, signatures);
     }
 
     function test_deposit_revertsWithInsufficientCustodianBalance() public {
@@ -598,11 +590,37 @@ contract FraxModuleTest is SafeTestSetup {
     function _requestAsyncWithdrawal(uint256 amount) internal {
         bytes32 digestHash = keccak256(abi.encodePacked(fraxModule.REQUEST_ASYNC_WITHDRAW_SIG(), block.chainid, address(fraxModule), fraxModule.getNonce(address(safe)), safe, abi.encode(fraxusd, depositAddress, amount))).toEthSignedMessageHash();
 
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Pk, digestHash);
-        bytes memory signature = abi.encodePacked(r, s, v);
+        (address[] memory signers, bytes[] memory signatures) = _signRequestAsync(digestHash);
 
         vm.expectEmit(true, true, true, true);
         emit FraxModule.AsyncWithdrawalRequested(address(safe), amount, 30_101, depositAddress);
-        fraxModule.requestAsyncWithdraw(address(safe), depositAddress, amount, owner1, signature);
+        fraxModule.requestAsyncWithdraw(address(safe), depositAddress, amount, signers, signatures);
+    }
+
+    function _signRequestAsync(bytes32 digestHash) internal view returns (address[] memory signers, bytes[] memory signatures) {
+        (uint8 v1, bytes32 r1, bytes32 s1) = vm.sign(owner1Pk, digestHash);
+        (uint8 v2, bytes32 r2, bytes32 s2) = vm.sign(owner2Pk, digestHash);
+        signers = new address[](2);
+        signers[0] = owner1;
+        signers[1] = owner2;
+        signatures = new bytes[](2);
+        signatures[0] = abi.encodePacked(r1, s1, v1);
+        signatures[1] = abi.encodePacked(r2, s2, v2);
+    }
+
+    function test_requestAsyncWithdraw_revertsWithSingleOwnerSignature() public {
+        uint256 amount = 1000 * 10 ** 18;
+        deal(address(fraxusd), address(safe), amount);
+
+        bytes32 digestHash = keccak256(abi.encodePacked(fraxModule.REQUEST_ASYNC_WITHDRAW_SIG(), block.chainid, address(fraxModule), fraxModule.getNonce(address(safe)), safe, abi.encode(fraxusd, depositAddress, amount))).toEthSignedMessageHash();
+
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Pk, digestHash);
+        address[] memory signers = new address[](1);
+        signers[0] = owner1;
+        bytes[] memory signatures = new bytes[](1);
+        signatures[0] = abi.encodePacked(r, s, v);
+
+        vm.expectRevert();
+        fraxModule.requestAsyncWithdraw(address(safe), depositAddress, amount, signers, signatures);
     }
 }

--- a/test/safe/modules/frax/FraxVerifyBytecode.t.sol
+++ b/test/safe/modules/frax/FraxVerifyBytecode.t.sol
@@ -19,12 +19,13 @@ contract FraxVerifyBytecode is ContractCodeChecker, Test {
         vm.createSelectFork(scrollRpc);
     }
 
+    // FraxModule source updated; re-enable after redeploy and updating `fraxModuleDeployment`.
     function test_fraxModule_verifyBytecode() public {
-        FraxModule fraxModule = new FraxModule(dataProvider, fraxusd, custodian, remoteHop);
-
-        console.log("-------------- FraxModule ----------------");
-        emit log_named_address("New deploy", address(fraxModule));
-        emit log_named_address("Verifying contract", address(fraxModuleDeployment));
-        verifyContractByteCodeMatch(address(fraxModuleDeployment), address(fraxModule));
+        vm.skip(true);
+        // FraxModule fraxModule = new FraxModule(dataProvider, fraxusd, custodian, remoteHop);
+        // console.log("-------------- FraxModule ----------------");
+        // emit log_named_address("New deploy", address(fraxModule));
+        // emit log_named_address("Verifying contract", address(fraxModuleDeployment));
+        // verifyContractByteCodeMatch(address(fraxModuleDeployment), address(fraxModule));
     }
 }

--- a/test/upgrade-bytecode-verification/VerifyOPMainnet.t.sol
+++ b/test/upgrade-bytecode-verification/VerifyOPMainnet.t.sol
@@ -304,6 +304,7 @@ contract VerifyOPMainnetBytecode is ContractCodeChecker, Utils {
     }
 
     function test_verifyBytecode_FraxModule() public {
+        vm.skip(true); // TODO: local impl intentionally differs from deployed until redeploy
         address local = address(new FraxModule(dataProviderProxy, cc.fraxusd, cc.fraxCustodian, cc.fraxRemoteHop));
         _verify("FraxModule", fraxModule, local);
     }


### PR DESCRIPTION
Modified the requestAsyncWithdraw function in FraxModule to accept an array of signers and their corresponding signatures, enhancing the security by requiring a quorum of signatures for withdrawal requests. Updated related tests to reflect these changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Authorization for cross-chain async withdrawals to arbitrary recipients is stricter (breaking API for integrators) and changes on-chain FraxModule bytecode; deploy/oracle config changes affect production setup until redeploy.
> 
> **Overview**
> **Frax async withdrawals** now require **Safe owner quorum** instead of a single admin signature. `requestAsyncWithdraw` takes `signers` and `signatures` arrays and validates them with `IEtherFiSafe.checkSignatures`, matching flows like `cancelAsyncWithdraw` and other bridge modules where funds leave to an external recipient.
> 
> The async-withdraw digest now uses **`IEtherFiSafe(safe).useNonce()`** for the nonce field (tests and helpers updated accordingly). A test asserts that **one owner signature is not enough**.
> 
> **Deploy script** changes: switches to **PriceProviderV2** (`isStableToken` + `baseAsset`), updates Frax-related **contract addresses**, and makes **DebtManager** collateral/borrow setup **idempotent** with `isCollateralToken` / `isBorrowToken` guards.
> 
> **Bytecode verification** for `FraxModule` is **skipped** in Scroll and OP mainnet tests until redeploy updates deployed addresses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 312edf927e6344caf95dff7d7642aeb9106fe9a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->