### PR TITLE
feat: repoint CashModule spend and repay to the Aave gateway

### DIFF
--- a/src/interfaces/ICashEventEmitter.sol
+++ b/src/interfaces/ICashEventEmitter.sol
@@ -26,6 +26,13 @@ interface ICashEventEmitter {
     function emitSettlementDispatcherUpdated(BinSponsor binSponsor, address oldDispatcher, address newDispatcher) external;
 
     /**
+     * @notice Emits the GatewayUpdated event
+     * @param oldGateway Address of the previous gateway
+     * @param newGateway Address of the new gateway
+     */
+    function emitGatewayUpdated(address oldGateway, address newGateway) external;
+
+    /**
      * @notice Emits an event when pending cashback is cleared
      * @param recipient Address receiving the cashback
      * @param cashbackToken Address of the cashback token

--- a/src/interfaces/ICashModule.sol
+++ b/src/interfaces/ICashModule.sol
@@ -5,6 +5,7 @@ import { EnumerableSetLib } from "solady/utils/EnumerableSetLib.sol";
 
 import { IDebtManager } from "../interfaces/IDebtManager.sol";
 import { IEtherFiDataProvider } from "../interfaces/IEtherFiDataProvider.sol";
+import { IGateway } from "../interfaces/IGateway.sol";
 import { IPriceProvider } from "../interfaces/IPriceProvider.sol";
 import { SpendingLimit, SpendingLimitLib } from "../libraries/SpendingLimitLib.sol";
 
@@ -333,6 +334,12 @@ interface ICashModule {
     function getSettlementDispatcher(BinSponsor binSponsor) external view returns (address settlementDispatcher);
 
     /**
+     * @notice Returns the Aave gateway contract
+     * @return Gateway instance
+     */
+    function getGateway() external view returns (IGateway);
+
+    /**
      * @notice Returns the EtherFiDataProvider contract reference
      * @dev Used to access global system configuration and services
      * @return The EtherFiDataProvider contract instance
@@ -476,6 +483,15 @@ interface ICashModule {
      * @custom:throws InvalidInput if caller doesn't have the controller role
      */
     function setSettlementDispatcher(BinSponsor binSponsor, address dispatcher) external;
+
+    /**
+     * @notice Sets the Aave gateway address
+     * @dev Only callable by accounts with CASH_MODULE_CONTROLLER_ROLE
+     * @param gateway Address of the gateway contract
+     * @custom:throws OnlyCashModuleController if caller doesn't have the controller role
+     * @custom:throws InvalidInput if gateway = address(0)
+     */
+    function setGateway(address gateway) external;
 
     /**
      * @notice Sets the tier for one or more safes

--- a/src/interfaces/ICashModule.sol
+++ b/src/interfaces/ICashModule.sol
@@ -272,6 +272,9 @@ interface ICashModule {
     /// @notice Error thrown when a withdrawal request is made by an invalid address or to an invalid recipient
     error InvalidWithdrawRequest();
 
+    /// @notice Error thrown when attempting to configure the Aave gateway after the initial bootstrap
+    error GatewayAlreadySet();
+
     /**
      * @notice Role identifier for EtherFi wallet access control
      * @return The role identifier as bytes32
@@ -485,11 +488,12 @@ interface ICashModule {
     function setSettlementDispatcher(BinSponsor binSponsor, address dispatcher) external;
 
     /**
-     * @notice Sets the Aave gateway address
-     * @dev Only callable by accounts with CASH_MODULE_CONTROLLER_ROLE
+     * @notice Sets the Aave gateway address for the initial Lend deployment
+     * @dev Only callable by accounts with CASH_MODULE_CONTROLLER_ROLE while no gateway is configured
      * @param gateway Address of the gateway contract
      * @custom:throws OnlyCashModuleController if caller doesn't have the controller role
      * @custom:throws InvalidInput if gateway = address(0)
+     * @custom:throws GatewayAlreadySet if the gateway has already been configured
      */
     function setGateway(address gateway) external;
 

--- a/src/interfaces/ICashModule.sol
+++ b/src/interfaces/ICashModule.sol
@@ -207,9 +207,6 @@ interface ICashModule {
     /// @notice Error thrown when a balance is insufficient for an operation
     error InsufficientBalance();
 
-    /// @notice Error thrown when borrowings would exceed maximum allowed after a spending operation
-    error BorrowingsExceedMaxBorrowAfterSpending();
-
     /// @notice Error thrown when a recipient address is zero
     error RecipientCannotBeAddressZero();
 

--- a/src/libraries/DebitHeadroomLib.sol
+++ b/src/libraries/DebitHeadroomLib.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+
+import { IGateway } from "../interfaces/IGateway.sol";
+import { IPriceProvider } from "../interfaces/IPriceProvider.sol";
+
+/**
+ * @title DebitHeadroomLib
+ * @notice Shared debit-sizing math for the Cash contracts: how much of a token's Aave-supplied balance can fund
+ *         a debit without pushing the safe past its LTV max borrow, and how much borrowing headroom a supplied
+ *         withdrawal consumes. CashModuleCore (execution) and CashLens (canSpend) both call it so the two agree.
+ * @author ether.fi
+ */
+library DebitHeadroomLib {
+    /// @dev The gateway reports LTV on the 100e18 = 100% scale (see IGateway.ltv)
+    uint256 internal constant LTV_SCALE = 100e18;
+
+    /**
+     * @notice Amount of `token` withdrawable from `safe`'s Aave-supplied balance to fund a debit
+     * @dev min(supplied, reserve cash); when the safe carries debt this is further capped by the borrowing
+     *      headroom, and is zero for a zero-LTV reserve (no borrow weight, so it cannot be sized against debt).
+     */
+    function withdrawableSupplied(IGateway gateway, IPriceProvider priceProvider, address safe, address token, uint256 borrowHeadroomUsd, bool hasDebt) internal view returns (uint256) {
+        uint256 supplied = gateway.suppliedOf(safe, token);
+        uint256 cash = gateway.availableCash(token);
+        uint256 cap = supplied < cash ? supplied : cash;
+
+        if (hasDebt) {
+            uint256 tokenLtv = gateway.ltv(token);
+            if (tokenLtv == 0) {
+                return 0;
+            }
+            uint256 headroomCap = _fromUsd(priceProvider, token, (borrowHeadroomUsd * LTV_SCALE) / tokenLtv);
+            if (headroomCap < cap) {
+                cap = headroomCap;
+            }
+        }
+
+        return cap;
+    }
+
+    /// @notice Borrowing headroom (USD) consumed by withdrawing `amount` of `token`: its USD value weighted by the LTV
+    function headroomConsumed(IGateway gateway, IPriceProvider priceProvider, address token, uint256 amount) internal view returns (uint256) {
+        return (_toUsd(priceProvider, token, amount) * gateway.ltv(token)) / LTV_SCALE;
+    }
+
+    function _toUsd(IPriceProvider priceProvider, address token, uint256 amount) private view returns (uint256) {
+        return (amount * priceProvider.price(token)) / (10 ** IERC20Metadata(token).decimals());
+    }
+
+    function _fromUsd(IPriceProvider priceProvider, address token, uint256 usd) private view returns (uint256) {
+        return (usd * (10 ** IERC20Metadata(token).decimals())) / priceProvider.price(token);
+    }
+}

--- a/src/libraries/DebitSourcingLib.sol
+++ b/src/libraries/DebitSourcingLib.sol
@@ -7,13 +7,13 @@ import { IGateway } from "../interfaces/IGateway.sol";
 import { IPriceProvider } from "../interfaces/IPriceProvider.sol";
 
 /**
- * @title DebitHeadroomLib
+ * @title DebitSourcingLib
  * @notice Shared debit-sizing math for the Cash contracts: how much of a token's Aave-supplied balance can fund
  *         a debit without pushing the safe past its LTV max borrow, and how much borrowing headroom a supplied
  *         withdrawal consumes. CashModuleCore (execution) and CashLens (canSpend) both call it so the two agree.
  * @author ether.fi
  */
-library DebitHeadroomLib {
+library DebitSourcingLib {
     /// @dev The gateway reports LTV on the 100e18 = 100% scale (see IGateway.ltv)
     uint256 internal constant LTV_SCALE = 100e18;
 
@@ -46,10 +46,12 @@ library DebitHeadroomLib {
         return (_toUsd(priceProvider, token, amount) * gateway.ltv(token)) / LTV_SCALE;
     }
 
+    /// @dev USD value of `amount` of `token` at its current price, on PriceProvider's USD scale
     function _toUsd(IPriceProvider priceProvider, address token, uint256 amount) private view returns (uint256) {
         return (amount * priceProvider.price(token)) / (10 ** IERC20Metadata(token).decimals());
     }
 
+    /// @dev Amount of `token` worth `usd` at its current price, inverting _toUsd
     function _fromUsd(IPriceProvider priceProvider, address token, uint256 usd) private view returns (uint256) {
         return (usd * (10 ** IERC20Metadata(token).decimals())) / priceProvider.price(token);
     }

--- a/src/mocks/MockGateway.sol
+++ b/src/mocks/MockGateway.sol
@@ -30,6 +30,14 @@ contract MockGateway is IGateway {
     Call public lastBorrow;
     Call public lastRepay;
 
+    /// @notice When set, borrow reverts, to model a blocked borrow (e.g. insufficient Aave collateral)
+    bool public borrowReverts;
+
+    /// @notice Toggles the borrow revert
+    function setBorrowReverts(bool value) external {
+        borrowReverts = value;
+    }
+
     /// @notice Sets the account data a subsequent `getAccountData(safe)` will return
     function setAccountData(address safe, AccountData calldata data) external {
         _accountData[safe] = data;
@@ -64,6 +72,7 @@ contract MockGateway is IGateway {
     }
 
     function borrow(address safe, address asset, uint256 amount, address to) external {
+        if (borrowReverts) revert("MockGateway: borrow blocked");
         lastBorrow = Call(safe, asset, amount, to);
     }
 

--- a/src/mocks/MockGateway.sol
+++ b/src/mocks/MockGateway.sol
@@ -77,8 +77,11 @@ contract MockGateway is IGateway {
     }
 
     function repay(address safe, address asset, uint256 amount) external returns (uint256) {
-        lastRepay = Call(safe, asset, amount, address(0));
-        return amount;
+        uint256 debt = _debtOf[safe][asset];
+        uint256 repaid = amount < debt ? amount : debt;
+        _debtOf[safe][asset] = debt - repaid;
+        lastRepay = Call(safe, asset, repaid, address(0));
+        return repaid;
     }
 
     function setUsingAsCollateral(address safe, address asset, bool useAsCollateral) external {

--- a/src/mocks/MockGateway.sol
+++ b/src/mocks/MockGateway.sol
@@ -10,6 +10,9 @@ import { IGateway } from "../interfaces/IGateway.sol";
  *         assertions. Not for production.
  */
 contract MockGateway is IGateway {
+    /// @notice Thrown when the mock is configured to reject borrow calls
+    error BorrowBlocked();
+
     /// @notice Recorded arguments of a mutating gateway call (`to` is zero for supply/repay)
     struct Call {
         address safe;
@@ -72,7 +75,7 @@ contract MockGateway is IGateway {
     }
 
     function borrow(address safe, address asset, uint256 amount, address to) external {
-        if (borrowReverts) revert("MockGateway: borrow blocked");
+        if (borrowReverts) revert BorrowBlocked();
         lastBorrow = Call(safe, asset, amount, to);
     }
 

--- a/src/mocks/MockGateway.sol
+++ b/src/mocks/MockGateway.sol
@@ -83,7 +83,7 @@ contract MockGateway is IGateway {
         uint256 debt = _debtOf[safe][asset];
         uint256 repaid = amount < debt ? amount : debt;
         _debtOf[safe][asset] = debt - repaid;
-        lastRepay = Call(safe, asset, repaid, address(0));
+        lastRepay = Call(safe, asset, amount, address(0));
         return repaid;
     }
 

--- a/src/modules/cash/CashEventEmitter.sol
+++ b/src/modules/cash/CashEventEmitter.sol
@@ -175,6 +175,13 @@ contract CashEventEmitter is UpgradeableProxy {
      * @param newDispatcher Address of the new dispatcher for the bin sponsor
      */
     event SettlementDispatcheUpdated(BinSponsor binSponsor, address oldDispatcher, address newDispatcher);
+
+    /**
+     * @notice Emitted when the gateway is updated
+     * @param oldGateway Address of the previous gateway
+     * @param newGateway Address of the new gateway
+     */
+    event GatewayUpdated(address oldGateway, address newGateway);
     
     /**
      * @notice Emitted when the withdrawal tokens are updated
@@ -217,6 +224,15 @@ contract CashEventEmitter is UpgradeableProxy {
      */
     function emitSettlementDispatcherUpdated(BinSponsor binSponsor, address oldDispatcher, address newDispatcher) external onlyCashModule {
         emit SettlementDispatcheUpdated(binSponsor, oldDispatcher, newDispatcher);
+    }
+
+    /**
+     * @notice Emits the GatewayUpdated event
+     * @param oldGateway Address of the previous gateway
+     * @param newGateway Address of the new gateway
+     */
+    function emitGatewayUpdated(address oldGateway, address newGateway) external onlyCashModule {
+        emit GatewayUpdated(oldGateway, newGateway);
     }
 
     /**

--- a/src/modules/cash/CashLens.sol
+++ b/src/modules/cash/CashLens.sol
@@ -10,7 +10,7 @@ import { IDebtManager } from "../../interfaces/IDebtManager.sol";
 import { IEtherFiDataProvider } from "../../interfaces/IEtherFiDataProvider.sol";
 import { IGateway } from "../../interfaces/IGateway.sol";
 import { IPriceProvider } from "../../interfaces/IPriceProvider.sol";
-import { DebitHeadroomLib } from "../../libraries/DebitHeadroomLib.sol";
+import { DebitSourcingLib } from "../../libraries/DebitSourcingLib.sol";
 import { SpendingLimit, SpendingLimitLib } from "../../libraries/SpendingLimitLib.sol";
 import { UpgradeableProxy } from "../../utils/UpgradeableProxy.sol";
 
@@ -483,12 +483,12 @@ contract CashLens is UpgradeableProxy {
      *      of this reserve can be withdrawn before the leftover debt exceeds its borrowing power, via its LTV.
      */
     function _withdrawableSupplied(address safe, address token, uint256 borrowHeadroomUsd, bool hasDebt) internal view returns (uint256) {
-        return DebitHeadroomLib.withdrawableSupplied(gateway, IPriceProvider(dataProvider.getPriceProvider()), safe, token, borrowHeadroomUsd, hasDebt);
+        return DebitSourcingLib.withdrawableSupplied(gateway, IPriceProvider(dataProvider.getPriceProvider()), safe, token, borrowHeadroomUsd, hasDebt);
     }
 
     /// @notice Borrowing headroom (USD) consumed by withdrawing `amount` of `token`: its USD value weighted by the LTV
     function _headroomConsumed(address token, uint256 amount) internal view returns (uint256) {
-        return DebitHeadroomLib.headroomConsumed(gateway, IPriceProvider(dataProvider.getPriceProvider()), token, amount);
+        return DebitSourcingLib.headroomConsumed(gateway, IPriceProvider(dataProvider.getPriceProvider()), token, amount);
     }
 
     /// @notice Debit spendable for `token` (token units) given the running borrowing headroom, and the headroom that withdrawal consumes

--- a/src/modules/cash/CashLens.sol
+++ b/src/modules/cash/CashLens.sol
@@ -42,8 +42,6 @@ contract CashLens is UpgradeableProxy {
     ICashModule public immutable cashModule;
     /// @notice Reference to the deployed EtherFiDataProvider contract
     IEtherFiDataProvider public immutable dataProvider;
-    /// @notice Reference to the Aave gateway that holds the Safe's position
-    IGateway public immutable gateway;
 
     /// @notice Error thrown when trying to use a token that is not on the collateral whitelist
     error NotACollateralToken();
@@ -54,12 +52,10 @@ contract CashLens is UpgradeableProxy {
      * @notice Initializes the CashLens contract with its dependencies
      * @param _cashModule Address of the deployed CashModule contract
      * @param _dataProvider Address of the deployed EtherFiDataProvider contract
-     * @param _gateway Address of the Aave gateway
      */
-    constructor(address _cashModule, address _dataProvider, address _gateway) {
+    constructor(address _cashModule, address _dataProvider) {
         cashModule = ICashModule(_cashModule);
         dataProvider = IEtherFiDataProvider(_dataProvider);
-        gateway = IGateway(_gateway);
 
         _disableInitializers();
     }
@@ -71,6 +67,11 @@ contract CashLens is UpgradeableProxy {
      */
     function initialize(address _roleRegistry) external initializer {
         __UpgradeableProxy_init(_roleRegistry);
+    }
+
+    /// @notice Returns the Aave gateway currently configured on CashModule
+    function gateway() public view returns (IGateway) {
+        return cashModule.getGateway();
     }
 
     /**
@@ -180,12 +181,13 @@ contract CashLens is UpgradeableProxy {
             return (false, "Not a supported borrow token");
         }
 
-        if (gateway.availableCash(token) < _fromUsd(token, totalSpendingInUsd)) {
+        IGateway lendGateway = cashModule.getGateway();
+        if (lendGateway.availableCash(token) < _fromUsd(token, totalSpendingInUsd)) {
             return (false, "Insufficient liquidity to cover the loan");
         }
 
         // availableBorrowsUsd is the supplied position's capacity; a pending sits against the loose balance, so it is not deducted here
-        if (totalSpendingInUsd > gateway.getAccountData(safe).availableBorrowsUsd) {
+        if (totalSpendingInUsd > lendGateway.getAccountData(safe).availableBorrowsUsd) {
             return (false, "Insufficient borrowing power");
         }
 
@@ -195,9 +197,13 @@ contract CashLens is UpgradeableProxy {
     /// @notice Debit mode check: each token's spendable amount must cover its share of the spend, threading the borrowing headroom across tokens
     function _debitCheck(address safe, address[] memory tokens, uint256[] memory amountsInUsd, SafeData memory safeData) internal view returns (bool, string memory) {
         IDebtManager debtManager = cashModule.getDebtManager();
-        IGateway.AccountData memory account = gateway.getAccountData(safe);
-        bool hasDebt = account.debtUsd != 0;
-        uint256 borrowHeadroom = hasDebt ? account.availableBorrowsUsd : 0;
+        bool hasDebt;
+        uint256 borrowHeadroom;
+        {
+            IGateway.AccountData memory account = gateway().getAccountData(safe);
+            hasDebt = account.debtUsd != 0;
+            borrowHeadroom = hasDebt ? account.availableBorrowsUsd : 0;
+        }
 
         for (uint256 i = 0; i < tokens.length; i++) {
             address token = tokens[i];
@@ -255,7 +261,7 @@ contract CashLens is UpgradeableProxy {
         IDebtManager debtManager = cashModule.getDebtManager();
         IPriceProvider priceProvider = IPriceProvider(dataProvider.getPriceProvider());
         SafeData memory safeData = cashModule.getData(safe);
-        IGateway.AccountData memory account = gateway.getAccountData(safe);
+        IGateway.AccountData memory account = gateway().getAccountData(safe);
 
         SafeCashData memory data;
 
@@ -328,7 +334,7 @@ contract CashLens is UpgradeableProxy {
         bool hasDebt;
         uint256 borrowHeadroom;
         {
-            IGateway.AccountData memory account = gateway.getAccountData(safe);
+            IGateway.AccountData memory account = gateway().getAccountData(safe);
             hasDebt = account.debtUsd != 0;
             if (hasDebt) {
                 borrowHeadroom = account.availableBorrowsUsd;
@@ -369,12 +375,13 @@ contract CashLens is UpgradeableProxy {
      * @return Maximum amount that can be spent in credit mode (USD, 6 decimals)
      */
     function getMaxSpendCredit(address safe) public view returns (uint256) {
-        uint256 borrowPower = gateway.getAccountData(safe).availableBorrowsUsd;
+        IGateway lendGateway = cashModule.getGateway();
+        uint256 borrowPower = lendGateway.getAccountData(safe).availableBorrowsUsd;
 
         address[] memory borrowTokens = cashModule.getDebtManager().getBorrowTokens();
         uint256 maxLiquidityUsd = 0;
         for (uint256 i = 0; i < borrowTokens.length;) {
-            uint256 liquidityUsd = _toUsd(borrowTokens[i], gateway.availableCash(borrowTokens[i]));
+            uint256 liquidityUsd = _toUsd(borrowTokens[i], lendGateway.availableCash(borrowTokens[i]));
             if (liquidityUsd > maxLiquidityUsd) {
                 maxLiquidityUsd = liquidityUsd;
             }
@@ -483,12 +490,12 @@ contract CashLens is UpgradeableProxy {
      *      of this reserve can be withdrawn before the leftover debt exceeds its borrowing power, via its LTV.
      */
     function _withdrawableSupplied(address safe, address token, uint256 borrowHeadroomUsd, bool hasDebt) internal view returns (uint256) {
-        return DebitSourcingLib.withdrawableSupplied(gateway, IPriceProvider(dataProvider.getPriceProvider()), safe, token, borrowHeadroomUsd, hasDebt);
+        return DebitSourcingLib.withdrawableSupplied(gateway(), IPriceProvider(dataProvider.getPriceProvider()), safe, token, borrowHeadroomUsd, hasDebt);
     }
 
     /// @notice Borrowing headroom (USD) consumed by withdrawing `amount` of `token`: its USD value weighted by the LTV
     function _headroomConsumed(address token, uint256 amount) internal view returns (uint256) {
-        return DebitSourcingLib.headroomConsumed(gateway, IPriceProvider(dataProvider.getPriceProvider()), token, amount);
+        return DebitSourcingLib.headroomConsumed(gateway(), IPriceProvider(dataProvider.getPriceProvider()), token, amount);
     }
 
     /// @notice Debit spendable for `token` (token units) given the running borrowing headroom, and the headroom that withdrawal consumes
@@ -515,10 +522,11 @@ contract CashLens is UpgradeableProxy {
 
     /// @notice Per-token supplied position in the Safe's Aave account, skipping zero balances
     function _suppliedBalances(address safe, address[] memory tokens) internal view returns (IDebtManager.TokenData[] memory) {
+        IGateway lendGateway = cashModule.getGateway();
         IDebtManager.TokenData[] memory out = new IDebtManager.TokenData[](tokens.length);
         uint256 m = 0;
         for (uint256 i = 0; i < tokens.length;) {
-            uint256 amount = gateway.suppliedOf(safe, tokens[i]);
+            uint256 amount = lendGateway.suppliedOf(safe, tokens[i]);
             if (amount != 0) {
                 out[m] = IDebtManager.TokenData({ token: tokens[i], amount: amount });
                 unchecked {
@@ -539,10 +547,11 @@ contract CashLens is UpgradeableProxy {
 
     /// @notice Per-token debt in the Safe's Aave account, skipping zero balances
     function _debtBalances(address safe, address[] memory tokens) internal view returns (IDebtManager.TokenData[] memory) {
+        IGateway lendGateway = cashModule.getGateway();
         IDebtManager.TokenData[] memory out = new IDebtManager.TokenData[](tokens.length);
         uint256 m = 0;
         for (uint256 i = 0; i < tokens.length;) {
-            uint256 amount = gateway.debtOf(safe, tokens[i]);
+            uint256 amount = lendGateway.debtOf(safe, tokens[i]);
             if (amount != 0) {
                 out[m] = IDebtManager.TokenData({ token: tokens[i], amount: amount });
                 unchecked {

--- a/src/modules/cash/CashLens.sol
+++ b/src/modules/cash/CashLens.sol
@@ -10,6 +10,7 @@ import { IDebtManager } from "../../interfaces/IDebtManager.sol";
 import { IEtherFiDataProvider } from "../../interfaces/IEtherFiDataProvider.sol";
 import { IGateway } from "../../interfaces/IGateway.sol";
 import { IPriceProvider } from "../../interfaces/IPriceProvider.sol";
+import { DebitHeadroomLib } from "../../libraries/DebitHeadroomLib.sol";
 import { SpendingLimit, SpendingLimitLib } from "../../libraries/SpendingLimitLib.sol";
 import { UpgradeableProxy } from "../../utils/UpgradeableProxy.sol";
 
@@ -43,9 +44,6 @@ contract CashLens is UpgradeableProxy {
     IEtherFiDataProvider public immutable dataProvider;
     /// @notice Reference to the Aave gateway that holds the Safe's position
     IGateway public immutable gateway;
-
-    /// @notice Percentage denominator (100e18 = 100%), matching the gateway's ltv scale and DebtManager's CollateralTokenConfig.ltv
-    uint256 internal constant HUNDRED_PERCENT = 100e18;
 
     /// @notice Error thrown when trying to use a token that is not on the collateral whitelist
     error NotACollateralToken();
@@ -485,28 +483,12 @@ contract CashLens is UpgradeableProxy {
      *      of this reserve can be withdrawn before the leftover debt exceeds its borrowing power, via its LTV.
      */
     function _withdrawableSupplied(address safe, address token, uint256 borrowHeadroomUsd, bool hasDebt) internal view returns (uint256) {
-        uint256 supplied = gateway.suppliedOf(safe, token);
-        uint256 cash = gateway.availableCash(token);
-        uint256 cap = supplied < cash ? supplied : cash;
-
-        if (hasDebt) {
-            uint256 ltv = gateway.ltv(token);
-            // A zero-LTV reserve has no borrow weight, so a withdrawal against debt cannot be sized safely; stay conservative
-            if (ltv == 0) {
-                return 0;
-            }
-            uint256 headroomCap = _fromUsd(token, (borrowHeadroomUsd * HUNDRED_PERCENT) / ltv);
-            if (headroomCap < cap) {
-                cap = headroomCap;
-            }
-        }
-
-        return cap;
+        return DebitHeadroomLib.withdrawableSupplied(gateway, IPriceProvider(dataProvider.getPriceProvider()), safe, token, borrowHeadroomUsd, hasDebt);
     }
 
     /// @notice Borrowing headroom (USD) consumed by withdrawing `amount` of `token`: its USD value weighted by the LTV
     function _headroomConsumed(address token, uint256 amount) internal view returns (uint256) {
-        return (_toUsd(token, amount) * gateway.ltv(token)) / HUNDRED_PERCENT;
+        return DebitHeadroomLib.headroomConsumed(gateway, IPriceProvider(dataProvider.getPriceProvider()), token, amount);
     }
 
     /// @notice Debit spendable for `token` (token units) given the running borrowing headroom, and the headroom that withdrawal consumes

--- a/src/modules/cash/CashModuleCore.sol
+++ b/src/modules/cash/CashModuleCore.sol
@@ -429,17 +429,19 @@ contract CashModuleCore is CashModuleStorageContract {
 
         // A pending withdrawal reserves loose balance. Prefer the unreserved portion plus the supplied
         // withdrawal so the request survives (matching CashLens); dip into the reserved portion, cancelling
-        // the request, only when the spend cannot be funded otherwise.
+        // the request, only when the spend cannot be funded otherwise. Dipping implies the request holds
+        // this token (unreserved < loose requires pending > 0), so the cancel is unconditional there.
+        uint256 fromLoose;
         {
             uint256 pending = getPendingWithdrawalAmount(safe, token);
             uint256 unreserved = loose > pending ? loose - pending : 0;
             if (unreserved + withdrawable >= amount) {
-                loose = unreserved;
+                fromLoose = unreserved < amount ? unreserved : amount;
+            } else {
+                fromLoose = loose < amount ? loose : amount;
+                _cancelOldWithdrawal(safe);
             }
         }
-
-        uint256 fromLoose = loose < amount ? loose : amount;
-        _cancelWithdrawalRequestIfNecessary(safe, token, fromLoose);
 
         // The supplied portion drawn for this token consumes borrowing headroom for later tokens.
         if (hasDebt) {
@@ -594,7 +596,7 @@ contract CashModuleCore is CashModuleStorageContract {
             amount = debt;
         }
         if (amount == 0) revert AmountZero();
-        _cancelWithdrawalRequestIfNecessary(safe, token, amount);
+        _cancelConflictingWithdrawal(safe, token, amount);
 
         // Gateway repays the safe's Aave debt on its behalf, pulling the repay token from the safe.
         // Full repays pass the max sentinel so no interest dust survives the exact-amount rounding.

--- a/src/modules/cash/CashModuleCore.sol
+++ b/src/modules/cash/CashModuleCore.sol
@@ -362,12 +362,7 @@ contract CashModuleCore is CashModuleStorageContract {
         address dispatcher = getSettlementDispatcher(binSponsor);
 
         // Gateway borrows against the safe's Aave position and forwards the borrowed token to the dispatcher.
-        // Retry once after clearing a stale withdrawal request if the first attempt reverts.
-        try $.gateway.borrow(safe, tokens[0], amount, dispatcher) { }
-        catch {
-            _cancelOldWithdrawal(safe);
-            $.gateway.borrow(safe, tokens[0], amount, dispatcher);
-        }
+        $.gateway.borrow(safe, tokens[0], amount, dispatcher);
 
         uint256[] memory amounts = new uint256[](1);
         amounts[0] = amount;
@@ -376,7 +371,8 @@ contract CashModuleCore is CashModuleStorageContract {
     }
 
     /**
-     * @dev Internal function to execute debit mode spending transactions (multiple tokens)
+     * @dev Debit spend across tokens: spend the safe's loose balance first, then withdraw the
+     *      Aave-supplied balance for any shortfall, both routed to the settlement dispatcher.
      * @param $ Storage reference to the CashModuleStorage
      * @param safe Address of the EtherFi Safe
      * @param txId Transaction identifier
@@ -384,42 +380,65 @@ contract CashModuleCore is CashModuleStorageContract {
      * @param amountsInUsd Array of amounts to spend in USD
      */
     function _spendDebit(CashModuleStorage storage $, address safe, bytes32 txId, BinSponsor binSponsor, address[] calldata tokens, uint256[] calldata amountsInUsd, uint256 totalSpendingInUsd) internal {
-        uint256[] memory amounts = new uint256[](tokens.length);
+        (uint256[] memory amounts, uint256[] memory fromLoose) = _sourceDebit($, safe, tokens, amountsInUsd);
 
-        // Convert USD amounts to token amounts and validate
+        address dispatcher = getSettlementDispatcher(binSponsor);
+        _transferLoose(safe, dispatcher, tokens, fromLoose);
+
+        bool withdrew;
         for (uint256 i = 0; i < tokens.length; i++) {
-            if (!_isBorrowToken($.debtManager, tokens[i])) revert UnsupportedToken();
-            amounts[i] = $.debtManager.convertUsdToCollateralToken(tokens[i], amountsInUsd[i]);
-            if (IERC20(tokens[i]).balanceOf(safe) < amounts[i]) revert InsufficientBalance();
-
-            _cancelWithdrawalRequestIfNecessary(safe, tokens[i], amounts[i]);
+            uint256 fromSupplied = amounts[i] - fromLoose[i];
+            if (fromSupplied != 0) {
+                $.gateway.withdraw(safe, tokens[i], fromSupplied, dispatcher);
+                withdrew = true;
+            }
         }
-
-        _spendDebit(safe, binSponsor, tokens, amounts);
 
         $.cashEventEmitter.emitSpend(safe, txId, binSponsor, tokens, amounts, amountsInUsd, totalSpendingInUsd, Mode.Debit);
 
-        // Ensuring the account is healthy
-        // If account is unhealthy after spend, cancel withdrawal and try again
-        try $.debtManager.ensureHealth(safe) { }
-        catch {
-            _cancelOldWithdrawal(safe);
-            $.debtManager.ensureHealth(safe);
+        // Only an Aave withdrawal can worsen the position; a loose-only spend leaves it untouched. After a
+        // withdrawal, a safe that still carries debt must stay within its LTV-based max borrow.
+        if (withdrew) {
+            IGateway.AccountData memory account = $.gateway.getAccountData(safe);
+            if (account.debtUsd != 0 && account.availableBorrowsUsd == 0) revert BorrowingsExceedMaxBorrowAfterSpending();
         }
     }
 
-    function _spendDebit(address safe, BinSponsor binSponsor, address[] calldata tokens, uint256[] memory amounts) internal {
-        // Execute transfers to settlement dispatcher for all tokens
+    /// @dev Per token, converts the USD amount, checks loose + withdrawable-supplied covers it, and frees a stale withdrawal against the loose portion. Returns the token amounts and the loose portion of each.
+    function _sourceDebit(CashModuleStorage storage $, address safe, address[] calldata tokens, uint256[] calldata amountsInUsd) internal returns (uint256[] memory, uint256[] memory) {
+        uint256[] memory amounts = new uint256[](tokens.length);
+        uint256[] memory fromLoose = new uint256[](tokens.length);
+
+        for (uint256 i = 0; i < tokens.length; i++) {
+            if (!_isBorrowToken($.debtManager, tokens[i])) revert UnsupportedToken();
+            amounts[i] = $.debtManager.convertUsdToCollateralToken(tokens[i], amountsInUsd[i]);
+
+            uint256 loose = IERC20(tokens[i]).balanceOf(safe);
+            if (loose + _withdrawableSupplied($.gateway, safe, tokens[i]) < amounts[i]) revert InsufficientBalance();
+
+            fromLoose[i] = loose < amounts[i] ? loose : amounts[i];
+            // A pending withdrawal reserves the loose balance; free it if the loose draw needs it.
+            _cancelWithdrawalRequestIfNecessary(safe, tokens[i], fromLoose[i]);
+        }
+
+        return (amounts, fromLoose);
+    }
+
+    /// @dev Amount of `token` withdrawable from the safe's Aave-supplied balance right now: min(supplied, reserve cash).
+    function _withdrawableSupplied(IGateway gateway, address safe, address token) internal view returns (uint256) {
+        uint256 supplied = gateway.suppliedOf(safe, token);
+        uint256 cash = gateway.availableCash(token);
+        return supplied < cash ? supplied : cash;
+    }
+
+    function _transferLoose(address safe, address dispatcher, address[] calldata tokens, uint256[] memory amounts) internal {
         address[] memory to = new address[](tokens.length);
         bytes[] memory data = new bytes[](tokens.length);
         uint256[] memory values = new uint256[](tokens.length);
 
-        address settlementDispatcher = getSettlementDispatcher(binSponsor);
-
         for (uint256 i = 0; i < tokens.length; i++) {
             to[i] = tokens[i];
-            data[i] = abi.encodeWithSelector(IERC20.transfer.selector, settlementDispatcher, amounts[i]);
-            values[i] = 0;
+            data[i] = abi.encodeWithSelector(IERC20.transfer.selector, dispatcher, amounts[i]);
         }
         IEtherFiSafe(safe).execTransactionFromModule(to, values, data);
     }

--- a/src/modules/cash/CashModuleCore.sol
+++ b/src/modules/cash/CashModuleCore.sol
@@ -563,11 +563,20 @@ contract CashModuleCore is CashModuleStorageContract {
     function _repay(address safe, IDebtManager debtManager, address token, uint256 amountInUsd) internal {
         uint256 amount = IDebtManager(debtManager).convertUsdToCollateralToken(token, amountInUsd);
         if (amount == 0) revert AmountZero();
+        CashModuleStorage storage $ = _getCashModuleStorage();
+        IGateway gateway = $.gateway;
+
+        uint256 debt = gateway.debtOf(safe, token);
+        if (debt < amount) {
+            amount = debt;
+        }
+        if (amount == 0) revert AmountZero();
         _cancelWithdrawalRequestIfNecessary(safe, token, amount);
 
         // Gateway repays the safe's Aave debt on its behalf, pulling the repay token from the safe.
-        _getCashModuleStorage().gateway.repay(safe, token, amount);
-        _getCashModuleStorage().cashEventEmitter.emitRepayDebtManager(safe, token, amount, amountInUsd);
+        uint256 repaid = gateway.repay(safe, token, amount);
+        uint256 repaidInUsd = debtManager.convertCollateralTokenToUsd(token, repaid);
+        $.cashEventEmitter.emitRepayDebtManager(safe, token, repaid, repaidInUsd);
     }
 
     /**

--- a/src/modules/cash/CashModuleCore.sol
+++ b/src/modules/cash/CashModuleCore.sol
@@ -579,14 +579,16 @@ contract CashModuleCore is CashModuleStorageContract {
         IGateway gateway = $.gateway;
 
         uint256 debt = gateway.debtOf(safe, token);
-        if (debt < amount) {
+        bool fullRepay = amount >= debt;
+        if (fullRepay) {
             amount = debt;
         }
         if (amount == 0) revert AmountZero();
         _cancelWithdrawalRequestIfNecessary(safe, token, amount);
 
         // Gateway repays the safe's Aave debt on its behalf, pulling the repay token from the safe.
-        uint256 repaid = gateway.repay(safe, token, amount);
+        // Full repays pass the max sentinel so no interest dust survives the exact-amount rounding.
+        uint256 repaid = gateway.repay(safe, token, fullRepay ? type(uint256).max : amount);
         uint256 repaidInUsd = debtManager.convertCollateralTokenToUsd(token, repaid);
         $.cashEventEmitter.emitRepayDebtManager(safe, token, repaid, repaidInUsd);
     }

--- a/src/modules/cash/CashModuleCore.sol
+++ b/src/modules/cash/CashModuleCore.sol
@@ -96,19 +96,6 @@ contract CashModuleCore is CashModuleStorageContract {
     }
 
     /**
-     * @notice Sets the Aave gateway address
-     * @dev Only callable by accounts with CASH_MODULE_CONTROLLER_ROLE
-     * @param gateway Address of the gateway contract
-     * @custom:throws OnlyCashModuleController if caller doesn't have the controller role
-     * @custom:throws InvalidInput if gateway = address(0)
-     */
-    function setGateway(address gateway) external {
-        if (!roleRegistry().hasRole(CASH_MODULE_CONTROLLER_ROLE, msg.sender)) revert OnlyCashModuleController();
-        if (gateway == address(0)) revert InvalidInput();
-        _getCashModuleStorage().gateway = IGateway(gateway);
-    }
-
-    /**
      * @notice Returns the address of CashEventEmitter contract
      * @return CashEventEmitter contract address
      */

--- a/src/modules/cash/CashModuleCore.sol
+++ b/src/modules/cash/CashModuleCore.sol
@@ -16,7 +16,7 @@ import { IGateway } from "../../interfaces/IGateway.sol";
 import { IPriceProvider } from "../../interfaces/IPriceProvider.sol";
 import { ArrayDeDupLib } from "../../libraries/ArrayDeDupLib.sol";
 import { CashVerificationLib } from "../../libraries/CashVerificationLib.sol";
-import { DebitHeadroomLib } from "../../libraries/DebitHeadroomLib.sol";
+import { DebitSourcingLib } from "../../libraries/DebitSourcingLib.sol";
 import { SignatureUtils } from "../../libraries/SignatureUtils.sol";
 import { SpendingLimit, SpendingLimitLib } from "../../libraries/SpendingLimitLib.sol";
 import { UpgradeableProxy } from "../../utils/UpgradeableProxy.sol";
@@ -272,14 +272,6 @@ contract CashModuleCore is CashModuleStorageContract {
     }
 
     /**
-     * @notice Returns the Aave gateway contract
-     * @return Gateway instance
-     */
-    function getGateway() public view returns (IGateway) {
-        return _getCashModuleStorage().gateway;
-    }
-
-    /**
      * @notice Processes a spending transaction with multiple tokens
      * @dev Only callable by EtherFi wallet for valid EtherFi Safe addresses
      * @param safe Address of the EtherFi Safe
@@ -300,9 +292,19 @@ contract CashModuleCore is CashModuleStorageContract {
 
         uint256 totalSpendingInUsd = _validateSpend($.safeCashConfig[safe], txId, tokens, amountsInUsd);
 
-        if ($.safeCashConfig[safe].mode == Mode.Credit) _spendCredit($, safe, txId, binSponsor, tokens, amountsInUsd, totalSpendingInUsd);
-        else _spendDebit($, safe, txId, binSponsor, tokens, amountsInUsd, totalSpendingInUsd);
+        _executeSpend($, safe, txId, binSponsor, tokens, amountsInUsd, totalSpendingInUsd);
         _cashback($, safe, totalSpendingInUsd, cashbacks);
+    }
+
+    /// @dev Runs the mode-specific spend and emits the shared Spend event with the resulting token amounts.
+    function _executeSpend(CashModuleStorage storage $, address safe, bytes32 txId, BinSponsor binSponsor, address[] calldata tokens, uint256[] calldata amountsInUsd, uint256 totalSpendingInUsd) internal {
+        Mode mode = $.safeCashConfig[safe].mode;
+
+        uint256[] memory amounts;
+        if (mode == Mode.Credit) amounts = _spendCredit($, safe, binSponsor, tokens, amountsInUsd);
+        else amounts = _spendDebit($, safe, binSponsor, tokens, amountsInUsd);
+
+        $.cashEventEmitter.emitSpend(safe, txId, binSponsor, tokens, amounts, amountsInUsd, totalSpendingInUsd, mode);
     }
 
     function _validateSpend(SafeCashConfig storage $$, bytes32 txId, address[] calldata tokens, uint256[] calldata amountsInUsd) internal returns (uint256) {
@@ -338,11 +340,12 @@ contract CashModuleCore is CashModuleStorageContract {
      * @dev Internal function to execute credit mode spending transaction (single token)
      * @param $ Storage reference to the CashModuleStorage
      * @param safe Address of the EtherFi Safe
-     * @param txId Transaction identifier
+     * @param binSponsor Bin sponsor used for spending
      * @param tokens Addresses of the tokens to spend
      * @param amountsInUsd Amounts to spend in USD
+     * @return Token amounts spent
      */
-    function _spendCredit(CashModuleStorage storage $, address safe, bytes32 txId, BinSponsor binSponsor, address[] memory tokens, uint256[] memory amountsInUsd, uint256 totalSpendingInUsd) internal {
+    function _spendCredit(CashModuleStorage storage $, address safe, BinSponsor binSponsor, address[] memory tokens, uint256[] memory amountsInUsd) internal returns (uint256[] memory) {
         // Credit mode validation
         if (!_isBorrowToken($.debtManager, tokens[0])) revert UnsupportedToken();
         uint256 amount = $.debtManager.convertUsdToCollateralToken(tokens[0], amountsInUsd[0]);
@@ -355,8 +358,7 @@ contract CashModuleCore is CashModuleStorageContract {
 
         uint256[] memory amounts = new uint256[](1);
         amounts[0] = amount;
-
-        $.cashEventEmitter.emitSpend(safe, txId, binSponsor, tokens, amounts, amountsInUsd, totalSpendingInUsd, Mode.Credit);
+        return amounts;
     }
 
     /**
@@ -364,18 +366,31 @@ contract CashModuleCore is CashModuleStorageContract {
      *      Aave-supplied balance for any shortfall, both routed to the settlement dispatcher.
      * @param $ Storage reference to the CashModuleStorage
      * @param safe Address of the EtherFi Safe
-     * @param txId Transaction identifier
+     * @param binSponsor Bin sponsor used for spending
      * @param tokens Array of addresses of the tokens to spend
      * @param amountsInUsd Array of amounts to spend in USD
+     * @return Token amounts spent
      */
-    function _spendDebit(CashModuleStorage storage $, address safe, bytes32 txId, BinSponsor binSponsor, address[] calldata tokens, uint256[] calldata amountsInUsd, uint256 totalSpendingInUsd) internal {
-        (uint256[] memory amounts, uint256[] memory fromLoose) = _sourceDebit($, safe, tokens, amountsInUsd);
+    function _spendDebit(CashModuleStorage storage $, address safe, BinSponsor binSponsor, address[] calldata tokens, uint256[] calldata amountsInUsd) internal returns (uint256[] memory) {
+        uint256[] memory amounts = new uint256[](tokens.length);
+        uint256[] memory fromLoose = new uint256[](tokens.length);
+
+        // Per token, _sourceDebitToken sizes the loose/supplied split and threads the borrowing headroom across
+        // tokens, so a debit cannot push a debt-carrying safe past its LTV max borrow.
+        {
+            IGateway.AccountData memory account = $.gateway.getAccountData(safe);
+            bool hasDebt = account.debtUsd != 0;
+            uint256 borrowHeadroom = hasDebt ? account.availableBorrowsUsd : 0;
+
+            for (uint256 i = 0; i < tokens.length; i++) {
+                (amounts[i], fromLoose[i], borrowHeadroom) = _sourceDebitToken($, safe, tokens[i], amountsInUsd[i], borrowHeadroom, hasDebt);
+            }
+        }
 
         address dispatcher = getSettlementDispatcher(binSponsor);
         _transferLoose(safe, dispatcher, tokens, fromLoose);
 
-        // _sourceDebit caps each supplied withdrawal by the borrowing headroom, so the debit cannot leave a
-        // debt-carrying safe past its LTV max borrow; no post-withdrawal health check is needed here.
+        // The headroom cap above already bounds the supplied withdrawals; no post-withdrawal health check is needed.
         for (uint256 i = 0; i < tokens.length; i++) {
             uint256 fromSupplied = amounts[i] - fromLoose[i];
             if (fromSupplied != 0) {
@@ -383,26 +398,7 @@ contract CashModuleCore is CashModuleStorageContract {
             }
         }
 
-        $.cashEventEmitter.emitSpend(safe, txId, binSponsor, tokens, amounts, amountsInUsd, totalSpendingInUsd, Mode.Debit);
-    }
-
-    /// @dev Per token, converts the USD amount and checks loose + withdrawable-supplied covers it, then frees a
-    ///      stale withdrawal against the loose portion. When the safe carries debt, the supplied portion is capped
-    ///      by the borrowing headroom (zero for a zero-LTV reserve) and the headroom is threaded across tokens, so
-    ///      a debit cannot push debt past its LTV max borrow. Returns the token amounts and the loose portion of each.
-    function _sourceDebit(CashModuleStorage storage $, address safe, address[] calldata tokens, uint256[] calldata amountsInUsd) internal returns (uint256[] memory, uint256[] memory) {
-        uint256[] memory amounts = new uint256[](tokens.length);
-        uint256[] memory fromLoose = new uint256[](tokens.length);
-
-        IGateway.AccountData memory account = $.gateway.getAccountData(safe);
-        bool hasDebt = account.debtUsd != 0;
-        uint256 borrowHeadroom = hasDebt ? account.availableBorrowsUsd : 0;
-
-        for (uint256 i = 0; i < tokens.length; i++) {
-            (amounts[i], fromLoose[i], borrowHeadroom) = _sourceDebitToken($, safe, tokens[i], amountsInUsd[i], borrowHeadroom, hasDebt);
-        }
-
-        return (amounts, fromLoose);
+        return amounts;
     }
 
     /// @dev Sources one token of a debit spend: validates it, sizes the loose/supplied split against the borrowing
@@ -416,7 +412,7 @@ contract CashModuleCore is CashModuleStorageContract {
         IPriceProvider priceProvider = IPriceProvider(etherFiDataProvider.getPriceProvider());
 
         uint256 loose = IERC20(token).balanceOf(safe);
-        uint256 withdrawable = DebitHeadroomLib.withdrawableSupplied($.gateway, priceProvider, safe, token, borrowHeadroom, hasDebt);
+        uint256 withdrawable = DebitSourcingLib.withdrawableSupplied($.gateway, priceProvider, safe, token, borrowHeadroom, hasDebt);
         if (loose + withdrawable < amount) {
             revert InsufficientBalance();
         }
@@ -427,7 +423,7 @@ contract CashModuleCore is CashModuleStorageContract {
 
         // The supplied portion drawn for this token consumes borrowing headroom for later tokens.
         if (hasDebt) {
-            uint256 usedUsd = DebitHeadroomLib.headroomConsumed($.gateway, priceProvider, token, amount - fromLoose);
+            uint256 usedUsd = DebitSourcingLib.headroomConsumed($.gateway, priceProvider, token, amount - fromLoose);
             borrowHeadroom = borrowHeadroom > usedUsd ? borrowHeadroom - usedUsd : 0;
         }
 
@@ -562,7 +558,6 @@ contract CashModuleCore is CashModuleStorageContract {
      */
     function _repay(address safe, IDebtManager debtManager, address token, uint256 amountInUsd) internal {
         uint256 amount = IDebtManager(debtManager).convertUsdToCollateralToken(token, amountInUsd);
-        if (amount == 0) revert AmountZero();
         CashModuleStorage storage $ = _getCashModuleStorage();
         IGateway gateway = $.gateway;
 

--- a/src/modules/cash/CashModuleCore.sol
+++ b/src/modules/cash/CashModuleCore.sol
@@ -403,7 +403,7 @@ contract CashModuleCore is CashModuleStorageContract {
 
     /**
      * @dev Sources one token of a debit spend: validates it, sizes the loose/supplied split against the borrowing
-     *      headroom, and frees a stale withdrawal against the loose portion.
+     *      headroom, and cancels a pending withdrawal only when the spend must dip into its reserved balance.
      * @param $ Storage reference to the CashModuleStorage
      * @param safe Address of the EtherFi Safe
      * @param token Address of the token to source
@@ -427,8 +427,18 @@ contract CashModuleCore is CashModuleStorageContract {
             revert InsufficientBalance();
         }
 
+        // A pending withdrawal reserves loose balance. Prefer the unreserved portion plus the supplied
+        // withdrawal so the request survives (matching CashLens); dip into the reserved portion, cancelling
+        // the request, only when the spend cannot be funded otherwise.
+        {
+            uint256 pending = getPendingWithdrawalAmount(safe, token);
+            uint256 unreserved = loose > pending ? loose - pending : 0;
+            if (unreserved + withdrawable >= amount) {
+                loose = unreserved;
+            }
+        }
+
         uint256 fromLoose = loose < amount ? loose : amount;
-        // A pending withdrawal reserves the loose balance; free it if the loose draw needs it.
         _cancelWithdrawalRequestIfNecessary(safe, token, fromLoose);
 
         // The supplied portion drawn for this token consumes borrowing headroom for later tokens.

--- a/src/modules/cash/CashModuleCore.sol
+++ b/src/modules/cash/CashModuleCore.sol
@@ -12,6 +12,7 @@ import { ICashbackDispatcher } from "../../interfaces/ICashbackDispatcher.sol";
 import { IDebtManager } from "../../interfaces/IDebtManager.sol";
 import { IEtherFiDataProvider } from "../../interfaces/IEtherFiDataProvider.sol";
 import { IEtherFiSafe } from "../../interfaces/IEtherFiSafe.sol";
+import { IGateway } from "../../interfaces/IGateway.sol";
 import { ArrayDeDupLib } from "../../libraries/ArrayDeDupLib.sol";
 import { CashVerificationLib } from "../../libraries/CashVerificationLib.sol";
 import { SignatureUtils } from "../../libraries/SignatureUtils.sol";
@@ -90,6 +91,19 @@ contract CashModuleCore is CashModuleStorageContract {
         if (!roleRegistry().hasRole(CASH_MODULE_CONTROLLER_ROLE, msg.sender)) revert OnlyCashModuleController();
         if (newCashModuleSetters == address(0)) revert InvalidInput();
         _getCashModuleStorage().cashModuleSetters = newCashModuleSetters;
+    }
+
+    /**
+     * @notice Sets the Aave gateway address
+     * @dev Only callable by accounts with CASH_MODULE_CONTROLLER_ROLE
+     * @param gateway Address of the gateway contract
+     * @custom:throws OnlyCashModuleController if caller doesn't have the controller role
+     * @custom:throws InvalidInput if gateway = address(0)
+     */
+    function setGateway(address gateway) external {
+        if (!roleRegistry().hasRole(CASH_MODULE_CONTROLLER_ROLE, msg.sender)) revert OnlyCashModuleController();
+        if (gateway == address(0)) revert InvalidInput();
+        _getCashModuleStorage().gateway = IGateway(gateway);
     }
 
     /**
@@ -269,6 +283,14 @@ contract CashModuleCore is CashModuleStorageContract {
     }
 
     /**
+     * @notice Returns the Aave gateway contract
+     * @return Gateway instance
+     */
+    function getGateway() public view returns (IGateway) {
+        return _getCashModuleStorage().gateway;
+    }
+
+    /**
      * @notice Processes a spending transaction with multiple tokens
      * @dev Only callable by EtherFi wallet for valid EtherFi Safe addresses
      * @param safe Address of the EtherFi Safe
@@ -337,18 +359,14 @@ contract CashModuleCore is CashModuleStorageContract {
         uint256 amount = $.debtManager.convertUsdToCollateralToken(tokens[0], amountsInUsd[0]);
         if (amount == 0) revert AmountZero();
 
-        address[] memory to = new address[](1);
-        bytes[] memory data = new bytes[](1);
-        uint256[] memory values = new uint256[](1);
+        address dispatcher = getSettlementDispatcher(binSponsor);
 
-        to[0] = address($.debtManager);
-        data[0] = abi.encodeWithSelector(IDebtManager.borrow.selector, binSponsor, tokens[0], amount);
-        values[0] = 0;
-
-        try IEtherFiSafe(safe).execTransactionFromModule(to, values, data) { }
+        // Gateway borrows against the safe's Aave position and forwards the borrowed token to the dispatcher.
+        // Retry once after clearing a stale withdrawal request if the first attempt reverts.
+        try $.gateway.borrow(safe, tokens[0], amount, dispatcher) { }
         catch {
             _cancelOldWithdrawal(safe);
-            IEtherFiSafe(safe).execTransactionFromModule(to, values, data);
+            $.gateway.borrow(safe, tokens[0], amount, dispatcher);
         }
 
         uint256[] memory amounts = new uint256[](1);
@@ -525,19 +543,8 @@ contract CashModuleCore is CashModuleStorageContract {
         if (amount == 0) revert AmountZero();
         _cancelWithdrawalRequestIfNecessary(safe, token, amount);
 
-        address[] memory to = new address[](3);
-        bytes[] memory data = new bytes[](3);
-        uint256[] memory values = new uint256[](3);
-
-        to[0] = token;
-        to[1] = address(debtManager);
-        to[2] = token;
-
-        data[0] = abi.encodeWithSelector(IERC20.approve.selector, address(debtManager), amount);
-        data[1] = abi.encodeWithSelector(IDebtManager.repay.selector, safe, token, amount);
-        data[2] = abi.encodeWithSelector(IERC20.approve.selector, address(debtManager), 0);
-
-        IEtherFiSafe(safe).execTransactionFromModule(to, values, data);
+        // Gateway repays the safe's Aave debt on its behalf, pulling the repay token from the safe.
+        _getCashModuleStorage().gateway.repay(safe, token, amount);
         _getCashModuleStorage().cashEventEmitter.emitRepayDebtManager(safe, token, amount, amountInUsd);
     }
 

--- a/src/modules/cash/CashModuleCore.sol
+++ b/src/modules/cash/CashModuleCore.sol
@@ -13,8 +13,10 @@ import { IDebtManager } from "../../interfaces/IDebtManager.sol";
 import { IEtherFiDataProvider } from "../../interfaces/IEtherFiDataProvider.sol";
 import { IEtherFiSafe } from "../../interfaces/IEtherFiSafe.sol";
 import { IGateway } from "../../interfaces/IGateway.sol";
+import { IPriceProvider } from "../../interfaces/IPriceProvider.sol";
 import { ArrayDeDupLib } from "../../libraries/ArrayDeDupLib.sol";
 import { CashVerificationLib } from "../../libraries/CashVerificationLib.sol";
+import { DebitHeadroomLib } from "../../libraries/DebitHeadroomLib.sol";
 import { SignatureUtils } from "../../libraries/SignatureUtils.sol";
 import { SpendingLimit, SpendingLimitLib } from "../../libraries/SpendingLimitLib.sol";
 import { UpgradeableProxy } from "../../utils/UpgradeableProxy.sol";
@@ -385,50 +387,64 @@ contract CashModuleCore is CashModuleStorageContract {
         address dispatcher = getSettlementDispatcher(binSponsor);
         _transferLoose(safe, dispatcher, tokens, fromLoose);
 
-        bool withdrew;
+        // _sourceDebit caps each supplied withdrawal by the borrowing headroom, so the debit cannot leave a
+        // debt-carrying safe past its LTV max borrow; no post-withdrawal health check is needed here.
         for (uint256 i = 0; i < tokens.length; i++) {
             uint256 fromSupplied = amounts[i] - fromLoose[i];
             if (fromSupplied != 0) {
                 $.gateway.withdraw(safe, tokens[i], fromSupplied, dispatcher);
-                withdrew = true;
             }
         }
 
         $.cashEventEmitter.emitSpend(safe, txId, binSponsor, tokens, amounts, amountsInUsd, totalSpendingInUsd, Mode.Debit);
-
-        // Only an Aave withdrawal can worsen the position; a loose-only spend leaves it untouched. After a
-        // withdrawal, a safe that still carries debt must stay within its LTV-based max borrow.
-        if (withdrew) {
-            IGateway.AccountData memory account = $.gateway.getAccountData(safe);
-            if (account.debtUsd != 0 && account.availableBorrowsUsd == 0) revert BorrowingsExceedMaxBorrowAfterSpending();
-        }
     }
 
-    /// @dev Per token, converts the USD amount, checks loose + withdrawable-supplied covers it, and frees a stale withdrawal against the loose portion. Returns the token amounts and the loose portion of each.
+    /// @dev Per token, converts the USD amount and checks loose + withdrawable-supplied covers it, then frees a
+    ///      stale withdrawal against the loose portion. When the safe carries debt, the supplied portion is capped
+    ///      by the borrowing headroom (zero for a zero-LTV reserve) and the headroom is threaded across tokens, so
+    ///      a debit cannot push debt past its LTV max borrow. Returns the token amounts and the loose portion of each.
     function _sourceDebit(CashModuleStorage storage $, address safe, address[] calldata tokens, uint256[] calldata amountsInUsd) internal returns (uint256[] memory, uint256[] memory) {
         uint256[] memory amounts = new uint256[](tokens.length);
         uint256[] memory fromLoose = new uint256[](tokens.length);
 
+        IGateway.AccountData memory account = $.gateway.getAccountData(safe);
+        bool hasDebt = account.debtUsd != 0;
+        uint256 borrowHeadroom = hasDebt ? account.availableBorrowsUsd : 0;
+
         for (uint256 i = 0; i < tokens.length; i++) {
-            if (!_isBorrowToken($.debtManager, tokens[i])) revert UnsupportedToken();
-            amounts[i] = $.debtManager.convertUsdToCollateralToken(tokens[i], amountsInUsd[i]);
-
-            uint256 loose = IERC20(tokens[i]).balanceOf(safe);
-            if (loose + _withdrawableSupplied($.gateway, safe, tokens[i]) < amounts[i]) revert InsufficientBalance();
-
-            fromLoose[i] = loose < amounts[i] ? loose : amounts[i];
-            // A pending withdrawal reserves the loose balance; free it if the loose draw needs it.
-            _cancelWithdrawalRequestIfNecessary(safe, tokens[i], fromLoose[i]);
+            (amounts[i], fromLoose[i], borrowHeadroom) = _sourceDebitToken($, safe, tokens[i], amountsInUsd[i], borrowHeadroom, hasDebt);
         }
 
         return (amounts, fromLoose);
     }
 
-    /// @dev Amount of `token` withdrawable from the safe's Aave-supplied balance right now: min(supplied, reserve cash).
-    function _withdrawableSupplied(IGateway gateway, address safe, address token) internal view returns (uint256) {
-        uint256 supplied = gateway.suppliedOf(safe, token);
-        uint256 cash = gateway.availableCash(token);
-        return supplied < cash ? supplied : cash;
+    /// @dev Sources one token of a debit spend: validates it, sizes the loose/supplied split against the borrowing
+    ///      headroom, frees a stale withdrawal against the loose portion, and returns the token amount, the loose
+    ///      portion, and the borrowing headroom left after this token's supplied withdrawal.
+    function _sourceDebitToken(CashModuleStorage storage $, address safe, address token, uint256 amountInUsd, uint256 borrowHeadroom, bool hasDebt) internal returns (uint256, uint256, uint256) {
+        if (!_isBorrowToken($.debtManager, token)) {
+            revert UnsupportedToken();
+        }
+        uint256 amount = $.debtManager.convertUsdToCollateralToken(token, amountInUsd);
+        IPriceProvider priceProvider = IPriceProvider(etherFiDataProvider.getPriceProvider());
+
+        uint256 loose = IERC20(token).balanceOf(safe);
+        uint256 withdrawable = DebitHeadroomLib.withdrawableSupplied($.gateway, priceProvider, safe, token, borrowHeadroom, hasDebt);
+        if (loose + withdrawable < amount) {
+            revert InsufficientBalance();
+        }
+
+        uint256 fromLoose = loose < amount ? loose : amount;
+        // A pending withdrawal reserves the loose balance; free it if the loose draw needs it.
+        _cancelWithdrawalRequestIfNecessary(safe, token, fromLoose);
+
+        // The supplied portion drawn for this token consumes borrowing headroom for later tokens.
+        if (hasDebt) {
+            uint256 usedUsd = DebitHeadroomLib.headroomConsumed($.gateway, priceProvider, token, amount - fromLoose);
+            borrowHeadroom = borrowHeadroom > usedUsd ? borrowHeadroom - usedUsd : 0;
+        }
+
+        return (amount, fromLoose, borrowHeadroom);
     }
 
     function _transferLoose(address safe, address dispatcher, address[] calldata tokens, uint256[] memory amounts) internal {

--- a/src/modules/cash/CashModuleCore.sol
+++ b/src/modules/cash/CashModuleCore.sol
@@ -401,9 +401,19 @@ contract CashModuleCore is CashModuleStorageContract {
         return amounts;
     }
 
-    /// @dev Sources one token of a debit spend: validates it, sizes the loose/supplied split against the borrowing
-    ///      headroom, frees a stale withdrawal against the loose portion, and returns the token amount, the loose
-    ///      portion, and the borrowing headroom left after this token's supplied withdrawal.
+    /**
+     * @dev Sources one token of a debit spend: validates it, sizes the loose/supplied split against the borrowing
+     *      headroom, and frees a stale withdrawal against the loose portion.
+     * @param $ Storage reference to the CashModuleStorage
+     * @param safe Address of the EtherFi Safe
+     * @param token Address of the token to source
+     * @param amountInUsd Amount to spend for this token in USD
+     * @param borrowHeadroom Borrowing headroom (USD) available to this token's supplied withdrawal
+     * @param hasDebt Whether the safe carries debt; the headroom cap only applies when true
+     * @return The token amount for this spend
+     * @return The loose portion of that amount
+     * @return The borrowing headroom left after this token's supplied withdrawal
+     */
     function _sourceDebitToken(CashModuleStorage storage $, address safe, address token, uint256 amountInUsd, uint256 borrowHeadroom, bool hasDebt) internal returns (uint256, uint256, uint256) {
         if (!_isBorrowToken($.debtManager, token)) {
             revert UnsupportedToken();
@@ -430,6 +440,13 @@ contract CashModuleCore is CashModuleStorageContract {
         return (amount, fromLoose, borrowHeadroom);
     }
 
+    /**
+     * @dev Transfers each token's loose amount from the safe to the dispatcher in one batched module call.
+     * @param safe Address of the EtherFi Safe
+     * @param dispatcher Settlement dispatcher receiving the tokens
+     * @param tokens Addresses of the tokens to transfer
+     * @param amounts Loose amount of each token to transfer
+     */
     function _transferLoose(address safe, address dispatcher, address[] calldata tokens, uint256[] memory amounts) internal {
         address[] memory to = new address[](tokens.length);
         bytes[] memory data = new bytes[](tokens.length);

--- a/src/modules/cash/CashModuleSetters.sol
+++ b/src/modules/cash/CashModuleSetters.sol
@@ -5,7 +5,7 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { EnumerableSetLib } from "solady/utils/EnumerableSetLib.sol";
 
 import { ICashEventEmitter } from "../../interfaces/ICashEventEmitter.sol";
-import { Mode, BinSponsor, SafeCashConfig, SafeData, SafeTiers, WithdrawalRequest } from "../../interfaces/ICashModule.sol";
+import { BinSponsor, Mode, SafeCashConfig, SafeData, SafeTiers, WithdrawalRequest } from "../../interfaces/ICashModule.sol";
 import { ICashbackDispatcher } from "../../interfaces/ICashbackDispatcher.sol";
 import { IDebtManager } from "../../interfaces/IDebtManager.sol";
 import { IEtherFiDataProvider } from "../../interfaces/IEtherFiDataProvider.sol";
@@ -13,13 +13,12 @@ import { IEtherFiSafe } from "../../interfaces/IEtherFiSafe.sol";
 import { IGateway } from "../../interfaces/IGateway.sol";
 import { ArrayDeDupLib } from "../../libraries/ArrayDeDupLib.sol";
 import { CashVerificationLib } from "../../libraries/CashVerificationLib.sol";
+import { EnumerableAddressWhitelistLib } from "../../libraries/EnumerableAddressWhitelistLib.sol";
 import { SignatureUtils } from "../../libraries/SignatureUtils.sol";
 import { SpendingLimit, SpendingLimitLib } from "../../libraries/SpendingLimitLib.sol";
 import { UpgradeableProxy } from "../../utils/UpgradeableProxy.sol";
 import { ModuleBase } from "../ModuleBase.sol";
 import { CashModuleStorageContract } from "./CashModuleStorageContract.sol";
-import { EnumerableAddressWhitelistLib } from "../../libraries/EnumerableAddressWhitelistLib.sol";
-
 
 /**
  * @title CashModule
@@ -31,7 +30,7 @@ contract CashModuleSetters is CashModuleStorageContract {
     using SpendingLimitLib for SpendingLimit;
     using ArrayDeDupLib for address[];
 
-    constructor(address _etherFiDataProvider) CashModuleStorageContract(_etherFiDataProvider) { 
+    constructor(address _etherFiDataProvider) CashModuleStorageContract(_etherFiDataProvider) {
         _disableInitializers();
     }
 
@@ -48,7 +47,7 @@ contract CashModuleSetters is CashModuleStorageContract {
 
         CashModuleStorage storage $ = _getCashModuleStorage();
 
-        if (binSponsor == BinSponsor.Rain) { 
+        if (binSponsor == BinSponsor.Rain) {
             $.cashEventEmitter.emitSettlementDispatcherUpdated(binSponsor, $.settlementDispatcherRain, dispatcher);
             $.settlementDispatcherRain = dispatcher;
         } else if (binSponsor == BinSponsor.PIX) {
@@ -64,17 +63,22 @@ contract CashModuleSetters is CashModuleStorageContract {
     }
 
     /**
-     * @notice Sets the Aave gateway address
-     * @dev Only callable by accounts with CASH_MODULE_CONTROLLER_ROLE
+     * @notice Sets the Aave gateway address for the initial Lend deployment
+     * @dev Only callable by accounts with CASH_MODULE_CONTROLLER_ROLE while no gateway is configured
      * @param gateway Address of the gateway contract
      * @custom:throws OnlyCashModuleController if caller doesn't have the controller role
      * @custom:throws InvalidInput if gateway = address(0)
+     * @custom:throws GatewayAlreadySet if the gateway has already been configured
      */
     function setGateway(address gateway) external {
         if (!roleRegistry().hasRole(CASH_MODULE_CONTROLLER_ROLE, msg.sender)) revert OnlyCashModuleController();
         if (gateway == address(0)) revert InvalidInput();
 
         CashModuleStorage storage $ = _getCashModuleStorage();
+        // CashModule was deployed before Lend existed, so this hook is only for the first gateway bootstrap.
+        // Repointing after positions exist can strand accounting and must use a dedicated migration flow.
+        if (address($.gateway) != address(0)) revert GatewayAlreadySet();
+
         $.cashEventEmitter.emitGatewayUpdated(address($.gateway), gateway);
         $.gateway = IGateway(gateway);
     }
@@ -90,7 +94,7 @@ contract CashModuleSetters is CashModuleStorageContract {
     /**
      * @notice Configures the withdraw assets whitelist
      * @dev Only callable by accounts with CASH_MODULE_CONTROLLER_ROLE
-     * @param assets Array of asset addresses to configure 
+     * @param assets Array of asset addresses to configure
      * @param shouldWhitelist Array of boolean suggesting whether to whitelist the assets
      * @custom:throws OnlyCashModuleController if the caller does not have CASH_MODULE_CONTROLLER_ROLE role
      * @custom:throws InvalidInput If the arrays are empty
@@ -156,7 +160,7 @@ contract CashModuleSetters is CashModuleStorageContract {
 
     /**
      * @notice Sets the operating mode for a safe
-     * @dev Switches between Debit and Credit modes with delay 
+     * @dev Switches between Debit and Credit modes with delay
      * @param safe Address of the EtherFi Safe
      * @param mode The target mode (Debit or Credit)
      * @param signer Address of the safe admin signing the transaction
@@ -190,7 +194,7 @@ contract CashModuleSetters is CashModuleStorageContract {
      * @param safe Address of the EtherFi Safe
      * @param tokens Array of token addresses to withdraw
      * @param amounts Array of token amounts to withdraw
-     * @param recipient Address to receive the withdrawn tokens 
+     * @param recipient Address to receive the withdrawn tokens
      * @param signers Array of safe owner addresses signing the transaction
      * @param signatures Array of signatures from the safe owners
      * @custom:throws OnlyEtherFiSafe if the caller is not a valid EtherFi Safe
@@ -202,7 +206,10 @@ contract CashModuleSetters is CashModuleStorageContract {
     function requestWithdrawal(address safe, address[] calldata tokens, uint256[] calldata amounts, address recipient, address[] calldata signers, bytes[] calldata signatures) external nonReentrant onlyEtherFiSafe(safe) {
         CashVerificationLib.verifyRequestWithdrawalSig(safe, IEtherFiSafe(safe).useNonce(), tokens, amounts, recipient, signers, signatures);
 
-        if (_getCashModuleStorage().whitelistedModulesCanRequestWithdraw.contains(msg.sender) || _getCashModuleStorage().whitelistedModulesCanRequestWithdraw.contains(recipient))  revert InvalidWithdrawRequest();
+        if (_getCashModuleStorage().whitelistedModulesCanRequestWithdraw.contains(msg.sender) || _getCashModuleStorage().whitelistedModulesCanRequestWithdraw.contains(recipient)) {
+            revert InvalidWithdrawRequest();
+        }
+
         _requestWithdrawal(safe, tokens, amounts, recipient);
     }
 
@@ -227,7 +234,7 @@ contract CashModuleSetters is CashModuleStorageContract {
         amounts[0] = amount;
 
         address recipient = msg.sender; // The module itself is the recipient
-        
+
         _requestWithdrawal(safe, tokens, amounts, recipient);
     }
 
@@ -245,7 +252,7 @@ contract CashModuleSetters is CashModuleStorageContract {
         uint256 len = modules.length;
         if (len == 0 || len != shouldWhitelist.length) revert ArrayLengthMismatch();
 
-        for (uint256 i = 0; i < len; ) {
+        for (uint256 i = 0; i < len;) {
             if (shouldWhitelist[i] && !etherFiDataProvider.isWhitelistedModule(modules[i])) revert ModuleNotWhitelistedOnDataProvider();
             unchecked {
                 ++i;
@@ -286,10 +293,10 @@ contract CashModuleSetters is CashModuleStorageContract {
         SafeCashConfig storage $$ = $.safeCashConfig[safe];
 
         if ($$.pendingWithdrawalRequest.tokens.length == 0) revert WithdrawalDoesNotExist();
-        if (!$.whitelistedModulesCanRequestWithdraw.contains($$.pendingWithdrawalRequest.recipient)) revert InvalidWithdrawRequest(); 
+        if (!$.whitelistedModulesCanRequestWithdraw.contains($$.pendingWithdrawalRequest.recipient)) revert InvalidWithdrawRequest();
         if (msg.sender != $$.pendingWithdrawalRequest.recipient) revert OnlyModuleThatRequestedCanCancel();
         if (!etherFiDataProvider.isWhitelistedModule(msg.sender)) revert ModuleNotWhitelistedOnDataProvider();
-        
+
         _cancelOldWithdrawal(safe);
     }
 
@@ -351,13 +358,13 @@ contract CashModuleSetters is CashModuleStorageContract {
      * @param recipient Address to receive the withdrawn tokens
      * @custom:throws RecipientCannotBeAddressZero if recipient is the zero address
      */
-function _requestWithdrawal(address safe, address[] memory tokens, uint256[] memory amounts, address recipient) internal {
+    function _requestWithdrawal(address safe, address[] memory tokens, uint256[] memory amounts, address recipient) internal {
         CashModuleStorage storage $ = _getCashModuleStorage();
         SafeCashConfig storage $$ = $.safeCashConfig[safe];
 
         if (recipient == address(0)) revert RecipientCannotBeAddressZero();
         if (tokens.length > 1) tokens.checkDuplicates();
-        
+
         _areAssetsWithdrawable($, tokens);
         _cancelOldWithdrawal(safe);
 

--- a/src/modules/cash/CashModuleSetters.sol
+++ b/src/modules/cash/CashModuleSetters.sol
@@ -67,12 +67,13 @@ contract CashModuleSetters is CashModuleStorageContract {
      * @dev Only callable by accounts with CASH_MODULE_CONTROLLER_ROLE while no gateway is configured
      * @param gateway Address of the gateway contract
      * @custom:throws OnlyCashModuleController if caller doesn't have the controller role
-     * @custom:throws InvalidInput if gateway = address(0)
+     * @custom:throws InvalidInput if gateway has no contract code (also rejects address(0))
      * @custom:throws GatewayAlreadySet if the gateway has already been configured
      */
     function setGateway(address gateway) external {
         if (!roleRegistry().hasRole(CASH_MODULE_CONTROLLER_ROLE, msg.sender)) revert OnlyCashModuleController();
-        if (gateway == address(0)) revert InvalidInput();
+        // One-time bootstrap that can't be repointed, so guard against a mistyped EOA or undeployed address.
+        if (gateway.code.length == 0) revert InvalidInput();
 
         CashModuleStorage storage $ = _getCashModuleStorage();
         // CashModule was deployed before Lend existed, so this hook is only for the first gateway bootstrap.

--- a/src/modules/cash/CashModuleSetters.sol
+++ b/src/modules/cash/CashModuleSetters.sol
@@ -10,6 +10,7 @@ import { ICashbackDispatcher } from "../../interfaces/ICashbackDispatcher.sol";
 import { IDebtManager } from "../../interfaces/IDebtManager.sol";
 import { IEtherFiDataProvider } from "../../interfaces/IEtherFiDataProvider.sol";
 import { IEtherFiSafe } from "../../interfaces/IEtherFiSafe.sol";
+import { IGateway } from "../../interfaces/IGateway.sol";
 import { ArrayDeDupLib } from "../../libraries/ArrayDeDupLib.sol";
 import { CashVerificationLib } from "../../libraries/CashVerificationLib.sol";
 import { SignatureUtils } from "../../libraries/SignatureUtils.sol";
@@ -60,7 +61,20 @@ contract CashModuleSetters is CashModuleStorageContract {
             $.cashEventEmitter.emitSettlementDispatcherUpdated(binSponsor, $.settlementDispatcherReap, dispatcher);
             $.settlementDispatcherReap = dispatcher;
         }
-    }   
+    }
+
+    /**
+     * @notice Sets the Aave gateway address
+     * @dev Only callable by accounts with CASH_MODULE_CONTROLLER_ROLE
+     * @param gateway Address of the gateway contract
+     * @custom:throws OnlyCashModuleController if caller doesn't have the controller role
+     * @custom:throws InvalidInput if gateway = address(0)
+     */
+    function setGateway(address gateway) external {
+        if (!roleRegistry().hasRole(CASH_MODULE_CONTROLLER_ROLE, msg.sender)) revert OnlyCashModuleController();
+        if (gateway == address(0)) revert InvalidInput();
+        _getCashModuleStorage().gateway = IGateway(gateway);
+    }
 
     /**
      * @notice Configures the withdraw assets whitelist

--- a/src/modules/cash/CashModuleSetters.sol
+++ b/src/modules/cash/CashModuleSetters.sol
@@ -77,6 +77,14 @@ contract CashModuleSetters is CashModuleStorageContract {
     }
 
     /**
+     * @notice Returns the Aave gateway contract
+     * @return Gateway instance
+     */
+    function getGateway() public view returns (IGateway) {
+        return _getCashModuleStorage().gateway;
+    }
+
+    /**
      * @notice Configures the withdraw assets whitelist
      * @dev Only callable by accounts with CASH_MODULE_CONTROLLER_ROLE
      * @param assets Array of asset addresses to configure 

--- a/src/modules/cash/CashModuleSetters.sol
+++ b/src/modules/cash/CashModuleSetters.sol
@@ -73,7 +73,10 @@ contract CashModuleSetters is CashModuleStorageContract {
     function setGateway(address gateway) external {
         if (!roleRegistry().hasRole(CASH_MODULE_CONTROLLER_ROLE, msg.sender)) revert OnlyCashModuleController();
         if (gateway == address(0)) revert InvalidInput();
-        _getCashModuleStorage().gateway = IGateway(gateway);
+
+        CashModuleStorage storage $ = _getCashModuleStorage();
+        $.cashEventEmitter.emitGatewayUpdated(address($.gateway), gateway);
+        $.gateway = IGateway(gateway);
     }
 
     /**

--- a/src/modules/cash/CashModuleStorageContract.sol
+++ b/src/modules/cash/CashModuleStorageContract.sol
@@ -159,6 +159,9 @@ contract CashModuleStorageContract is UpgradeableProxy, ModuleBase {
     /// @notice Error thrown when a withdrawal request is made by an invalid address or to an invalid recipient
     error InvalidWithdrawRequest();
 
+    /// @notice Error thrown when attempting to configure the Aave gateway after the initial bootstrap
+    error GatewayAlreadySet();
+
     constructor(address _etherFiDataProvider) ModuleBase(_etherFiDataProvider) {
         _disableInitializers();
     }

--- a/src/modules/cash/CashModuleStorageContract.sol
+++ b/src/modules/cash/CashModuleStorageContract.sol
@@ -10,6 +10,7 @@ import { ICashbackDispatcher } from "../../interfaces/ICashbackDispatcher.sol";
 import { IDebtManager } from "../../interfaces/IDebtManager.sol";
 import { IEtherFiDataProvider } from "../../interfaces/IEtherFiDataProvider.sol";
 import { IEtherFiSafe } from "../../interfaces/IEtherFiSafe.sol";
+import { IGateway } from "../../interfaces/IGateway.sol";
 import { ArrayDeDupLib } from "../../libraries/ArrayDeDupLib.sol";
 import { CashVerificationLib } from "../../libraries/CashVerificationLib.sol";
 import { SignatureUtils } from "../../libraries/SignatureUtils.sol";
@@ -71,6 +72,8 @@ contract CashModuleStorageContract is UpgradeableProxy, ModuleBase {
         address settlementDispatcherPix;
         /// @notice Address of the SettlementDispatcher for CardOrder
         address settlementDispatcherCardOrder;
+        /// @notice The Aave gateway that runs position operations (borrow/withdraw/repay) on a safe's behalf
+        IGateway gateway;
     }
 
     // keccak256(abi.encode(uint256(keccak256("etherfi.storage.CashModuleStorage")) - 1)) & ~bytes32(uint256(0xff))

--- a/src/modules/cash/CashModuleStorageContract.sol
+++ b/src/modules/cash/CashModuleStorageContract.sol
@@ -106,9 +106,6 @@ contract CashModuleStorageContract is UpgradeableProxy, ModuleBase {
     /// @notice Error thrown when a balance is insufficient for an operation
     error InsufficientBalance();
 
-    /// @notice Error thrown when borrowings would exceed maximum allowed after a spending operation
-    error BorrowingsExceedMaxBorrowAfterSpending();
-
     /// @notice Error thrown when a recipient address is set to zero
     error RecipientCannotBeAddressZero();
 

--- a/src/modules/cash/CashModuleStorageContract.sol
+++ b/src/modules/cash/CashModuleStorageContract.sol
@@ -208,17 +208,19 @@ contract CashModuleStorageContract is UpgradeableProxy, ModuleBase {
     }
 
     /**
-     * @dev Cancels withdrawal request if necessary based on available balance
+     * @dev The upcoming outflow and a pending withdrawal are competing claims on the safe's balance.
+     *      If the balance cannot honor both, the outflow wins: the whole request is cancelled (requests
+     *      are all-or-nothing across their tokens). No-op if no pending withdrawal holds this token.
      * @param safe Address of the EtherFi Safe
-     * @param token Address of the token to update
-     * @param amount Amount being processed
-     * @custom:throws InsufficientBalance if there is not enough balance for the operation
+     * @param token Address of the token about to leave the safe
+     * @param outflow Amount about to leave the safe
+     * @custom:throws InsufficientBalance if the safe's balance cannot cover the outflow itself
      */
-    function _cancelWithdrawalRequestIfNecessary(address safe, address token, uint256 amount) internal {
+    function _cancelConflictingWithdrawal(address safe, address token, uint256 outflow) internal {
         SafeCashConfig storage safeCashConfig = _getCashModuleStorage().safeCashConfig[safe];
         uint256 balance = IERC20(token).balanceOf(safe);
 
-        if (amount > balance) revert InsufficientBalance();
+        if (outflow > balance) revert InsufficientBalance();
 
         uint256 len = safeCashConfig.pendingWithdrawalRequest.tokens.length;
         uint256 tokenIndex = len;
@@ -235,7 +237,10 @@ contract CashModuleStorageContract is UpgradeableProxy, ModuleBase {
         // If the token does not exist in withdrawal request, return
         if (tokenIndex == len) return;
 
-        if (amount + safeCashConfig.pendingWithdrawalRequest.amounts[tokenIndex] > balance) {
+        // The pending withdrawal reserves part of the balance; balance - pending is the unreserved rest.
+        // An outflow larger than that dips into the reservation, so the request can no longer be honored
+        // afterwards: cancel it and free the reservation.
+        if (outflow + safeCashConfig.pendingWithdrawalRequest.amounts[tokenIndex] > balance) {
             _cancelOldWithdrawal(safe);
         }
     }

--- a/test/Errors.t.sol
+++ b/test/Errors.t.sol
@@ -81,6 +81,7 @@ contract ErrorsTest is Test {
     error SplitAlreadyTheSame();
     error OnlyOneTokenAllowedInCreditMode();
     error SettlementDispatcherNotSetForBinSponsor();
+    error GatewayAlreadySet();
     error UnsupportedLiquidAsset();
     error AssetNotSupportedForDeposit();
     error Unauthorized();
@@ -226,6 +227,7 @@ contract ErrorsTest is Test {
         emit log_named_bytes("SplitAlreadyTheSame", abi.encodePacked(SplitAlreadyTheSame.selector));
         emit log_named_bytes("OnlyOneTokenAllowedInCreditMode", abi.encodePacked(OnlyOneTokenAllowedInCreditMode.selector));
         emit log_named_bytes("SettlementDispatcherNotSetForBinSponsor", abi.encodePacked(SettlementDispatcherNotSetForBinSponsor.selector));
+        emit log_named_bytes("GatewayAlreadySet", abi.encodePacked(GatewayAlreadySet.selector));
         emit log_named_bytes("UnsupportedLiquidAsset", abi.encodePacked(UnsupportedLiquidAsset.selector));
         emit log_named_bytes("AssetNotSupportedForDeposit", abi.encodePacked(AssetNotSupportedForDeposit.selector));
         emit log_named_bytes("Unauthorized", abi.encodePacked(Unauthorized.selector));
@@ -292,5 +294,5 @@ contract ErrorsTest is Test {
         emit log_named_bytes("OnlyUnsupportedTokens", abi.encodePacked(OnlyUnsupportedTokens.selector));
         emit log_named_bytes("InvalidConfig", abi.encodePacked(InvalidConfig.selector));
         emit log_named_bytes("OnlyRoleRegistryOwner", abi.encodePacked(OnlyRoleRegistryOwner.selector));
-    } 
+    }
 }

--- a/test/Errors.t.sol
+++ b/test/Errors.t.sol
@@ -72,7 +72,6 @@ contract ErrorsTest is Test {
     error OnlyBorrowToken();
     error AmountZero();
     error InsufficientBalance();
-    error BorrowingsExceedMaxBorrowAfterSpending();
     error RecipientCannotBeAddressZero();
     error OnlyCashModuleController();
     error CannotWithdrawYet();
@@ -218,7 +217,6 @@ contract ErrorsTest is Test {
         emit log_named_bytes("OnlyBorrowToken", abi.encodePacked(OnlyBorrowToken.selector));
         emit log_named_bytes("AmountZero", abi.encodePacked(AmountZero.selector));
         emit log_named_bytes("InsufficientBalance", abi.encodePacked(InsufficientBalance.selector));
-        emit log_named_bytes("BorrowingsExceedMaxBorrowAfterSpending", abi.encodePacked(BorrowingsExceedMaxBorrowAfterSpending.selector));
         emit log_named_bytes("RecipientCannotBeAddressZero", abi.encodePacked(RecipientCannotBeAddressZero.selector));
         emit log_named_bytes("OnlyCashModuleController", abi.encodePacked(OnlyCashModuleController.selector));
         emit log_named_bytes("CannotWithdrawYet", abi.encodePacked(CannotWithdrawYet.selector));

--- a/test/safe/SafeTestSetup.t.sol
+++ b/test/safe/SafeTestSetup.t.sol
@@ -203,7 +203,7 @@ contract SafeTestSetup is Utils {
         roleRegistry.grantRole(cashModule.ETHER_FI_WALLET_ROLE(), etherFiWallet);
         roleRegistry.grantRole(cashModule.CASH_MODULE_CONTROLLER_ROLE(), owner);
 
-        CashModuleSetters(address(cashModule)).setGateway(address(gateway));
+        cashModule.setGateway(address(gateway));
 
         _setupWithdrawTokenWhitelist();
 

--- a/test/safe/SafeTestSetup.t.sol
+++ b/test/safe/SafeTestSetup.t.sol
@@ -180,7 +180,7 @@ contract SafeTestSetup is Utils {
         hook = EtherFiHook(address(new UUPSProxy(hookImpl, abi.encodeWithSelector(EtherFiHook.initialize.selector, address(roleRegistry)))));
 
         gateway = new MockGateway();
-        address cashLensImpl = address(new CashLens(address(cashModule), address(dataProvider), address(gateway)));
+        address cashLensImpl = address(new CashLens(address(cashModule), address(dataProvider)));
         cashLens = CashLens(address(new UUPSProxy(cashLensImpl, abi.encodeWithSelector(CashLens.initialize.selector, address(roleRegistry)))));
 
         dataProvider.initialize(EtherFiDataProvider.InitParams(address(roleRegistry), address(cashModule), address(cashLens), modules, defaultModules, address(hook), address(safeFactory), address(priceProvider), etherFiRecoverySigner, thirdPartyRecoverySigner, refundWallet));

--- a/test/safe/SafeTestSetup.t.sol
+++ b/test/safe/SafeTestSetup.t.sol
@@ -203,6 +203,8 @@ contract SafeTestSetup is Utils {
         roleRegistry.grantRole(cashModule.ETHER_FI_WALLET_ROLE(), etherFiWallet);
         roleRegistry.grantRole(cashModule.CASH_MODULE_CONTROLLER_ROLE(), owner);
 
+        CashModuleCore(address(cashModule)).setGateway(address(gateway));
+
         _setupWithdrawTokenWhitelist();
 
         address[] memory owners = new address[](3);

--- a/test/safe/SafeTestSetup.t.sol
+++ b/test/safe/SafeTestSetup.t.sol
@@ -203,7 +203,7 @@ contract SafeTestSetup is Utils {
         roleRegistry.grantRole(cashModule.ETHER_FI_WALLET_ROLE(), etherFiWallet);
         roleRegistry.grantRole(cashModule.CASH_MODULE_CONTROLLER_ROLE(), owner);
 
-        CashModuleCore(address(cashModule)).setGateway(address(gateway));
+        CashModuleSetters(address(cashModule)).setGateway(address(gateway));
 
         _setupWithdrawTokenWhitelist();
 

--- a/test/safe/modules/cash/CashLens.t.sol
+++ b/test/safe/modules/cash/CashLens.t.sol
@@ -7,6 +7,7 @@ import { IERC20Metadata } from "@openzeppelin/contracts/interfaces/IERC20Metadat
 
 import { Mode, SafeCashData, BinSponsor, SafeData, Cashback, CashbackTokens } from "../../../../src/interfaces/ICashModule.sol";
 import { IEtherFiSafeFactory } from "../../../../src/interfaces/IEtherFiSafeFactory.sol";
+import { IGateway } from "../../../../src/interfaces/IGateway.sol";
 import { CashLens } from "../../../../src/modules/cash/CashLens.sol";
 import { IDebtManager } from "../../../../src/interfaces/IDebtManager.sol";
 import { CashModuleTestSetup } from "./CashModuleTestSetup.t.sol";
@@ -206,35 +207,19 @@ contract CashLensTest is CashModuleTestSetup {
 
         uint256 spendAmount = 1000e6;
 
-        address[] memory spendTokens = new address[](1);
-        spendTokens[0] = address(usdc);
-        uint256[] memory spendAmounts = new uint256[](1);
-        spendAmounts[0] = spendAmount;
-
-        Cashback[] memory cashbacks = new Cashback[](1);
-        CashbackTokens[] memory cashbackTokens = new CashbackTokens[](1);
-
-        CashbackTokens memory scr = CashbackTokens({
-            token: address(cashbackToken),
-            amountInUsd: 1e6,
-            cashbackType: 0
-        });
-
-        cashbackTokens[0] = scr;
-
-        Cashback memory scrCashback = Cashback({
-            to: address(safe),
-            cashbackTokens: cashbackTokens
-        });
-
-        cashbacks[0] = scrCashback;
-        
-        // Spend in credit mode to create a borrow
-        vm.prank(etherFiWallet);
-        cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
+        // Mirror the current position (collateral only; no real borrow was executed, so debt is 0).
+        _mirrorPositionToGateway(address(safe));
+        // Layer a fabricated borrow on top for CashLens to read.
+        IGateway.AccountData memory account = gateway.getAccountData(address(safe));
+        gateway.setDebtOf(address(safe), address(usdc), spendAmount);
+        gateway.setAccountData(address(safe), IGateway.AccountData({
+            collateralUsd: account.collateralUsd,
+            debtUsd: spendAmount,
+            availableBorrowsUsd: account.availableBorrowsUsd > spendAmount ? account.availableBorrowsUsd - spendAmount : 0,
+            healthFactor: account.healthFactor
+        }));
 
         // Get safe cash data
-        _mirrorPositionToGateway(address(safe));
         SafeCashData memory data = cashLens.getSafeCashData(address(safe), new address[](0));
         
         // Verify borrows

--- a/test/safe/modules/cash/MultiSpend.t.sol
+++ b/test/safe/modules/cash/MultiSpend.t.sol
@@ -9,6 +9,7 @@ import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
 import { UUPSProxy } from "../../../../src/UUPSProxy.sol";
 import { ICashModule, Mode, BinSponsor, Cashback, CashbackTokens } from "../../../../src/interfaces/ICashModule.sol";
 import { IDebtManager } from "../../../../src/interfaces/IDebtManager.sol";
+import { IGateway } from "../../../../src/interfaces/IGateway.sol";
 import { SpendingLimitLib } from "../../../../src/libraries/SpendingLimitLib.sol";
 import { CashEventEmitter, CashModuleTestSetup } from "./CashModuleTestSetup.t.sol";
 import { UpgradeableProxy } from "../../../../src/utils/UpgradeableProxy.sol";
@@ -617,6 +618,90 @@ contract CashModuleMultiSpendTest is CashModuleTestSetup {
         expectedIncreases[2] = debtManager.convertUsdToCollateralToken(address(cashbackToken), scrAmountInUsd);
         
         _verifySettlementDispatcherBalances(initialBalances, expectedIncreases);
+    }
+
+    // Debit spend across two tokens while the safe carries Aave debt: usdc is fully sourced from the loose
+    // balance, weETH from a mix of loose and Aave-supplied balance, and the supplied withdrawal is sized
+    // against the borrowing headroom.
+    function test_spend_multiToken_mixedLooseAndSupplied_withDebt() public {
+        uint256 usdcAmount = debtManager.convertUsdToCollateralToken(address(usdc), 50e6); // fully from the loose balance
+        uint256 weETHAmount = debtManager.convertUsdToCollateralToken(address(weETH), 40e6); // part loose, part from Aave
+        uint256 weETHLoose = debtManager.convertUsdToCollateralToken(address(weETH), 10e6); // $10 of the weETH sits loose
+
+        // Fund loose balances; weETH's remaining spend is backed by its Aave-supplied balance.
+        deal(address(usdc), address(safe), usdcAmount);
+        deal(address(weETH), address(safe), weETHLoose);
+        gateway.setLtv(address(usdc), 80e18);
+        gateway.setLtv(address(weETH), 80e18);
+        gateway.setSuppliedOf(address(safe), address(weETH), weETHAmount);
+        gateway.setAvailableCash(address(weETH), type(uint128).max);
+
+        // Safe carries debt with ample borrowing headroom, so the weETH withdrawal is allowed.
+        gateway.setAccountData(address(safe), IGateway.AccountData({ collateralUsd: 500e6, debtUsd: 100e6, availableBorrowsUsd: 100e6, healthFactor: 1e18 }));
+
+        uint256 dispatcherUsdcBefore = usdc.balanceOf(address(settlementDispatcherReap));
+        uint256 dispatcherWeETHBefore = weETH.balanceOf(address(settlementDispatcherReap));
+
+        {
+            address[] memory spendTokens = new address[](2);
+            spendTokens[0] = address(usdc);
+            spendTokens[1] = address(weETH);
+            uint256[] memory spendAmounts = new uint256[](2);
+            spendAmounts[0] = 50e6;
+            spendAmounts[1] = 40e6;
+            uint256[] memory tokenAmounts = new uint256[](2);
+            tokenAmounts[0] = usdcAmount;
+            tokenAmounts[1] = weETHAmount;
+
+            Cashback[] memory cashbacks;
+
+            vm.prank(etherFiWallet);
+            vm.expectEmit(true, true, true, true);
+            emit CashEventEmitter.Spend(address(safe), txId, BinSponsor.Reap, spendTokens, tokenAmounts, spendAmounts, 90e6, Mode.Debit);
+            cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
+        }
+
+        // Loose balances of both tokens are drained to the dispatcher.
+        assertEq(usdc.balanceOf(address(safe)), 0);
+        assertEq(weETH.balanceOf(address(safe)), 0);
+        assertEq(usdc.balanceOf(address(settlementDispatcherReap)), dispatcherUsdcBefore + usdcAmount);
+        assertEq(weETH.balanceOf(address(settlementDispatcherReap)), dispatcherWeETHBefore + weETHLoose);
+
+        // The weETH shortfall is withdrawn from the Aave-supplied balance via the gateway (usdc needed no withdrawal).
+        (address s, address asset, uint256 amt, address to) = gateway.lastWithdraw();
+        assertEq(s, address(safe));
+        assertEq(asset, address(weETH));
+        assertEq(amt, weETHAmount - weETHLoose);
+        assertEq(to, address(settlementDispatcherReap));
+    }
+
+    // With debt, the borrowing headroom is shared across every token in one debit: usdc's Aave withdrawal
+    // consumes it first, leaving too little for weETH's, so the spend reverts. Either token alone would fit.
+    function test_spend_multiToken_revertsWhenSuppliedDrawsExceedSharedHeadroom_withDebt() public {
+        // Both tokens are sourced from their Aave-supplied balances (no loose funding).
+        gateway.setLtv(address(usdc), 80e18);
+        gateway.setLtv(address(weETH), 80e18);
+        gateway.setSuppliedOf(address(safe), address(usdc), debtManager.convertUsdToCollateralToken(address(usdc), 100e6));
+        gateway.setSuppliedOf(address(safe), address(weETH), debtManager.convertUsdToCollateralToken(address(weETH), 100e6));
+        gateway.setAvailableCash(address(usdc), type(uint128).max);
+        gateway.setAvailableCash(address(weETH), type(uint128).max);
+
+        // $40 headroom at 80% LTV funds $50 of withdrawals in total. usdc's $30 draw spends $24 of it, leaving
+        // room for only $20 of weETH, short of its $30 draw.
+        gateway.setAccountData(address(safe), IGateway.AccountData({ collateralUsd: 500e6, debtUsd: 100e6, availableBorrowsUsd: 40e6, healthFactor: 1e18 }));
+
+        address[] memory spendTokens = new address[](2);
+        spendTokens[0] = address(usdc);
+        spendTokens[1] = address(weETH);
+        uint256[] memory spendAmounts = new uint256[](2);
+        spendAmounts[0] = 30e6;
+        spendAmounts[1] = 30e6;
+
+        Cashback[] memory cashbacks;
+
+        vm.prank(etherFiWallet);
+        vm.expectRevert(ICashModule.InsufficientBalance.selector);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
     }
 
         // Helper function to fund the safe with a specific token amount

--- a/test/safe/modules/cash/SetGateway.t.sol
+++ b/test/safe/modules/cash/SetGateway.t.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { ICashModule } from "../../../../src/interfaces/ICashModule.sol";
+import { MockGateway } from "../../../../src/mocks/MockGateway.sol";
+import { CashEventEmitter, CashModuleTestSetup } from "./CashModuleTestSetup.t.sol";
+
+contract CashModuleSetGatewayTest is CashModuleTestSetup {
+    function test_setGateway_emitsAndUpdates() public {
+        MockGateway newGateway = new MockGateway();
+        address oldGateway = address(cashModule.getGateway());
+
+        vm.expectEmit(true, true, true, true);
+        emit CashEventEmitter.GatewayUpdated(oldGateway, address(newGateway));
+
+        vm.prank(owner);
+        cashModule.setGateway(address(newGateway));
+
+        assertEq(address(cashModule.getGateway()), address(newGateway));
+    }
+
+    function test_setGateway_revertsForNonController() public {
+        MockGateway newGateway = new MockGateway();
+
+        vm.prank(notOwner);
+        vm.expectRevert(ICashModule.OnlyCashModuleController.selector);
+        cashModule.setGateway(address(newGateway));
+    }
+
+    function test_setGateway_revertsForZeroAddress() public {
+        vm.prank(owner);
+        vm.expectRevert(ICashModule.InvalidInput.selector);
+        cashModule.setGateway(address(0));
+    }
+}

--- a/test/safe/modules/cash/SetGateway.t.sol
+++ b/test/safe/modules/cash/SetGateway.t.sol
@@ -1,35 +1,104 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-import { ICashModule } from "../../../../src/interfaces/ICashModule.sol";
+import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+
+import { UUPSProxy } from "../../../../src/UUPSProxy.sol";
+import { ICashModule, Mode, SafeCashData } from "../../../../src/interfaces/ICashModule.sol";
+import { IGateway } from "../../../../src/interfaces/IGateway.sol";
+import { CashVerificationLib } from "../../../../src/libraries/CashVerificationLib.sol";
 import { MockGateway } from "../../../../src/mocks/MockGateway.sol";
+import { CashLens } from "../../../../src/modules/cash/CashLens.sol";
+import { CashModuleCore } from "../../../../src/modules/cash/CashModuleCore.sol";
+import { CashModuleSetters } from "../../../../src/modules/cash/CashModuleSetters.sol";
 import { CashEventEmitter, CashModuleTestSetup } from "./CashModuleTestSetup.t.sol";
 
 contract CashModuleSetGatewayTest is CashModuleTestSetup {
+    using MessageHashUtils for bytes32;
+
+    /// @notice A controller can configure the first gateway during Lend bootstrap and the change is emitted.
     function test_setGateway_emitsAndUpdates() public {
+        (ICashModule unconfiguredCashModule,) = _deployUnconfiguredCashModule();
         MockGateway newGateway = new MockGateway();
-        address oldGateway = address(cashModule.getGateway());
 
         vm.expectEmit(true, true, true, true);
-        emit CashEventEmitter.GatewayUpdated(oldGateway, address(newGateway));
+        emit CashEventEmitter.GatewayUpdated(address(0), address(newGateway));
 
         vm.prank(owner);
-        cashModule.setGateway(address(newGateway));
+        unconfiguredCashModule.setGateway(address(newGateway));
 
-        assertEq(address(cashModule.getGateway()), address(newGateway));
+        assertEq(address(unconfiguredCashModule.getGateway()), address(newGateway));
     }
 
-    function test_setGateway_revertsForNonController() public {
+    /// @notice CashLens should read the gateway configured during the one-time Lend bootstrap.
+    function test_setGateway_bootstrapUpdatesCashLensReads() public {
+        (ICashModule unconfiguredCashModule, CashLens unconfiguredCashLens) = _deployUnconfiguredCashModule();
+        MockGateway newGateway = new MockGateway();
+
+        vm.prank(address(safe));
+        unconfiguredCashModule.setupModule(abi.encode(dailyLimitInUsd, monthlyLimitInUsd, timezoneOffset));
+        _setMode(unconfiguredCashModule, Mode.Credit);
+        vm.warp(unconfiguredCashModule.incomingModeStartTime(address(safe)) + 1);
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amountsInUsd = new uint256[](1);
+        amountsInUsd[0] = 100e6;
+
+        newGateway.setAvailableCash(address(usdc), type(uint128).max);
+        newGateway.setAccountData(address(safe), IGateway.AccountData({ collateralUsd: 200e6, debtUsd: 0, availableBorrowsUsd: amountsInUsd[0], healthFactor: type(uint256).max }));
+
+        vm.prank(owner);
+        unconfiguredCashModule.setGateway(address(newGateway));
+
+        assertEq(address(unconfiguredCashLens.gateway()), address(newGateway));
+
+        SafeCashData memory data = unconfiguredCashLens.getSafeCashData(address(safe), tokens);
+        assertEq(data.totalCollateral, 200e6);
+        assertEq(data.creditMaxSpend, amountsInUsd[0]);
+
+        (bool canSpendAfter, string memory reason) = unconfiguredCashLens.canSpend(address(safe), txId, tokens, amountsInUsd);
+        assertEq(canSpendAfter, true);
+        assertEq(reason, "");
+    }
+
+    /// @notice Gateway bootstrap rejects unauthorized callers, zero addresses, and attempts to overwrite a configured gateway.
+    function test_setGateway_revertsForInvalidCalls() public {
         MockGateway newGateway = new MockGateway();
 
         vm.prank(notOwner);
         vm.expectRevert(ICashModule.OnlyCashModuleController.selector);
         cashModule.setGateway(address(newGateway));
-    }
 
-    function test_setGateway_revertsForZeroAddress() public {
         vm.prank(owner);
         vm.expectRevert(ICashModule.InvalidInput.selector);
         cashModule.setGateway(address(0));
+
+        vm.prank(owner);
+        vm.expectRevert(ICashModule.GatewayAlreadySet.selector);
+        cashModule.setGateway(address(newGateway));
+    }
+
+    /// @dev Deploys a CashModule/CashLens pair with no gateway configured so tests can exercise first-time bootstrap.
+    function _deployUnconfiguredCashModule() internal returns (ICashModule unconfiguredCashModule, CashLens unconfiguredCashLens) {
+        address cashModuleSettersImpl = address(new CashModuleSetters(address(dataProvider)));
+        address cashModuleCoreImpl = address(new CashModuleCore(address(dataProvider)));
+        unconfiguredCashModule = ICashModule(address(new UUPSProxy(cashModuleCoreImpl, "")));
+        address cashEventEmitterImpl = address(new CashEventEmitter(address(unconfiguredCashModule)));
+        address unconfiguredCashEventEmitter = address(new UUPSProxy(cashEventEmitterImpl, abi.encodeWithSelector(CashEventEmitter.initialize.selector, address(roleRegistry))));
+
+        CashModuleCore(address(unconfiguredCashModule)).initialize(address(roleRegistry), address(debtManager), address(settlementDispatcherReap), address(settlementDispatcherRain), address(cashbackDispatcher), unconfiguredCashEventEmitter, cashModuleSettersImpl);
+
+        address cashLensImpl = address(new CashLens(address(unconfiguredCashModule), address(dataProvider)));
+        unconfiguredCashLens = CashLens(address(new UUPSProxy(cashLensImpl, abi.encodeWithSelector(CashLens.initialize.selector, address(roleRegistry)))));
+    }
+
+    /// @dev Sets mode on a specific CashModule instance using the shared Safe owner key.
+    function _setMode(ICashModule module, Mode mode) internal {
+        uint256 nonce = module.getNonce(address(safe));
+        bytes32 digestHash = keccak256(abi.encodePacked(CashVerificationLib.SET_MODE_METHOD, block.chainid, address(safe), nonce, abi.encode(mode))).toEthSignedMessageHash();
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Pk, digestHash);
+
+        module.setMode(address(safe), mode, owner1, abi.encodePacked(r, s, v));
     }
 }

--- a/test/safe/modules/cash/SetGateway.t.sol
+++ b/test/safe/modules/cash/SetGateway.t.sol
@@ -74,6 +74,11 @@ contract CashModuleSetGatewayTest is CashModuleTestSetup {
         vm.expectRevert(ICashModule.InvalidInput.selector);
         cashModule.setGateway(address(0));
 
+        // An address with no contract code is rejected by the deployed-contract check.
+        vm.prank(owner);
+        vm.expectRevert(ICashModule.InvalidInput.selector);
+        cashModule.setGateway(makeAddr("codelessGateway"));
+
         vm.prank(owner);
         vm.expectRevert(ICashModule.GatewayAlreadySet.selector);
         cashModule.setGateway(address(newGateway));

--- a/test/safe/modules/cash/Spend.t.sol
+++ b/test/safe/modules/cash/Spend.t.sol
@@ -331,26 +331,68 @@ contract CashModuleSpendTest is CashModuleTestSetup {
         assertTrue(cashModule.transactionCleared(address(safe), keccak256("txId2")));
     }
 
-    function test_spend_inDebitMode_fails_whenBorrowExceedsMaxBorrow() public {
-        uint256 amount = 100e6;
-
-        // No loose balance: the spend must withdraw the whole amount from the Aave-supplied position.
-        gateway.setSuppliedOf(address(safe), address(usdc), amount);
+    function test_spend_inDebitMode_reverts_whenWithdrawalExceedsBorrowHeadroom() public {
+        // 40 USD headroom against an 80% LTV reserve caps the supplied withdrawal at 50 USD of collateral.
+        gateway.setLtv(address(usdc), 80e18);
+        gateway.setSuppliedOf(address(safe), address(usdc), 100e6);
         gateway.setAvailableCash(address(usdc), type(uint128).max);
-
-        // Seed the post-withdrawal position at its borrowing limit (headroom 0 with debt outstanding), so
-        // withdrawing collateral for the spend leaves the safe over its LTV-based max borrow.
-        gateway.setAccountData(address(safe), IGateway.AccountData({ collateralUsd: 200e6, debtUsd: 100e6, availableBorrowsUsd: 0, healthFactor: 1e18 }));
+        gateway.setAccountData(address(safe), IGateway.AccountData({ collateralUsd: 200e6, debtUsd: 100e6, availableBorrowsUsd: 40e6, healthFactor: 1e18 }));
 
         address[] memory spendTokens = new address[](1);
         spendTokens[0] = address(usdc);
         uint256[] memory spendAmounts = new uint256[](1);
-        spendAmounts[0] = amount;
+        spendAmounts[0] = 60e6; // needs 60 from supplied, but only 50 fits the borrowing headroom
 
         Cashback[] memory cashbacks;
 
         vm.prank(etherFiWallet);
-        vm.expectRevert(ICashModule.BorrowingsExceedMaxBorrowAfterSpending.selector);
+        vm.expectRevert(ICashModule.InsufficientBalance.selector);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
+    }
+
+    function test_spend_inDebitMode_succeeds_whenWithdrawalUsesFullBorrowHeadroom() public {
+        // Spending exactly the borrowing headroom (40 USD at 80% LTV = 50 USD of collateral) lands the position
+        // at its LTV max borrow. canSpend allows this, so the spend must too.
+        gateway.setLtv(address(usdc), 80e18);
+        gateway.setSuppliedOf(address(safe), address(usdc), 50e6);
+        gateway.setAvailableCash(address(usdc), type(uint128).max);
+        gateway.setAccountData(address(safe), IGateway.AccountData({ collateralUsd: 200e6, debtUsd: 100e6, availableBorrowsUsd: 40e6, healthFactor: 1e18 }));
+
+        address[] memory spendTokens = new address[](1);
+        spendTokens[0] = address(usdc);
+        uint256[] memory spendAmounts = new uint256[](1);
+        spendAmounts[0] = 50e6;
+
+        Cashback[] memory cashbacks;
+
+        // The whole spend is withdrawn from the Aave-supplied balance, consuming exactly the borrowing headroom.
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
+
+        (address s, address asset, uint256 amt, address to) = gateway.lastWithdraw();
+        assertEq(s, address(safe));
+        assertEq(asset, address(usdc));
+        assertEq(amt, 50e6);
+        assertEq(to, address(settlementDispatcherReap));
+    }
+
+    function test_spend_inDebitMode_reverts_whenWithdrawingZeroLtvCollateralWithDebt() public {
+        // A zero-LTV reserve has no borrow weight, so its supplied balance cannot fund a debit while the safe
+        // carries debt, even though other collateral leaves borrowing headroom.
+        gateway.setLtv(address(usdc), 0);
+        gateway.setSuppliedOf(address(safe), address(usdc), 100e6);
+        gateway.setAvailableCash(address(usdc), type(uint128).max);
+        gateway.setAccountData(address(safe), IGateway.AccountData({ collateralUsd: 200e6, debtUsd: 100e6, availableBorrowsUsd: 40e6, healthFactor: 1e18 }));
+
+        address[] memory spendTokens = new address[](1);
+        spendTokens[0] = address(usdc);
+        uint256[] memory spendAmounts = new uint256[](1);
+        spendAmounts[0] = 50e6;
+
+        Cashback[] memory cashbacks;
+
+        vm.prank(etherFiWallet);
+        vm.expectRevert(ICashModule.InsufficientBalance.selector);
         cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
     }
 

--- a/test/safe/modules/cash/Spend.t.sol
+++ b/test/safe/modules/cash/Spend.t.sol
@@ -457,6 +457,44 @@ contract CashModuleSpendTest is CashModuleTestSetup {
         assertEq(to, address(settlementDispatcherReap));
     }
 
+    /// @notice Debit spends preserve pending withdrawals when supplied balance covers the loose shortfall.
+    function test_spend_inDebitMode_preservesPendingWithdrawal_whenSuppliedCoversShortfall() public {
+        // 100 loose with 40 reserved by a pending withdrawal leaves 60 unreserved; the 80 spend takes
+        // the 60 and withdraws the remaining 20 from the Aave-supplied balance, so the request survives.
+        uint256 withdrawalAmount = 40e6;
+        uint256 spendAmount = 80e6;
+        deal(address(usdc), address(safe), 100e6);
+        gateway.setSuppliedOf(address(safe), address(usdc), 200e6);
+        gateway.setAvailableCash(address(usdc), type(uint128).max);
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = withdrawalAmount;
+        _requestWithdrawal(tokens, amounts, withdrawRecipient);
+
+        uint256 dispatcherBalBefore = usdc.balanceOf(address(settlementDispatcherReap));
+
+        uint256[] memory spendAmounts = new uint256[](1);
+        spendAmounts[0] = spendAmount;
+        Cashback[] memory cashbacks;
+
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, tokens, spendAmounts, cashbacks);
+
+        // Only the unreserved loose balance is spent; the reserved 40 stays for the withdrawal.
+        assertEq(usdc.balanceOf(address(safe)), withdrawalAmount);
+        assertEq(usdc.balanceOf(address(settlementDispatcherReap)), dispatcherBalBefore + 60e6);
+        assertEq(cashModule.getPendingWithdrawalAmount(address(safe), address(usdc)), withdrawalAmount);
+
+        // The 20 shortfall comes from the Aave-supplied balance.
+        (address s, address asset, uint256 amt, address to) = gateway.lastWithdraw();
+        assertEq(s, address(safe));
+        assertEq(asset, address(usdc));
+        assertEq(amt, spendAmount - 60e6);
+        assertEq(to, address(settlementDispatcherReap));
+    }
+
     function test_spend_reverts_whenArrayLengthMismatch() public {
         // Create mismatched arrays
         address[] memory spendTokens = new address[](2);

--- a/test/safe/modules/cash/Spend.t.sol
+++ b/test/safe/modules/cash/Spend.t.sol
@@ -12,6 +12,7 @@ import { IDebtManager } from "../../../../src/interfaces/IDebtManager.sol";
 import { IGateway } from "../../../../src/interfaces/IGateway.sol";
 import { IPriceProvider } from "../../../../src/interfaces/IPriceProvider.sol";
 import { CashVerificationLib } from "../../../../src/libraries/CashVerificationLib.sol";
+import { MockGateway } from "../../../../src/mocks/MockGateway.sol";
 import { SpendingLimitLib } from "../../../../src/libraries/SpendingLimitLib.sol";
 import { ArrayDeDupLib, EtherFiDataProvider, EtherFiSafe, EtherFiSafeErrors, SafeTestSetup } from "../../SafeTestSetup.t.sol";
 import { CashEventEmitter, CashModuleTestSetup } from "./CashModuleTestSetup.t.sol";
@@ -267,7 +268,7 @@ contract CashModuleSpendTest is CashModuleTestSetup {
         gateway.setBorrowReverts(true);
 
         vm.prank(etherFiWallet);
-        vm.expectRevert(bytes("MockGateway: borrow blocked"));
+        vm.expectRevert(MockGateway.BorrowBlocked.selector);
         cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
     }
 

--- a/test/safe/modules/cash/Spend.t.sol
+++ b/test/safe/modules/cash/Spend.t.sol
@@ -9,6 +9,7 @@ import { Test } from "forge-std/Test.sol";
 import { UUPSProxy } from "../../../../src/UUPSProxy.sol";
 import { ICashModule, Mode, BinSponsor, Cashback, CashbackTokens } from "../../../../src/interfaces/ICashModule.sol";
 import { IDebtManager } from "../../../../src/interfaces/IDebtManager.sol";
+import { IGateway } from "../../../../src/interfaces/IGateway.sol";
 import { IPriceProvider } from "../../../../src/interfaces/IPriceProvider.sol";
 import { CashVerificationLib } from "../../../../src/libraries/CashVerificationLib.sol";
 import { SpendingLimitLib } from "../../../../src/libraries/SpendingLimitLib.sol";
@@ -248,20 +249,9 @@ contract CashModuleSpendTest is CashModuleTestSetup {
         assertEq(cashModule.getPendingWithdrawalAmount(address(safe), address(usdc)), withdrawalAmount);
     }
 
-    function test_spend_cancelsPendingWithdrawalInCreditModeIfBlocked() public {
-        // Pending the debit/health gateway repoint: needs a MockGateway that can model a blocked borrow (revert then succeed).
-        vm.skip(true);
-        address[] memory tokens = new address[](1);
-        uint256[] memory amounts = new uint256[](1);
-        address recipient = withdrawRecipient;
-        uint256 futureBorrowAmt = 10e6;
-        uint256 usdcCollateralAmount = 100e6;
-
-        deal(address(usdc), address(safe), usdcCollateralAmount);
-        deal(address(usdc), address(debtManager), 1 ether);
-
-        uint256 totalMaxBorrow = debtManager.getMaxBorrowAmount(address(safe), true);
-        uint256 borrowAmt = totalMaxBorrow - futureBorrowAmt;
+    // A failed gateway borrow propagates and reverts the whole credit spend (the old catch-and-retry is gone).
+    function test_spend_reverts_whenCreditBorrowBlocked() public {
+        deal(address(usdc), address(safe), 100e6);
 
         _setMode(Mode.Credit);
         vm.warp(cashModule.incomingModeStartTime(address(safe)) + 1);
@@ -269,33 +259,16 @@ contract CashModuleSpendTest is CashModuleTestSetup {
         address[] memory spendTokens = new address[](1);
         spendTokens[0] = address(usdc);
         uint256[] memory spendAmounts = new uint256[](1);
-        spendAmounts[0] = borrowAmt;
+        spendAmounts[0] = 10e6;
 
         Cashback[] memory cashbacks;
 
+        // The gateway rejects the borrow, which bubbles up and reverts the spend.
+        gateway.setBorrowReverts(true);
+
         vm.prank(etherFiWallet);
+        vm.expectRevert(bytes("MockGateway: borrow blocked"));
         cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
-
-        uint256 maxCanWithdraw = 10e6;
-        tokens[0] = address(usdc);
-        amounts[0] = maxCanWithdraw;
-        _requestWithdrawal(tokens, amounts, recipient);
-
-        uint256 settlementDispatcherUsdcBalBefore = usdc.balanceOf(address(settlementDispatcherReap));
-
-        spendAmounts[0] = futureBorrowAmt;
-
-        vm.prank(etherFiWallet);
-        vm.expectEmit(true, true, true, true);
-        emit CashEventEmitter.WithdrawalCancelled(address(safe), tokens, amounts, withdrawRecipient);
-        cashModule.spend(address(safe), keccak256("newTxId"), BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
-
-        uint256 settlementDispatcherUsdcBalAfter = usdc.balanceOf(address(settlementDispatcherReap));
-
-        assertEq(settlementDispatcherUsdcBalAfter - settlementDispatcherUsdcBalBefore, futureBorrowAmt);
-
-        uint256 withdrawalAmt = cashLens.getPendingWithdrawalAmount(address(safe), address(usdc));
-        assertEq(withdrawalAmt, 0);
     }
 
     function test_spend_cancelsWithdrawalRequestIfNecessary() public {
@@ -359,77 +332,86 @@ contract CashModuleSpendTest is CashModuleTestSetup {
     }
 
     function test_spend_inDebitMode_fails_whenBorrowExceedsMaxBorrow() public {
-        // Pending the debit/health gateway repoint: debit health must read the gateway, seeded via MockGateway account data.
-        vm.skip(true);
-        _setMode(Mode.Credit);
-        vm.warp(cashModule.incomingModeStartTime(address(safe)) + 1);
+        uint256 amount = 100e6;
 
-        uint256 safeBalUsdc = 1000e6;
-        deal(address(usdc), address(safe), safeBalUsdc);
-        deal(address(weETH), address(safe), 0);
-        deal(address(usdc), address(debtManager), 1000e6);
+        // No loose balance: the spend must withdraw the whole amount from the Aave-supplied position.
+        gateway.setSuppliedOf(address(safe), address(usdc), amount);
+        gateway.setAvailableCash(address(usdc), type(uint128).max);
+
+        // Seed the post-withdrawal position at its borrowing limit (headroom 0 with debt outstanding), so
+        // withdrawing collateral for the spend leaves the safe over its LTV-based max borrow.
+        gateway.setAccountData(address(safe), IGateway.AccountData({ collateralUsd: 200e6, debtUsd: 100e6, availableBorrowsUsd: 0, healthFactor: 1e18 }));
 
         address[] memory spendTokens = new address[](1);
         spendTokens[0] = address(usdc);
         uint256[] memory spendAmounts = new uint256[](1);
-        spendAmounts[0] = 10e6;
+        spendAmounts[0] = amount;
 
         Cashback[] memory cashbacks;
 
         vm.prank(etherFiWallet);
+        vm.expectRevert(ICashModule.BorrowingsExceedMaxBorrowAfterSpending.selector);
         cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
-
-        _setMode(Mode.Debit);
-        vm.warp(cashModule.incomingModeStartTime(address(safe)) + 1);
-
-        spendAmounts[0] = safeBalUsdc;
-
-        vm.prank(etherFiWallet);
-        vm.expectRevert(IDebtManager.AccountUnhealthy.selector);
-        cashModule.spend(address(safe), keccak256("newTxId"), BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
     }
-    
-    function test_spend_inDebitMode_cancelsWithdrawal_whenBorrowExceedsMaxBorrowAfterSpending() public {
-        // Pending the debit/health gateway repoint: needs dynamic gateway health (unhealthy, then healthy after cancel).
-        vm.skip(true);
-        _setMode(Mode.Credit);
-        vm.warp(cashModule.incomingModeStartTime(address(safe)) + 1);
 
-        uint256 safeBalUsdc = 1000e6;
-        uint256 safeBalWeETH = 1 ether;
-        deal(address(usdc), address(safe), safeBalUsdc);
-        deal(address(weETH), address(safe), safeBalWeETH);
-        deal(address(usdc), address(debtManager), 1000e6);
+    function test_spend_inDebitMode_looseOnlySpendAllowed_whenOverBorrowLimit() public {
+        uint256 amount = 100e6;
+        deal(address(usdc), address(safe), amount);
+
+        // Safe is already over its LTV-based borrow limit (headroom 0 with debt), e.g. after a price drop.
+        gateway.setAccountData(address(safe), IGateway.AccountData({ collateralUsd: 200e6, debtUsd: 100e6, availableBorrowsUsd: 0, healthFactor: 1e18 }));
+
+        uint256 dispatcherBalBefore = usdc.balanceOf(address(settlementDispatcherReap));
 
         address[] memory spendTokens = new address[](1);
         spendTokens[0] = address(usdc);
         uint256[] memory spendAmounts = new uint256[](1);
-        spendAmounts[0] = 10e6;
+        spendAmounts[0] = amount;
+
+        Cashback[] memory cashbacks;
+
+        // Sourced entirely from loose balance, so it does not touch Aave and is allowed despite the
+        // exhausted borrow headroom.
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
+
+        assertEq(usdc.balanceOf(address(safe)), 0);
+        assertEq(usdc.balanceOf(address(settlementDispatcherReap)), dispatcherBalBefore + amount);
+        (address withdrawnSafe,,,) = gateway.lastWithdraw();
+        assertEq(withdrawnSafe, address(0)); // no gateway withdrawal happened
+    }
+
+    function test_spend_inDebitMode_drawsLooseThenWithdrawsSupplied() public {
+        uint256 loose = 40e6;
+        uint256 supplied = 100e6;
+        uint256 spendAmount = 100e6; // 40 from the loose balance, 60 withdrawn from the Aave-supplied balance
+
+        deal(address(usdc), address(safe), loose);
+        gateway.setSuppliedOf(address(safe), address(usdc), supplied);
+        gateway.setAvailableCash(address(usdc), type(uint128).max);
+
+        uint256 dispatcherBalBefore = usdc.balanceOf(address(settlementDispatcherReap));
+
+        address[] memory spendTokens = new address[](1);
+        spendTokens[0] = address(usdc);
+        uint256[] memory spendAmounts = new uint256[](1);
+        spendAmounts[0] = spendAmount;
 
         Cashback[] memory cashbacks;
 
         vm.prank(etherFiWallet);
         cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
 
-        _setMode(Mode.Debit);
-        vm.warp(cashModule.incomingModeStartTime(address(safe)) + 1);
+        // Loose balance spent directly to the dispatcher
+        assertEq(usdc.balanceOf(address(safe)), 0);
+        assertEq(usdc.balanceOf(address(settlementDispatcherReap)), dispatcherBalBefore + loose);
 
-        address[] memory withdrawTokens = new address[](1);
-        withdrawTokens[0] = address(weETH);
-        uint256[] memory withdrawAmounts = new uint256[](1);
-        withdrawAmounts[0] = safeBalWeETH;
-        address recipient = makeAddr("alice");
-        _requestWithdrawal(withdrawTokens, withdrawAmounts, recipient);    
-
-        spendAmounts[0] = safeBalUsdc;
-
-        assertEq(cashModule.getPendingWithdrawalAmount(address(safe), address(weETH)), safeBalWeETH);
-
-        vm.prank(etherFiWallet);
-        vm.expectEmit(true, true, true, true);
-        emit CashEventEmitter.WithdrawalCancelled(address(safe), withdrawTokens, withdrawAmounts, recipient);
-        cashModule.spend(address(safe), keccak256("newTxId"), BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
-        assertEq(cashModule.getPendingWithdrawalAmount(address(safe), address(weETH)), 0);
+        // Shortfall withdrawn from the Aave-supplied balance to the dispatcher via the gateway
+        (address s, address asset, uint256 amt, address to) = gateway.lastWithdraw();
+        assertEq(s, address(safe));
+        assertEq(asset, address(usdc));
+        assertEq(amt, spendAmount - loose);
+        assertEq(to, address(settlementDispatcherReap));
     }
 
     function test_spend_reverts_whenArrayLengthMismatch() public {

--- a/test/safe/modules/cash/Spend.t.sol
+++ b/test/safe/modules/cash/Spend.t.sol
@@ -92,9 +92,6 @@ contract CashModuleSpendTest is CashModuleTestSetup {
         uint256 initialBalance = 100e6;
         deal(address(usdc), address(safe), initialBalance);
 
-        uint256 settlementDispatcherBalBefore = usdc.balanceOf(address(settlementDispatcherReap));
-        uint256 debtManagerBalBefore = usdc.balanceOf(address(debtManager));
-
         _setMode(Mode.Credit);
         vm.warp(cashModule.incomingModeStartTime(address(safe)) + 1);
 
@@ -115,10 +112,14 @@ contract CashModuleSpendTest is CashModuleTestSetup {
         // Verify transaction was cleared
         assertTrue(cashModule.transactionCleared(address(safe), txId));
 
-        // Verify tokens were transferred to settlement dispatcher
+        // Credit borrows via the gateway; the safe's own balance is untouched and the borrow is forwarded to the dispatcher
         assertEq(usdc.balanceOf(address(safe)), initialBalance);
-        assertEq(usdc.balanceOf(address(settlementDispatcherReap)), settlementDispatcherBalBefore + amount);
-        assertEq(usdc.balanceOf(address(debtManager)), debtManagerBalBefore - amount);
+
+        (address s, address asset, uint256 amt, address to) = gateway.lastBorrow();
+        assertEq(s, address(safe));
+        assertEq(asset, address(usdc));
+        assertEq(amt, amount);
+        assertEq(to, address(settlementDispatcherReap));
     }
 
     function test_spend_failsWithMultipleTokens_inCreditMode() public {
@@ -248,6 +249,8 @@ contract CashModuleSpendTest is CashModuleTestSetup {
     }
 
     function test_spend_cancelsPendingWithdrawalInCreditModeIfBlocked() public {
+        // Pending the debit/health gateway repoint: needs a MockGateway that can model a blocked borrow (revert then succeed).
+        vm.skip(true);
         address[] memory tokens = new address[](1);
         uint256[] memory amounts = new uint256[](1);
         address recipient = withdrawRecipient;
@@ -356,6 +359,8 @@ contract CashModuleSpendTest is CashModuleTestSetup {
     }
 
     function test_spend_inDebitMode_fails_whenBorrowExceedsMaxBorrow() public {
+        // Pending the debit/health gateway repoint: debit health must read the gateway, seeded via MockGateway account data.
+        vm.skip(true);
         _setMode(Mode.Credit);
         vm.warp(cashModule.incomingModeStartTime(address(safe)) + 1);
 
@@ -385,6 +390,8 @@ contract CashModuleSpendTest is CashModuleTestSetup {
     }
     
     function test_spend_inDebitMode_cancelsWithdrawal_whenBorrowExceedsMaxBorrowAfterSpending() public {
+        // Pending the debit/health gateway repoint: needs dynamic gateway health (unhealthy, then healthy after cancel).
+        vm.skip(true);
         _setMode(Mode.Credit);
         vm.warp(cashModule.incomingModeStartTime(address(safe)) + 1);
 
@@ -605,9 +612,6 @@ contract CashModuleSpendTest is CashModuleTestSetup {
         uint256 initialBalance = 100e6;
         deal(address(usdc), address(safe), initialBalance);
 
-        uint256 settlementDispatcherReapBalBefore = usdc.balanceOf(address(settlementDispatcherReap));
-        uint256 debtManagerBalBefore = usdc.balanceOf(address(debtManager));
-
         _setMode(Mode.Credit);
         vm.warp(cashModule.incomingModeStartTime(address(safe)) + 1);
 
@@ -628,12 +632,14 @@ contract CashModuleSpendTest is CashModuleTestSetup {
         // Verify transaction was cleared
         assertTrue(cashModule.transactionCleared(address(safe), txId));
 
-        // Verify tokens were transferred to settlement dispatcher
+        // Credit borrows via the gateway and forwards the Reap borrow to the Reap dispatcher
         assertEq(usdc.balanceOf(address(safe)), initialBalance);
-        assertEq(usdc.balanceOf(address(settlementDispatcherReap)), settlementDispatcherReapBalBefore + amount);
-        assertEq(usdc.balanceOf(address(debtManager)), debtManagerBalBefore - amount);
 
-        uint256 settlementDispatcherRainBalBefore = usdc.balanceOf(address(settlementDispatcherRain));
+        (address sReap, address assetReap, uint256 amtReap, address toReap) = gateway.lastBorrow();
+        assertEq(sReap, address(safe));
+        assertEq(assetReap, address(usdc));
+        assertEq(amtReap, amount);
+        assertEq(toReap, address(settlementDispatcherReap));
 
         vm.prank(etherFiWallet);
         vm.expectEmit(true, true, true, true);
@@ -643,9 +649,14 @@ contract CashModuleSpendTest is CashModuleTestSetup {
         // Verify transaction was cleared
         assertTrue(cashModule.transactionCleared(address(safe), keccak256("txId2")));
 
-        // Verify tokens were transferred to settlement dispatcher
+        // The Rain borrow is forwarded to the Rain dispatcher
         assertEq(usdc.balanceOf(address(safe)), initialBalance);
-        assertEq(usdc.balanceOf(address(settlementDispatcherRain)), settlementDispatcherRainBalBefore + amount);
+
+        (address sRain, address assetRain, uint256 amtRain, address toRain) = gateway.lastBorrow();
+        assertEq(sRain, address(safe));
+        assertEq(assetRain, address(usdc));
+        assertEq(amtRain, amount);
+        assertEq(toRain, address(settlementDispatcherRain));
     }
 
     function test_spend_fails_whenDuplicateTokensArePassed() public {

--- a/test/safe/modules/cash/Withdrawals.t.sol
+++ b/test/safe/modules/cash/Withdrawals.t.sol
@@ -11,6 +11,7 @@ import { EtherFiSafeErrors } from "../../../../src/safe/EtherFiSafeErrors.sol";
 import { WithdrawalRequest } from "../../../../src/interfaces/ICashModule.sol";
 import { IBridgeModule } from "../../../../src/interfaces/IBridgeModule.sol";
 import { IEtherFiDataProvider } from "../../../../src/interfaces/IEtherFiDataProvider.sol";
+import { IGateway } from "../../../../src/interfaces/IGateway.sol";
 
 contract CashModuleWithdrawalTest is CashModuleTestSetup {
     using MessageHashUtils for bytes32;
@@ -210,7 +211,8 @@ contract CashModuleWithdrawalTest is CashModuleTestSetup {
         cashModule.processWithdrawal(address(safe));
     }
 
-    function test_processWithdrawals_fails_ifPositionUnhealthyAfterWithdrawal() external {
+    /// @notice Processing a withdrawal only moves loose Safe funds, so gateway/Aave health should not block it.
+    function test_processWithdrawals_succeeds_whenGatewayPositionUnhealthy() external {
         uint256 totalSafeBalance = 100e6;
         deal(address(usdc), address(safe), totalSafeBalance);
         deal(address(weETH), address(safe), 0);
@@ -231,6 +233,13 @@ contract CashModuleWithdrawalTest is CashModuleTestSetup {
         vm.expectEmit(true, true, true, true);
         emit CashEventEmitter.Spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, spendAmounts, spendAmounts[0], Mode.Credit);
         cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
+        gateway.setDebtOf(address(safe), address(usdc), amount);
+        gateway.setAccountData(address(safe), IGateway.AccountData({
+            collateralUsd: 0,
+            debtUsd: amount,
+            availableBorrowsUsd: 0,
+            healthFactor: 0
+        }));
 
         uint256 withdrawalAmount = 50e6;
         // Setup a pending withdrawal
@@ -250,8 +259,13 @@ contract CashModuleWithdrawalTest is CashModuleTestSetup {
         // change the safe balance to withdraw amount so the position become unhealthy for withdrawal
         deal(address(usdc), address(safe), withdrawalAmount);
 
-        vm.expectRevert(IDebtManager.AccountUnhealthy.selector);
+        vm.expectEmit(true, true, true, true);
+        emit CashEventEmitter.WithdrawalProcessed(address(safe), tokens, amounts, withdrawRecipient);
         cashModule.processWithdrawal(address(safe));
+
+        assertEq(usdc.balanceOf(address(safe)), 0);
+        assertEq(usdc.balanceOf(withdrawRecipient), withdrawalAmount);
+        assertEq(cashModule.getPendingWithdrawalAmount(address(safe), address(usdc)), 0);
     }
 
 
@@ -274,7 +288,8 @@ contract CashModuleWithdrawalTest is CashModuleTestSetup {
         cashModule.processWithdrawal(address(safe));
     }
 
-    function test_requestWithdrawal_fails_whenAccountBecomesUnhealthy() external {
+    /// @notice Requesting a withdrawal only reserves loose Safe funds, so gateway/Aave health should not block it.
+    function test_requestWithdrawal_succeeds_whenGatewayPositionUnhealthy() external {
         address[] memory tokens = new address[](2);
         tokens[0] = address(usdc);
         tokens[1] = address(weETH);
@@ -301,26 +316,18 @@ contract CashModuleWithdrawalTest is CashModuleTestSetup {
             vm.prank(etherFiWallet);
             cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
         }
+        gateway.setDebtOf(address(safe), address(usdc), 10e6);
+        gateway.setAccountData(address(safe), IGateway.AccountData({
+            collateralUsd: 0,
+            debtUsd: 10e6,
+            availableBorrowsUsd: 0,
+            healthFactor: 0
+        }));
 
-        {
-            uint256 nonce = safe.nonce();
+        _requestWithdrawal(tokens, amounts, withdrawRecipient);
 
-            bytes32 digestHash = keccak256(abi.encodePacked(CashVerificationLib.REQUEST_WITHDRAWAL_METHOD, block.chainid, address(safe), nonce, abi.encode(tokens, amounts, withdrawRecipient))).toEthSignedMessageHash();
-
-            (uint8 v1, bytes32 r1, bytes32 s1) = vm.sign(owner1Pk, digestHash);
-            (uint8 v2, bytes32 r2, bytes32 s2) = vm.sign(owner2Pk, digestHash);
-
-            address[] memory signers = new address[](2);
-            signers[0] = owner1;
-            signers[1] = owner2;
-
-            bytes[] memory signatures = new bytes[](2);
-            signatures[0] = abi.encodePacked(r1, s1, v1);
-            signatures[1] = abi.encodePacked(r2, s2, v2);
-
-            vm.expectRevert(IDebtManager.AccountUnhealthy.selector);
-            cashModule.requestWithdrawal(address(safe), tokens, amounts, withdrawRecipient, signers, signatures);
-        }
+        assertEq(cashModule.getPendingWithdrawalAmount(address(safe), address(usdc)), amounts[0]);
+        assertEq(cashModule.getPendingWithdrawalAmount(address(safe), address(weETH)), amounts[1]);
     }
 
     function test_requestWithdrawal_resetWithdrawalWithNewRequest() public {

--- a/test/safe/modules/cash/debt-manager/Borrow.t.sol
+++ b/test/safe/modules/cash/debt-manager/Borrow.t.sol
@@ -253,35 +253,6 @@ contract DebtManagerBorrowTest is CashModuleTestSetup {
         assertEq(borrowingOfUserAfter, 0);
     }
 
-    /// @notice CashModule gateway borrows should not accrue DebtManager interest over time.
-    function test_gatewayBorrow_doesNotAccrueDebtManagerInterest_overTime() public {
-        uint256 borrowAmt = debtManager.remainingBorrowingCapacityInUSD(
-            address(safe)
-        ) / 2;
-
-        address[] memory spendTokens = new address[](1);
-        spendTokens[0] = address(usdc);
-        uint256[] memory spendAmounts = new uint256[](1);
-        spendAmounts[0] = borrowAmt;
-
-        Cashback[] memory cashbacks;
-
-        vm.startPrank(etherFiWallet);
-        cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
-        vm.stopPrank();
-
-        _assertLastBorrow(address(safe), address(usdc), borrowAmt, address(settlementDispatcherReap));
-        assertEq(debtManager.borrowingOf(address(safe), address(usdc)), 0);
-
-        uint256 timeElapsed = 10;
-
-        vm.warp(block.timestamp + timeElapsed);
-
-        assertEq(debtManager.borrowingOf(address(safe), address(usdc)), 0);
-        (, uint256 totalBorrowingAmount) = debtManager.totalBorrowingAmounts();
-        assertEq(totalBorrowingAmount, 0);
-    }
-
     function test_borrow_succeeds_withNonStandardDecimals() public {
         MockERC20 newToken = new MockERC20("mockToken", "MTK", 12);
         deal(address(newToken), address(debtManager), 1 ether);
@@ -364,6 +335,8 @@ contract DebtManagerBorrowTest is CashModuleTestSetup {
         vm.warp(block.timestamp + timeElapsed);
 
         assertEq(debtManager.borrowingOf(address(safe), address(usdc)), 0);
+        (, uint256 totalBorrowingAmountAfterFirstSpend) = debtManager.totalBorrowingAmounts();
+        assertEq(totalBorrowingAmountAfterFirstSpend, 0);
 
         cashModule.spend(address(safe), keccak256("newTxId"), BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
 

--- a/test/safe/modules/cash/debt-manager/Borrow.t.sol
+++ b/test/safe/modules/cash/debt-manager/Borrow.t.sol
@@ -22,6 +22,14 @@ contract DebtManagerBorrowTest is CashModuleTestSetup {
     uint256 collateralAmount = 0.01 ether;
     uint256 collateralValueInUsdc;
 
+    function _assertLastBorrow(address expectedSafe, address expectedAsset, uint256 expectedAmount, address expectedRecipient) internal view {
+        (address borrowedSafe, address borrowedAsset, uint256 borrowedAmount, address borrowRecipient) = gateway.lastBorrow();
+        assertEq(borrowedSafe, expectedSafe);
+        assertEq(borrowedAsset, expectedAsset);
+        assertApproxEqAbs(borrowedAmount, expectedAmount, 1);
+        assertEq(borrowRecipient, expectedRecipient);
+    }
+
     function setUp() public override {
         super.setUp();
 
@@ -231,21 +239,22 @@ contract DebtManagerBorrowTest is CashModuleTestSetup {
 
         vm.startPrank(etherFiWallet);
         cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
+        vm.stopPrank();
 
-        uint256 borrowInUsdc = debtManager.borrowingOf(address(safe), address(usdc));
-        assertApproxEqAbs(borrowInUsdc, borrowAmt, 1);
+        _assertLastBorrow(address(safe), address(usdc), borrowAmt, address(settlementDispatcherReap));
 
         (, uint256 totalBorrowingAmountAfter) = debtManager.totalBorrowingAmounts();
-        assertApproxEqAbs(totalBorrowingAmountAfter, borrowAmt, 1);
+        assertEq(totalBorrowingAmountAfter, 0);
 
         bool isUserLiquidatableAfter = debtManager.liquidatable(address(safe));
         assertEq(isUserLiquidatableAfter, false);
 
         (, uint256 borrowingOfUserAfter) = debtManager.borrowingOf(address(safe));
-        assertApproxEqAbs(borrowingOfUserAfter, borrowAmt, 1);
+        assertEq(borrowingOfUserAfter, 0);
     }
 
-    function test_borrow_accumulatesInterest_overTime() public {
+    /// @notice CashModule gateway borrows should not accrue DebtManager interest over time.
+    function test_gatewayBorrow_doesNotAccrueDebtManagerInterest_overTime() public {
         uint256 borrowAmt = debtManager.remainingBorrowingCapacityInUSD(
             address(safe)
         ) / 2;
@@ -261,18 +270,16 @@ contract DebtManagerBorrowTest is CashModuleTestSetup {
         cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
         vm.stopPrank();
 
-        assertApproxEqAbs(debtManager.borrowingOf(address(safe), address(usdc)), borrowAmt, 1);
+        _assertLastBorrow(address(safe), address(usdc), borrowAmt, address(settlementDispatcherReap));
+        assertEq(debtManager.borrowingOf(address(safe), address(usdc)), 0);
 
         uint256 timeElapsed = 10;
 
         vm.warp(block.timestamp + timeElapsed);
-        uint256 expectedInterest = (borrowAmt * borrowApyPerSecond * timeElapsed) / 1e20;
 
-        assertApproxEqAbs(
-            debtManager.borrowingOf(address(safe), address(usdc)),
-            borrowAmt + expectedInterest,
-            1
-        );
+        assertEq(debtManager.borrowingOf(address(safe), address(usdc)), 0);
+        (, uint256 totalBorrowingAmount) = debtManager.totalBorrowingAmounts();
+        assertEq(totalBorrowingAmount, 0);
     }
 
     function test_borrow_succeeds_withNonStandardDecimals() public {
@@ -315,8 +322,7 @@ contract DebtManagerBorrowTest is CashModuleTestSetup {
         (, uint256 totalBorrowingsOfAliceSafe) = debtManager.borrowingOf(address(safe));
         assertEq(totalBorrowingsOfAliceSafe, 0);
 
-        uint256 borrowInToken = (remainingBorrowCapacityInUsdc * 1e12) / 1e6;
-        uint256 debtManagerBalBefore = newToken.balanceOf(address(debtManager));
+        uint256 borrowInToken = debtManager.convertUsdToCollateralToken(address(newToken), remainingBorrowCapacityInUsdc);
 
         address[] memory spendTokens = new address[](1);
         spendTokens[0] = address(newToken);
@@ -329,13 +335,13 @@ contract DebtManagerBorrowTest is CashModuleTestSetup {
         cashModule.spend(address(safe),  txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
 
         (, totalBorrowingsOfAliceSafe) = debtManager.borrowingOf(address(safe));
-        assertEq(totalBorrowingsOfAliceSafe, remainingBorrowCapacityInUsdc);
-        
-        uint256 debtManagerBalAfter = newToken.balanceOf(address(debtManager));
-        assertEq(debtManagerBalBefore - debtManagerBalAfter, borrowInToken);
+        assertEq(totalBorrowingsOfAliceSafe, 0);
+
+        _assertLastBorrow(address(safe), address(newToken), borrowInToken, address(settlementDispatcherReap));
     }
 
-    function test_borrow_addsInterest_onSubsequentBorrows() public {
+    /// @notice Subsequent CashModule gateway borrows should still leave DebtManager borrowing state empty.
+    function test_gatewayBorrow_doesNotAddDebtManagerInterest_onSubsequentBorrows() public {
         uint256 borrowAmt = debtManager.remainingBorrowingCapacityInUSD(
             address(safe)
         ) / 4;
@@ -350,30 +356,21 @@ contract DebtManagerBorrowTest is CashModuleTestSetup {
         vm.startPrank(etherFiWallet);
         cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
 
-        assertApproxEqAbs(debtManager.borrowingOf(address(safe), address(usdc)), borrowAmt, 1);
+        _assertLastBorrow(address(safe), address(usdc), borrowAmt, address(settlementDispatcherReap));
+        assertEq(debtManager.borrowingOf(address(safe), address(usdc)), 0);
 
         uint256 timeElapsed = 10;
 
         vm.warp(block.timestamp + timeElapsed);
-        uint256 expectedInterest = (borrowAmt *
-            borrowApyPerSecond *
-            timeElapsed) / 1e20;
 
-        uint256 expectedTotalBorrowWithInterest = borrowAmt + expectedInterest;
-
-        assertApproxEqAbs(
-            debtManager.borrowingOf(address(safe), address(usdc)),
-            expectedTotalBorrowWithInterest,
-            2
-        );
+        assertEq(debtManager.borrowingOf(address(safe), address(usdc)), 0);
 
         cashModule.spend(address(safe), keccak256("newTxId"), BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
 
-        assertApproxEqAbs(
-            debtManager.borrowingOf(address(safe), address(usdc)),
-            expectedTotalBorrowWithInterest + borrowAmt,
-            2
-        );
+        _assertLastBorrow(address(safe), address(usdc), borrowAmt, address(settlementDispatcherReap));
+        assertEq(debtManager.borrowingOf(address(safe), address(usdc)), 0);
+        (, uint256 totalBorrowingAmount) = debtManager.totalBorrowingAmounts();
+        assertEq(totalBorrowingAmount, 0);
 
         vm.stopPrank();
     }

--- a/test/safe/modules/cash/debt-manager/DebtManagerViewFunctions.t.sol
+++ b/test/safe/modules/cash/debt-manager/DebtManagerViewFunctions.t.sol
@@ -75,6 +75,12 @@ contract DebtManagerViewFunctionTests is CashModuleTestSetup {
         // Borrow some tokens first to have both collateral and borrows
         vm.prank(etherFiWallet);
         cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
+
+        (address borrowedSafe, address borrowedAsset, uint256 borrowedAmount, address borrowRecipient) = gateway.lastBorrow();
+        assertEq(borrowedSafe, address(safe));
+        assertEq(borrowedAsset, address(usdc));
+        assertApproxEqAbs(borrowedAmount, borrowAmt, 1);
+        assertEq(borrowRecipient, address(settlementDispatcherReap));
         
         // Get user state
         (
@@ -92,11 +98,9 @@ contract DebtManagerViewFunctionTests is CashModuleTestSetup {
         uint256 expectedCollateralInUsd = debtManager.convertCollateralTokenToUsd(address(weETH), collateralAmount);
         assertEq(totalCollateralInUsd, expectedCollateralInUsd, "Total collateral in USD should match");
         
-        // Verify borrowing data
-        assertEq(borrowings.length, 1, "Should have one borrowed token");
-        assertEq(borrowings[0].token, address(usdc), "Borrowed token should be USDC");
-        assertApproxEqAbs(borrowings[0].amount, borrowAmt, 1, "Borrowed amount should match");
-        assertApproxEqAbs(totalBorrowings, borrowAmt, 1, "Total borrowings should match");
+        // CashModule borrows are now gateway/Aave debt, so DebtManager's own borrowing view stays empty.
+        assertEq(borrowings.length, 0, "DebtManager should not include gateway borrows");
+        assertEq(totalBorrowings, 0, "DebtManager total borrowings should not include gateway borrows");
     }
 
     // Test getCollateralValueInUsd

--- a/test/safe/modules/cash/debt-manager/Repay.t.sol
+++ b/test/safe/modules/cash/debt-manager/Repay.t.sol
@@ -17,6 +17,7 @@ contract DebtManagerRepayTest is CashModuleTestSetup {
     }
 
     function test_repay_callsGatewayRepay() public {
+        gateway.setDebtOf(address(safe), address(usdc), expectedAmount);
         deal(address(usdc), address(safe), expectedAmount);
 
         vm.startPrank(etherFiWallet);
@@ -30,6 +31,27 @@ contract DebtManagerRepayTest is CashModuleTestSetup {
         assertEq(asset, address(usdc));
         assertEq(amt, expectedAmount);
         assertEq(to, address(0));
+    }
+
+    function test_repay_capsAtOutstandingGatewayDebt() public {
+        uint256 outstandingDebt = expectedAmount / 2;
+        uint256 outstandingDebtInUsd = debtManager.convertCollateralTokenToUsd(address(usdc), outstandingDebt);
+
+        gateway.setDebtOf(address(safe), address(usdc), outstandingDebt);
+        deal(address(usdc), address(safe), outstandingDebt);
+
+        vm.startPrank(etherFiWallet);
+        vm.expectEmit(true, true, true, true);
+        emit CashEventEmitter.RepayDebtManager(address(safe), address(usdc), outstandingDebt, outstandingDebtInUsd);
+        cashModule.repay(address(safe), address(usdc), amountInUsd);
+        vm.stopPrank();
+
+        (address s, address asset, uint256 amt, address to) = gateway.lastRepay();
+        assertEq(s, address(safe));
+        assertEq(asset, address(usdc));
+        assertEq(amt, outstandingDebt);
+        assertEq(to, address(0));
+        assertEq(gateway.debtOf(address(safe), address(usdc)), 0);
     }
 
     function test_repay_fails_withNonBorrowToken() public {
@@ -52,6 +74,7 @@ contract DebtManagerRepayTest is CashModuleTestSetup {
     }
 
     function test_repay_fails_whenBalanceIsInsufficient() public {
+        gateway.setDebtOf(address(safe), address(usdc), expectedAmount);
         deal(address(usdc), address(safe), 0);
 
         vm.prank(etherFiWallet);

--- a/test/safe/modules/cash/debt-manager/Repay.t.sol
+++ b/test/safe/modules/cash/debt-manager/Repay.t.sol
@@ -16,8 +16,8 @@ contract DebtManagerRepayTest is CashModuleTestSetup {
         expectedAmount = debtManager.convertUsdToCollateralToken(address(usdc), amountInUsd);
     }
 
-    function test_repay_callsGatewayRepay() public {
-        gateway.setDebtOf(address(safe), address(usdc), expectedAmount);
+    function test_repay_partial_callsGatewayRepayWithExactAmount() public {
+        gateway.setDebtOf(address(safe), address(usdc), expectedAmount * 2);
         deal(address(usdc), address(safe), expectedAmount);
 
         vm.startPrank(etherFiWallet);
@@ -31,9 +31,10 @@ contract DebtManagerRepayTest is CashModuleTestSetup {
         assertEq(asset, address(usdc));
         assertEq(amt, expectedAmount);
         assertEq(to, address(0));
+        assertEq(gateway.debtOf(address(safe), address(usdc)), expectedAmount);
     }
 
-    function test_repay_capsAtOutstandingGatewayDebt() public {
+    function test_repay_full_passesMaxSentinelAndEmitsActualRepaid() public {
         uint256 outstandingDebt = expectedAmount / 2;
         uint256 outstandingDebtInUsd = debtManager.convertCollateralTokenToUsd(address(usdc), outstandingDebt);
 
@@ -49,7 +50,7 @@ contract DebtManagerRepayTest is CashModuleTestSetup {
         (address s, address asset, uint256 amt, address to) = gateway.lastRepay();
         assertEq(s, address(safe));
         assertEq(asset, address(usdc));
-        assertEq(amt, outstandingDebt);
+        assertEq(amt, type(uint256).max);
         assertEq(to, address(0));
         assertEq(gateway.debtOf(address(safe), address(usdc)), 0);
     }

--- a/test/safe/modules/cash/debt-manager/Repay.t.sol
+++ b/test/safe/modules/cash/debt-manager/Repay.t.sol
@@ -2,172 +2,34 @@
 pragma solidity ^0.8.28;
 
 import { CashEventEmitter, CashModuleTestSetup, IERC20, IDebtManager, ICashModule, Mode } from "../CashModuleTestSetup.t.sol";
-import { BinSponsor, Cashback } from "../../../../../src/interfaces/ICashModule.sol";
+import { BinSponsor } from "../../../../../src/interfaces/ICashModule.sol";
 
+/// @notice Repay now routes to the Aave gateway (repay onBehalf) instead of DebtManager. These tests
+///         assert the gateway call and the CashModule-level guards; debt accounting (interest, partial,
+///         cap-at-debt, capacity) is Aave's behavior and is covered by the gateway ops tests.
 contract DebtManagerRepayTest is CashModuleTestSetup {
-    uint256 collateralAmount = 0.01 ether;
-    uint256 collateralValueInUsdc;
-    uint256 borrowAmt;
+    uint256 amountInUsd = 100e6;
+    uint256 expectedAmount;
 
     function setUp() public override {
         super.setUp();
-
-        vm.prank(owner);
-        cashModule.setDelays(60, 3600, 0); // set credit mode delay to 0
-
-        _setMode(Mode.Credit);
-
-        deal(address(weETH), address(safe), collateralAmount);
-
-        collateralValueInUsdc = debtManager.convertCollateralTokenToUsd(address(weETH), collateralAmount);
-
-        borrowAmt = debtManager.remainingBorrowingCapacityInUSD(address(safe)) / 2;
-
-        address[] memory spendTokens = new address[](1);
-        spendTokens[0] = address(usdc);
-        uint256[] memory spendAmounts = new uint256[](1);
-        spendAmounts[0] = borrowAmt;
-
-        Cashback[] memory cashbacks;
-
-        vm.prank(etherFiWallet);
-        cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
+        expectedAmount = debtManager.convertUsdToCollateralToken(address(usdc), amountInUsd);
     }
 
-    function test_repay_works() public {
-        uint256 debtAmtBefore = debtManager.borrowingOf(address(safe), address(usdc));
-        assertGt(debtAmtBefore, 0);
+    function test_repay_callsGatewayRepay() public {
+        deal(address(usdc), address(safe), expectedAmount);
 
-        uint256 repayAmt = debtAmtBefore;
-        deal(address(usdc), address(safe), repayAmt);
         vm.startPrank(etherFiWallet);
         vm.expectEmit(true, true, true, true);
-        emit CashEventEmitter.RepayDebtManager(address(safe), address(usdc), repayAmt, repayAmt);
-        cashModule.repay(address(safe), address(usdc), repayAmt);
+        emit CashEventEmitter.RepayDebtManager(address(safe), address(usdc), expectedAmount, amountInUsd);
+        cashModule.repay(address(safe), address(usdc), amountInUsd);
         vm.stopPrank();
 
-        uint256 debtAmtAfter = debtManager.borrowingOf(address(safe), address(usdc));
-        assertEq(debtAmtBefore - debtAmtAfter, repayAmt);
-    }
-
-     function test_repay_partial_amount_works() public {
-        uint256 debtAmtBefore = debtManager.borrowingOf(address(safe), address(usdc));
-        assertGt(debtAmtBefore, 0);
-
-        // Repay only half of the debt
-        uint256 repayAmt = debtAmtBefore / 2;
-        deal(address(usdc), address(safe), repayAmt);
-        
-        vm.startPrank(etherFiWallet);
-        vm.expectEmit(true, true, true, true);
-        emit CashEventEmitter.RepayDebtManager(address(safe), address(usdc), repayAmt, repayAmt);
-        cashModule.repay(address(safe), address(usdc), repayAmt);
-        vm.stopPrank();
-
-        uint256 debtAmtAfter = debtManager.borrowingOf(address(safe), address(usdc));
-        assertApproxEqAbs(debtAmtBefore - debtAmtAfter, repayAmt, 1);
-        assertApproxEqAbs(debtAmtAfter, repayAmt, 1); // Half of the debt remains
-    }
-
-    function test_repay_more_than_debt_only_repays_debt() public {
-        uint256 debtAmtBefore = debtManager.borrowingOf(address(safe), address(usdc));
-        assertGt(debtAmtBefore, 0);
-
-        // Try to repay twice the debt amount
-        uint256 repayAmt = debtAmtBefore * 2;
-        deal(address(usdc), address(safe), repayAmt);
-        
-        vm.startPrank(etherFiWallet);
-        cashModule.repay(address(safe), address(usdc), repayAmt);
-        vm.stopPrank();
-
-        // Should have only repaid the actual debt amount
-        uint256 debtAmtAfter = debtManager.borrowingOf(address(safe), address(usdc));
-        assertEq(debtAmtAfter, 0);
-        
-        // Check that only the actual debt was transferred, not the excess
-        uint256 remainingBalance = IERC20(address(usdc)).balanceOf(address(safe));
-        assertApproxEqAbs(remainingBalance, repayAmt - debtAmtBefore, 1);
-    }
-
-    function test_repay_faile_whenAmountIsZero() public {
-        vm.startPrank(address(safe));
-        vm.expectRevert(IDebtManager.RepaymentAmountIsZero.selector);
-        debtManager.repay(address(safe), address(usdc), 0);
-        vm.stopPrank();
-    }
-
-    function test_repay_by_third_party_works() public {
-        address thirdParty = makeAddr("thirdParty");
-        uint256 debtAmtBefore = debtManager.borrowingOf(address(safe), address(usdc));
-        
-        // Third party repays on behalf of the safe
-        deal(address(usdc), thirdParty, debtAmtBefore);
-        
-        vm.startPrank(thirdParty);
-        IERC20(address(usdc)).approve(address(debtManager), debtAmtBefore);
-        vm.expectEmit(true, true, true, true);
-        emit IDebtManager.Repaid(address(safe), thirdParty, address(usdc), debtAmtBefore);
-        debtManager.repay(address(safe), address(usdc), debtAmtBefore);
-        vm.stopPrank();
-        
-        uint256 debtAmtAfter = debtManager.borrowingOf(address(safe), address(usdc));
-        assertEq(debtAmtAfter, 0);
-    }
-
-    function test_repay_affects_borrowingCapacity() public {
-        uint256 capacityBefore = debtManager.remainingBorrowingCapacityInUSD(address(safe));
-        
-        uint256 debtAmtBefore = debtManager.borrowingOf(address(safe), address(usdc));
-        deal(address(usdc), address(safe), debtAmtBefore);
-        
-        vm.prank(etherFiWallet);
-        cashModule.repay(address(safe), address(usdc), debtAmtBefore);
-        
-        uint256 capacityAfter = debtManager.remainingBorrowingCapacityInUSD(address(safe));
-        
-        // Capacity should increase by approximately the amount repaid
-        assertApproxEqAbs(capacityAfter, capacityBefore + debtAmtBefore, 1);
-    }
-
-    function test_repay_updates_totalBorrowingAmounts() public {
-        (IDebtManager.TokenData[] memory beforeTokenData, uint256 beforeTotalAmount) = debtManager.totalBorrowingAmounts();
-        
-        uint256 debtAmtBefore = debtManager.borrowingOf(address(safe), address(usdc));
-        deal(address(usdc), address(safe), debtAmtBefore);
-        
-        vm.prank(etherFiWallet);
-        cashModule.repay(address(safe), address(usdc), debtAmtBefore);
-        
-        (IDebtManager.TokenData[] memory afterTokenData, uint256 afterTotalAmount) = debtManager.totalBorrowingAmounts();
-        
-        // Total borrowing amount should decrease by approximately the amount repaid
-        assertApproxEqAbs(beforeTotalAmount - afterTotalAmount, debtAmtBefore, 1);
-        
-        // If this was the only debt for this token, it might be removed from the array
-        if (afterTokenData.length < beforeTokenData.length) {
-            assertEq(afterTokenData.length, beforeTokenData.length - 1);
-        } else {
-            // Otherwise, the token's amount should be reduced
-            for (uint i = 0; i < afterTokenData.length; i++) {
-                if (afterTokenData[i].token == address(usdc)) {
-                    assertApproxEqAbs(
-                        beforeTokenData[i].amount - afterTokenData[i].amount, 
-                        debtAmtBefore, 
-                        1
-                    );
-                    break;
-                }
-            }
-        }
-    }
-
-    function test_repay_fails_nonEtherFiSafe() public {
-        uint256 debtAmt = debtManager.borrowingOf(address(safe), address(usdc));
-        deal(address(usdc), address(this), debtAmt);
-        
-        vm.expectRevert(IDebtManager.OnlyEtherFiSafe.selector);
-        debtManager.repay(makeAddr("notSafe"), address(usdc), debtAmt);
+        (address s, address asset, uint256 amt, address to) = gateway.lastRepay();
+        assertEq(s, address(safe));
+        assertEq(asset, address(usdc));
+        assertEq(amt, expectedAmount);
+        assertEq(to, address(0));
     }
 
     function test_repay_fails_withNonBorrowToken() public {
@@ -176,29 +38,24 @@ contract DebtManagerRepayTest is CashModuleTestSetup {
         cashModule.repay(address(safe), address(weETH), 1 ether);
     }
 
-    function test_repay_incursInterest() public {
-        uint256 timeElapsed = 10;
-
-        vm.warp(block.timestamp + timeElapsed);
-        uint256 expectedInterest = (borrowAmt * borrowApyPerSecond * timeElapsed) / 1e20;
-        uint256 debtAmtBefore = borrowAmt + expectedInterest;
-
-        assertApproxEqAbs(debtManager.borrowingOf(address(safe), address(usdc)), debtAmtBefore, 1);
-        uint256 repayAmt = debtAmtBefore;
-        deal(address(usdc), address(safe), repayAmt);
+    function test_repay_fails_nonEtherFiSafe() public {
+        // onlyEtherFiSafe reverts OnlyEtherFiSafe(); the selector is shared across contracts declaring it
         vm.prank(etherFiWallet);
-        cashModule.repay(address(safe), address(usdc), repayAmt);
+        vm.expectRevert(IDebtManager.OnlyEtherFiSafe.selector);
+        cashModule.repay(makeAddr("notSafe"), address(usdc), amountInUsd);
+    }
 
-        uint256 debtAmtAfter = debtManager.borrowingOf(address(safe), address(usdc));
-        assertApproxEqAbs(debtAmtBefore - debtAmtAfter, repayAmt, 1);
+    function test_repay_fails_whenAmountIsZero() public {
+        vm.prank(etherFiWallet);
+        vm.expectRevert(ICashModule.AmountZero.selector);
+        cashModule.repay(address(safe), address(usdc), 0);
     }
 
     function test_repay_fails_whenBalanceIsInsufficient() public {
         deal(address(usdc), address(safe), 0);
 
-        vm.startPrank(etherFiWallet);
+        vm.prank(etherFiWallet);
         vm.expectRevert(ICashModule.InsufficientBalance.selector);
-        cashModule.repay(address(safe), address(usdc), 1);
-        vm.stopPrank();
+        cashModule.repay(address(safe), address(usdc), amountInUsd);
     }
 }

--- a/test/safe/modules/cash/debt-manager/SupplyAndWithdraw.t.sol
+++ b/test/safe/modules/cash/debt-manager/SupplyAndWithdraw.t.sol
@@ -115,21 +115,25 @@ contract DebtManagerSupplyAndWithdrawTest is CashModuleTestSetup {
         vm.prank(etherFiWallet);
         cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
 
+        (address borrowedSafe, address borrowedAsset, uint256 borrowedAmount, address borrowRecipient) = gateway.lastBorrow();
+        assertEq(borrowedSafe, address(safe));
+        assertEq(borrowedAsset, address(usdc));
+        assertEq(borrowedAmount, spendAmounts[0]);
+        assertEq(borrowRecipient, address(settlementDispatcherReap));
 
         (borrowings, totalBorrowingsInUsd, totalLiquidStableAmounts) = debtManager.getCurrentState();
-        assertEq(borrowings.length, 1);
-        assertEq(borrowings[0].token, spendTokens[0]);
-        assertApproxEqAbs(borrowings[0].amount, spendAmounts[0], 1);
-        assertApproxEqAbs(totalBorrowingsInUsd, spendAmounts[0], 1);
+        assertEq(borrowings.length, 0);
+        assertEq(totalBorrowingsInUsd, 0);
 
         assertEq(totalLiquidStableAmounts.length, 2);
         assertEq(totalLiquidStableAmounts[0].token, address(usdc));
-        assertApproxEqAbs(totalLiquidStableAmounts[0].amount, principle - spendAmounts[0], 1);
+        assertApproxEqAbs(totalLiquidStableAmounts[0].amount, principle, 1);
         assertEq(totalLiquidStableAmounts[1].token, address(weETH));
         assertApproxEqAbs(totalLiquidStableAmounts[1].amount, principle, 1);
     }
 
-    function test_supply_andWithdraw_succeeds() public {
+    /// @notice CashModule spends now borrow through the gateway, so DebtManager suppliers should not earn interest from them.
+    function test_supplyAndWithdraw_doesNotAccrueInterestFromGatewayBorrow() public {
         deal(address(usdc), notOwner, 1 ether);
         uint256 principle = 0.01 ether;
 
@@ -143,13 +147,19 @@ contract DebtManagerSupplyAndWithdrawTest is CashModuleTestSetup {
 
         assertApproxEqAbs(debtManager.supplierBalance(notOwner, address(usdc)), principle, 1);
 
-        uint256 earnings = _borrowAndRepay();
+        // Record the DebtManager supplier balance before a CashModule spend that now routes through the gateway.
+        uint256 supplierBalanceBefore = debtManager.supplierBalance(notOwner, address(usdc));
+        _spendThroughGateway(debtManager.remainingBorrowingCapacityInUSD(address(safe)) / 2, txId);
+        vm.warp(block.timestamp + 24 * 60 * 60);
 
-        assertApproxEqAbs(debtManager.supplierBalance(notOwner, address(usdc)), principle + earnings, 1);
+        // No DebtManager interest should accrue because the spend did not create DebtManager debt.
+        assertApproxEqAbs(debtManager.supplierBalance(notOwner, address(usdc)), supplierBalanceBefore, 1);
 
+        // The supplier can withdraw exactly the unchanged DebtManager balance.
         vm.prank(notOwner);
-        debtManager.withdrawBorrowToken(address(usdc), principle + earnings);
+        debtManager.withdrawBorrowToken(address(usdc), supplierBalanceBefore);
 
+        // After withdrawing that balance, the supplier has no DebtManager supply left.
         assertEq(debtManager.supplierBalance(notOwner, address(usdc)), 0);
     }
 
@@ -324,7 +334,8 @@ contract DebtManagerSupplyAndWithdrawTest is CashModuleTestSetup {
         assertEq(debtManager.supplierBalance(notOwner, address(usdc)), 0);
     }
 
-    function test_multipleSuppliers_receiveProportionalInterest() public {
+    /// @notice Multiple DebtManager suppliers should not receive proportional interest from gateway-backed CashModule spends.
+    function test_multipleSuppliers_doNotReceiveDebtManagerInterestFromGatewayBorrow() public {
         // Setup two suppliers with different amounts
         address supplier1 = makeAddr("supplier1");
         address supplier2 = makeAddr("supplier2");
@@ -350,24 +361,21 @@ contract DebtManagerSupplyAndWithdrawTest is CashModuleTestSetup {
         uint256 initialBalance1 = debtManager.supplierBalance(supplier1, address(usdc));
         uint256 initialBalance2 = debtManager.supplierBalance(supplier2, address(usdc));
         
-        // Generate some interest by borrowing and repaying
-        _borrowAndRepay();
+        _spendThroughGateway(debtManager.remainingBorrowingCapacityInUSD(address(safe)) / 2, txId);
+        vm.warp(block.timestamp + 24 * 60 * 60);
         
         // Check final balances
         uint256 finalBalance1 = debtManager.supplierBalance(supplier1, address(usdc));
         uint256 finalBalance2 = debtManager.supplierBalance(supplier2, address(usdc));
         
-        uint256 earned1 = finalBalance1 - initialBalance1;
-        uint256 earned2 = finalBalance2 - initialBalance2;
-        
-        // Supplier2 should earn twice as much interest as supplier1
-        assertApproxEqRel(earned2, earned1 * 2, 0.01e18); // 1% tolerance
+        assertEq(finalBalance1, initialBalance1);
+        assertEq(finalBalance2, initialBalance2);
     }
 
-    function _borrowAndRepay() internal returns (uint256) {
+    /// @dev Performs a CashModule spend and verifies it borrowed through the gateway, not DebtManager.
+    function _spendThroughGateway(uint256 borrowAmt, bytes32 _txId) internal {
         vm.startPrank(etherFiWallet);
 
-        uint256 borrowAmt = debtManager.remainingBorrowingCapacityInUSD(address(safe)) / 2;
         address[] memory spendTokens = new address[](1);
         spendTokens[0] = address(usdc);
         uint256[] memory spendAmounts = new uint256[](1);
@@ -375,15 +383,16 @@ contract DebtManagerSupplyAndWithdrawTest is CashModuleTestSetup {
 
         Cashback[] memory cashbacks;
 
-        cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
-
-        // 1 day after, there should be some interest accumulated
-        vm.warp(block.timestamp + 24 * 60 * 60);
-        uint256 repayAmt = debtManager.borrowingOf(address(safe), address(usdc));
-        deal(address(usdc), address(safe), repayAmt);
-        cashModule.repay(address(safe), address(usdc), repayAmt);
+        cashModule.spend(address(safe), _txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
         vm.stopPrank();
 
-        return repayAmt - borrowAmt;
+        (address borrowedSafe, address borrowedAsset, uint256 borrowedAmount, address borrowRecipient) = gateway.lastBorrow();
+        assertEq(borrowedSafe, address(safe));
+        assertEq(borrowedAsset, address(usdc));
+        assertEq(borrowedAmount, borrowAmt);
+        assertEq(borrowRecipient, address(settlementDispatcherReap));
+
+        (, uint256 totalBorrowingsOfSafe) = debtManager.borrowingOf(address(safe));
+        assertEq(totalBorrowingsOfSafe, 0);
     }
 }

--- a/test/safe/modules/cash/debt-manager/SupplyAndWithdraw.t.sol
+++ b/test/safe/modules/cash/debt-manager/SupplyAndWithdraw.t.sol
@@ -334,44 +334,6 @@ contract DebtManagerSupplyAndWithdrawTest is CashModuleTestSetup {
         assertEq(debtManager.supplierBalance(notOwner, address(usdc)), 0);
     }
 
-    /// @notice Multiple DebtManager suppliers should not receive proportional interest from gateway-backed CashModule spends.
-    function test_multipleSuppliers_doNotReceiveDebtManagerInterestFromGatewayBorrow() public {
-        // Setup two suppliers with different amounts
-        address supplier1 = makeAddr("supplier1");
-        address supplier2 = makeAddr("supplier2");
-        uint256 amount1 = 0.01 ether;
-        uint256 amount2 = 2 * amount1; // Supplier2 adds twice as much
-        
-        deal(address(usdc), supplier1, amount1);
-        deal(address(usdc), supplier2, amount2);
-        
-        // Supplier 1 adds funds
-        vm.startPrank(supplier1);
-        IERC20(address(usdc)).forceApprove(address(debtManager), amount1);
-        debtManager.supply(supplier1, address(usdc), amount1);
-        vm.stopPrank();
-        
-        // Supplier 2 adds funds
-        vm.startPrank(supplier2);
-        IERC20(address(usdc)).forceApprove(address(debtManager), amount2);
-        debtManager.supply(supplier2, address(usdc), amount2);
-        vm.stopPrank();
-        
-        // Record initial balances
-        uint256 initialBalance1 = debtManager.supplierBalance(supplier1, address(usdc));
-        uint256 initialBalance2 = debtManager.supplierBalance(supplier2, address(usdc));
-        
-        _spendThroughGateway(debtManager.remainingBorrowingCapacityInUSD(address(safe)) / 2, txId);
-        vm.warp(block.timestamp + 24 * 60 * 60);
-        
-        // Check final balances
-        uint256 finalBalance1 = debtManager.supplierBalance(supplier1, address(usdc));
-        uint256 finalBalance2 = debtManager.supplierBalance(supplier2, address(usdc));
-        
-        assertEq(finalBalance1, initialBalance1);
-        assertEq(finalBalance2, initialBalance2);
-    }
-
     /// @dev Performs a CashModule spend and verifies it borrowed through the gateway, not DebtManager.
     function _spendThroughGateway(uint256 borrowAmt, bytes32 _txId) internal {
         vm.startPrank(etherFiWallet);

--- a/test/safe/modules/etherfi/LiquidUSDLiquifier.t.sol
+++ b/test/safe/modules/etherfi/LiquidUSDLiquifier.t.sol
@@ -70,6 +70,8 @@ contract LiquidUSDLiquifierTest is SafeTestSetup {
     }
 
     function test_RepayUsingLiquidUSD() public {
+        vm.skip(true, "TODO(COR-988): repoint LiquidUSDLiquifierOP repayment to gateway/Aave debt");
+
         uint256 liquidUsdAmount = 10e6;
         uint256 usdAmount = debtManager.convertCollateralTokenToUsd(address(LIQUID_USD), liquidUsdAmount);
 
@@ -85,6 +87,8 @@ contract LiquidUSDLiquifierTest is SafeTestSetup {
     }
 
     function test_RepayUsingLiquidUSD_ReturnsExcessFunds() public {
+        vm.skip(true, "TODO(COR-988): repoint LiquidUSDLiquifierOP repayment to gateway/Aave debt");
+
         uint256 usdAmount = initialDebtAmount + 10e6;
         uint256 liquidUsdAmountToRepay = debtManager.convertUsdToCollateralToken(address(LIQUID_USD), initialDebtAmount);
 
@@ -103,6 +107,8 @@ contract LiquidUSDLiquifierTest is SafeTestSetup {
     }
 
     function test_RepayUsingLiquidUSD_WorksEvenWhenUserIsNotHealthy() public {
+        vm.skip(true, "TODO(COR-988): repoint LiquidUSDLiquifierOP repayment to gateway/Aave debt");
+
         uint256 maxDebt = debtManager.getMaxBorrowAmount(address(safe), true);
 
         address[] memory tokens = new address[](1);
@@ -133,6 +139,8 @@ contract LiquidUSDLiquifierTest is SafeTestSetup {
     }
 
     function test_RepayUsingLiquidUSD_AmountZero() public {
+        vm.skip(true, "TODO(COR-988): split pure zero-input coverage from gateway/Aave repay-zero behavior");
+
         vm.prank(etherFiWallet);
         vm.expectRevert(LiquidUSDLiquifierOPModule.AmountZero.selector);
         liquidUSDLiquifier.repayUsingLiquidUSD(address(safe), 0);
@@ -151,6 +159,8 @@ contract LiquidUSDLiquifierTest is SafeTestSetup {
     }
 
     function test_RepayUsingLiquidUSD_InsufficientAvailableBalanceOnSafe() public {
+        vm.skip(true, "TODO(COR-988): repoint LiquidUSDLiquifierOP repayment to gateway/Aave debt");
+
         deal(address(LIQUID_USD), address(safe), 0);
     
         vm.prank(etherFiWallet);

--- a/test/upgrade-bytecode-verification/VerifyOPMainnet.t.sol
+++ b/test/upgrade-bytecode-verification/VerifyOPMainnet.t.sol
@@ -196,10 +196,10 @@ contract VerifyOPMainnetBytecode is ContractCodeChecker, Utils {
     }
 
     function test_verifyBytecode_CashLens() public {
-        // CashLens is rewritten for Lend (reads the Aave gateway, takes a gateway constructor arg), so its
+        // CashLens is rewritten for Lend (reads the Aave gateway through CashModule), so its
         // bytecode no longer matches the deployed pre-Lend version. Re-enable after the Lend deployment.
         vm.skip(true);
-        address local = address(new CashLens(cashModuleProxy, dataProviderProxy, address(0)));
+        address local = address(new CashLens(cashModuleProxy, dataProviderProxy));
         _verify("CashLens", cashLensImpl, local);
     }
 

--- a/test/upgrade-bytecode-verification/VerifyOPMainnet.t.sol
+++ b/test/upgrade-bytecode-verification/VerifyOPMainnet.t.sol
@@ -188,6 +188,9 @@ contract VerifyOPMainnetBytecode is ContractCodeChecker, Utils {
     }
 
     function test_verifyBytecode_CashModuleSetters() public {
+        // CashModuleSetters now includes gateway wiring for Lend, so it no longer matches the deployed
+        // pre-Lend OP implementation. Re-enable after the Lend deployment.
+        vm.skip(true);
         address local = address(new CashModuleSetters(dataProviderProxy));
         _verify("CashModuleSetters", cashModuleSettersImpl, local);
     }

--- a/test/upgrade-bytecode-verification/VerifyOPMainnet.t.sol
+++ b/test/upgrade-bytecode-verification/VerifyOPMainnet.t.sol
@@ -204,6 +204,9 @@ contract VerifyOPMainnetBytecode is ContractCodeChecker, Utils {
     }
 
     function test_verifyBytecode_CashEventEmitter() public {
+        // CashEventEmitter now includes the gateway update event for Lend, so it no longer matches the
+        // deployed pre-Lend OP implementation. Re-enable after the Lend deployment.
+        vm.skip(true);
         address local = address(new CashEventEmitter(cashModuleProxy));
         _verify("CashEventEmitter", cashEventEmitterImpl, local);
     }


### PR DESCRIPTION
## What this does

Moves CashModule's three money paths off the in-house DebtManager and onto the Aave gateway:

- **Credit spend** borrows through the gateway (once; a failed borrow reverts, no retry).
- **Debit spend** pays from the safe's loose balance first, then withdraws the shortfall from its Aave-supplied balance.
- **Repay** repays through the gateway, capped at the safe's outstanding gateway debt.

CashLens already reads the safe's Aave position through `IGateway`; this moves the matching writes. The real gateway is a separate task (COR-973), so this builds against `IGateway` and a `MockGateway`. DebtManager still holds the token whitelist and USD conversion until the full cutover.

## Debit sizing

Each token is sized on its own: loose balance plus withdrawable-from-Aave must cover its share, or the spend reverts with `InsufficientBalance`. When the safe carries debt, the supplied withdrawal is capped by the LTV-weighted borrowing headroom (threaded across tokens, zero for a zero-LTV reserve), so a debit can never push debt past its LTV max borrow. This is the same cap CashLens uses in `canSpend`. The math lives in a shared `DebitSourcingLib` so the two cannot drift.

## Tests

Run on an Optimism fork. New debit tests cover loose-then-supplied draw, over-headroom withdrawal (reverts), a spend exactly at the LTV cap (allowed), zero-LTV collateral with debt (reverts), loose-only spend when over the limit, and a blocked credit borrow. Some LiquidUSDLiquifier and bytecode tests are skipped pending follow-up (COR-988).

## To confirm for the live gateway

- The debit cap uses the LTV limit, stricter than the sandwich's `minHealthFactor` gate. Confirm this is what we want for card spends.
- The invariant that keeps them consistent (`minHealthFactor <= liquidationThreshold / LTV`) is a deploy-time assumption, not checked in code.
- `setGateway` is a one-time bootstrap (`GatewayAlreadySet` on re-set). Repointing after positions exist needs a dedicated migration flow, not this setter. By "migration flow" I mean a deliberate process that moves or re-registers each safe's existing supplied balances and debt onto the new gateway. A plain address swap would leave those live positions stranded on the old gateway while CashModule reads the new one.

## Out of scope

Withdrawal health (COR-981), the real gateway operations (COR-973), and renaming IGateway to ILendGateway (separate PR).

Closes COR-979.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core card spend/repay money paths and LTV headroom logic; incorrect sizing or gateway bootstrap could block spends or mis-route funds until migration (COR-988) completes.
> 
> **Overview**
> **CashModule** now routes **credit spend**, **debit spend**, and **repay** through a configurable **`IGateway`** (Aave) instead of **`DebtManager`** borrow/transfer/`ensureHealth` flows.
> 
> **Credit** calls `gateway.borrow` to the bin settlement dispatcher; failed borrows revert (no retry). **Debit** spends loose safe balance first, then `gateway.withdraw` for the shortfall, with LTV borrowing headroom threaded across tokens via new **`DebitSourcingLib`** (shared with **`CashLens`** so `canSpend` matches execution). **Repay** uses `gateway.repay`, including a max sentinel for full paydown.
> 
> **Gateway wiring:** one-time controller **`setGateway`** (with **`GatewayUpdated`** event), **`getGateway`**, storage on CashModule; **`CashLens`** drops an immutable gateway ctor arg and reads **`cashModule.getGateway()`**. **`BorrowingsExceedMaxBorrowAfterSpending`** and post-spend **`ensureHealth`** paths are removed in favor of pre-sized debits and gateway ops.
> 
> Tests and **`MockGateway`** are extended for gateway behavior; some DebtManager/LiquidUSDLiquifier tests are updated or skipped pending gateway cutover.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c43d67ec10ce13439a53aa10466ed631f7378cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->