### PR TITLE
fix(recovery): bind a signed deadline into AssetRecoveryModule (I-04 parity with SafeAssetRecoveryModule)

### DIFF
--- a/src/interfaces/IAssetRecoveryModule.sol
+++ b/src/interfaces/IAssetRecoveryModule.sol
@@ -14,6 +14,7 @@ interface IAssetRecoveryModule {
     error InvalidRecipient();
     error InvalidToken();
     error RefundFailed();
+    error RecoveryExpired();
     // InvalidSignature() comes from ModuleBase; redeclaring here would collide on inheritance.
 
     function recover(
@@ -22,6 +23,7 @@ interface IAssetRecoveryModule {
         address recipient,
         bytes32 safeSalt,
         uint32 destEid,
+        uint256 deadline,
         bytes calldata lzOptions,
         address[] calldata signers,
         bytes[] calldata signatures

--- a/src/modules/recovery/AssetRecoveryModule.sol
+++ b/src/modules/recovery/AssetRecoveryModule.sol
@@ -37,6 +37,12 @@ contract AssetRecoveryModule is IAssetRecoveryModule, ModuleBase, OAppSender, Pa
      *                  prevent gas-grief replays with cheaper options. Must be sized for the
      *                  worst case (deploy TopUp + sweep), since the sender doesn't know which
      *                  branch will run on the dest.
+     * @param deadline Unix timestamp after which the owner authorization is void. Bound into the
+     *                 signed digest so a relayer cannot stash the signature and replay it against a
+     *                 future deposit of the same token (audit I-04 — the destination sweeps the full
+     *                 balance present at delivery, and no amount is signed). Mirrors the deadline on
+     *                 `SafeAssetRecoveryModule.recover`; the per-safe nonce already makes a signature
+     *                 single-use, but without a deadline a valid signature never expires.
      * @return lzGuid LayerZero v2 message GUID for delivery tracking.
      */
     function recover(
@@ -45,6 +51,7 @@ contract AssetRecoveryModule is IAssetRecoveryModule, ModuleBase, OAppSender, Pa
         address recipient,
         bytes32 safeSalt,
         uint32 destEid,
+        uint256 deadline,
         bytes calldata lzOptions,
         address[] calldata signers,
         bytes[] calldata signatures
@@ -52,8 +59,9 @@ contract AssetRecoveryModule is IAssetRecoveryModule, ModuleBase, OAppSender, Pa
         if (recipient == address(0)) revert InvalidRecipient();
         if (token == address(0)) revert InvalidToken();
         if (peers[destEid] == bytes32(0)) revert InvalidDestEid();
+        if (block.timestamp > deadline) revert RecoveryExpired();
 
-        _verifyRecoverySignatures(safe, token, recipient, safeSalt, destEid, lzOptions, signers, signatures);
+        _verifyRecoverySignatures(safe, token, recipient, safeSalt, destEid, deadline, lzOptions, signers, signatures);
 
         lzGuid = _dispatchRecovery(safe, token, recipient, safeSalt, destEid, lzOptions);
 
@@ -108,6 +116,7 @@ contract AssetRecoveryModule is IAssetRecoveryModule, ModuleBase, OAppSender, Pa
         address recipient,
         bytes32 safeSalt,
         uint32 destEid,
+        uint256 deadline,
         bytes calldata lzOptions,
         address[] calldata signers,
         bytes[] calldata signatures
@@ -121,6 +130,7 @@ contract AssetRecoveryModule is IAssetRecoveryModule, ModuleBase, OAppSender, Pa
             recipient,
             safeSalt,
             destEid,
+            deadline,
             keccak256(lzOptions)
         ));
         if (!IEtherFiSafe(safe).checkSignatures(digest, signers, signatures)) revert InvalidSignature();

--- a/test/integration/RecoveryE2E.t.sol
+++ b/test/integration/RecoveryE2E.t.sol
@@ -90,6 +90,7 @@ contract RecoveryE2ETest is SafeTestSetup {
         // ── Phase 1: source side — single call submits + dispatches LZ ──────────────────
         uint256 nonce = module.getNonce(address(safe));
         bytes memory lzOptions = "";
+        uint256 deadline = type(uint256).max;
         bytes32 digest = keccak256(abi.encode(
             block.chainid,
             address(module),
@@ -99,6 +100,7 @@ contract RecoveryE2ETest is SafeTestSetup {
             recipient,
             SAFE_SALT,
             ARB_EID,
+            deadline,
             keccak256(lzOptions)
         ));
         address[] memory signers = new address[](2);
@@ -110,7 +112,7 @@ contract RecoveryE2ETest is SafeTestSetup {
 
         vm.deal(owner1, 1 ether);
         vm.prank(owner1);
-        module.recover{value: 1e15}(address(safe), address(token), recipient, SAFE_SALT, ARB_EID, lzOptions, signers, sigs);
+        module.recover{value: 1e15}(address(safe), address(token), recipient, SAFE_SALT, ARB_EID, deadline, lzOptions, signers, sigs);
 
         (uint32 dstEid, bytes memory message) = srcEndpoint.lastSendArgs();
         assertEq(uint256(dstEid), uint256(ARB_EID), "dstEid mismatch");

--- a/test/safe/modules/recovery/AssetRecoveryModule.t.sol
+++ b/test/safe/modules/recovery/AssetRecoveryModule.t.sol
@@ -29,11 +29,12 @@ contract NonPayableCaller {
         address recipient,
         bytes32 safeSalt,
         uint32 destEid,
+        uint256 deadline,
         bytes calldata lzOptions,
         address[] calldata signers,
         bytes[] calldata sigs
     ) external payable returns (bytes32) {
-        return module.recover{value: msg.value}(safe, token, recipient, safeSalt, destEid, lzOptions, signers, sigs);
+        return module.recover{value: msg.value}(safe, token, recipient, safeSalt, destEid, deadline, lzOptions, signers, sigs);
     }
 }
 
@@ -46,6 +47,9 @@ contract AssetRecoveryModuleTest is SafeTestSetup {
     address public dispatcher = makeAddr("dispatcher");
     uint32 public constant ARB_EID = 30_110;
     bytes32 public constant SAFE_SALT = bytes32(uint256(0xC0DE));
+
+    /// @dev Never-expiring deadline for tests that don't exercise expiry.
+    uint256 internal constant DEADLINE = type(uint256).max;
 
     function setUp() public override {
         super.setUp();
@@ -88,7 +92,7 @@ contract AssetRecoveryModuleTest is SafeTestSetup {
         vm.recordLogs();
         vm.prank(owner1);
         bytes32 lzGuid = module.recover{value: 1e15}(
-            safeAddr, address(token), recipient, SAFE_SALT, destEid, "", signers, sigs
+            safeAddr, address(token), recipient, SAFE_SALT, destEid, DEADLINE, "", signers, sigs
         );
         assertTrue(lzGuid != bytes32(0), "guid should be non-zero");
 
@@ -125,7 +129,7 @@ contract AssetRecoveryModuleTest is SafeTestSetup {
         vm.deal(owner1, 1 ether);
         vm.prank(owner1);
         vm.expectRevert(IAssetRecoveryModule.InvalidToken.selector);
-        module.recover{value: 1e15}(safeAddr, address(0), makeAddr("recipient"), SAFE_SALT, ARB_EID, "", signers, sigs);
+        module.recover{value: 1e15}(safeAddr, address(0), makeAddr("recipient"), SAFE_SALT, ARB_EID, DEADLINE, "", signers, sigs);
     }
 
     function test_recover_revertsIfRecipientZero() public {
@@ -133,7 +137,7 @@ contract AssetRecoveryModuleTest is SafeTestSetup {
         vm.deal(owner1, 1 ether);
         vm.prank(owner1);
         vm.expectRevert(IAssetRecoveryModule.InvalidRecipient.selector);
-        module.recover{value: 1e15}(safeAddr, address(token), address(0), SAFE_SALT, ARB_EID, "", signers, sigs);
+        module.recover{value: 1e15}(safeAddr, address(token), address(0), SAFE_SALT, ARB_EID, DEADLINE, "", signers, sigs);
     }
 
     function test_recover_revertsIfPeerUnset() public {
@@ -144,7 +148,7 @@ contract AssetRecoveryModuleTest is SafeTestSetup {
         vm.deal(owner1, 1 ether);
         vm.prank(owner1);
         vm.expectRevert(IAssetRecoveryModule.InvalidDestEid.selector);
-        module.recover{value: 1e15}(safeAddr, address(token), makeAddr("recipient"), SAFE_SALT, ARB_EID, "", signers, sigs);
+        module.recover{value: 1e15}(safeAddr, address(token), makeAddr("recipient"), SAFE_SALT, ARB_EID, DEADLINE, "", signers, sigs);
     }
 
     function test_recover_revertsIfBadSignature() public {
@@ -153,7 +157,7 @@ contract AssetRecoveryModuleTest is SafeTestSetup {
         vm.deal(owner1, 1 ether);
         vm.prank(owner1);
         vm.expectRevert(ModuleBase.InvalidSignature.selector);
-        module.recover{value: 1e15}(safeAddr, address(token), makeAddr("differentRecipient"), SAFE_SALT, ARB_EID, "", signers, sigs);
+        module.recover{value: 1e15}(safeAddr, address(token), makeAddr("differentRecipient"), SAFE_SALT, ARB_EID, DEADLINE, "", signers, sigs);
     }
 
     function test_recover_revertsIfSaltMismatch() public {
@@ -162,7 +166,7 @@ contract AssetRecoveryModuleTest is SafeTestSetup {
         vm.deal(owner1, 1 ether);
         vm.prank(owner1);
         vm.expectRevert(ModuleBase.InvalidSignature.selector);
-        module.recover{value: 1e15}(safeAddr, address(token), makeAddr("recipient"), bytes32(uint256(0xBADBAD)), ARB_EID, "", signers, sigs);
+        module.recover{value: 1e15}(safeAddr, address(token), makeAddr("recipient"), bytes32(uint256(0xBADBAD)), ARB_EID, DEADLINE, "", signers, sigs);
     }
 
     function test_recover_digestReplayReverts() public {
@@ -171,12 +175,47 @@ contract AssetRecoveryModuleTest is SafeTestSetup {
 
         vm.deal(owner1, 1 ether);
         vm.startPrank(owner1);
-        module.recover{value: 1e15}(safeAddr, address(token), recipient, SAFE_SALT, ARB_EID, "", signers, sigs);
+        module.recover{value: 1e15}(safeAddr, address(token), recipient, SAFE_SALT, ARB_EID, DEADLINE, "", signers, sigs);
 
         // Replay with same sigs — nonce has advanced, digest no longer matches.
         vm.expectRevert(ModuleBase.InvalidSignature.selector);
-        module.recover{value: 1e15}(safeAddr, address(token), recipient, SAFE_SALT, ARB_EID, "", signers, sigs);
+        module.recover{value: 1e15}(safeAddr, address(token), recipient, SAFE_SALT, ARB_EID, DEADLINE, "", signers, sigs);
         vm.stopPrank();
+    }
+
+    /// @dev I-04 regression (ported from SafeAssetRecoveryModule): an expired deadline must revert
+    ///      before the signature is honoured, so a relayer cannot stash a signed cross-chain recovery
+    ///      and replay it against a future, larger deposit of the same token. Amount is not signed
+    ///      (the dest sweeps the full balance at delivery), and the per-safe nonce only makes a
+    ///      signature single-use — without a deadline it never expires.
+    function test_recover_revertsIfExpired() public {
+        address recipient = makeAddr("recipient");
+        uint256 deadline = block.timestamp + 1 hours;
+
+        bytes32 digest = keccak256(abi.encode(
+            block.chainid,
+            address(module),
+            module.getNonce(safeAddr),
+            safeAddr,
+            address(token),
+            recipient,
+            SAFE_SALT,
+            ARB_EID,
+            deadline,
+            keccak256(bytes(""))
+        ));
+        address[] memory signers = new address[](2);
+        signers[0] = owner1;
+        signers[1] = owner2;
+        bytes[] memory sigs = new bytes[](2);
+        sigs[0] = _signDigest(owner1Pk, digest);
+        sigs[1] = _signDigest(owner2Pk, digest);
+
+        vm.warp(deadline + 1);
+        vm.deal(owner1, 1 ether);
+        vm.prank(owner1);
+        vm.expectRevert(IAssetRecoveryModule.RecoveryExpired.selector);
+        module.recover{value: 1e15}(safeAddr, address(token), recipient, SAFE_SALT, ARB_EID, deadline, "", signers, sigs);
     }
 
     function test_recover_revertsIfLzOptionsMismatch() public {
@@ -192,7 +231,7 @@ contract AssetRecoveryModuleTest is SafeTestSetup {
         vm.prank(owner1);
         vm.expectRevert(ModuleBase.InvalidSignature.selector);
         module.recover{value: 1e15}(
-            safeAddr, address(token), makeAddr("recipient"), SAFE_SALT, ARB_EID, submittedOptions, signers, sigs
+            safeAddr, address(token), makeAddr("recipient"), SAFE_SALT, ARB_EID, DEADLINE, submittedOptions, signers, sigs
         );
     }
 
@@ -205,7 +244,7 @@ contract AssetRecoveryModuleTest is SafeTestSetup {
         vm.prank(owner1);
         // Pinned to OZ Pausable's `EnforcedPause()` — `whenNotPaused` is the first guard.
         vm.expectRevert(bytes4(keccak256("EnforcedPause()")));
-        module.recover{value: 1e15}(safeAddr, address(token), makeAddr("recipient"), SAFE_SALT, ARB_EID, "", signers, sigs);
+        module.recover{value: 1e15}(safeAddr, address(token), makeAddr("recipient"), SAFE_SALT, ARB_EID, DEADLINE, "", signers, sigs);
     }
 
     function test_pause_onlyPauser() public {
@@ -225,7 +264,7 @@ contract AssetRecoveryModuleTest is SafeTestSetup {
         // Our override pins to the same selector.
         vm.expectRevert(abi.encodeWithSelector(OAppSender.NotEnoughNative.selector, 0.05 ether));
         module.recover{value: 0.05 ether}(
-            safeAddr, address(token), makeAddr("recipient"), SAFE_SALT, ARB_EID, "", signers, sigs
+            safeAddr, address(token), makeAddr("recipient"), SAFE_SALT, ARB_EID, DEADLINE, "", signers, sigs
         );
     }
 
@@ -238,7 +277,7 @@ contract AssetRecoveryModuleTest is SafeTestSetup {
         uint256 startBal = owner1.balance;
 
         vm.prank(owner1);
-        module.recover{value: 0.5 ether}(safeAddr, address(token), recipient, SAFE_SALT, ARB_EID, "", signers, sigs);
+        module.recover{value: 0.5 ether}(safeAddr, address(token), recipient, SAFE_SALT, ARB_EID, DEADLINE, "", signers, sigs);
 
         // 0.4 ether refunded; net cost = 0.1 ether (the quoted fee).
         assertEq(owner1.balance, startBal - 0.1 ether, "should be charged exactly the fee");
@@ -257,7 +296,7 @@ contract AssetRecoveryModuleTest is SafeTestSetup {
 
         vm.expectRevert(IAssetRecoveryModule.RefundFailed.selector);
         caller.callRecover{value: 0.5 ether}(
-            safeAddr, address(token), recipient, SAFE_SALT, ARB_EID, "", signers, sigs
+            safeAddr, address(token), recipient, SAFE_SALT, ARB_EID, DEADLINE, "", signers, sigs
         );
     }
 
@@ -284,6 +323,7 @@ contract AssetRecoveryModuleTest is SafeTestSetup {
             recipient,
             SAFE_SALT,
             destEid,
+            DEADLINE,
             keccak256(lzOptions)
         ));
 


### PR DESCRIPTION
## Summary

`AssetRecoveryModule` (the LayerZero recovery variant) did not bind a **signed deadline**, while its sibling `SafeAssetRecoveryModule` does (audit finding **I-04**). This PR ports that mitigation so the two recovery modules are consistent.

## Why

Both recovery modules sweep the **full token balance** and **do not sign an amount** — the destination sweeps whatever balance is present at delivery. `SafeAssetRecoveryModule` binds a signed `deadline` (I-04) precisely so a relayer cannot stash a valid owner signature and later replay it against a **future, larger deposit** of the same token.

`AssetRecoveryModule` bound no deadline, so a valid recovery signature **never expired**: the per-safe nonce made it single-use, but it remained replayable in time until consumed. Since the recovery caller is untrusted (EtherFi submits the owner-authorized recovery), a signed authorization for a small stuck balance could be held and dispatched later against a much larger balance. The recipient is bound in the digest (so this is not fund redirection), but the authorization should be time-bounded like the sibling module.

## Changes

- `recover()` takes a `deadline` and reverts `RecoveryExpired` once `block.timestamp > deadline`
- `deadline` is bound into the recovery digest (mirrors `SafeAssetRecoveryModule`)
- `IAssetRecoveryModule`: add `RecoveryExpired` error + `deadline` param
- update LZ `recover` callers in the unit + E2E suites
- add `test_recover_revertsIfExpired` regression (parity with the safe variant)

## Test plan

```
TEST_CHAIN=10 forge test --match-contract "AssetRecoveryModuleTest|SafeAssetRecoveryModuleTest|RecoveryE2E"
```
- [x] 29/29 pass (14 AssetRecoveryModule incl. new expiry regression, 14 SafeAssetRecoveryModule, 1 RecoveryE2E)

## Note for reviewers

`recover()`'s signature changes (adds `deadline`). Any off-chain owner-signing tooling that builds the recovery digest must add `deadline` to the ABI-encoded digest, in the same position as the on-chain `_verifyRecoverySignatures`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes fund-recovery authorization semantics and breaks the recover ABI/digest for integrators, but the guard is narrow and mirrors an existing sibling module pattern.
> 
> **Overview**
> Adds a **signed `deadline`** to cross-chain `AssetRecoveryModule.recover`, matching `SafeAssetRecoveryModule` and closing audit **I-04**: destination recovery sweeps the **full** token balance with **no signed amount**, so a relayer could otherwise hold a valid owner signature until a larger balance arrived.
> 
> `recover` now takes `uint256 deadline`, reverts **`RecoveryExpired`** when `block.timestamp > deadline`, and includes `deadline` in the EIP-style recovery digest in `_verifyRecoverySignatures`. **`IAssetRecoveryModule`** gains the error and updated signature.
> 
> Unit and E2E tests pass `deadline` (default `type(uint256).max`); **`test_recover_revertsIfExpired`** covers post-deadline rejection. **Breaking:** off-chain digest/signing must ABI-encode `deadline` in the same slot as on-chain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit debb68237cefe3581a02cc5f56550041eb1b2b2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->