### PR TITLE
feat: add debt manager migration and lend disable toggle

### DIFF
--- a/src/debt-manager/DebtManagerCore.sol
+++ b/src/debt-manager/DebtManagerCore.sol
@@ -9,6 +9,7 @@ import { ICashLens } from "../interfaces/ICashLens.sol";
 import { BinSponsor, ICashModule } from "../interfaces/ICashModule.sol";
 import { IDebtManager } from "../interfaces/IDebtManager.sol";
 import { IEtherFiDataProvider } from "../interfaces/IEtherFiDataProvider.sol";
+import { IGateway } from "../interfaces/IGateway.sol";
 import { IPriceProvider } from "../interfaces/IPriceProvider.sol";
 import { DebtManagerStorageContract } from "./DebtManagerStorageContract.sol";
 
@@ -458,7 +459,7 @@ contract DebtManagerCore is DebtManagerStorageContract {
      * @param token Address of the token to borrow
      * @param amount Amount of tokens to borrow
      */
-    function borrow(BinSponsor binSponsor, address token, uint256 amount) public whenNotPaused nonReentrant onlyEtherFiSafe {
+    function borrow(BinSponsor binSponsor, address token, uint256 amount) public whenNotPaused nonReentrant onlyEtherFiSafe whenNotMigrated(msg.sender) {
         DebtManagerStorage storage $ = _getDebtManagerStorage();
 
         if (!isBorrowToken(token)) revert UnsupportedBorrowToken();
@@ -488,7 +489,7 @@ contract DebtManagerCore is DebtManagerStorageContract {
      * @param token Address of the token being repaid
      * @param amount Amount of tokens to repay
      */
-    function repay(address user, address token, uint256 amount) external whenNotPaused nonReentrant {
+    function repay(address user, address token, uint256 amount) external whenNotPaused nonReentrant whenNotMigrated(user) {
         DebtManagerStorage storage $ = _getDebtManagerStorage();
 
         _onlyEtherFiSafe(user);
@@ -527,6 +528,132 @@ contract DebtManagerCore is DebtManagerStorageContract {
         IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
 
         emit Repaid(user, msg.sender, token, repayDebtusdAmount);
+    }
+
+    /**
+     * @notice The Aave v4 gateway used by migrateToAave
+     */
+    function gateway() external view returns (IGateway) {
+        return _getDebtManagerStorage().gateway;
+    }
+
+    /**
+     * @notice Whether a Safe's position has been migrated to Aave
+     * @param safe The Safe to query
+     */
+    function hasMigratedToAave(address safe) external view returns (bool) {
+        return _getDebtManagerStorage().migratedToAave[safe];
+    }
+
+    /**
+     * @notice Sets the Aave v4 gateway used by migrateToAave
+     * @dev Only callable by accounts with DEBT_MANAGER_ADMIN_ROLE
+     * @param _gateway Address of the gateway
+     * @custom:throws InvalidValue if the gateway is the zero address
+     */
+    function setGateway(address _gateway) external onlyRole(DEBT_MANAGER_ADMIN_ROLE) {
+        if (_gateway == address(0)) revert InvalidValue();
+        _getDebtManagerStorage().gateway = IGateway(_gateway);
+        emit GatewaySet(_gateway);
+    }
+
+    /**
+     * @notice Migrates a Safe's position from DebtManager to the Aave instance, atomically and without a
+     *         flash loan: the Safe's collateral is supplied to Aave, the outstanding debt is borrowed against
+     *         it, and that borrow funds the DebtManager repayment. End state: same collateral and debt size,
+     *         now on Aave, with the legacy DebtManager debt cleared.
+     * @dev The order (supply -> borrow -> repay) is load-bearing — the repayment is funded by the Aave borrow,
+     *      which is only possible once the collateral is on Aave. The whole thing reverts (leaving the Safe
+     *      untouched) if the Safe has no debt, the Aave reserve lacks liquidity, or the position does not fit
+     *      Aave's LTVs. Only callable by DEBT_MANAGER_ADMIN_ROLE (the migration runner).
+     *      Requires the gateway to be a default module on the Safe and DebtManager to be an authorized gateway
+     *      driver; the gateway self-approves as the Safe's Aave position manager on its first op.
+     * @param safe The Safe to migrate
+     */
+    function migrateToAave(address safe) external whenNotPaused nonReentrant onlyRole(DEBT_MANAGER_ADMIN_ROLE) {
+        _onlyEtherFiSafe(safe);
+        DebtManagerStorage storage $ = _getDebtManagerStorage();
+
+        // 1. Snapshot the outstanding debt. A Safe with no debt is trivially migrated: mark it and return,
+        //    so a batch runner can call this over every Safe without special-casing (and idempotently).
+        (TokenData[] memory borrowings, uint256 totalDebtUsd) = borrowingOf(safe);
+        if (totalDebtUsd == 0) {
+            $.migratedToAave[safe] = true;
+            emit MigratedToAave(safe, 0);
+            return;
+        }
+
+        IGateway _gateway = $.gateway;
+        if (address(_gateway) == address(0)) revert GatewayNotSet();
+        uint256 bLen = borrowings.length;
+
+        // 2. Clear the legacy DebtManager debt FIRST, capturing the token amount to re-borrow, and check Aave
+        //    has the cash to fund it. Clearing first is load-bearing: supplying collateral (step 3) moves it
+        //    out of the Safe via execTransactionFromModule, which runs the EtherFiHook's DebtManager health
+        //    check — that would revert while the debt is still open. The Aave borrow (step 4) re-funds the
+        //    pool; the whole tx reverts on any failure, so the Safe is never left half-migrated nor the pool short.
+        uint256[] memory debtTokenAmts = new uint256[](bLen);
+        for (uint256 i = 0; i < bLen;) {
+            if (borrowings[i].amount != 0) {
+                uint256 debtTokenAmt = _clearLegacyDebt(safe, borrowings[i].token);
+                if (_gateway.availableCash(borrowings[i].token) < debtTokenAmt) revert InsufficientAaveLiquidity(borrowings[i].token);
+                debtTokenAmts[i] = debtTokenAmt;
+            }
+            unchecked {
+                ++i;
+            }
+        }
+
+        // 3. Supply all of the Safe's collateral into Aave, enabled as collateral (Safe is now debt-free on
+        //    DebtManager, so the hook's health check passes as the collateral moves).
+        address[] memory collateralTokens = getCollateralTokens();
+        uint256 cLen = collateralTokens.length;
+        for (uint256 i = 0; i < cLen;) {
+            uint256 bal = IERC20(collateralTokens[i]).balanceOf(safe);
+            if (bal != 0) {
+                _gateway.supply(safe, collateralTokens[i], bal);
+                _gateway.setUsingAsCollateral(safe, collateralTokens[i], true);
+            }
+            unchecked {
+                ++i;
+            }
+        }
+
+        // 4. LTV-fit check (specific error) so the runner can route positions that fit DebtManager's params
+        //    but not Aave's. availableBorrowsUsd is the supplied collateral weighted by Aave's LTVs.
+        if (_gateway.getAccountData(safe).availableBorrowsUsd < totalDebtUsd) revert PositionExceedsAaveLtv();
+
+        // 5. Borrow each debt from Aave into this contract — these funds re-fund the debt cleared in step 2
+        for (uint256 i = 0; i < bLen;) {
+            if (debtTokenAmts[i] != 0) _gateway.borrow(safe, borrowings[i].token, debtTokenAmts[i], address(this));
+            unchecked {
+                ++i;
+            }
+        }
+
+        $.migratedToAave[safe] = true;
+        emit MigratedToAave(safe, totalDebtUsd);
+    }
+
+    /**
+     * @dev Clears a Safe's full outstanding debt in `token` from DebtManager's books and returns the debt in
+     *      token units (to be re-borrowed from Aave). Only the accounting is cleared here; the re-borrowed
+     *      funds arriving later ARE the repayment that replenishes the lent-out balance.
+     */
+    function _clearLegacyDebt(address safe, address token) internal returns (uint256 debtTokenAmt) {
+        DebtManagerStorage storage $ = _getDebtManagerStorage();
+
+        uint256 interestIndex = _updateInterestIndex(token);
+        uint256 normalizedAmount = $.userNormalizedBorrowings[safe][token];
+        if (normalizedAmount == 0) return 0;
+
+        uint256 debtUsd = _getActualBorrowAmount(normalizedAmount, interestIndex);
+        debtTokenAmt = convertUsdToCollateralToken(token, debtUsd);
+
+        $.userNormalizedBorrowings[safe][token] = 0;
+        $.borrowTokenConfig[token].totalNormalizedBorrowingAmount -= normalizedAmount;
+
+        emit Repaid(safe, address(this), token, debtUsd);
     }
 
     /**
@@ -598,6 +725,16 @@ contract DebtManagerCore is DebtManagerStorageContract {
      */
     function _onlyEtherFiSafe(address account) internal view {
         if (!etherFiDataProvider.isEtherFiSafe(account)) revert OnlyEtherFiSafe();
+    }
+
+    /**
+     * @dev Blocks legacy DebtManager operations for a Safe once it has migrated to Aave
+     * @param safe The Safe to check
+     * @custom:throws AlreadyMigratedToAave if the Safe has been migrated
+     */
+    modifier whenNotMigrated(address safe) {
+        if (_getDebtManagerStorage().migratedToAave[safe]) revert AlreadyMigratedToAave();
+        _;
     }
 
     /**

--- a/src/debt-manager/DebtManagerCore.sol
+++ b/src/debt-manager/DebtManagerCore.sol
@@ -574,24 +574,19 @@ contract DebtManagerCore is DebtManagerStorageContract {
         _onlyEtherFiSafe(safe);
         DebtManagerStorage storage $ = _getDebtManagerStorage();
 
-        // 1. Snapshot the outstanding debt. A Safe with no debt is trivially migrated: mark it and return,
-        //    so a batch runner can call this over every Safe without special-casing (and idempotently).
-        (TokenData[] memory borrowings, uint256 totalDebtUsd) = borrowingOf(safe);
-        if (totalDebtUsd == 0) {
-            $.migratedToAave[safe] = true;
-            emit MigratedToAave(safe, 0);
-            return;
-        }
-
         IGateway _gateway = $.gateway;
         if (address(_gateway) == address(0)) revert GatewayNotSet();
+
+        // 1. Snapshot the outstanding DebtManager debt. A debt-free Safe still migrates its collateral (below),
+        //    so a batch runner can call this over every Safe without special-casing (and idempotently).
+        (TokenData[] memory borrowings, uint256 totalDebtUsd) = borrowingOf(safe);
         uint256 bLen = borrowings.length;
 
-        // 2. Clear the legacy DebtManager debt FIRST, capturing the token amount to re-borrow, and check Aave
-        //    has the cash to fund it. Clearing first is load-bearing: supplying collateral (step 3) moves it
-        //    out of the Safe via execTransactionFromModule, which runs the EtherFiHook's DebtManager health
-        //    check — that would revert while the debt is still open. The Aave borrow (step 4) re-funds the
-        //    pool; the whole tx reverts on any failure, so the Safe is never left half-migrated nor the pool short.
+        // 2. Clear the legacy DebtManager debt FIRST (if any), capturing the token amount to re-borrow, and
+        //    check Aave has the cash to fund it. Clearing first is load-bearing: supplying collateral (step 3)
+        //    moves it out of the Safe via execTransactionFromModule, which runs the EtherFiHook's DebtManager
+        //    health check — that would revert while the debt is still open. The Aave borrow (step 5) re-funds
+        //    the pool; the whole tx reverts on any failure, so the Safe is never left half-migrated nor the pool short.
         uint256[] memory debtTokenAmts = new uint256[](bLen);
         for (uint256 i = 0; i < bLen;) {
             if (borrowings[i].amount != 0) {
@@ -605,7 +600,9 @@ contract DebtManagerCore is DebtManagerStorageContract {
         }
 
         // 3. Supply all of the Safe's collateral into Aave, enabled as collateral (Safe is now debt-free on
-        //    DebtManager, so the hook's health check passes as the collateral moves).
+        //    DebtManager, so the hook's health check passes as the collateral moves). This runs even for a
+        //    debt-free Safe: once migrated, credit spends borrow against the Aave position, so the collateral
+        //    must actually move to Aave rather than sit idle in the Safe.
         address[] memory collateralTokens = getCollateralTokens();
         uint256 cLen = collateralTokens.length;
         for (uint256 i = 0; i < cLen;) {
@@ -619,15 +616,17 @@ contract DebtManagerCore is DebtManagerStorageContract {
             }
         }
 
-        // 4. LTV-fit check (specific error) so the runner can route positions that fit DebtManager's params
-        //    but not Aave's. availableBorrowsUsd is the supplied collateral weighted by Aave's LTVs.
-        if (_gateway.getAccountData(safe).availableBorrowsUsd < totalDebtUsd) revert PositionExceedsAaveLtv();
+        // 4/5. Only when there is debt to re-home: check the supplied collateral (weighted by Aave's LTVs) covers
+        //      it — specific error so the runner can route positions that fit DebtManager's params but not Aave's —
+        //      then borrow each debt from Aave into this contract, re-funding the debt cleared in step 2.
+        if (totalDebtUsd != 0) {
+            if (_gateway.getAccountData(safe).availableBorrowsUsd < totalDebtUsd) revert PositionExceedsAaveLtv();
 
-        // 5. Borrow each debt from Aave into this contract — these funds re-fund the debt cleared in step 2
-        for (uint256 i = 0; i < bLen;) {
-            if (debtTokenAmts[i] != 0) _gateway.borrow(safe, borrowings[i].token, debtTokenAmts[i], address(this));
-            unchecked {
-                ++i;
+            for (uint256 i = 0; i < bLen;) {
+                if (debtTokenAmts[i] != 0) _gateway.borrow(safe, borrowings[i].token, debtTokenAmts[i], address(this));
+                unchecked {
+                    ++i;
+                }
             }
         }
 

--- a/src/debt-manager/DebtManagerCore.sol
+++ b/src/debt-manager/DebtManagerCore.sol
@@ -531,30 +531,11 @@ contract DebtManagerCore is DebtManagerStorageContract {
     }
 
     /**
-     * @notice The Aave v4 gateway used by migrateToAave
-     */
-    function gateway() external view returns (IGateway) {
-        return _getDebtManagerStorage().gateway;
-    }
-
-    /**
      * @notice Whether a Safe's position has been migrated to Aave
      * @param safe The Safe to query
      */
     function hasMigratedToAave(address safe) external view returns (bool) {
         return _getDebtManagerStorage().migratedToAave[safe];
-    }
-
-    /**
-     * @notice Sets the Aave v4 gateway used by migrateToAave
-     * @dev Only callable by accounts with DEBT_MANAGER_ADMIN_ROLE
-     * @param _gateway Address of the gateway
-     * @custom:throws InvalidValue if the gateway is the zero address
-     */
-    function setGateway(address _gateway) external onlyRole(DEBT_MANAGER_ADMIN_ROLE) {
-        if (_gateway == address(0)) revert InvalidValue();
-        _getDebtManagerStorage().gateway = IGateway(_gateway);
-        emit GatewaySet(_gateway);
     }
 
     /**
@@ -574,13 +555,23 @@ contract DebtManagerCore is DebtManagerStorageContract {
         _onlyEtherFiSafe(safe);
         DebtManagerStorage storage $ = _getDebtManagerStorage();
 
-        IGateway _gateway = $.gateway;
+        // Single source of truth: the gateway lives on CashModule (this contract already reaches it for the
+        // settlement dispatcher), so migration reads it from there rather than keeping its own copy.
+        ICashModule cashModule = ICashModule(etherFiDataProvider.getCashModule());
+        IGateway _gateway = IGateway(cashModule.getLendGateway());
         if (address(_gateway) == address(0)) revert GatewayNotSet();
 
         // 1. Snapshot the outstanding DebtManager debt. A debt-free Safe still migrates its collateral (below),
         //    so a batch runner can call this over every Safe without special-casing (and idempotently).
         (TokenData[] memory borrowings, uint256 totalDebtUsd) = borrowingOf(safe);
         uint256 bLen = borrowings.length;
+
+        // A safe that opted out of lend has no Aave position by choice: skip the supply below and just mark it
+        // migrated (freezing legacy borrow/repay). It should be debt-free (disabling lend requires zero borrows),
+        // but it can still call DebtManager.borrow directly afterward, so reject a disabled safe with debt rather
+        // than let the gateway borrow/supply revert opaquely.
+        bool lendEnabled = cashModule.isLendEnabled(safe);
+        if (!lendEnabled && totalDebtUsd != 0) revert LendDisabledSafeHasDebt();
 
         // 2. Clear the legacy DebtManager debt FIRST (if any), capturing the token amount to re-borrow, and
         //    check Aave has the cash to fund it. Clearing first is load-bearing: supplying collateral (step 3)
@@ -602,17 +593,20 @@ contract DebtManagerCore is DebtManagerStorageContract {
         // 3. Supply all of the Safe's collateral into Aave, enabled as collateral (Safe is now debt-free on
         //    DebtManager, so the hook's health check passes as the collateral moves). This runs even for a
         //    debt-free Safe: once migrated, credit spends borrow against the Aave position, so the collateral
-        //    must actually move to Aave rather than sit idle in the Safe.
-        address[] memory collateralTokens = getCollateralTokens();
-        uint256 cLen = collateralTokens.length;
-        for (uint256 i = 0; i < cLen;) {
-            uint256 bal = IERC20(collateralTokens[i]).balanceOf(safe);
-            if (bal != 0) {
-                _gateway.supply(safe, collateralTokens[i], bal);
-                _gateway.setUsingAsCollateral(safe, collateralTokens[i], true);
-            }
-            unchecked {
-                ++i;
+        //    must actually move to Aave rather than sit idle in the Safe. Skipped for a lend-disabled safe,
+        //    which keeps its funds idle in the Safe by choice.
+        if (lendEnabled) {
+            address[] memory collateralTokens = getCollateralTokens();
+            uint256 cLen = collateralTokens.length;
+            for (uint256 i = 0; i < cLen;) {
+                uint256 bal = IERC20(collateralTokens[i]).balanceOf(safe);
+                if (bal != 0) {
+                    _gateway.supply(safe, collateralTokens[i], bal);
+                    _gateway.setUsingAsCollateral(safe, collateralTokens[i], true);
+                }
+                unchecked {
+                    ++i;
+                }
             }
         }
 
@@ -639,7 +633,7 @@ contract DebtManagerCore is DebtManagerStorageContract {
      *      token units (to be re-borrowed from Aave). Only the accounting is cleared here; the re-borrowed
      *      funds arriving later ARE the repayment that replenishes the lent-out balance.
      */
-    function _clearLegacyDebt(address safe, address token) internal returns (uint256 debtTokenAmt) {
+    function _clearLegacyDebt(address safe, address token) internal returns (uint256) {
         DebtManagerStorage storage $ = _getDebtManagerStorage();
 
         uint256 interestIndex = _updateInterestIndex(token);
@@ -647,12 +641,13 @@ contract DebtManagerCore is DebtManagerStorageContract {
         if (normalizedAmount == 0) return 0;
 
         uint256 debtUsd = _getActualBorrowAmount(normalizedAmount, interestIndex);
-        debtTokenAmt = convertUsdToCollateralToken(token, debtUsd);
+        uint256 debtTokenAmt = convertUsdToCollateralToken(token, debtUsd);
 
         $.userNormalizedBorrowings[safe][token] = 0;
         $.borrowTokenConfig[token].totalNormalizedBorrowingAmount -= normalizedAmount;
 
         emit Repaid(safe, address(this), token, debtUsd);
+        return debtTokenAmt;
     }
 
     /**

--- a/src/debt-manager/DebtManagerStorageContract.sol
+++ b/src/debt-manager/DebtManagerStorageContract.sol
@@ -8,7 +8,6 @@ import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 
 import { IDebtManager } from "../interfaces/IDebtManager.sol";
 import { IEtherFiDataProvider } from "../interfaces/IEtherFiDataProvider.sol";
-import { IGateway } from "../interfaces/IGateway.sol";
 import { IPriceProvider } from "../interfaces/IPriceProvider.sol";
 import { UpgradeableProxy } from "../utils/UpgradeableProxy.sol";
 
@@ -124,9 +123,6 @@ contract DebtManagerStorageContract is UpgradeableProxy {
                 
         /// @notice Shares of borrow tokens with 18 decimals precision
         mapping(address supplier => mapping(address borrowToken => uint256 shares)) sharesOfBorrowTokens;
-
-        /// @notice The Aave v4 gateway used to migrate positions off DebtManager (see DebtManagerCore.migrateToAave)
-        IGateway gateway;
 
         /// @notice Whether a Safe's position has been migrated to Aave (set once migrated, including Safes that had no debt)
         mapping(address safe => bool migrated) migratedToAave;
@@ -282,10 +278,6 @@ contract DebtManagerStorageContract is UpgradeableProxy {
     /// @param debtUsd The total debt migrated, in USD with 6 decimals
     event MigratedToAave(address indexed safe, uint256 debtUsd);
 
-    /// @notice Emitted when the Aave gateway used for migrations is set
-    /// @param gateway The gateway address
-    event GatewaySet(address indexed gateway);
-
     /**
      * @notice Error thrown when collateral token preference array is empty while liquidating
      */
@@ -407,11 +399,11 @@ contract DebtManagerStorageContract is UpgradeableProxy {
     /// @notice Thrown when, after supplying its collateral, the Safe's debt does not fit Aave's LTVs
     error PositionExceedsAaveLtv();
 
-    /// @notice Thrown when the migration would leave the Safe below the minimum health factor on Aave
-    error PositionUnhealthyAfterMigration();
-
     /// @notice Thrown when the migration gateway has not been configured
     error GatewayNotSet();
+
+    /// @notice Thrown when migrating a lend-disabled Safe that still carries DebtManager debt (repay it first)
+    error LendDisabledSafeHasDebt();
 
     /// @notice Thrown when a legacy DebtManager operation (borrow/repay) is attempted on a Safe already migrated to Aave
     error AlreadyMigratedToAave();

--- a/src/debt-manager/DebtManagerStorageContract.sol
+++ b/src/debt-manager/DebtManagerStorageContract.sol
@@ -8,6 +8,7 @@ import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 
 import { IDebtManager } from "../interfaces/IDebtManager.sol";
 import { IEtherFiDataProvider } from "../interfaces/IEtherFiDataProvider.sol";
+import { IGateway } from "../interfaces/IGateway.sol";
 import { IPriceProvider } from "../interfaces/IPriceProvider.sol";
 import { UpgradeableProxy } from "../utils/UpgradeableProxy.sol";
 
@@ -123,6 +124,12 @@ contract DebtManagerStorageContract is UpgradeableProxy {
                 
         /// @notice Shares of borrow tokens with 18 decimals precision
         mapping(address supplier => mapping(address borrowToken => uint256 shares)) sharesOfBorrowTokens;
+
+        /// @notice The Aave v4 gateway used to migrate positions off DebtManager (see DebtManagerCore.migrateToAave)
+        IGateway gateway;
+
+        /// @notice Whether a Safe's position has been migrated to Aave (set once migrated, including Safes that had no debt)
+        mapping(address safe => bool migrated) migratedToAave;
     }
 
     /// @notice Storage location for DebtManagerStorage (ERC-7201 compliant)
@@ -270,6 +277,15 @@ contract DebtManagerStorageContract is UpgradeableProxy {
      */
     event InterestIndexUpdated(address indexed borrowToken, uint256 oldIndex, uint256 newIndex);
 
+    /// @notice Emitted when a Safe's position is migrated from DebtManager to the Aave instance
+    /// @param safe The migrated Safe
+    /// @param debtUsd The total debt migrated, in USD with 6 decimals
+    event MigratedToAave(address indexed safe, uint256 debtUsd);
+
+    /// @notice Emitted when the Aave gateway used for migrations is set
+    /// @param gateway The gateway address
+    event GatewaySet(address indexed gateway);
+
     /**
      * @notice Error thrown when collateral token preference array is empty while liquidating
      */
@@ -384,6 +400,21 @@ contract DebtManagerStorageContract is UpgradeableProxy {
      * @notice Error thrown when borrow shares are insufficient
      */
     error InsufficientBorrowShares();
+
+    /// @notice Thrown when the Aave reserve lacks the liquidity to fund the migration borrow
+    error InsufficientAaveLiquidity(address token);
+
+    /// @notice Thrown when, after supplying its collateral, the Safe's debt does not fit Aave's LTVs
+    error PositionExceedsAaveLtv();
+
+    /// @notice Thrown when the migration would leave the Safe below the minimum health factor on Aave
+    error PositionUnhealthyAfterMigration();
+
+    /// @notice Thrown when the migration gateway has not been configured
+    error GatewayNotSet();
+
+    /// @notice Thrown when a legacy DebtManager operation (borrow/repay) is attempted on a Safe already migrated to Aave
+    error AlreadyMigratedToAave();
     
     /**
      * @notice Error thrown when user is still liquidatable

--- a/src/interfaces/ICashEventEmitter.sol
+++ b/src/interfaces/ICashEventEmitter.sol
@@ -125,6 +125,15 @@ interface ICashEventEmitter {
     function emitRepayDebtManager(address safe, address token, uint256 amount, uint256 amountInUsd) external;
 
     /**
+     * @notice Emits an event when a migrated safe repays debt on Aave via the gateway
+     * @param safe Address of the safe whose debt was repaid
+     * @param token Address of the token repaid
+     * @param amount Amount of token actually repaid (net of any refunded dust)
+     * @param amountInUsd USD value requested for the repayment
+     */
+    function emitRepay(address safe, address token, uint256 amount, uint256 amountInUsd) external;
+
+    /**
      * @notice Emits an event when spending limits are changed
      * @param oldLimit Previous spending limit
      * @param newLimit New spending limit

--- a/src/interfaces/ICashEventEmitter.sol
+++ b/src/interfaces/ICashEventEmitter.sol
@@ -129,9 +129,21 @@ interface ICashEventEmitter {
      * @param safe Address of the safe whose debt was repaid
      * @param token Address of the token repaid
      * @param amount Amount of token actually repaid (net of any refunded dust)
-     * @param amountInUsd USD value requested for the repayment
+     * @param amountInUsd USD value of the debt actually repaid
      */
     function emitRepay(address safe, address token, uint256 amount, uint256 amountInUsd) external;
+
+    /// @notice Emits the LendDisableRequested event
+    function emitLendDisableRequested(address safe, uint256 finalizeTime) external;
+
+    /// @notice Emits the LendDisableExecuted event
+    function emitLendDisableExecuted(address safe) external;
+
+    /// @notice Emits the LendEnabled event
+    function emitLendEnabled(address safe) external;
+
+    /// @notice Emits the LendGatewaySet event
+    function emitLendGatewaySet(address gateway) external;
 
     /**
      * @notice Emits an event when spending limits are changed

--- a/src/interfaces/ICashModule.sol
+++ b/src/interfaces/ICashModule.sol
@@ -136,6 +136,10 @@ struct SafeCashConfig {
     uint256 totalCashbackEarnedInUsd;
     /// @notice Incoming mode that will be applied after the delay
     Mode incomingMode;
+    /// @notice True once the safe has opted out of the Aave lend market (no auto-supply, no lend ops)
+    bool lendDisabled;
+    /// @notice Timestamp after which a pending disable-lend request can be executed (0 if none)
+    uint96 lendDisableFinalizeTime;
 }
 
 /**
@@ -224,6 +228,21 @@ interface ICashModule {
 
     /// @notice Error thrown when trying to set a mode that's already active
     error ModeAlreadySet();
+
+    /// @notice Error thrown when a lend op is attempted while the safe has opted out of lend
+    error LendDisabled();
+    /// @notice Error thrown when disabling lend while the safe still has open borrows
+    error HasOpenBorrows();
+    /// @notice Error thrown when executing a disable-lend that was never requested
+    error NoPendingLendDisable();
+    /// @notice Error thrown when executing a disable-lend before its delay has elapsed
+    error LendDisableNotReady();
+    /// @notice Error thrown when disabling lend that is already disabled, or when a request is already pending
+    error LendAlreadyDisabled();
+    /// @notice Error thrown when enabling lend that is already enabled
+    error LendNotDisabled();
+    /// @notice Error thrown when the lend gateway has not been configured
+    error LendGatewayNotSet();
 
     /// @notice Error thrown when trying to set a tier that's already set
     error AlreadyInSameTier(uint256 index);
@@ -320,6 +339,26 @@ interface ICashModule {
      * @custom:throws OnlyEtherFiSafe if the address is not a valid EtherFi Safe
      */
     function transactionCleared(address safe, bytes32 txId) external view returns (bool);
+
+    /**
+     * @notice Whether the safe currently participates in the Aave lend market (auto-supply + lend ops enabled)
+     * @param safe The safe to query
+     * @return True unless the safe has opted out via toggleLend(false) + processLendDisable
+     */
+    function isLendEnabled(address safe) external view returns (bool);
+
+    /**
+     * @notice Returns the timestamp when a pending lend-disable request becomes executable
+     * @param safe The safe to query
+     * @return Timestamp when processLendDisable may be called, or 0 if none pending
+     */
+    function lendDisableFinalizeTime(address safe) external view returns (uint256);
+
+    /**
+     * @notice Returns the configured Aave gateway used for lend operations
+     * @return Address of the gateway (address(0) if not set)
+     */
+    function getLendGateway() external view returns (address);
 
     /**
      * @notice Gets the debt manager contract
@@ -515,6 +554,37 @@ interface ICashModule {
      * @custom:throws InvalidSignatures if signature verification fails
      */
     function setMode(address safe, Mode mode, address signer, bytes calldata signature) external;
+
+    /**
+     * @notice Sets the Aave gateway used to withdraw collateral when a safe disables lend
+     * @dev Only callable by accounts with CASH_MODULE_CONTROLLER_ROLE
+     * @param gateway Address of the gateway
+     */
+    function setLendGateway(address gateway) external;
+
+    /**
+     * @notice Toggles a safe's participation in the Aave lend market (auto-supply and borrow ops)
+     * @dev Owner-signed, with the requested flag bound into the signature. Enabling (enable == true) opts the
+     *      safe back in immediately and cancels any pending disable. Disabling (enable == false) does not act
+     *      immediately: it records a request that becomes executable after the mode-change delay, at which
+     *      point anyone may call processLendDisable. Disabling requires the safe to have no open borrows.
+     * @param safe Address of the EtherFi Safe
+     * @param enable True to enable lend now, false to request disabling it
+     * @param signer A safe admin authorizing the change
+     * @param signature The signer's signature over the intent
+     * @custom:throws LendNotDisabled if enabling while lend is already enabled and no disable is pending
+     * @custom:throws LendAlreadyDisabled if disabling while lend is already disabled or a request is pending
+     * @custom:throws HasOpenBorrows if disabling while the safe still has open borrows
+     */
+    function toggleLend(address safe, bool enable, address signer, bytes calldata signature) external;
+
+    /**
+     * @notice Executes a pending lend-disable request (from toggleLend(false)) once its delay has elapsed
+     * @dev Permissionless. Withdraws all of the safe's Aave collateral back to the safe, marks lend disabled,
+     *      and forces the safe into Debit mode. Re-checks the safe has no open borrows.
+     * @param safe Address of the EtherFi Safe
+     */
+    function processLendDisable(address safe) external;
 
     /**
      * @notice Updates the spending limits for a safe

--- a/src/interfaces/IDebtManager.sol
+++ b/src/interfaces/IDebtManager.sol
@@ -301,6 +301,14 @@ interface IDebtManager {
     function borrowingOf(address user) external view returns (TokenData[] memory, uint256);
 
     /**
+     * @notice Whether a safe has migrated its position from the DebtManager to the Aave gateway.
+     * @dev Once migrated, DebtManager borrow/repay are frozen for the safe and credit spends borrow via the gateway.
+     * @param safe Address of the EtherFi Safe.
+     * @return True if the safe has migrated to Aave.
+     */
+    function hasMigratedToAave(address safe) external view returns (bool);
+
+    /**
      * @notice Function to fetch the max borrow amount for ltv or liquidation purpose.
      * @notice Calculates user's total collateral amount in USD and finds max borrowable amount using liquidation threshold.
      * @param  user Address of the user.

--- a/src/interfaces/IGateway.sol
+++ b/src/interfaces/IGateway.sol
@@ -112,4 +112,12 @@ interface IGateway {
      * @return True if lend is enabled, false if the safe has opted out
      */
     function isLendEnabled(address safe) external view returns (bool);
+
+    /**
+     * @notice Returns the assets registered on the gateway (each mapped to an Aave reserveId)
+     * @dev The authoritative list of assets a safe can have a position in, keyed on the gateway rather than
+     *      DebtManager's collateral list (which can be delisted while an Aave position is still open).
+     * @return The registered asset addresses
+     */
+    function registeredAssets() external view returns (address[] memory);
 }

--- a/src/interfaces/IGateway.sol
+++ b/src/interfaces/IGateway.sol
@@ -102,4 +102,14 @@ interface IGateway {
      * @return The LTV, where 100e18 is 100%
      */
     function ltv(address asset) external view returns (uint256);
+
+    /**
+     * @notice Returns whether lend is enabled for `safe` (i.e. the safe participates in the Aave market)
+     * @dev Source of truth is the CashModule. When false, the gateway rejects supply / borrow /
+     *      setUsingAsCollateral for the safe and the sandwich skips its Aave bookends. Withdraw and
+     *      repay stay open so an opted-out safe can always exit or reduce debt.
+     * @param safe The safe to query
+     * @return True if lend is enabled, false if the safe has opted out
+     */
+    function isLendEnabled(address safe) external view returns (bool);
 }

--- a/src/libraries/CashVerificationLib.sol
+++ b/src/libraries/CashVerificationLib.sol
@@ -33,6 +33,9 @@ library CashVerificationLib {
     /// @notice Method identifier for cashback split changes for a safe
     bytes32 public constant SET_CASHBACK_SPLIT_TO_SAFE_PERCENTAGE = keccak256("setCashbackSplitToSafePercentage");
 
+    /// @notice Method identifier for toggling lend participation (opt in/out of Aave)
+    bytes32 public constant TOGGLE_LEND_METHOD = keccak256("toggleLend");
+
     /// @notice Error for Invalid Owner quorum signatures
     error InvalidSignatures();
 
@@ -123,5 +126,20 @@ library CashVerificationLib {
      */
     function verifySetCashbackSplitToSafePercentage(address safe, address signer, uint256 nonce, uint256 split, bytes calldata signature) internal view {
         verifySignature(safe, signer, SET_CASHBACK_SPLIT_TO_SAFE_PERCENTAGE, nonce, abi.encode(split), signature);
+    }
+
+    /**
+     * @notice Verifies a signature for toggling lend participation (opt in/out of the Aave market)
+     * @dev Creates and validates an EIP-191 signed message hash. The requested `enable` flag is bound into
+     *      the digest, so an authorization to enable cannot be replayed to disable (or vice versa).
+     * @param safe Address of the safe
+     * @param signer Address of the signer to verify against
+     * @param nonce Transaction nonce for replay protection
+     * @param enable True to enable lend, false to request disabling it
+     * @param signature ECDSA signature bytes
+     * @custom:throws SignatureUtils.InvalidSigner if the signature is invalid
+     */
+    function verifyToggleLendSig(address safe, address signer, uint256 nonce, bool enable, bytes calldata signature) internal view {
+        verifySignature(safe, signer, TOGGLE_LEND_METHOD, nonce, abi.encode(enable), signature);
     }
 }

--- a/src/mocks/MockGateway.sol
+++ b/src/mocks/MockGateway.sol
@@ -24,6 +24,8 @@ contract MockGateway is IGateway {
     mapping(address safe => mapping(address asset => uint256)) internal _debtOf;
     mapping(address asset => uint256) internal _availableCash;
     mapping(address asset => uint256) internal _ltv;
+    /// @dev Whether lend is disabled for a safe; defaults to false so isLendEnabled returns true
+    mapping(address safe => bool) internal _lendDisabled;
 
     Call public lastSupply;
     Call public lastWithdraw;
@@ -53,6 +55,11 @@ contract MockGateway is IGateway {
     /// @notice Sets the LTV (100e18 = 100%) a subsequent `ltv(asset)` will return
     function setLtv(address asset, uint256 ltvValue) external {
         _ltv[asset] = ltvValue;
+    }
+
+    /// @notice Sets whether lend is enabled for a safe (defaults to enabled)
+    function setLendEnabled(address safe, bool enabled) external {
+        _lendDisabled[safe] = !enabled;
     }
 
     function supply(address safe, address asset, uint256 amount) external {
@@ -94,5 +101,9 @@ contract MockGateway is IGateway {
 
     function ltv(address asset) external view returns (uint256) {
         return _ltv[asset];
+    }
+
+    function isLendEnabled(address safe) external view returns (bool) {
+        return !_lendDisabled[safe];
     }
 }

--- a/src/mocks/MockGateway.sol
+++ b/src/mocks/MockGateway.sol
@@ -26,6 +26,7 @@ contract MockGateway is IGateway {
     mapping(address asset => uint256) internal _ltv;
     /// @dev Whether lend is disabled for a safe; defaults to false so isLendEnabled returns true
     mapping(address safe => bool) internal _lendDisabled;
+    address[] internal _registeredAssets;
 
     Call public lastSupply;
     Call public lastWithdraw;
@@ -60,6 +61,11 @@ contract MockGateway is IGateway {
     /// @notice Sets whether lend is enabled for a safe (defaults to enabled)
     function setLendEnabled(address safe, bool enabled) external {
         _lendDisabled[safe] = !enabled;
+    }
+
+    /// @notice Sets the assets a subsequent `registeredAssets()` will return
+    function setRegisteredAssets(address[] calldata assets) external {
+        _registeredAssets = assets;
     }
 
     function supply(address safe, address asset, uint256 amount) external {
@@ -105,5 +111,9 @@ contract MockGateway is IGateway {
 
     function isLendEnabled(address safe) external view returns (bool) {
         return !_lendDisabled[safe];
+    }
+
+    function registeredAssets() external view returns (address[] memory) {
+        return _registeredAssets;
     }
 }

--- a/src/modules/ModuleGatewaySandwich.sol
+++ b/src/modules/ModuleGatewaySandwich.sol
@@ -55,6 +55,9 @@ abstract contract ModuleGatewaySandwich {
      * @param amount The amount to withdraw
      */
     function _withdrawFromGateway(address safe, address asset, uint256 amount) internal {
+        // A lend-disabled safe holds no Aave position: its assets already sit in the safe, so there is
+        // nothing to pull back. Skipping keeps the sandwich a no-op for opted-out safes.
+        if (!gateway.isLendEnabled(safe)) return;
         gateway.withdraw(safe, asset, amount, safe);
     }
 
@@ -65,6 +68,9 @@ abstract contract ModuleGatewaySandwich {
      * @param amount The amount to supply
      */
     function _resupplyToGateway(address safe, address asset, uint256 amount) internal {
+        // A lend-disabled safe does not participate in Aave: leave the output in the safe rather than
+        // re-supplying. The gateway would reject the supply anyway; skipping avoids the revert.
+        if (!gateway.isLendEnabled(safe)) return;
         gateway.supply(safe, asset, amount);
         gateway.setUsingAsCollateral(safe, asset, true);
     }

--- a/src/modules/cash/CashEventEmitter.sol
+++ b/src/modules/cash/CashEventEmitter.sol
@@ -91,9 +91,28 @@ contract CashEventEmitter is UpgradeableProxy {
      * @param safe Address of the safe whose debt was repaid
      * @param token Address of the token used to repay
      * @param debtAmount Amount of debt actually repaid in token units (net of any refunded dust)
-     * @param debtAmountInUsd USD value requested for the repayment
+     * @param debtAmountInUsd USD value of the debt actually repaid
      */
     event Repay(address indexed safe, address indexed token, uint256 debtAmount, uint256 debtAmountInUsd);
+
+    /**
+     * @notice Emitted when a safe requests to disable lend (opt out of the Aave market)
+     * @param safe Address of the safe
+     * @param finalizeTime Timestamp after which the request can be executed
+     */
+    event LendDisableRequested(address indexed safe, uint256 finalizeTime);
+
+    /// @notice Emitted when a safe's pending lend-disable request is executed
+    /// @param safe Address of the safe
+    event LendDisableExecuted(address indexed safe);
+
+    /// @notice Emitted when a safe re-enables lend (opts back into the Aave market)
+    /// @param safe Address of the safe
+    event LendEnabled(address indexed safe);
+
+    /// @notice Emitted when the Aave lend gateway is set on the CashModule
+    /// @param gateway Address of the gateway
+    event LendGatewaySet(address indexed gateway);
 
     /**
      * @notice Emitted when a spending limit is changed
@@ -388,6 +407,30 @@ contract CashEventEmitter is UpgradeableProxy {
 
     function emitRepay(address safe, address token, uint256 amount, uint256 amountInUsd) external onlyCashModule {
         emit Repay(safe, token, amount, amountInUsd);
+    }
+
+    /// @notice Emits the LendDisableRequested event
+    /// @dev Can only be called by the Cash Module
+    function emitLendDisableRequested(address safe, uint256 finalizeTime) external onlyCashModule {
+        emit LendDisableRequested(safe, finalizeTime);
+    }
+
+    /// @notice Emits the LendDisableExecuted event
+    /// @dev Can only be called by the Cash Module
+    function emitLendDisableExecuted(address safe) external onlyCashModule {
+        emit LendDisableExecuted(safe);
+    }
+
+    /// @notice Emits the LendEnabled event
+    /// @dev Can only be called by the Cash Module
+    function emitLendEnabled(address safe) external onlyCashModule {
+        emit LendEnabled(safe);
+    }
+
+    /// @notice Emits the LendGatewaySet event
+    /// @dev Can only be called by the Cash Module
+    function emitLendGatewaySet(address gateway) external onlyCashModule {
+        emit LendGatewaySet(gateway);
     }
 
     /**

--- a/src/modules/cash/CashEventEmitter.sol
+++ b/src/modules/cash/CashEventEmitter.sol
@@ -85,7 +85,16 @@ contract CashEventEmitter is UpgradeableProxy {
      * @param debtAmountInUsd USD value of the debt repaid
      */
     event RepayDebtManager(address indexed safe, address indexed token, uint256 debtAmount, uint256 debtAmountInUsd);
-    
+
+    /**
+     * @notice Emitted when a migrated safe repays debt on Aave via the gateway
+     * @param safe Address of the safe whose debt was repaid
+     * @param token Address of the token used to repay
+     * @param debtAmount Amount of debt actually repaid in token units (net of any refunded dust)
+     * @param debtAmountInUsd USD value requested for the repayment
+     */
+    event Repay(address indexed safe, address indexed token, uint256 debtAmount, uint256 debtAmountInUsd);
+
     /**
      * @notice Emitted when a spending limit is changed
      * @param safe Address of the safe changing the spending limit
@@ -375,6 +384,10 @@ contract CashEventEmitter is UpgradeableProxy {
      */
     function emitRepayDebtManager(address safe, address token, uint256 amount, uint256 amountInUsd) external onlyCashModule {
         emit RepayDebtManager(safe, token, amount, amountInUsd);
+    }
+
+    function emitRepay(address safe, address token, uint256 amount, uint256 amountInUsd) external onlyCashModule {
+        emit Repay(safe, token, amount, amountInUsd);
     }
 
     /**

--- a/src/modules/cash/CashModuleCore.sol
+++ b/src/modules/cash/CashModuleCore.sol
@@ -12,6 +12,7 @@ import { ICashbackDispatcher } from "../../interfaces/ICashbackDispatcher.sol";
 import { IDebtManager } from "../../interfaces/IDebtManager.sol";
 import { IEtherFiDataProvider } from "../../interfaces/IEtherFiDataProvider.sol";
 import { IEtherFiSafe } from "../../interfaces/IEtherFiSafe.sol";
+import { IGateway } from "../../interfaces/IGateway.sol";
 import { ArrayDeDupLib } from "../../libraries/ArrayDeDupLib.sol";
 import { CashVerificationLib } from "../../libraries/CashVerificationLib.sol";
 import { SignatureUtils } from "../../libraries/SignatureUtils.sol";
@@ -19,6 +20,7 @@ import { SpendingLimit, SpendingLimitLib } from "../../libraries/SpendingLimitLi
 import { UpgradeableProxy } from "../../utils/UpgradeableProxy.sol";
 import { ModuleBase } from "../ModuleBase.sol";
 import { CashModuleStorageContract } from "./CashModuleStorageContract.sol";
+import { CashbackLib } from "./CashbackLib.sol";
 
 /**
  * @title CashModule
@@ -138,32 +140,7 @@ contract CashModuleCore is CashModuleStorageContract {
      * @return totalCashbackInUsd Total pending cashback amount in USD
      */
     function getPendingCashback(address account, address[] memory tokens) external view returns (TokenDataInUsd[] memory data, uint256 totalCashbackInUsd) {
-        CashModuleStorage storage $ = _getCashModuleStorage();
-
-        uint256 len = tokens.length;
-        if (len > 1) tokens.checkDuplicates();
-        data = new TokenDataInUsd[](len);
-        uint256 m = 0;
-
-        for (uint256 i = 0; i < len;) {
-            uint256 pendingCashbackInUsd = $.pendingCashbackForTokenInUsd[account][tokens[i]];
-            if (pendingCashbackInUsd > 0) {
-                data[m] = TokenDataInUsd({ token: tokens[i], amountInUsd: pendingCashbackInUsd });
-
-                totalCashbackInUsd += pendingCashbackInUsd;
-
-                unchecked {
-                    ++m;
-                }
-            }
-            unchecked {
-                ++i;
-            }
-        }
-
-        assembly ("memory-safe") {
-            mstore(data, m)
-        }
+        return CashbackLib.getPendingCashback(_getCashModuleStorage(), account, tokens);
     }
 
     /**
@@ -338,7 +315,7 @@ contract CashModuleCore is CashModuleStorageContract {
 
         if ($.safeCashConfig[safe].mode == Mode.Credit) _spendCredit($, safe, txId, binSponsor, tokens, amountsInUsd, totalSpendingInUsd);
         else _spendDebit($, safe, txId, binSponsor, tokens, amountsInUsd, totalSpendingInUsd);
-        _cashback($, safe, totalSpendingInUsd, cashbacks);
+        CashbackLib.processCashback($, safe, totalSpendingInUsd, cashbacks);
     }
 
     function _validateSpend(SafeCashConfig storage $$, bytes32 txId, address[] calldata tokens, uint256[] calldata amountsInUsd) internal returns (uint256) {
@@ -387,18 +364,30 @@ contract CashModuleCore is CashModuleStorageContract {
         uint256 amount = $.debtManager.convertUsdToCollateralToken(tokens[0], amountsInUsd[0]);
         if (amount == 0) revert AmountZero();
 
-        address[] memory to = new address[](1);
-        bytes[] memory data = new bytes[](1);
-        uint256[] memory values = new uint256[](1);
+        if ($.debtManager.hasMigratedToAave(safe)) {
+            // Migrated safe: its position lives on Aave. Borrow there via the gateway (the CashModule is always
+            // a gateway driver) and send the borrowed token straight to the settlement dispatcher. The legacy
+            // DebtManager.borrow path reverts for a migrated safe, and CashLens already sizes credit against the
+            // gateway, so routing here keeps the on-chain spend consistent with the precheck. Aave enforces the
+            // borrowing-power/health check on the borrow itself.
+            IGateway gateway = $.gateway;
+            if (address(gateway) == address(0)) revert LendGatewayNotSet();
+            gateway.borrow(safe, tokens[0], amount, getSettlementDispatcher(binSponsor));
+        } else {
+            // Legacy safe: borrow from the DebtManager, executed by the safe itself.
+            address[] memory to = new address[](1);
+            bytes[] memory data = new bytes[](1);
+            uint256[] memory values = new uint256[](1);
 
-        to[0] = address($.debtManager);
-        data[0] = abi.encodeWithSelector(IDebtManager.borrow.selector, binSponsor, tokens[0], amount);
-        values[0] = 0;
+            to[0] = address($.debtManager);
+            data[0] = abi.encodeWithSelector(IDebtManager.borrow.selector, binSponsor, tokens[0], amount);
+            values[0] = 0;
 
-        try IEtherFiSafe(safe).execTransactionFromModule(to, values, data) { }
-        catch {
-            _cancelOldWithdrawal(safe);
-            IEtherFiSafe(safe).execTransactionFromModule(to, values, data);
+            try IEtherFiSafe(safe).execTransactionFromModule(to, values, data) { }
+            catch {
+                _cancelOldWithdrawal(safe);
+                IEtherFiSafe(safe).execTransactionFromModule(to, values, data);
+            }
         }
 
         uint256[] memory amounts = new uint256[](1);
@@ -462,90 +451,7 @@ contract CashModuleCore is CashModuleStorageContract {
      * @param tokens Addresses of cashback tokens
      */
     function clearPendingCashback(address[] calldata users, address[] calldata tokens) external nonReentrant whenNotPaused {
-        uint256 len = users.length;
-        if (len == 0) revert InvalidInput();
-        if (tokens.length > 1) tokens.checkDuplicates();
-        if (len > 1) users.checkDuplicates();
-
-        for (uint256 i = 0; i < len;) {
-            if (users[i] == address(0)) revert InvalidInput();
-
-            for (uint256 j = 0; j < tokens.length;) {
-                if (tokens[j] == address(0)) revert InvalidInput();
-
-                _retrievePendingCashback(users[i], tokens[j]);
-                unchecked {
-                    ++j;
-                }
-            }
-
-            unchecked {
-                ++i;
-            }
-        }
-    }
-
-    /**
-     * @notice Attempts to retrieve pending cashback for a user
-     * @dev Calls the cashback dispatcher to clear pending cashback and updates storage if successful
-     * @param user Address of the user who may have pending cashback
-     * @param token Address of the cashback token
-     */
-    function _retrievePendingCashback(address user, address token) internal {
-        CashModuleStorage storage $ = _getCashModuleStorage();
-
-        uint256 amountInUsd = getPendingCashbackForToken(user, token);
-
-        if (amountInUsd > 0) {
-            try $.cashbackDispatcher.clearPendingCashback(user, token, amountInUsd) returns (uint256 cashbackAmountInToken, bool paid) {
-                if (paid) {
-                    $.cashEventEmitter.emitPendingCashbackClearedEvent(user, token, cashbackAmountInToken, amountInUsd);
-                    delete $.pendingCashbackForTokenInUsd[user][token];
-                }
-            } catch { }
-        }
-    }
-
-    /**
-     * @notice Processes cashback for a spending transaction
-     * @dev Calculates and distributes cashback
-     * @param $ Storage reference to the CashModuleStorage
-     * @param cashbacks Array of Cashback struct
-     */
-    function _cashback(CashModuleStorage storage $, address safe, uint256 spendAmount, Cashback[] calldata cashbacks) internal {
-        uint256 len = cashbacks.length;
-
-        for (uint256 i = 0; i < len;) {
-            address to = cashbacks[i].to;
-            if (to == address(0)) continue;
-            CashbackTokens[] memory cashbackTokens = cashbacks[i].cashbackTokens;
-
-            for (uint256 j = 0; j < cashbackTokens.length;) {
-                address token = cashbackTokens[j].token;
-                _retrievePendingCashback(to, token);
-
-                uint256 amountInUsd = cashbackTokens[j].amountInUsd;
-                $.safeCashConfig[to].totalCashbackEarnedInUsd += amountInUsd;
-
-                if (amountInUsd != 0) {
-                    try $.cashbackDispatcher.cashback(to, token, amountInUsd) returns (uint256 cashbackAmountInToken, bool paid) {
-                        if (!paid) $.pendingCashbackForTokenInUsd[to][token] += amountInUsd;
-                        $.cashEventEmitter.emitCashbackEvent(safe, spendAmount, to, token, cashbackAmountInToken, amountInUsd, cashbackTokens[j].cashbackType, paid);
-                    } catch {
-                        $.pendingCashbackForTokenInUsd[to][token] += amountInUsd;
-                        $.cashEventEmitter.emitCashbackEvent(safe, spendAmount, to, token, 0, amountInUsd, cashbackTokens[j].cashbackType, false);
-                    }
-                }
-
-                unchecked {
-                    ++j;
-                }
-            }
-
-            unchecked {
-                ++i;
-            }
-        }
+        CashbackLib.clearPending(_getCashModuleStorage(), users, tokens);
     }
 
     /**

--- a/src/modules/cash/CashModuleCore.sol
+++ b/src/modules/cash/CashModuleCore.sol
@@ -217,6 +217,34 @@ contract CashModuleCore is CashModuleStorageContract {
     }
 
     /**
+     * @notice Returns whether lend (Aave auto-supply and borrow ops) is enabled for a safe
+     * @dev Lend is enabled by default; a safe with no borrows may opt out via toggleLend(false) + processLendDisable
+     * @param safe Address of the EtherFi Safe
+     * @return True if lend is enabled, false if the safe has opted out
+     */
+    function isLendEnabled(address safe) external view returns (bool) {
+        return !_getCashModuleStorage().safeCashConfig[safe].lendDisabled;
+    }
+
+    /**
+     * @notice Returns the timestamp when a pending lend-disable request becomes executable
+     * @dev Returns 0 if no disable is pending
+     * @param safe Address of the EtherFi Safe
+     * @return Timestamp when processLendDisable may be called, or 0 if none pending
+     */
+    function lendDisableFinalizeTime(address safe) external view returns (uint256) {
+        return _getCashModuleStorage().safeCashConfig[safe].lendDisableFinalizeTime;
+    }
+
+    /**
+     * @notice Returns the configured Aave gateway used for lend operations
+     * @return Address of the gateway (address(0) if not set)
+     */
+    function getLendGateway() external view returns (address) {
+        return address(_getCashModuleStorage().gateway);
+    }
+
+    /**
      * @notice Processes a pending withdrawal request after the delay period
      * @dev Executes the token transfers and clears the request
      * @param safe Address of the EtherFi Safe
@@ -224,6 +252,25 @@ contract CashModuleCore is CashModuleStorageContract {
      */
     function processWithdrawal(address safe) public onlyEtherFiSafe(safe) nonReentrant {
         _processWithdrawal(safe);
+    }
+
+    /**
+     * @notice Executes a pending lend-disable request (from toggleLend(false)) after its delay has elapsed
+     * @dev Permissionless once the delay has elapsed. Withdraws all Aave collateral back to the safe, marks
+     *      lend disabled, and forces the safe into Debit mode. Re-checks that the safe has no open borrows so
+     *      a borrow taken during the delay window cannot strand collateral.
+     * @param safe Address of the EtherFi Safe
+     * @custom:throws OnlyEtherFiSafe if safe is not a valid EtherFi Safe
+     * @custom:throws NoPendingLendDisable if no disable request is pending
+     * @custom:throws LendDisableNotReady if the delay period hasn't passed
+     * @custom:throws HasOpenBorrows if the safe borrowed during the delay window
+     */
+    function processLendDisable(address safe) external onlyEtherFiSafe(safe) nonReentrant {
+        SafeCashConfig storage safeConfig = _getCashModuleStorage().safeCashConfig[safe];
+        if (safeConfig.lendDisableFinalizeTime == 0) revert NoPendingLendDisable();
+        if (block.timestamp < safeConfig.lendDisableFinalizeTime) revert LendDisableNotReady();
+        if (_hasOpenBorrows(safe)) revert HasOpenBorrows();
+        _disableLend(safe);
     }
 
     /**
@@ -333,6 +380,9 @@ contract CashModuleCore is CashModuleStorageContract {
      */
     function _spendCredit(CashModuleStorage storage $, address safe, bytes32 txId, BinSponsor binSponsor, address[] memory tokens, uint256[] memory amountsInUsd, uint256 totalSpendingInUsd) internal {
         // Credit mode validation
+        // Defense-in-depth: a safe that opted out of lend is forced to Debit and blocked from re-entering Credit,
+        // so credit spending must never reach a lend-disabled safe.
+        if ($.safeCashConfig[safe].lendDisabled) revert LendDisabled();
         if (!_isBorrowToken($.debtManager, tokens[0])) revert UnsupportedToken();
         uint256 amount = $.debtManager.convertUsdToCollateralToken(tokens[0], amountsInUsd[0]);
         if (amount == 0) revert AmountZero();

--- a/src/modules/cash/CashModuleCore.sol
+++ b/src/modules/cash/CashModuleCore.sol
@@ -20,7 +20,7 @@ import { SpendingLimit, SpendingLimitLib } from "../../libraries/SpendingLimitLi
 import { UpgradeableProxy } from "../../utils/UpgradeableProxy.sol";
 import { ModuleBase } from "../ModuleBase.sol";
 import { CashModuleStorageContract } from "./CashModuleStorageContract.sol";
-import { CashbackLib } from "./CashbackLib.sol";
+import { CashModuleLib } from "./CashModuleLib.sol";
 
 /**
  * @title CashModule
@@ -140,7 +140,7 @@ contract CashModuleCore is CashModuleStorageContract {
      * @return totalCashbackInUsd Total pending cashback amount in USD
      */
     function getPendingCashback(address account, address[] memory tokens) external view returns (TokenDataInUsd[] memory data, uint256 totalCashbackInUsd) {
-        return CashbackLib.getPendingCashback(_getCashModuleStorage(), account, tokens);
+        return CashModuleLib.getPendingCashback(_getCashModuleStorage(), account, tokens);
     }
 
     /**
@@ -315,7 +315,7 @@ contract CashModuleCore is CashModuleStorageContract {
 
         if ($.safeCashConfig[safe].mode == Mode.Credit) _spendCredit($, safe, txId, binSponsor, tokens, amountsInUsd, totalSpendingInUsd);
         else _spendDebit($, safe, txId, binSponsor, tokens, amountsInUsd, totalSpendingInUsd);
-        CashbackLib.processCashback($, safe, totalSpendingInUsd, cashbacks);
+        CashModuleLib.processCashback($, safe, totalSpendingInUsd, cashbacks);
     }
 
     function _validateSpend(SafeCashConfig storage $$, bytes32 txId, address[] calldata tokens, uint256[] calldata amountsInUsd) internal returns (uint256) {
@@ -451,7 +451,7 @@ contract CashModuleCore is CashModuleStorageContract {
      * @param tokens Addresses of cashback tokens
      */
     function clearPendingCashback(address[] calldata users, address[] calldata tokens) external nonReentrant whenNotPaused {
-        CashbackLib.clearPending(_getCashModuleStorage(), users, tokens);
+        CashModuleLib.clearPending(_getCashModuleStorage(), users, tokens);
     }
 
     /**
@@ -477,24 +477,13 @@ contract CashModuleCore is CashModuleStorageContract {
      * @custom:throws AmountZero if the converted amount is zero
      */
     function _repay(address safe, IDebtManager debtManager, address token, uint256 amountInUsd) internal {
-        uint256 amount = IDebtManager(debtManager).convertUsdToCollateralToken(token, amountInUsd);
+        uint256 amount = debtManager.convertUsdToCollateralToken(token, amountInUsd);
         if (amount == 0) revert AmountZero();
         _cancelWithdrawalRequestIfNecessary(safe, token, amount);
 
-        address[] memory to = new address[](3);
-        bytes[] memory data = new bytes[](3);
-        uint256[] memory values = new uint256[](3);
-
-        to[0] = token;
-        to[1] = address(debtManager);
-        to[2] = token;
-
-        data[0] = abi.encodeWithSelector(IERC20.approve.selector, address(debtManager), amount);
-        data[1] = abi.encodeWithSelector(IDebtManager.repay.selector, safe, token, amount);
-        data[2] = abi.encodeWithSelector(IERC20.approve.selector, address(debtManager), 0);
-
-        IEtherFiSafe(safe).execTransactionFromModule(to, values, data);
-        _getCashModuleStorage().cashEventEmitter.emitRepayDebtManager(safe, token, amount, amountInUsd);
+        // A migrated safe repays on Aave via the gateway; a legacy safe repays the DebtManager. Both paths run
+        // in CashModuleLib (extracted to keep this contract within the code-size limit).
+        CashModuleLib.repay(_getCashModuleStorage(), safe, token, amount, amountInUsd);
     }
 
     /**

--- a/src/modules/cash/CashModuleLib.sol
+++ b/src/modules/cash/CashModuleLib.sol
@@ -109,7 +109,12 @@ library CashModuleLib {
 
         for (uint256 i = 0; i < len;) {
             address to = cashbacks[i].to;
-            if (to == address(0)) continue;
+            if (to == address(0)) {
+                unchecked {
+                    ++i;
+                }
+                continue;
+            }
             CashbackTokens[] memory cashbackTokens = cashbacks[i].cashbackTokens;
 
             for (uint256 j = 0; j < cashbackTokens.length;) {
@@ -157,7 +162,10 @@ library CashModuleLib {
             IGateway gateway = $.gateway;
             if (address(gateway) == address(0)) revert LendGatewayNotSet();
             uint256 repaid = gateway.repay(safe, token, amount);
-            $.cashEventEmitter.emitRepay(safe, token, repaid, amountInUsd);
+            // The gateway may repay less than requested (dust refund, or the live Aave debt being smaller than
+            // the quote), so report the USD value of what was actually repaid, not the requested amount.
+            uint256 repaidInUsd = repaid == amount ? amountInUsd : $.debtManager.convertCollateralTokenToUsd(token, repaid);
+            $.cashEventEmitter.emitRepay(safe, token, repaid, repaidInUsd);
             return;
         }
 

--- a/src/modules/cash/CashModuleLib.sol
+++ b/src/modules/cash/CashModuleLib.sol
@@ -1,15 +1,21 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
 import { Cashback, CashbackTokens, TokenDataInUsd } from "../../interfaces/ICashModule.sol";
 import { ICashEventEmitter } from "../../interfaces/ICashEventEmitter.sol";
 import { ICashbackDispatcher } from "../../interfaces/ICashbackDispatcher.sol";
+import { IDebtManager } from "../../interfaces/IDebtManager.sol";
+import { IEtherFiSafe } from "../../interfaces/IEtherFiSafe.sol";
+import { IGateway } from "../../interfaces/IGateway.sol";
 import { ArrayDeDupLib } from "../../libraries/ArrayDeDupLib.sol";
 import { CashModuleStorageContract } from "./CashModuleStorageContract.sol";
 
 /**
- * @title CashbackLib
- * @notice Cashback accounting for the CashModule, extracted into an external (delegatecalled) library.
+ * @title CashModuleLib
+ * @notice Heavy CashModule logic (cashback accounting and repayment execution) extracted into an external,
+ *         delegatecalled library.
  * @dev Deployed once and linked into CashModuleCore, so this logic does not count against CashModuleCore's
  *      EIP-170 runtime code-size limit. Every function is called via delegatecall and therefore runs in the
  *      CashModule's storage context: the caller passes its CashModuleStorage pointer and the library reads and
@@ -17,11 +23,13 @@ import { CashModuleStorageContract } from "./CashModuleStorageContract.sol";
  *      implementation.
  * @author ether.fi
  */
-library CashbackLib {
+library CashModuleLib {
     using ArrayDeDupLib for address[];
 
     /// @dev Same selector as CashModule's InvalidInput, so reverts are indistinguishable to callers
     error InvalidInput();
+    /// @dev Same selector as CashModule's LendGatewayNotSet
+    error LendGatewayNotSet();
 
     /**
      * @notice Gets the pending cashback amounts for an account across a set of tokens
@@ -130,6 +138,43 @@ library CashbackLib {
                 ++i;
             }
         }
+    }
+
+    /**
+     * @notice Executes a repayment on behalf of a safe, routing by migration state
+     * @dev The caller must have already validated the amount and cancelled any conflicting withdrawal request.
+     *      A migrated safe repays on Aave via the gateway (which pulls the token from the safe, repays, refunds
+     *      dust, and emits Repaid); a legacy safe repays the DebtManager through the safe's module execution.
+     * @param $ The CashModule storage (passed by the delegatecalling module)
+     * @param safe The safe whose debt is repaid
+     * @param token The token to repay
+     * @param amount The token amount to repay
+     * @param amountInUsd The USD value of the repayment (for the emitted DebtManager event)
+     * @custom:throws LendGatewayNotSet if the safe is migrated but no gateway is configured
+     */
+    function repay(CashModuleStorageContract.CashModuleStorage storage $, address safe, address token, uint256 amount, uint256 amountInUsd) external {
+        if ($.debtManager.hasMigratedToAave(safe)) {
+            IGateway gateway = $.gateway;
+            if (address(gateway) == address(0)) revert LendGatewayNotSet();
+            uint256 repaid = gateway.repay(safe, token, amount);
+            $.cashEventEmitter.emitRepay(safe, token, repaid, amountInUsd);
+            return;
+        }
+
+        address[] memory to = new address[](3);
+        bytes[] memory data = new bytes[](3);
+        uint256[] memory values = new uint256[](3);
+
+        to[0] = token;
+        to[1] = address($.debtManager);
+        to[2] = token;
+
+        data[0] = abi.encodeWithSelector(IERC20.approve.selector, address($.debtManager), amount);
+        data[1] = abi.encodeWithSelector(IDebtManager.repay.selector, safe, token, amount);
+        data[2] = abi.encodeWithSelector(IERC20.approve.selector, address($.debtManager), 0);
+
+        IEtherFiSafe(safe).execTransactionFromModule(to, values, data);
+        $.cashEventEmitter.emitRepayDebtManager(safe, token, amount, amountInUsd);
     }
 
     /**

--- a/src/modules/cash/CashModuleSetters.sol
+++ b/src/modules/cash/CashModuleSetters.sol
@@ -10,6 +10,7 @@ import { ICashbackDispatcher } from "../../interfaces/ICashbackDispatcher.sol";
 import { IDebtManager } from "../../interfaces/IDebtManager.sol";
 import { IEtherFiDataProvider } from "../../interfaces/IEtherFiDataProvider.sol";
 import { IEtherFiSafe } from "../../interfaces/IEtherFiSafe.sol";
+import { IGateway } from "../../interfaces/IGateway.sol";
 import { ArrayDeDupLib } from "../../libraries/ArrayDeDupLib.sol";
 import { CashVerificationLib } from "../../libraries/CashVerificationLib.sol";
 import { SignatureUtils } from "../../libraries/SignatureUtils.sol";
@@ -130,6 +131,45 @@ contract CashModuleSetters is CashModuleStorageContract {
     }
 
     /**
+     * @notice Sets the Aave gateway used to withdraw collateral when a safe disables lend
+     * @dev Only callable by accounts with CASH_MODULE_CONTROLLER_ROLE
+     * @param gateway Address of the gateway
+     */
+    function setLendGateway(address gateway) external {
+        if (!roleRegistry().hasRole(CASH_MODULE_CONTROLLER_ROLE, msg.sender)) revert OnlyCashModuleController();
+        if (gateway == address(0)) revert InvalidInput();
+        _getCashModuleStorage().gateway = IGateway(gateway);
+        emit LendGatewaySet(gateway);
+    }
+
+    /**
+     * @notice Toggles a safe's participation in the Aave lend market (auto-supply and borrow ops)
+     * @dev Owner-signed, and the signature binds the requested `enable` flag. The two directions are
+     *      deliberately asymmetric:
+     *      - enable == true: opts the safe back in immediately (opting into earning is not risk-increasing)
+     *        and cancels any pending disable request. Auto-supply resumes on the safe's next deposit.
+     *      - enable == false: does NOT disable immediately. It records a request that becomes executable
+     *        after the mode-change delay, at which point anyone may call processLendDisable to carry it out
+     *        (withdraw all collateral from Aave, force Debit mode). Disabling is only allowed when the safe
+     *        has no open borrows, since the collateral backing them is about to leave Aave.
+     * @param safe Address of the EtherFi Safe
+     * @param enable True to enable lend now, false to request disabling it
+     * @param signer A safe admin authorizing the change
+     * @param signature The signer's signature over the intent
+     * @custom:throws OnlyEtherFiSafe if safe is not a valid EtherFi Safe
+     * @custom:throws OnlySafeAdmin if signer is not a safe admin
+     * @custom:throws InvalidSignatures if signature verification fails
+     * @custom:throws LendNotDisabled if enabling while lend is already enabled and no disable is pending
+     * @custom:throws LendAlreadyDisabled if disabling while lend is already disabled or a request is pending
+     * @custom:throws HasOpenBorrows if disabling while the safe still has open borrows
+     */
+    function toggleLend(address safe, bool enable, address signer, bytes calldata signature) external nonReentrant onlyEtherFiSafe(safe) onlySafeAdmin(safe, signer) {
+        CashVerificationLib.verifyToggleLendSig(safe, signer, _useNonce(safe), enable, signature);
+        if (enable) _enableLend(safe);
+        else _requestDisableLend(safe);
+    }
+
+    /**
      * @notice Sets the operating mode for a safe
      * @dev Switches between Debit and Credit modes with delay 
      * @param safe Address of the EtherFi Safe
@@ -144,6 +184,8 @@ contract CashModuleSetters is CashModuleStorageContract {
         _setCurrentMode($.safeCashConfig[safe]);
 
         if (mode == $.safeCashConfig[safe].mode) revert ModeAlreadySet();
+        // Credit mode requires lend collateral on Aave; a safe that opted out of lend cannot enter Credit
+        if (mode == Mode.Credit && $.safeCashConfig[safe].lendDisabled) revert LendDisabled();
 
         CashVerificationLib.verifySetModeSig(safe, signer, _useNonce(safe), mode, signature);
 

--- a/src/modules/cash/CashModuleSetters.sol
+++ b/src/modules/cash/CashModuleSetters.sol
@@ -138,8 +138,9 @@ contract CashModuleSetters is CashModuleStorageContract {
     function setLendGateway(address gateway) external {
         if (!roleRegistry().hasRole(CASH_MODULE_CONTROLLER_ROLE, msg.sender)) revert OnlyCashModuleController();
         if (gateway == address(0)) revert InvalidInput();
-        _getCashModuleStorage().gateway = IGateway(gateway);
-        emit LendGatewaySet(gateway);
+        CashModuleStorage storage $ = _getCashModuleStorage();
+        $.gateway = IGateway(gateway);
+        $.cashEventEmitter.emitLendGatewaySet(gateway);
     }
 
     /**

--- a/src/modules/cash/CashModuleStorageContract.sol
+++ b/src/modules/cash/CashModuleStorageContract.sol
@@ -10,6 +10,7 @@ import { ICashbackDispatcher } from "../../interfaces/ICashbackDispatcher.sol";
 import { IDebtManager } from "../../interfaces/IDebtManager.sol";
 import { IEtherFiDataProvider } from "../../interfaces/IEtherFiDataProvider.sol";
 import { IEtherFiSafe } from "../../interfaces/IEtherFiSafe.sol";
+import { IGateway } from "../../interfaces/IGateway.sol";
 import { ArrayDeDupLib } from "../../libraries/ArrayDeDupLib.sol";
 import { CashVerificationLib } from "../../libraries/CashVerificationLib.sol";
 import { SignatureUtils } from "../../libraries/SignatureUtils.sol";
@@ -71,7 +72,18 @@ contract CashModuleStorageContract is UpgradeableProxy, ModuleBase {
         address settlementDispatcherPix;
         /// @notice Address of the SettlementDispatcher for CardOrder
         address settlementDispatcherCardOrder;
+        /// @notice The Aave v4 gateway used to withdraw collateral when a safe opts out of lend
+        IGateway gateway;
     }
+
+    /// @notice Emitted when a safe requests to disable lend (opt out of Aave); executable after finalizeTime
+    event LendDisableRequested(address indexed safe, uint256 finalizeTime);
+    /// @notice Emitted when a safe's lend is disabled: collateral withdrawn from Aave, mode forced to Debit
+    event LendDisableExecuted(address indexed safe);
+    /// @notice Emitted when a safe re-enables lend (opts back into Aave)
+    event LendEnabled(address indexed safe);
+    /// @notice Emitted when the lend gateway is configured
+    event LendGatewaySet(address indexed gateway);
 
     // keccak256(abi.encode(uint256(keccak256("etherfi.storage.CashModuleStorage")) - 1)) & ~bytes32(uint256(0xff))
     bytes32 private constant CashModuleStorageLocation = 0xe000c7adec5855bcf51f74b73aa86172d0a325bc54c3f73cb406d259df90ea00;
@@ -158,6 +170,21 @@ contract CashModuleStorageContract is UpgradeableProxy, ModuleBase {
 
     /// @notice Error thrown when a withdrawal request is made by an invalid address or to an invalid recipient
     error InvalidWithdrawRequest();
+
+    /// @notice Error thrown when a lend op is attempted while the safe has opted out of lend
+    error LendDisabled();
+    /// @notice Error thrown when disabling lend while the safe still has open borrows
+    error HasOpenBorrows();
+    /// @notice Error thrown when executing a disable-lend that was never requested
+    error NoPendingLendDisable();
+    /// @notice Error thrown when executing a disable-lend before its delay has elapsed
+    error LendDisableNotReady();
+    /// @notice Error thrown when disabling lend that is already disabled, or when a request is already pending
+    error LendAlreadyDisabled();
+    /// @notice Error thrown when enabling lend that is already enabled
+    error LendNotDisabled();
+    /// @notice Error thrown when the lend gateway has not been configured
+    error LendGatewayNotSet();
 
     constructor(address _etherFiDataProvider) ModuleBase(_etherFiDataProvider) {
         _disableInitializers();
@@ -267,6 +294,81 @@ contract CashModuleStorageContract is UpgradeableProxy, ModuleBase {
             delete $.incomingModeStartTime;
             delete $.incomingMode;
         }
+    }
+
+    /**
+     * @dev Whether a safe has any open borrows (Aave debt via the gateway, or legacy DebtManager debt).
+     *      Disabling lend is only allowed with zero debt — the collateral backing it is about to leave Aave.
+     */
+    function _hasOpenBorrows(address safe) internal view returns (bool) {
+        CashModuleStorage storage $ = _getCashModuleStorage();
+        if (address($.gateway) != address(0) && $.gateway.getAccountData(safe).debtUsd != 0) return true;
+        (, uint256 debtManagerDebt) = $.debtManager.borrowingOf(safe);
+        return debtManagerDebt != 0;
+    }
+
+    /**
+     * @dev Records a request to disable lend for a safe (executable after modeDelay). Reverts if lend is
+     *      already disabled/pending or the safe has open borrows. Executes immediately if the delay is zero.
+     */
+    function _requestDisableLend(address safe) internal {
+        CashModuleStorage storage $ = _getCashModuleStorage();
+        SafeCashConfig storage $$ = $.safeCashConfig[safe];
+
+        if ($$.lendDisabled || $$.lendDisableFinalizeTime != 0) revert LendAlreadyDisabled();
+        if (_hasOpenBorrows(safe)) revert HasOpenBorrows();
+
+        uint96 finalizeTime = uint96(block.timestamp) + $.modeDelay;
+        $$.lendDisableFinalizeTime = finalizeTime;
+        emit LendDisableRequested(safe, finalizeTime);
+
+        if ($.modeDelay == 0) _disableLend(safe);
+    }
+
+    /**
+     * @dev Executes the disable-lend: withdraws ALL of the safe's Aave collateral back to the safe, marks
+     *      lend disabled, and forces the safe into Debit mode (credit is impossible without lend collateral).
+     *      The whole thing reverts if the gateway isn't set. Re-checks no open borrows at the call sites.
+     */
+    function _disableLend(address safe) internal {
+        CashModuleStorage storage $ = _getCashModuleStorage();
+        IGateway gateway = $.gateway;
+        if (address(gateway) == address(0)) revert LendGatewayNotSet();
+
+        // Pull every supported collateral token out of Aave, back into the safe (idle)
+        address[] memory collateralTokens = $.debtManager.getCollateralTokens();
+        uint256 len = collateralTokens.length;
+        for (uint256 i = 0; i < len;) {
+            uint256 supplied = gateway.suppliedOf(safe, collateralTokens[i]);
+            if (supplied != 0) gateway.withdraw(safe, collateralTokens[i], supplied, safe);
+            unchecked {
+                ++i;
+            }
+        }
+
+        SafeCashConfig storage $$ = $.safeCashConfig[safe];
+        $$.lendDisabled = true;
+        $$.lendDisableFinalizeTime = 0;
+        // Credit needs lend collateral, so force Debit and drop any pending mode change
+        $$.mode = Mode.Debit;
+        delete $$.incomingMode;
+        delete $$.incomingModeStartTime;
+
+        emit LendDisableExecuted(safe);
+    }
+
+    /**
+     * @dev Re-enables lend for a safe (opts it back into the Aave market) and cancels any pending disable
+     *      request. Instant — opting back into earning is not risk-increasing. Auto-supply resumes on the
+     *      safe's next deposit. Reverts if lend is already enabled and no disable is pending.
+     */
+    function _enableLend(address safe) internal {
+        SafeCashConfig storage $$ = _getCashModuleStorage().safeCashConfig[safe];
+        if (!$$.lendDisabled && $$.lendDisableFinalizeTime == 0) revert LendNotDisabled();
+
+        $$.lendDisabled = false;
+        $$.lendDisableFinalizeTime = 0;
+        emit LendEnabled(safe);
     }
 
     /**

--- a/src/modules/cash/CashModuleStorageContract.sol
+++ b/src/modules/cash/CashModuleStorageContract.sol
@@ -76,15 +76,6 @@ contract CashModuleStorageContract is UpgradeableProxy, ModuleBase {
         IGateway gateway;
     }
 
-    /// @notice Emitted when a safe requests to disable lend (opt out of Aave); executable after finalizeTime
-    event LendDisableRequested(address indexed safe, uint256 finalizeTime);
-    /// @notice Emitted when a safe's lend is disabled: collateral withdrawn from Aave, mode forced to Debit
-    event LendDisableExecuted(address indexed safe);
-    /// @notice Emitted when a safe re-enables lend (opts back into Aave)
-    event LendEnabled(address indexed safe);
-    /// @notice Emitted when the lend gateway is configured
-    event LendGatewaySet(address indexed gateway);
-
     // keccak256(abi.encode(uint256(keccak256("etherfi.storage.CashModuleStorage")) - 1)) & ~bytes32(uint256(0xff))
     bytes32 private constant CashModuleStorageLocation = 0xe000c7adec5855bcf51f74b73aa86172d0a325bc54c3f73cb406d259df90ea00;
 
@@ -302,7 +293,20 @@ contract CashModuleStorageContract is UpgradeableProxy, ModuleBase {
      */
     function _hasOpenBorrows(address safe) internal view returns (bool) {
         CashModuleStorage storage $ = _getCashModuleStorage();
-        if (address($.gateway) != address(0) && $.gateway.getAccountData(safe).debtUsd != 0) return true;
+        IGateway gateway = $.gateway;
+        if (address(gateway) != address(0)) {
+            // Check raw per-asset debt, not getAccountData().debtUsd: the USD aggregate floors to 6 decimals,
+            // so sub-$0.000001 dust reads as zero here and then reverts deep in Aave (HealthFactorBelowThreshold)
+            // when _disableLend tries to withdraw all collateral.
+            address[] memory assets = gateway.registeredAssets();
+            uint256 aLen = assets.length;
+            for (uint256 i = 0; i < aLen;) {
+                if (gateway.debtOf(safe, assets[i]) != 0) return true;
+                unchecked {
+                    ++i;
+                }
+            }
+        }
         (, uint256 debtManagerDebt) = $.debtManager.borrowingOf(safe);
         return debtManagerDebt != 0;
     }
@@ -320,7 +324,7 @@ contract CashModuleStorageContract is UpgradeableProxy, ModuleBase {
 
         uint96 finalizeTime = uint96(block.timestamp) + $.modeDelay;
         $$.lendDisableFinalizeTime = finalizeTime;
-        emit LendDisableRequested(safe, finalizeTime);
+        $.cashEventEmitter.emitLendDisableRequested(safe, finalizeTime);
 
         if ($.modeDelay == 0) _disableLend(safe);
     }
@@ -335,8 +339,10 @@ contract CashModuleStorageContract is UpgradeableProxy, ModuleBase {
         IGateway gateway = $.gateway;
         if (address(gateway) == address(0)) revert LendGatewayNotSet();
 
-        // Pull every supported collateral token out of Aave, back into the safe (idle)
-        address[] memory collateralTokens = $.debtManager.getCollateralTokens();
+        // Pull every gateway-registered asset out of Aave, back into the safe (idle). Iterate the gateway's
+        // registry, not DebtManager's collateral list: a token delisted from DebtManager while still supplied
+        // on Aave must remain withdrawable, and the Aave position is keyed on the gateway's assets anyway.
+        address[] memory collateralTokens = gateway.registeredAssets();
         uint256 len = collateralTokens.length;
         for (uint256 i = 0; i < len;) {
             uint256 supplied = gateway.suppliedOf(safe, collateralTokens[i]);
@@ -354,7 +360,7 @@ contract CashModuleStorageContract is UpgradeableProxy, ModuleBase {
         delete $$.incomingMode;
         delete $$.incomingModeStartTime;
 
-        emit LendDisableExecuted(safe);
+        $.cashEventEmitter.emitLendDisableExecuted(safe);
     }
 
     /**
@@ -363,12 +369,13 @@ contract CashModuleStorageContract is UpgradeableProxy, ModuleBase {
      *      safe's next deposit. Reverts if lend is already enabled and no disable is pending.
      */
     function _enableLend(address safe) internal {
-        SafeCashConfig storage $$ = _getCashModuleStorage().safeCashConfig[safe];
+        CashModuleStorage storage $ = _getCashModuleStorage();
+        SafeCashConfig storage $$ = $.safeCashConfig[safe];
         if (!$$.lendDisabled && $$.lendDisableFinalizeTime == 0) revert LendNotDisabled();
 
         $$.lendDisabled = false;
         $$.lendDisableFinalizeTime = 0;
-        emit LendEnabled(safe);
+        $.cashEventEmitter.emitLendEnabled(safe);
     }
 
     /**

--- a/src/modules/cash/CashbackLib.sol
+++ b/src/modules/cash/CashbackLib.sol
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { Cashback, CashbackTokens, TokenDataInUsd } from "../../interfaces/ICashModule.sol";
+import { ICashEventEmitter } from "../../interfaces/ICashEventEmitter.sol";
+import { ICashbackDispatcher } from "../../interfaces/ICashbackDispatcher.sol";
+import { ArrayDeDupLib } from "../../libraries/ArrayDeDupLib.sol";
+import { CashModuleStorageContract } from "./CashModuleStorageContract.sol";
+
+/**
+ * @title CashbackLib
+ * @notice Cashback accounting for the CashModule, extracted into an external (delegatecalled) library.
+ * @dev Deployed once and linked into CashModuleCore, so this logic does not count against CashModuleCore's
+ *      EIP-170 runtime code-size limit. Every function is called via delegatecall and therefore runs in the
+ *      CashModule's storage context: the caller passes its CashModuleStorage pointer and the library reads and
+ *      writes the same namespaced storage the module would. Behaviour is identical to the previous in-module
+ *      implementation.
+ * @author ether.fi
+ */
+library CashbackLib {
+    using ArrayDeDupLib for address[];
+
+    /// @dev Same selector as CashModule's InvalidInput, so reverts are indistinguishable to callers
+    error InvalidInput();
+
+    /**
+     * @notice Gets the pending cashback amounts for an account across a set of tokens
+     * @param $ The CashModule storage (passed by the delegatecalling module)
+     * @param account Address of the account (safe or spender)
+     * @param tokens Addresses of tokens for cashback
+     * @return data Pending cashback data for the tokens that have a nonzero pending amount
+     * @return totalCashbackInUsd Total pending cashback amount in USD across the tokens
+     */
+    function getPendingCashback(CashModuleStorageContract.CashModuleStorage storage $, address account, address[] memory tokens) external view returns (TokenDataInUsd[] memory data, uint256 totalCashbackInUsd) {
+        uint256 len = tokens.length;
+        if (len > 1) tokens.checkDuplicates();
+        data = new TokenDataInUsd[](len);
+        uint256 m = 0;
+
+        for (uint256 i = 0; i < len;) {
+            uint256 pendingCashbackInUsd = $.pendingCashbackForTokenInUsd[account][tokens[i]];
+            if (pendingCashbackInUsd > 0) {
+                data[m] = TokenDataInUsd({ token: tokens[i], amountInUsd: pendingCashbackInUsd });
+
+                totalCashbackInUsd += pendingCashbackInUsd;
+
+                unchecked {
+                    ++m;
+                }
+            }
+            unchecked {
+                ++i;
+            }
+        }
+
+        assembly ("memory-safe") {
+            mstore(data, m)
+        }
+    }
+
+    /**
+     * @notice Attempts to retrieve (pay out) the pending cashback for a set of users and tokens
+     * @param $ The CashModule storage (passed by the delegatecalling module)
+     * @param users Addresses of users who may have pending cashback
+     * @param tokens Addresses of cashback tokens
+     * @custom:throws InvalidInput if users is empty or any user/token is the zero address
+     */
+    function clearPending(CashModuleStorageContract.CashModuleStorage storage $, address[] calldata users, address[] calldata tokens) external {
+        uint256 len = users.length;
+        if (len == 0) revert InvalidInput();
+        if (tokens.length > 1) tokens.checkDuplicates();
+        if (len > 1) users.checkDuplicates();
+
+        for (uint256 i = 0; i < len;) {
+            if (users[i] == address(0)) revert InvalidInput();
+
+            for (uint256 j = 0; j < tokens.length;) {
+                if (tokens[j] == address(0)) revert InvalidInput();
+
+                _retrievePendingCashback($, users[i], tokens[j]);
+                unchecked {
+                    ++j;
+                }
+            }
+
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    /**
+     * @notice Processes cashback for a spending transaction, paying what it can and queuing the rest
+     * @param $ The CashModule storage (passed by the delegatecalling module)
+     * @param safe Address of the EtherFi Safe that spent
+     * @param spendAmount Amount spent in USD (for the emitted event)
+     * @param cashbacks Array of Cashback structs describing recipients, tokens, and amounts
+     */
+    function processCashback(CashModuleStorageContract.CashModuleStorage storage $, address safe, uint256 spendAmount, Cashback[] calldata cashbacks) external {
+        uint256 len = cashbacks.length;
+
+        for (uint256 i = 0; i < len;) {
+            address to = cashbacks[i].to;
+            if (to == address(0)) continue;
+            CashbackTokens[] memory cashbackTokens = cashbacks[i].cashbackTokens;
+
+            for (uint256 j = 0; j < cashbackTokens.length;) {
+                address token = cashbackTokens[j].token;
+                _retrievePendingCashback($, to, token);
+
+                uint256 amountInUsd = cashbackTokens[j].amountInUsd;
+                $.safeCashConfig[to].totalCashbackEarnedInUsd += amountInUsd;
+
+                if (amountInUsd != 0) {
+                    try $.cashbackDispatcher.cashback(to, token, amountInUsd) returns (uint256 cashbackAmountInToken, bool paid) {
+                        if (!paid) $.pendingCashbackForTokenInUsd[to][token] += amountInUsd;
+                        $.cashEventEmitter.emitCashbackEvent(safe, spendAmount, to, token, cashbackAmountInToken, amountInUsd, cashbackTokens[j].cashbackType, paid);
+                    } catch {
+                        $.pendingCashbackForTokenInUsd[to][token] += amountInUsd;
+                        $.cashEventEmitter.emitCashbackEvent(safe, spendAmount, to, token, 0, amountInUsd, cashbackTokens[j].cashbackType, false);
+                    }
+                }
+
+                unchecked {
+                    ++j;
+                }
+            }
+
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    /**
+     * @dev Attempts to retrieve pending cashback for a single user/token, clearing storage on success
+     * @param $ The CashModule storage (passed by the delegatecalling module)
+     * @param user Address of the user who may have pending cashback
+     * @param token Address of the cashback token
+     */
+    function _retrievePendingCashback(CashModuleStorageContract.CashModuleStorage storage $, address user, address token) internal {
+        uint256 amountInUsd = $.pendingCashbackForTokenInUsd[user][token];
+
+        if (amountInUsd > 0) {
+            try $.cashbackDispatcher.clearPendingCashback(user, token, amountInUsd) returns (uint256 cashbackAmountInToken, bool paid) {
+                if (paid) {
+                    $.cashEventEmitter.emitPendingCashbackClearedEvent(user, token, cashbackAmountInToken, amountInUsd);
+                    delete $.pendingCashbackForTokenInUsd[user][token];
+                }
+            } catch { }
+        }
+    }
+}

--- a/src/modules/gateway/Gateway.sol
+++ b/src/modules/gateway/Gateway.sol
@@ -341,15 +341,20 @@ contract Gateway is IGateway, UpgradeableProxy, ModuleBase {
 
     /**
      * @notice Toggles whether `safe`'s supplied `asset` counts as collateral on Aave
-     * @dev Driver-only. Rejected if the safe has opted out of lend, or while the gateway is paused.
+     * @dev Driver-only. Enabling collateral is a lend op, rejected if the safe has opted out of lend; disabling
+     *      is an exit action (like withdraw/repay) and stays open to opted-out safes so a residual position can
+     *      still be cleaned up. Rejected while the gateway is paused.
      * @param safe The safe whose position is updated
      * @param asset The supplied asset (must be a registered reserve)
      * @param useAsCollateral True to use as collateral, false to disable
      * @custom:throws OnlyDriver if the caller is not the CashModule or an authorized driver
-     * @custom:throws LendDisabled if the safe has opted out of lend
+     * @custom:throws LendDisabled if enabling collateral usage for a safe that has opted out of lend
      * @custom:throws AssetNotRegistered if asset has no registered reserveId
      */
-    function setUsingAsCollateral(address safe, address asset, bool useAsCollateral) external onlyDriver whenNotPaused nonReentrant whenLendEnabled(safe) ensuresApproval(safe) {
+    function setUsingAsCollateral(address safe, address asset, bool useAsCollateral) external onlyDriver whenNotPaused nonReentrant ensuresApproval(safe) {
+        // Gate only enabling (a lend op); disabling must stay open so an opted-out safe can drop a residual
+        // supplied position from collateral (e.g. one left on Aave after processLendDisable). It only de-risks.
+        if (useAsCollateral && !_isLendEnabled(safe)) revert LendDisabled();
         spoke.setUsingAsCollateral(_reserveIdOf(asset), useAsCollateral, safe);
         emit CollateralUsageSet(safe, asset, useAsCollateral);
     }

--- a/src/modules/gateway/Gateway.sol
+++ b/src/modules/gateway/Gateway.sol
@@ -7,6 +7,7 @@ import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.s
 import { EnumerableSetLib } from "solady/utils/EnumerableSetLib.sol";
 
 import { IAaveV4Spoke } from "../../interfaces/IAaveV4Spoke.sol";
+import { ICashModule } from "../../interfaces/ICashModule.sol";
 import { IEtherFiSafe } from "../../interfaces/IEtherFiSafe.sol";
 import { IGateway } from "../../interfaces/IGateway.sol";
 import { IPriceProvider } from "../../interfaces/IPriceProvider.sol";
@@ -101,6 +102,8 @@ contract Gateway is IGateway, UpgradeableProxy, ModuleBase {
     error ZeroAddress();
     /// @notice Thrown when an amount argument is zero
     error ZeroAmount();
+    /// @notice Thrown when a lend op is attempted for a safe that has opted out of lend
+    error LendDisabled();
 
     /**
      * @param _etherFiDataProvider Address of the EtherFiDataProvider
@@ -131,6 +134,13 @@ contract Gateway is IGateway, UpgradeableProxy, ModuleBase {
 
     modifier onlyDriver() {
         _onlyDriver();
+        _;
+    }
+
+    /// @dev Reverts if `safe` has opted out of lend. Placed before ensuresApproval so a disabled safe's
+    ///      supply/borrow reverts without re-establishing position-manager approval as a side effect.
+    modifier whenLendEnabled(address safe) {
+        if (!_isLendEnabled(safe)) revert LendDisabled();
         _;
     }
 
@@ -219,8 +229,20 @@ contract Gateway is IGateway, UpgradeableProxy, ModuleBase {
     // IGateway operations (drivers only)
     // ---------------------------------------------------------------------
 
-    /// @inheritdoc IGateway
-    function supply(address safe, address asset, uint256 amount) external onlyDriver whenNotPaused nonReentrant ensuresApproval(safe) {
+    /**
+     * @notice Supplies `amount` of `asset` to Aave on behalf of `safe`
+     * @dev Driver-only. The Spoke debits the caller, so the gateway first pulls the asset from the safe and
+     *      approves the Spoke, then supplies into the safe's position. Rejected if the safe has opted out of
+     *      lend, or while the gateway is paused.
+     * @param safe The safe whose position is credited
+     * @param asset The asset being supplied (must be a registered reserve)
+     * @param amount The amount to supply
+     * @custom:throws OnlyDriver if the caller is not the CashModule or an authorized driver
+     * @custom:throws LendDisabled if the safe has opted out of lend
+     * @custom:throws ZeroAmount if amount is zero
+     * @custom:throws AssetNotRegistered if asset has no registered reserveId
+     */
+    function supply(address safe, address asset, uint256 amount) external onlyDriver whenNotPaused nonReentrant whenLendEnabled(safe) ensuresApproval(safe) {
         if (amount == 0) revert ZeroAmount();
         uint256 reserveId = _reserveIdOf(asset);
 
@@ -232,7 +254,21 @@ contract Gateway is IGateway, UpgradeableProxy, ModuleBase {
         emit Supplied(safe, asset, amount);
     }
 
-    /// @inheritdoc IGateway
+    /**
+     * @notice Withdraws `amount` of `asset` from `safe`'s Aave position to `to`
+     * @dev Driver-only. The Spoke sends the underlying to this gateway, which forwards exactly the amount
+     *      received to `to`. Intentionally NOT gated by lend being enabled, so an opted-out safe can always
+     *      exit its position. Aave reverts the withdraw itself if it would drop the position below its
+     *      liquidation threshold.
+     * @param safe The safe whose position is debited
+     * @param asset The asset being withdrawn (must be a registered reserve)
+     * @param amount The amount to withdraw
+     * @param to The recipient of the withdrawn asset
+     * @custom:throws OnlyDriver if the caller is not the CashModule or an authorized driver
+     * @custom:throws ZeroAmount if amount is zero
+     * @custom:throws ZeroAddress if to is the zero address
+     * @custom:throws AssetNotRegistered if asset has no registered reserveId
+     */
     function withdraw(address safe, address asset, uint256 amount, address to) external onlyDriver whenNotPaused nonReentrant ensuresApproval(safe) {
         if (amount == 0) revert ZeroAmount();
         if (to == address(0)) revert ZeroAddress();
@@ -245,8 +281,22 @@ contract Gateway is IGateway, UpgradeableProxy, ModuleBase {
         emit Withdrawn(safe, asset, assetsWithdrawn, to);
     }
 
-    /// @inheritdoc IGateway
-    function borrow(address safe, address asset, uint256 amount, address to) external onlyDriver whenNotPaused nonReentrant ensuresApproval(safe) {
+    /**
+     * @notice Borrows `amount` of `asset` against `safe`'s position and sends it to `to`
+     * @dev Driver-only. The Spoke sends the borrowed underlying to this gateway, which forwards it to `to`.
+     *      Rejected if the safe has opted out of lend, or while the gateway is paused. Aave reverts if the
+     *      borrow would exceed the position's borrowing power.
+     * @param safe The safe whose position takes on the debt
+     * @param asset The asset being borrowed (must be a registered reserve)
+     * @param amount The amount to borrow
+     * @param to The recipient of the borrowed asset
+     * @custom:throws OnlyDriver if the caller is not the CashModule or an authorized driver
+     * @custom:throws LendDisabled if the safe has opted out of lend
+     * @custom:throws ZeroAmount if amount is zero
+     * @custom:throws ZeroAddress if to is the zero address
+     * @custom:throws AssetNotRegistered if asset has no registered reserveId
+     */
+    function borrow(address safe, address asset, uint256 amount, address to) external onlyDriver whenNotPaused nonReentrant whenLendEnabled(safe) ensuresApproval(safe) {
         if (amount == 0) revert ZeroAmount();
         if (to == address(0)) revert ZeroAddress();
         uint256 reserveId = _reserveIdOf(asset);
@@ -258,7 +308,19 @@ contract Gateway is IGateway, UpgradeableProxy, ModuleBase {
         emit Borrowed(safe, asset, assetsBorrowed, to);
     }
 
-    /// @inheritdoc IGateway
+    /**
+     * @notice Repays `amount` of `asset` debt on behalf of `safe`
+     * @dev Driver-only. Resolves type(uint256).max to the current debt, pulls that amount from the safe,
+     *      approves the Spoke, and repays; any amount the Spoke does not consume is refunded to the safe.
+     *      Intentionally NOT gated by lend being enabled, so an opted-out safe can always reduce its debt.
+     * @param safe The safe whose debt is repaid
+     * @param asset The asset being repaid (must be a registered reserve)
+     * @param amount The amount to repay; use type(uint256).max to repay the full debt
+     * @return The actual amount repaid
+     * @custom:throws OnlyDriver if the caller is not the CashModule or an authorized driver
+     * @custom:throws ZeroAmount if the resolved repay amount is zero (e.g. max with no outstanding debt)
+     * @custom:throws AssetNotRegistered if asset has no registered reserveId
+     */
     function repay(address safe, address asset, uint256 amount) external onlyDriver whenNotPaused nonReentrant ensuresApproval(safe) returns (uint256) {
         uint256 reserveId = _reserveIdOf(asset);
 
@@ -277,8 +339,17 @@ contract Gateway is IGateway, UpgradeableProxy, ModuleBase {
         return assetsRepaid;
     }
 
-    /// @inheritdoc IGateway
-    function setUsingAsCollateral(address safe, address asset, bool useAsCollateral) external onlyDriver whenNotPaused nonReentrant ensuresApproval(safe) {
+    /**
+     * @notice Toggles whether `safe`'s supplied `asset` counts as collateral on Aave
+     * @dev Driver-only. Rejected if the safe has opted out of lend, or while the gateway is paused.
+     * @param safe The safe whose position is updated
+     * @param asset The supplied asset (must be a registered reserve)
+     * @param useAsCollateral True to use as collateral, false to disable
+     * @custom:throws OnlyDriver if the caller is not the CashModule or an authorized driver
+     * @custom:throws LendDisabled if the safe has opted out of lend
+     * @custom:throws AssetNotRegistered if asset has no registered reserveId
+     */
+    function setUsingAsCollateral(address safe, address asset, bool useAsCollateral) external onlyDriver whenNotPaused nonReentrant whenLendEnabled(safe) ensuresApproval(safe) {
         spoke.setUsingAsCollateral(_reserveIdOf(asset), useAsCollateral, safe);
         emit CollateralUsageSet(safe, asset, useAsCollateral);
     }
@@ -287,7 +358,15 @@ contract Gateway is IGateway, UpgradeableProxy, ModuleBase {
     // IGateway reads
     // ---------------------------------------------------------------------
 
-    /// @inheritdoc IGateway
+    /**
+     * @notice Returns `safe`'s Aave position summary (collateral, debt, borrow headroom, health factor)
+     * @dev Re-derives USD from ether.fi's PriceProvider over the registered assets (not from Aave's opaque
+     *      value units): sums supplied value into collateralUsd, weights collateral-enabled supply by each
+     *      reserve's LTV for the borrow headroom, sums debt into debtUsd, and takes healthFactor (WAD)
+     *      directly from Aave. Source of truth for CashLens canSpend and EtherFiHook health checks.
+     * @param safe The safe to query
+     * @return data The safe's account data (USD fields are 6-decimal; healthFactor is 1e18)
+     */
     function getAccountData(address safe) external view returns (AccountData memory data) {
         IPriceProvider priceProvider = IPriceProvider(etherFiDataProvider.getPriceProvider());
         GatewayStorage storage $ = _getGatewayStorage();
@@ -320,21 +399,35 @@ contract Gateway is IGateway, UpgradeableProxy, ModuleBase {
         data.healthFactor = spoke.getUserAccountData(safe).healthFactor;
     }
 
-    /// @inheritdoc IGateway
+    /**
+     * @notice Returns the amount of `asset` that `safe` has supplied to Aave
+     * @param safe The safe to query
+     * @param asset The supplied asset
+     * @return The supplied amount in asset units, or 0 if the asset is not registered
+     */
     function suppliedOf(address safe, address asset) external view returns (uint256) {
         GatewayStorage storage $ = _getGatewayStorage();
         if (!$.assets.contains(asset)) return 0;
         return spoke.getUserSuppliedAssets($.reserveId[asset], safe);
     }
 
-    /// @inheritdoc IGateway
+    /**
+     * @notice Returns the amount of `asset` debt that `safe` owes Aave
+     * @param safe The safe to query
+     * @param asset The borrowed asset
+     * @return The debt amount in asset units, or 0 if the asset is not registered
+     */
     function debtOf(address safe, address asset) external view returns (uint256) {
         GatewayStorage storage $ = _getGatewayStorage();
         if (!$.assets.contains(asset)) return 0;
         return spoke.getUserTotalDebt($.reserveId[asset], safe);
     }
 
-    /// @inheritdoc IGateway
+    /**
+     * @notice Returns the withdrawable/borrowable liquidity of `asset`'s reserve (supplied minus borrowed)
+     * @param asset The reserve asset
+     * @return The available liquidity in asset units, or 0 if the asset is not registered
+     */
     function availableCash(address asset) external view returns (uint256) {
         GatewayStorage storage $ = _getGatewayStorage();
         if (!$.assets.contains(asset)) return 0;
@@ -344,11 +437,27 @@ contract Gateway is IGateway, UpgradeableProxy, ModuleBase {
         return supplied > debt ? supplied - debt : 0;
     }
 
-    /// @inheritdoc IGateway
+    /**
+     * @notice Returns the loan-to-value of `asset`'s reserve in the 100e18 = 100% scale (matching DebtManager)
+     * @dev Derived from the reserve's current dynamic collateralFactor (BPS), scaled by 1e16.
+     * @param asset The reserve asset
+     * @return The LTV where 100e18 is 100%, or 0 if the asset is not registered
+     */
     function ltv(address asset) external view returns (uint256) {
         GatewayStorage storage $ = _getGatewayStorage();
         if (!$.assets.contains(asset)) return 0;
         return _ltv($.reserveId[asset]);
+    }
+
+    /**
+     * @notice Returns whether lend is enabled for `safe` (i.e. the safe participates in the Aave market)
+     * @dev Reads the CashModule, the source of truth for the opt-out. When false, this gateway rejects
+     *      supply / borrow / setUsingAsCollateral for the safe; withdraw and repay stay open.
+     * @param safe The safe to query
+     * @return True if lend is enabled, false if the safe has opted out
+     */
+    function isLendEnabled(address safe) external view returns (bool) {
+        return _isLendEnabled(safe);
     }
 
     // ---------------------------------------------------------------------
@@ -391,6 +500,11 @@ contract Gateway is IGateway, UpgradeableProxy, ModuleBase {
         to[0] = asset;
         data[0] = abi.encodeWithSelector(IERC20.transfer.selector, address(this), amount);
         IEtherFiSafe(safe).execTransactionFromModule(to, new uint256[](1), data);
+    }
+
+    /// @dev Whether `safe` participates in lend, per the CashModule (the source of truth for the opt-out)
+    function _isLendEnabled(address safe) internal view returns (bool) {
+        return ICashModule(etherFiDataProvider.getCashModule()).isLendEnabled(safe);
     }
 
     /// @dev The registered reserveId for `asset`, reverting if unregistered

--- a/src/modules/gateway/Gateway.sol
+++ b/src/modules/gateway/Gateway.sol
@@ -143,6 +143,9 @@ contract Gateway is IGateway, UpgradeableProxy, ModuleBase {
      * @dev Reverts unless the Spoke's reserve `reserveId` has `underlying == asset`
      * @param asset The underlying asset
      * @param reserveId The Aave reserveId for the asset
+     * @dev Warning: do not re-point an asset safes already hold positions under; 
+     * the USD views then read the new reserve and miss the old, understating debt and 
+     * inflating borrow headroom.
      */
     function setReserveId(address asset, uint256 reserveId) external onlyRole(GATEWAY_ADMIN_ROLE) {
         if (asset == address(0)) revert ZeroAddress();
@@ -158,6 +161,8 @@ contract Gateway is IGateway, UpgradeableProxy, ModuleBase {
     /**
      * @notice De-registers an asset
      * @param asset The asset to remove from the registry
+     * @dev Warning: do not remove an asset any safe still holds a position in; 
+     * it drops from the USD views (debt reads 0), understating debt and inflating borrow headroom.
      */
     function removeReserve(address asset) external onlyRole(GATEWAY_ADMIN_ROLE) {
         GatewayStorage storage $ = _getGatewayStorage();

--- a/test/gateway/CashLendDisable.t.sol
+++ b/test/gateway/CashLendDisable.t.sol
@@ -1,0 +1,352 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+
+import { UUPSProxy } from "../../src/UUPSProxy.sol";
+import { IAggregatorV3 } from "../../src/interfaces/IAggregatorV3.sol";
+import { BinSponsor, ICashModule, Mode } from "../../src/interfaces/ICashModule.sol";
+import { IGateway } from "../../src/interfaces/IGateway.sol";
+import { CashVerificationLib } from "../../src/libraries/CashVerificationLib.sol";
+import { SignatureUtils } from "../../src/libraries/SignatureUtils.sol";
+import { CashModuleStorageContract } from "../../src/modules/cash/CashModuleStorageContract.sol";
+import { Gateway } from "../../src/modules/gateway/Gateway.sol";
+import { ChainlinkCompositePriceFeed } from "../../src/oracle/ChainlinkCompositePriceFeed.sol";
+import { UpgradeableProxy } from "../../src/utils/UpgradeableProxy.sol";
+import { CashModuleTestSetup } from "../safe/modules/cash/CashModuleTestSetup.t.sol";
+import { AaveV4Fixture } from "./helpers/AaveV4Fixture.sol";
+
+/**
+ * @title CashLendDisableTest
+ * @notice Fork tests for the lend opt-out toggle: a safe with no open borrows can request to leave the Aave
+ *         market via toggleLend(false), and after the mode-change delay execute it via processLendDisable —
+ *         pulling ALL its collateral out of Aave back into the safe, forcing Debit mode, and blocking every
+ *         further lend op (auto-supply / borrow) until it opts back in with toggleLend(true). Runs against a
+ *         REAL Aave v4 instance deployed in-test on an Optimism fork, driven by the real ether.fi stack
+ *         (CashModule, Gateway, EtherFiSafe) — no mocks.
+ * @dev Run with: source .env && FOUNDRY_PROFILE=aave TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test --match-path test/gateway/CashLendDisable.t.sol
+ */
+contract CashLendDisableTest is CashModuleTestSetup, AaveV4Fixture {
+    using MessageHashUtils for bytes32;
+
+    Gateway internal gw;
+    address internal driver = makeAddr("gwDriver"); // arranges Aave positions directly in tests
+
+    uint256 internal usdcReserveId;
+    uint256 internal weethReserveId;
+
+    uint64 internal constant MODE_DELAY = 10; // mirrors the "takes ~10 seconds" opt-out spec
+
+    function setUp() public override {
+        super.setUp();
+
+        // Real Aave v4 instance on the fork, weETH + USDC reserves priced by live Chainlink feeds
+        _deployAaveV4();
+        address weethSource = address(new ChainlinkCompositePriceFeed(IAggregatorV3(weEthWethOracle), IAggregatorV3(ethUsdcOracle), 8, 30 days, 30 days, "weETH / USD"));
+        weethReserveId = _addAaveReserve(address(weETH), weethSource, 8000, false);
+        usdcReserveId = _addAaveReserve(address(usdc), usdcUsdOracle, 8000, true);
+        _seedAaveLiquidity(usdcReserveId, address(usdc), 1_000_000e6);
+
+        // Gateway proxy + wiring
+        address gwImpl = address(new Gateway(address(dataProvider), address(spoke)));
+        gw = Gateway(address(new UUPSProxy(gwImpl, abi.encodeWithSelector(Gateway.initialize.selector, address(roleRegistry)))));
+
+        vm.startPrank(owner);
+        roleRegistry.grantRole(gw.GATEWAY_ADMIN_ROLE(), owner);
+        dataProvider.configureModules(_addr1(address(gw)), _bool1(true));
+        gw.setReserveId(address(weETH), weethReserveId);
+        gw.setReserveId(address(usdc), usdcReserveId);
+        gw.setDriver(driver, true);
+        // Wire the CashModule to the gateway (source of the collateral-withdraw path) and give a real mode delay
+        cashModule.setLendGateway(address(gw));
+        cashModule.setDelays(1, 3600, MODE_DELAY);
+        vm.stopPrank();
+
+        _enableModule(address(gw));
+        _activateAavePositionManager(address(gw));
+    }
+
+    // ----------------------------------------------------------------- wiring & defaults
+
+    function test_setLendGateway_setsAddressAndGuardsRole() public {
+        assertEq(cashModule.getLendGateway(), address(gw));
+
+        vm.prank(makeAddr("notController"));
+        vm.expectRevert(ICashModule.OnlyCashModuleController.selector);
+        cashModule.setLendGateway(address(gw));
+
+        vm.prank(owner);
+        vm.expectRevert(ICashModule.InvalidInput.selector);
+        cashModule.setLendGateway(address(0));
+    }
+
+    function test_lendEnabledByDefault() public view {
+        assertTrue(cashModule.isLendEnabled(address(safe)), "lend on by default (cash module)");
+        assertTrue(gw.isLendEnabled(address(safe)), "lend on by default (gateway view)");
+        assertEq(cashModule.lendDisableFinalizeTime(address(safe)), 0, "no pending disable");
+    }
+
+    // ----------------------------------------------------------------- happy path
+
+    function test_disableLend_withdrawsCollateralForcesDebitAndBlocksLend() public {
+        // Position: 5 weETH supplied as collateral on Aave, no debt
+        deal(address(weETH), address(safe), 5 ether);
+        vm.startPrank(driver);
+        gw.supply(address(safe), address(weETH), 5 ether);
+        gw.setUsingAsCollateral(address(safe), address(weETH), true);
+        vm.stopPrank();
+        assertApproxEqAbs(gw.suppliedOf(address(safe), address(weETH)), 5 ether, 2, "collateral on Aave");
+
+        // Request the opt-out (owner-signed); it becomes executable after MODE_DELAY
+        uint256 expectedFinalize = block.timestamp + MODE_DELAY;
+        vm.expectEmit(true, false, false, true, address(cashModule));
+        emit CashModuleStorageContract.LendDisableRequested(address(safe), expectedFinalize);
+        _requestDisable();
+        assertEq(cashModule.lendDisableFinalizeTime(address(safe)), expectedFinalize, "finalize time recorded");
+        assertTrue(cashModule.isLendEnabled(address(safe)), "still enabled until executed");
+
+        // Execute after the delay: permissionless
+        vm.warp(block.timestamp + MODE_DELAY);
+        vm.expectEmit(true, false, false, false, address(cashModule));
+        emit CashModuleStorageContract.LendDisableExecuted(address(safe));
+        cashModule.processLendDisable(address(safe));
+
+        // Collateral pulled back into the safe; Aave position emptied
+        assertApproxEqAbs(weETH.balanceOf(address(safe)), 5 ether, 2, "collateral back in safe");
+        assertLe(gw.suppliedOf(address(safe), address(weETH)), 2, "nothing left on Aave");
+        // Lend now off everywhere, mode forced to Debit, pending cleared
+        assertFalse(cashModule.isLendEnabled(address(safe)), "lend disabled (cash module)");
+        assertFalse(gw.isLendEnabled(address(safe)), "lend disabled (gateway view)");
+        assertEq(uint8(cashModule.getMode(address(safe))), uint8(Mode.Debit), "forced to Debit");
+        assertEq(cashModule.lendDisableFinalizeTime(address(safe)), 0, "pending cleared");
+
+        // Every lend op through the gateway is now rejected
+        deal(address(weETH), address(safe), 1 ether);
+        vm.startPrank(driver);
+        vm.expectRevert(Gateway.LendDisabled.selector);
+        gw.supply(address(safe), address(weETH), 1 ether);
+        vm.expectRevert(Gateway.LendDisabled.selector);
+        gw.borrow(address(safe), address(usdc), 1e6, driver);
+        vm.expectRevert(Gateway.LendDisabled.selector);
+        gw.setUsingAsCollateral(address(safe), address(weETH), true);
+        vm.stopPrank();
+    }
+
+    function test_disableLend_forcesDebitFromCreditMode() public {
+        // Move the safe into Credit mode first (no borrows), then opt out
+        _setModeCredit();
+        assertEq(uint8(cashModule.getMode(address(safe))), uint8(Mode.Credit), "in credit mode");
+
+        _requestDisable();
+        vm.warp(block.timestamp + MODE_DELAY);
+        cashModule.processLendDisable(address(safe));
+
+        assertEq(uint8(cashModule.getMode(address(safe))), uint8(Mode.Debit), "credit dropped to debit");
+    }
+
+    function test_disableLend_noCollateral_marksDisabled() public {
+        // No Aave position at all: opting out is still valid and just flips the flag
+        _requestDisable();
+        vm.warp(block.timestamp + MODE_DELAY);
+        cashModule.processLendDisable(address(safe));
+
+        assertFalse(cashModule.isLendEnabled(address(safe)), "disabled with no collateral");
+        assertEq(uint8(cashModule.getMode(address(safe))), uint8(Mode.Debit));
+    }
+
+    // ----------------------------------------------------------------- disable-request guards
+
+    function test_toggleLendDisable_revertsWithOpenAaveBorrow() public {
+        // Open an Aave borrow so the safe has debt
+        deal(address(weETH), address(safe), 5 ether);
+        vm.startPrank(driver);
+        gw.supply(address(safe), address(weETH), 5 ether);
+        gw.setUsingAsCollateral(address(safe), address(weETH), true);
+        gw.borrow(address(safe), address(usdc), 1000e6, driver);
+        vm.stopPrank();
+
+        (address signer, bytes memory sig) = _toggleLendSig(false);
+        vm.expectRevert(ICashModule.HasOpenBorrows.selector);
+        cashModule.toggleLend(address(safe), false, signer, sig);
+    }
+
+    function test_toggleLendDisable_revertsWhenAlreadyPending() public {
+        _requestDisable();
+
+        (address signer, bytes memory sig) = _toggleLendSig(false);
+        vm.expectRevert(ICashModule.LendAlreadyDisabled.selector);
+        cashModule.toggleLend(address(safe), false, signer, sig);
+    }
+
+    function test_toggleLendDisable_revertsWhenAlreadyDisabled() public {
+        _requestDisable();
+        vm.warp(block.timestamp + MODE_DELAY);
+        cashModule.processLendDisable(address(safe));
+
+        (address signer, bytes memory sig) = _toggleLendSig(false);
+        vm.expectRevert(ICashModule.LendAlreadyDisabled.selector);
+        cashModule.toggleLend(address(safe), false, signer, sig);
+    }
+
+    function test_toggleLend_rejectsNonAdminSigner() public {
+        (, bytes memory sig) = _toggleLendSig(false);
+        vm.expectRevert(ICashModule.OnlySafeAdmin.selector);
+        cashModule.toggleLend(address(safe), false, makeAddr("notAdmin"), sig);
+    }
+
+    function test_toggleLend_rejectsBadSignature() public {
+        // Correct signer (an admin) but signed by the wrong key
+        uint256 nonce = cashModule.getNonce(address(safe));
+        bytes32 digest = keccak256(abi.encodePacked(CashVerificationLib.TOGGLE_LEND_METHOD, block.chainid, address(safe), nonce, abi.encode(false))).toEthSignedMessageHash();
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner2Pk, digest); // owner2 signs, but we claim owner1
+        bytes memory sig = abi.encodePacked(r, s, v);
+
+        vm.expectRevert(SignatureUtils.InvalidSigner.selector);
+        cashModule.toggleLend(address(safe), false, owner1, sig);
+    }
+
+    function test_toggleLend_signatureBindsEnableFlag() public {
+        // A signature authorizing disable (enable=false) must not be accepted for enable (enable=true)
+        (address signer, bytes memory sig) = _toggleLendSig(false);
+        vm.expectRevert(SignatureUtils.InvalidSigner.selector);
+        cashModule.toggleLend(address(safe), true, signer, sig);
+    }
+
+    // ----------------------------------------------------------------- execute (processLendDisable) guards
+
+    function test_processLendDisable_revertsWhenNoPending() public {
+        vm.expectRevert(ICashModule.NoPendingLendDisable.selector);
+        cashModule.processLendDisable(address(safe));
+    }
+
+    function test_processLendDisable_revertsWhenNotReady() public {
+        _requestDisable();
+        // Still inside the delay window
+        vm.expectRevert(ICashModule.LendDisableNotReady.selector);
+        cashModule.processLendDisable(address(safe));
+    }
+
+    function test_processLendDisable_revertsWhenBorrowTakenDuringDelay() public {
+        // Request with no debt, then take an Aave borrow during the delay window
+        _requestDisable();
+
+        deal(address(weETH), address(safe), 5 ether);
+        vm.startPrank(driver);
+        gw.supply(address(safe), address(weETH), 5 ether);
+        gw.setUsingAsCollateral(address(safe), address(weETH), true);
+        gw.borrow(address(safe), address(usdc), 1000e6, driver);
+        vm.stopPrank();
+
+        vm.warp(block.timestamp + MODE_DELAY);
+        vm.expectRevert(ICashModule.HasOpenBorrows.selector);
+        cashModule.processLendDisable(address(safe));
+    }
+
+    // ----------------------------------------------------------------- credit mode interaction
+
+    function test_afterDisable_cannotEnterCreditMode() public {
+        _requestDisable();
+        vm.warp(block.timestamp + MODE_DELAY);
+        cashModule.processLendDisable(address(safe));
+
+        uint256 nonce = cashModule.getNonce(address(safe));
+        bytes32 digest = keccak256(abi.encodePacked(CashVerificationLib.SET_MODE_METHOD, block.chainid, address(safe), nonce, abi.encode(Mode.Credit))).toEthSignedMessageHash();
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Pk, digest);
+        bytes memory sig = abi.encodePacked(r, s, v);
+
+        vm.expectRevert(ICashModule.LendDisabled.selector);
+        cashModule.setMode(address(safe), Mode.Credit, owner1, sig);
+    }
+
+    // ----------------------------------------------------------------- re-enable (toggleLend true)
+
+    function test_enableLend_reenablesAndResumesSupply() public {
+        _requestDisable();
+        vm.warp(block.timestamp + MODE_DELAY);
+        cashModule.processLendDisable(address(safe));
+        assertFalse(cashModule.isLendEnabled(address(safe)));
+
+        vm.expectEmit(true, false, false, false, address(cashModule));
+        emit CashModuleStorageContract.LendEnabled(address(safe));
+        _enable();
+
+        assertTrue(cashModule.isLendEnabled(address(safe)), "lend re-enabled (cash module)");
+        assertTrue(gw.isLendEnabled(address(safe)), "lend re-enabled (gateway view)");
+
+        // Auto-supply works again
+        deal(address(weETH), address(safe), 2 ether);
+        vm.prank(driver);
+        gw.supply(address(safe), address(weETH), 2 ether);
+        assertApproxEqAbs(gw.suppliedOf(address(safe), address(weETH)), 2 ether, 2, "supply resumed");
+    }
+
+    function test_enableLend_revertsWhenNotDisabled() public {
+        (address signer, bytes memory sig) = _toggleLendSig(true);
+        vm.expectRevert(ICashModule.LendNotDisabled.selector);
+        cashModule.toggleLend(address(safe), true, signer, sig);
+    }
+
+    function test_enableLend_cancelsPendingRequest() public {
+        // A pending (not-yet-executed) request can be cancelled by re-enabling
+        _requestDisable();
+        assertTrue(cashModule.lendDisableFinalizeTime(address(safe)) != 0, "pending recorded");
+
+        _enable();
+        assertEq(cashModule.lendDisableFinalizeTime(address(safe)), 0, "pending cancelled");
+        assertTrue(cashModule.isLendEnabled(address(safe)), "still enabled");
+
+        // With the request cancelled, executing must revert
+        vm.warp(block.timestamp + MODE_DELAY);
+        vm.expectRevert(ICashModule.NoPendingLendDisable.selector);
+        cashModule.processLendDisable(address(safe));
+    }
+
+    // ----------------------------------------------------------------- signing helpers
+
+    function _requestDisable() internal {
+        (address signer, bytes memory sig) = _toggleLendSig(false);
+        cashModule.toggleLend(address(safe), false, signer, sig);
+    }
+
+    function _enable() internal {
+        (address signer, bytes memory sig) = _toggleLendSig(true);
+        cashModule.toggleLend(address(safe), true, signer, sig);
+    }
+
+    function _toggleLendSig(bool enable) internal view returns (address signer, bytes memory sig) {
+        uint256 nonce = cashModule.getNonce(address(safe));
+        bytes32 digest = keccak256(abi.encodePacked(CashVerificationLib.TOGGLE_LEND_METHOD, block.chainid, address(safe), nonce, abi.encode(enable))).toEthSignedMessageHash();
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Pk, digest);
+        return (owner1, abi.encodePacked(r, s, v));
+    }
+
+    function _setModeCredit() internal {
+        uint256 nonce = cashModule.getNonce(address(safe));
+        bytes32 digest = keccak256(abi.encodePacked(CashVerificationLib.SET_MODE_METHOD, block.chainid, address(safe), nonce, abi.encode(Mode.Credit))).toEthSignedMessageHash();
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Pk, digest);
+        cashModule.setMode(address(safe), Mode.Credit, owner1, abi.encodePacked(r, s, v));
+        // Credit takes effect after the mode delay
+        vm.warp(block.timestamp + MODE_DELAY + 1);
+    }
+
+    // ----------------------------------------------------------------- module helpers
+
+    function _enableModule(address module) internal {
+        address[] memory modules = _addr1(module);
+        bool[] memory shouldWhitelist = _bool1(true);
+        bytes[] memory setupData = new bytes[](1);
+        setupData[0] = "";
+        _configureModules(modules, shouldWhitelist, setupData);
+    }
+
+    function _addr1(address a) internal pure returns (address[] memory arr) {
+        arr = new address[](1);
+        arr[0] = a;
+    }
+
+    function _bool1(bool b) internal pure returns (bool[] memory arr) {
+        arr = new bool[](1);
+        arr[0] = b;
+    }
+}

--- a/test/gateway/CashLendDisable.t.sol
+++ b/test/gateway/CashLendDisable.t.sol
@@ -10,7 +10,8 @@ import { BinSponsor, ICashModule, Mode } from "../../src/interfaces/ICashModule.
 import { IGateway } from "../../src/interfaces/IGateway.sol";
 import { CashVerificationLib } from "../../src/libraries/CashVerificationLib.sol";
 import { SignatureUtils } from "../../src/libraries/SignatureUtils.sol";
-import { CashModuleStorageContract } from "../../src/modules/cash/CashModuleStorageContract.sol";
+import { CashEventEmitter } from "../../src/modules/cash/CashEventEmitter.sol";
+import { MockGateway } from "../../src/mocks/MockGateway.sol";
 import { Gateway } from "../../src/modules/gateway/Gateway.sol";
 import { ChainlinkCompositePriceFeed } from "../../src/oracle/ChainlinkCompositePriceFeed.sol";
 import { UpgradeableProxy } from "../../src/utils/UpgradeableProxy.sol";
@@ -100,16 +101,16 @@ contract CashLendDisableTest is CashModuleTestSetup, AaveV4Fixture {
 
         // Request the opt-out (owner-signed); it becomes executable after MODE_DELAY
         uint256 expectedFinalize = block.timestamp + MODE_DELAY;
-        vm.expectEmit(true, false, false, true, address(cashModule));
-        emit CashModuleStorageContract.LendDisableRequested(address(safe), expectedFinalize);
+        vm.expectEmit(true, false, false, true, address(cashEventEmitter));
+        emit CashEventEmitter.LendDisableRequested(address(safe), expectedFinalize);
         _requestDisable();
         assertEq(cashModule.lendDisableFinalizeTime(address(safe)), expectedFinalize, "finalize time recorded");
         assertTrue(cashModule.isLendEnabled(address(safe)), "still enabled until executed");
 
         // Execute after the delay: permissionless
         vm.warp(block.timestamp + MODE_DELAY);
-        vm.expectEmit(true, false, false, false, address(cashModule));
-        emit CashModuleStorageContract.LendDisableExecuted(address(safe));
+        vm.expectEmit(true, false, false, false, address(cashEventEmitter));
+        emit CashEventEmitter.LendDisableExecuted(address(safe));
         cashModule.processLendDisable(address(safe));
 
         // Collateral pulled back into the safe; Aave position emptied
@@ -243,6 +244,41 @@ contract CashLendDisableTest is CashModuleTestSetup, AaveV4Fixture {
         cashModule.processLendDisable(address(safe));
     }
 
+    /// @dev Dust debt (sub-$0.000001) floors to zero in getAccountData's 6-decimal debtUsd, so the open-borrows
+    ///      check must look at the raw per-asset debtOf instead, else disable would proceed and later revert
+    ///      deep in Aave when withdrawing the collateral. Uses a mock gateway to inject the dust precisely.
+    function test_toggleLendDisable_revertsOnDustDebtBelowUsdFloor() public {
+        MockGateway mockGw = new MockGateway();
+        mockGw.setRegisteredAssets(_addr1(address(weETH)));
+        mockGw.setDebtOf(address(safe), address(weETH), 1); // 1 wei of raw debt
+        vm.prank(owner);
+        cashModule.setLendGateway(address(mockGw));
+
+        // Premise of the test: the USD aggregate floors this dust to zero, so only the raw debtOf check catches it
+        assertEq(mockGw.getAccountData(address(safe)).debtUsd, 0, "dust floors to zero USD");
+
+        (address signer, bytes memory sig) = _toggleLendSig(false);
+        vm.expectRevert(ICashModule.HasOpenBorrows.selector);
+        cashModule.toggleLend(address(safe), false, signer, sig);
+    }
+
+    // ----------------------------------------------------------------- collateral-flag exit
+
+    /// @dev Turning the collateral flag OFF is an exit action (like withdraw/repay), so it stays open to a
+    ///      lend-disabled safe; only turning it ON is a lend op that a disabled safe is blocked from.
+    function test_setUsingAsCollateralFalse_allowedWhenLendDisabled() public {
+        _requestDisable();
+        vm.warp(block.timestamp + MODE_DELAY);
+        cashModule.processLendDisable(address(safe));
+        assertFalse(cashModule.isLendEnabled(address(safe)));
+
+        vm.startPrank(driver);
+        gw.setUsingAsCollateral(address(safe), address(weETH), false); // must not revert
+        vm.expectRevert(Gateway.LendDisabled.selector);
+        gw.setUsingAsCollateral(address(safe), address(weETH), true);
+        vm.stopPrank();
+    }
+
     // ----------------------------------------------------------------- credit mode interaction
 
     function test_afterDisable_cannotEnterCreditMode() public {
@@ -267,8 +303,8 @@ contract CashLendDisableTest is CashModuleTestSetup, AaveV4Fixture {
         cashModule.processLendDisable(address(safe));
         assertFalse(cashModule.isLendEnabled(address(safe)));
 
-        vm.expectEmit(true, false, false, false, address(cashModule));
-        emit CashModuleStorageContract.LendEnabled(address(safe));
+        vm.expectEmit(true, false, false, false, address(cashEventEmitter));
+        emit CashEventEmitter.LendEnabled(address(safe));
         _enable();
 
         assertTrue(cashModule.isLendEnabled(address(safe)), "lend re-enabled (cash module)");

--- a/test/gateway/DebtManagerMigration.t.sol
+++ b/test/gateway/DebtManagerMigration.t.sol
@@ -10,6 +10,7 @@ import { IAggregatorV3 } from "../../src/interfaces/IAggregatorV3.sol";
 import { BinSponsor, Cashback, Mode } from "../../src/interfaces/ICashModule.sol";
 import { IGateway } from "../../src/interfaces/IGateway.sol";
 import { Gateway } from "../../src/modules/gateway/Gateway.sol";
+import { CashEventEmitter } from "../../src/modules/cash/CashEventEmitter.sol";
 import { ChainlinkCompositePriceFeed } from "../../src/oracle/ChainlinkCompositePriceFeed.sol";
 import { UpgradeableProxy } from "../../src/utils/UpgradeableProxy.sol";
 import { CashModuleTestSetup } from "../safe/modules/cash/CashModuleTestSetup.t.sol";
@@ -124,7 +125,7 @@ contract DebtManagerMigrationTest is CashModuleTestSetup, AaveV4Fixture {
         dm.migrateToAave(address(safe));
     }
 
-    function test_migrateToAave_noDebt_marksMigratedWithoutReverting() public {
+    function test_migrateToAave_noDebt_suppliesCollateralAndMarksMigrated() public {
         deal(address(weETH), address(safe), 10 ether); // collateral but no debt
         assertFalse(dm.hasMigratedToAave(address(safe)));
 
@@ -132,9 +133,11 @@ contract DebtManagerMigrationTest is CashModuleTestSetup, AaveV4Fixture {
         dm.migrateToAave(address(safe));
 
         assertTrue(dm.hasMigratedToAave(address(safe)), "marked migrated");
-        // Nothing moved: no debt to migrate, so the collateral stays in the Safe
-        assertEq(weETH.balanceOf(address(safe)), 10 ether, "collateral untouched");
-        assertEq(gw.suppliedOf(address(safe), address(weETH)), 0, "nothing supplied to Aave");
+        // A debt-free migration still moves the collateral to Aave, so credit borrowing works post-migration
+        // (marking migrated while leaving collateral idle in the Safe would break gateway-based credit spends).
+        assertEq(weETH.balanceOf(address(safe)), 0, "collateral moved out of the Safe");
+        assertApproxEqAbs(gw.suppliedOf(address(safe), address(weETH)), 10 ether, 2, "collateral supplied to Aave");
+        assertGt(gw.getAccountData(address(safe)).availableBorrowsUsd, 0, "has Aave borrowing power");
     }
 
     function test_migrateToAave_onlyDebtManagerAdmin() public {
@@ -212,6 +215,40 @@ contract DebtManagerMigrationTest is CashModuleTestSetup, AaveV4Fixture {
         assertApproxEqAbs(gw.debtOf(address(safe), address(usdc)) - aaveDebtBefore, spendUsd, 1e6, "borrowed from Aave");
         assertApproxEqAbs(usdc.balanceOf(dispatcher) - dispatcherBefore, spendUsd, 2, "dispatcher funded from Aave borrow");
         assertEq(debtManager.borrowingOf(address(safe), address(usdc)), 0, "no new DebtManager debt");
+    }
+
+    /// @dev After migration, the wallet's standard repay must reduce the Aave debt via the gateway, not revert
+    ///      on the frozen DebtManager.repay. Regression for the "migrated safes cannot repay" finding.
+    function test_migratedSafe_repayReducesAaveDebt() public {
+        _seedAaveLiquidity(usdcReserveId, address(usdc), 5_000_000e6);
+
+        // Migrate a position carrying debt, so there is Aave debt to repay
+        deal(address(weETH), address(safe), 10 ether);
+        uint256 borrowAmt = dm.getMaxBorrowAmount(address(safe), true) / 4;
+        vm.prank(address(safe));
+        debtManager.borrow(BinSponsor.Reap, address(usdc), borrowAmt);
+
+        vm.prank(migrator);
+        dm.migrateToAave(address(safe));
+        uint256 aaveDebtBefore = gw.debtOf(address(safe), address(usdc));
+        assertGt(aaveDebtBefore, 0, "has Aave debt");
+
+        // Point the CashModule at the gateway and fund the safe to repay
+        vm.prank(owner);
+        cashModule.setLendGateway(address(gw));
+        deal(address(usdc), address(safe), 500e6);
+        uint256 repayUsd = 200e6;
+
+        // Must NOT revert with AlreadyMigratedToAave, and must surface a gateway-repay event (indexed topics
+        // checked; the exact repaid amount is left to the assertions below)
+        vm.expectEmit(true, true, false, false);
+        emit CashEventEmitter.Repay(address(safe), address(usdc), 0, 0);
+        vm.prank(etherFiWallet);
+        cashModule.repay(address(safe), address(usdc), repayUsd);
+
+        // Aave debt reduced by ~the repay amount; the DebtManager was never touched
+        assertApproxEqAbs(aaveDebtBefore - gw.debtOf(address(safe), address(usdc)), repayUsd, 1e6, "Aave debt reduced");
+        assertEq(debtManager.borrowingOf(address(safe), address(usdc)), 0, "DebtManager debt still zero");
     }
 
     // ----------------------------------------------------------------- helpers

--- a/test/gateway/DebtManagerMigration.t.sol
+++ b/test/gateway/DebtManagerMigration.t.sol
@@ -2,12 +2,14 @@
 pragma solidity ^0.8.28;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
 import { UUPSProxy } from "../../src/UUPSProxy.sol";
 import { DebtManagerCore } from "../../src/debt-manager/DebtManagerCore.sol";
 import { DebtManagerStorageContract } from "../../src/debt-manager/DebtManagerStorageContract.sol";
 import { IAggregatorV3 } from "../../src/interfaces/IAggregatorV3.sol";
 import { BinSponsor, Cashback, Mode } from "../../src/interfaces/ICashModule.sol";
+import { CashVerificationLib } from "../../src/libraries/CashVerificationLib.sol";
 import { IGateway } from "../../src/interfaces/IGateway.sol";
 import { Gateway } from "../../src/modules/gateway/Gateway.sol";
 import { CashEventEmitter } from "../../src/modules/cash/CashEventEmitter.sol";
@@ -25,6 +27,8 @@ import { AaveV4Fixture } from "./helpers/AaveV4Fixture.sol";
  * @dev Run with: FOUNDRY_PROFILE=aave TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test --match-path test/gateway/DebtManagerMigration.t.sol
  */
 contract DebtManagerMigrationTest is CashModuleTestSetup, AaveV4Fixture {
+    using MessageHashUtils for bytes32;
+
     DebtManagerCore internal dm;
     Gateway internal gw;
     address internal migrator = makeAddr("migrationRunner");
@@ -54,12 +58,10 @@ contract DebtManagerMigrationTest is CashModuleTestSetup, AaveV4Fixture {
         gw.setReserveId(address(weETH), weethReserveId);
         gw.setReserveId(address(usdc), usdcReserveId);
         gw.setDriver(address(dm), true); // DebtManager drives the gateway during migration
-        // DebtManager migration wiring: point it at the gateway and authorize the migration runner
+        // Migration reads the gateway from CashModule (single source of truth); authorize the migration runner
+        cashModule.setLendGateway(address(gw));
         roleRegistry.grantRole(DEBT_MANAGER_ADMIN_ROLE, migrator);
         vm.stopPrank();
-
-        vm.prank(migrator);
-        dm.setGateway(address(gw));
 
         _enableModule(address(gw));
         _activateAavePositionManager(address(gw));
@@ -140,6 +142,38 @@ contract DebtManagerMigrationTest is CashModuleTestSetup, AaveV4Fixture {
         assertGt(gw.getAccountData(address(safe)).availableBorrowsUsd, 0, "has Aave borrowing power");
     }
 
+    /// @dev A lend-disabled safe opted out of Aave, so migration must not force its collateral in: it just
+    ///      gets marked migrated (freezing legacy borrow/repay) with its balance left idle in the safe.
+    function test_migrateToAave_lendDisabledSafe_marksMigratedWithoutSupplying() public {
+        deal(address(weETH), address(safe), 10 ether);
+        _disableLendForSafe();
+        assertFalse(cashModule.isLendEnabled(address(safe)), "lend disabled");
+
+        vm.prank(migrator);
+        dm.migrateToAave(address(safe));
+
+        assertTrue(dm.hasMigratedToAave(address(safe)), "marked migrated");
+        assertEq(weETH.balanceOf(address(safe)), 10 ether, "collateral stayed in the safe");
+        assertEq(gw.suppliedOf(address(safe), address(weETH)), 0, "nothing supplied to Aave");
+    }
+
+    /// @dev A lend-disabled safe should be debt-free (disabling requires zero borrows), but it can still borrow
+    ///      on DebtManager directly afterward. Migration must reject that case rather than revert opaquely.
+    function test_migrateToAave_lendDisabledSafe_withDebt_reverts() public {
+        _seedAaveLiquidity(usdcReserveId, address(usdc), 5_000_000e6);
+        deal(address(weETH), address(safe), 10 ether);
+        _disableLendForSafe();
+
+        // Borrow on DebtManager while lend is disabled (borrow only checks whenNotMigrated, not lend)
+        uint256 borrowAmt = dm.getMaxBorrowAmount(address(safe), true) / 4;
+        vm.prank(address(safe));
+        debtManager.borrow(BinSponsor.Reap, address(usdc), borrowAmt);
+
+        vm.prank(migrator);
+        vm.expectRevert(DebtManagerStorageContract.LendDisabledSafeHasDebt.selector);
+        dm.migrateToAave(address(safe));
+    }
+
     function test_migrateToAave_onlyDebtManagerAdmin() public {
         _seedAaveLiquidity(usdcReserveId, address(usdc), 5_000_000e6);
         deal(address(weETH), address(safe), 10 ether);
@@ -189,9 +223,7 @@ contract DebtManagerMigrationTest is CashModuleTestSetup, AaveV4Fixture {
         dm.migrateToAave(address(safe));
         assertTrue(dm.hasMigratedToAave(address(safe)), "safe migrated");
 
-        // Point the CashModule at the gateway (owner holds CASH_MODULE_CONTROLLER_ROLE) and enter Credit mode
-        vm.prank(owner);
-        cashModule.setLendGateway(address(gw));
+        // Enter Credit mode (the gateway is wired to the CashModule in setUp)
         _setMode(Mode.Credit);
         vm.warp(cashModule.incomingModeStartTime(address(safe)) + 1);
         assertEq(uint8(cashModule.getMode(address(safe))), uint8(Mode.Credit), "in credit mode");
@@ -233,9 +265,7 @@ contract DebtManagerMigrationTest is CashModuleTestSetup, AaveV4Fixture {
         uint256 aaveDebtBefore = gw.debtOf(address(safe), address(usdc));
         assertGt(aaveDebtBefore, 0, "has Aave debt");
 
-        // Point the CashModule at the gateway and fund the safe to repay
-        vm.prank(owner);
-        cashModule.setLendGateway(address(gw));
+        // Fund the safe to repay (the gateway is wired to the CashModule in setUp)
         deal(address(usdc), address(safe), 500e6);
         uint256 repayUsd = 200e6;
 
@@ -252,6 +282,21 @@ contract DebtManagerMigrationTest is CashModuleTestSetup, AaveV4Fixture {
     }
 
     // ----------------------------------------------------------------- helpers
+
+    /// @dev Opts the safe out of lend (owner-signed toggleLend(false)), executing the pending request if the
+    ///      mode delay is nonzero so the safe ends up fully lend-disabled.
+    function _disableLendForSafe() internal {
+        uint256 nonce = cashModule.getNonce(address(safe));
+        bytes32 digest = keccak256(abi.encodePacked(CashVerificationLib.TOGGLE_LEND_METHOD, block.chainid, address(safe), nonce, abi.encode(false))).toEthSignedMessageHash();
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Pk, digest);
+        cashModule.toggleLend(address(safe), false, owner1, abi.encodePacked(r, s, v));
+
+        if (cashModule.isLendEnabled(address(safe))) {
+            (,, uint64 modeDelay) = cashModule.getDelays();
+            vm.warp(block.timestamp + modeDelay + 1);
+            cashModule.processLendDisable(address(safe));
+        }
+    }
 
     function _enableModule(address module) internal {
         address[] memory modules = _addr1(module);

--- a/test/gateway/DebtManagerMigration.t.sol
+++ b/test/gateway/DebtManagerMigration.t.sol
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import { UUPSProxy } from "../../src/UUPSProxy.sol";
+import { DebtManagerCore } from "../../src/debt-manager/DebtManagerCore.sol";
+import { DebtManagerStorageContract } from "../../src/debt-manager/DebtManagerStorageContract.sol";
+import { IAggregatorV3 } from "../../src/interfaces/IAggregatorV3.sol";
+import { BinSponsor } from "../../src/interfaces/ICashModule.sol";
+import { IGateway } from "../../src/interfaces/IGateway.sol";
+import { Gateway } from "../../src/modules/gateway/Gateway.sol";
+import { ChainlinkCompositePriceFeed } from "../../src/oracle/ChainlinkCompositePriceFeed.sol";
+import { UpgradeableProxy } from "../../src/utils/UpgradeableProxy.sol";
+import { CashModuleTestSetup } from "../safe/modules/cash/CashModuleTestSetup.t.sol";
+import { AaveV4Fixture } from "./helpers/AaveV4Fixture.sol";
+
+/**
+ * @title DebtManagerMigrationTest
+ * @notice Fork tests for DebtManager.migrateToAave: a legacy Safe position (weETH collateral + USDC debt on
+ *         DebtManager) migrates atomically to a REAL Aave v4 instance (deployed in-test on an Optimism fork)
+ *         via the gateway — no flash loan. Aave's weETH LTV is set below DebtManager's so the LTV-fit path
+ *         is exercised.
+ * @dev Run with: FOUNDRY_PROFILE=aave TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test --match-path test/gateway/DebtManagerMigration.t.sol
+ */
+contract DebtManagerMigrationTest is CashModuleTestSetup, AaveV4Fixture {
+    DebtManagerCore internal dm;
+    Gateway internal gw;
+    address internal migrator = makeAddr("migrationRunner");
+
+    uint256 internal usdcReserveId;
+    uint256 internal weethReserveId;
+
+    uint16 internal constant AAVE_WEETH_LTV = 3000; // below DebtManager's 50%, to exercise the LTV-fit guard
+
+    function setUp() public override {
+        super.setUp();
+        dm = DebtManagerCore(address(debtManager));
+
+        // Real Aave v4 instance on the fork
+        _deployAaveV4();
+        address weethSource = address(new ChainlinkCompositePriceFeed(IAggregatorV3(weEthWethOracle), IAggregatorV3(ethUsdcOracle), 8, 30 days, 30 days, "weETH / USD"));
+        weethReserveId = _addAaveReserve(address(weETH), weethSource, AAVE_WEETH_LTV, false);
+        usdcReserveId = _addAaveReserve(address(usdc), usdcUsdOracle, 8000, true);
+
+        // Gateway proxy + wiring
+        address gwImpl = address(new Gateway(address(dataProvider), address(spoke)));
+        gw = Gateway(address(new UUPSProxy(gwImpl, abi.encodeWithSelector(Gateway.initialize.selector, address(roleRegistry)))));
+
+        vm.startPrank(owner);
+        roleRegistry.grantRole(gw.GATEWAY_ADMIN_ROLE(), owner);
+        dataProvider.configureModules(_addr1(address(gw)), _bool1(true));
+        gw.setReserveId(address(weETH), weethReserveId);
+        gw.setReserveId(address(usdc), usdcReserveId);
+        gw.setDriver(address(dm), true); // DebtManager drives the gateway during migration
+        // DebtManager migration wiring: point it at the gateway and authorize the migration runner
+        roleRegistry.grantRole(DEBT_MANAGER_ADMIN_ROLE, migrator);
+        vm.stopPrank();
+
+        vm.prank(migrator);
+        dm.setGateway(address(gw));
+
+        _enableModule(address(gw));
+        _activateAavePositionManager(address(gw));
+    }
+
+    // ----------------------------------------------------------------- happy path
+
+    function test_migrateToAave_atomic_noFlashLoan() public {
+        _seedAaveLiquidity(usdcReserveId, address(usdc), 5_000_000e6);
+
+        // Legacy position: 10 weETH collateral, borrow a modest fraction that fits Aave's 30% LTV
+        deal(address(weETH), address(safe), 10 ether);
+        uint256 borrowAmt = dm.getMaxBorrowAmount(address(safe), true) / 4; // ~12.5% of collateral value
+        vm.prank(address(safe));
+        debtManager.borrow(BinSponsor.Reap, address(usdc), borrowAmt);
+        assertApproxEqAbs(debtManager.borrowingOf(address(safe), address(usdc)), borrowAmt, 1, "legacy debt created");
+
+        uint256 dmUsdcBefore = usdc.balanceOf(address(debtManager));
+
+        vm.prank(migrator);
+        dm.migrateToAave(address(safe));
+
+        // Legacy debt closed and Safe flagged migrated
+        assertEq(debtManager.borrowingOf(address(safe), address(usdc)), 0, "legacy debt cleared");
+        assertTrue(dm.hasMigratedToAave(address(safe)), "marked migrated");
+        // Position now lives on Aave: same collateral, same debt size
+        assertApproxEqAbs(gw.suppliedOf(address(safe), address(weETH)), 10 ether, 3, "collateral on Aave");
+        assertApproxEqAbs(gw.debtOf(address(safe), address(usdc)), borrowAmt, 1e6, "debt on Aave");
+        assertGt(gw.getAccountData(address(safe)).healthFactor, 1e18, "healthy on Aave");
+        // Collateral left the Safe
+        assertEq(weETH.balanceOf(address(safe)), 0, "safe collateral moved");
+        // No funds stranded: gateway holds nothing; the Aave borrow replenished DebtManager's lent-out USDC
+        assertEq(weETH.balanceOf(address(gw)), 0, "no stranded weETH");
+        assertEq(usdc.balanceOf(address(gw)), 0, "no stranded USDC");
+        assertApproxEqAbs(usdc.balanceOf(address(debtManager)), dmUsdcBefore + borrowAmt, 1e6, "DebtManager USDC replenished");
+    }
+
+    // ----------------------------------------------------------------- reverts
+
+    function test_migrateToAave_revertsWhenExceedsAaveLtv() public {
+        _seedAaveLiquidity(usdcReserveId, address(usdc), 5_000_000e6);
+
+        // Borrow ~90% of DebtManager's max: fits DebtManager's 50% LTV, exceeds Aave's 30%
+        deal(address(weETH), address(safe), 10 ether);
+        uint256 borrowAmt = (dm.getMaxBorrowAmount(address(safe), true) * 9) / 10;
+        vm.prank(address(safe));
+        debtManager.borrow(BinSponsor.Reap, address(usdc), borrowAmt);
+
+        vm.prank(migrator);
+        vm.expectRevert(DebtManagerStorageContract.PositionExceedsAaveLtv.selector);
+        dm.migrateToAave(address(safe));
+    }
+
+    function test_migrateToAave_revertsWhenInsufficientAaveLiquidity() public {
+        // No Aave liquidity seeded → the reserve cannot fund the borrow
+        deal(address(weETH), address(safe), 10 ether);
+        uint256 borrowAmt = dm.getMaxBorrowAmount(address(safe), true) / 4;
+        vm.prank(address(safe));
+        debtManager.borrow(BinSponsor.Reap, address(usdc), borrowAmt);
+
+        vm.prank(migrator);
+        vm.expectRevert(abi.encodeWithSelector(DebtManagerStorageContract.InsufficientAaveLiquidity.selector, address(usdc)));
+        dm.migrateToAave(address(safe));
+    }
+
+    function test_migrateToAave_noDebt_marksMigratedWithoutReverting() public {
+        deal(address(weETH), address(safe), 10 ether); // collateral but no debt
+        assertFalse(dm.hasMigratedToAave(address(safe)));
+
+        vm.prank(migrator);
+        dm.migrateToAave(address(safe));
+
+        assertTrue(dm.hasMigratedToAave(address(safe)), "marked migrated");
+        // Nothing moved: no debt to migrate, so the collateral stays in the Safe
+        assertEq(weETH.balanceOf(address(safe)), 10 ether, "collateral untouched");
+        assertEq(gw.suppliedOf(address(safe), address(weETH)), 0, "nothing supplied to Aave");
+    }
+
+    function test_migrateToAave_onlyDebtManagerAdmin() public {
+        _seedAaveLiquidity(usdcReserveId, address(usdc), 5_000_000e6);
+        deal(address(weETH), address(safe), 10 ether);
+        uint256 borrowAmt = dm.getMaxBorrowAmount(address(safe), true) / 4;
+        vm.prank(address(safe));
+        debtManager.borrow(BinSponsor.Reap, address(usdc), borrowAmt);
+
+        vm.prank(makeAddr("notMigrator"));
+        vm.expectRevert(UpgradeableProxy.Unauthorized.selector);
+        dm.migrateToAave(address(safe));
+    }
+
+    function test_migratedSafe_cannotBorrowOrRepayOnDebtManager() public {
+        _seedAaveLiquidity(usdcReserveId, address(usdc), 5_000_000e6);
+        deal(address(weETH), address(safe), 10 ether);
+        uint256 borrowAmt = dm.getMaxBorrowAmount(address(safe), true) / 4;
+        vm.prank(address(safe));
+        debtManager.borrow(BinSponsor.Reap, address(usdc), borrowAmt);
+
+        vm.prank(migrator);
+        dm.migrateToAave(address(safe));
+        assertTrue(dm.hasMigratedToAave(address(safe)));
+
+        // Legacy borrow is frozen for a migrated Safe
+        vm.prank(address(safe));
+        vm.expectRevert(DebtManagerStorageContract.AlreadyMigratedToAave.selector);
+        debtManager.borrow(BinSponsor.Reap, address(usdc), 1e6);
+
+        // Legacy repay is frozen for a migrated Safe
+        vm.expectRevert(DebtManagerStorageContract.AlreadyMigratedToAave.selector);
+        debtManager.repay(address(safe), address(usdc), 1e6);
+    }
+
+    // ----------------------------------------------------------------- helpers
+
+    function _enableModule(address module) internal {
+        address[] memory modules = _addr1(module);
+        bool[] memory shouldWhitelist = _bool1(true);
+        bytes[] memory setupData = new bytes[](1);
+        setupData[0] = "";
+        _configureModules(modules, shouldWhitelist, setupData);
+    }
+
+    function _addr1(address a) internal pure returns (address[] memory arr) {
+        arr = new address[](1);
+        arr[0] = a;
+    }
+
+    function _bool1(bool b) internal pure returns (bool[] memory arr) {
+        arr = new bool[](1);
+        arr[0] = b;
+    }
+}

--- a/test/gateway/DebtManagerMigration.t.sol
+++ b/test/gateway/DebtManagerMigration.t.sol
@@ -7,7 +7,7 @@ import { UUPSProxy } from "../../src/UUPSProxy.sol";
 import { DebtManagerCore } from "../../src/debt-manager/DebtManagerCore.sol";
 import { DebtManagerStorageContract } from "../../src/debt-manager/DebtManagerStorageContract.sol";
 import { IAggregatorV3 } from "../../src/interfaces/IAggregatorV3.sol";
-import { BinSponsor } from "../../src/interfaces/ICashModule.sol";
+import { BinSponsor, Cashback, Mode } from "../../src/interfaces/ICashModule.sol";
 import { IGateway } from "../../src/interfaces/IGateway.sol";
 import { Gateway } from "../../src/modules/gateway/Gateway.sol";
 import { ChainlinkCompositePriceFeed } from "../../src/oracle/ChainlinkCompositePriceFeed.sol";
@@ -168,6 +168,50 @@ contract DebtManagerMigrationTest is CashModuleTestSetup, AaveV4Fixture {
         // Legacy repay is frozen for a migrated Safe
         vm.expectRevert(DebtManagerStorageContract.AlreadyMigratedToAave.selector);
         debtManager.repay(address(safe), address(usdc), 1e6);
+    }
+
+    /// @dev After migration, a credit-mode spend must borrow from Aave (via the gateway), not the frozen
+    ///      DebtManager. Regression for: migrated safe passes CashLens (gateway-based) but reverts on spend
+    ///      with AlreadyMigratedToAave because _spendCredit still called DebtManager.borrow.
+    function test_migratedSafe_creditSpendBorrowsFromAave() public {
+        _seedAaveLiquidity(usdcReserveId, address(usdc), 5_000_000e6);
+
+        // Legacy position with collateral + modest debt, then migrate to Aave (leaves borrow headroom there)
+        deal(address(weETH), address(safe), 10 ether);
+        uint256 borrowAmt = dm.getMaxBorrowAmount(address(safe), true) / 4;
+        vm.prank(address(safe));
+        debtManager.borrow(BinSponsor.Reap, address(usdc), borrowAmt);
+
+        vm.prank(migrator);
+        dm.migrateToAave(address(safe));
+        assertTrue(dm.hasMigratedToAave(address(safe)), "safe migrated");
+
+        // Point the CashModule at the gateway (owner holds CASH_MODULE_CONTROLLER_ROLE) and enter Credit mode
+        vm.prank(owner);
+        cashModule.setLendGateway(address(gw));
+        _setMode(Mode.Credit);
+        vm.warp(cashModule.incomingModeStartTime(address(safe)) + 1);
+        assertEq(uint8(cashModule.getMode(address(safe))), uint8(Mode.Credit), "in credit mode");
+
+        address dispatcher = cashModule.getSettlementDispatcher(BinSponsor.Reap);
+        uint256 dispatcherBefore = usdc.balanceOf(dispatcher);
+        uint256 aaveDebtBefore = gw.debtOf(address(safe), address(usdc));
+
+        uint256 spendUsd = 100e6; // $100, within the daily limit
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = spendUsd;
+        Cashback[] memory cashbacks;
+
+        // Must NOT revert with AlreadyMigratedToAave
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), keccak256("credit-after-migration"), BinSponsor.Reap, tokens, amounts, cashbacks);
+
+        // Borrowed from Aave and forwarded to the settlement dispatcher; DebtManager debt stays zero
+        assertApproxEqAbs(gw.debtOf(address(safe), address(usdc)) - aaveDebtBefore, spendUsd, 1e6, "borrowed from Aave");
+        assertApproxEqAbs(usdc.balanceOf(dispatcher) - dispatcherBefore, spendUsd, 2, "dispatcher funded from Aave borrow");
+        assertEq(debtManager.borrowingOf(address(safe), address(usdc)), 0, "no new DebtManager debt");
     }
 
     // ----------------------------------------------------------------- helpers

--- a/test/gateway/GatewayAaveV4.t.sol
+++ b/test/gateway/GatewayAaveV4.t.sol
@@ -3,15 +3,16 @@ pragma solidity ^0.8.28;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
+import { UUPSProxy } from "../../src/UUPSProxy.sol";
 import { IAggregatorV3 } from "../../src/interfaces/IAggregatorV3.sol";
 import { IGateway } from "../../src/interfaces/IGateway.sol";
 import { Gateway } from "../../src/modules/gateway/Gateway.sol";
 import { ChainlinkCompositePriceFeed } from "../../src/oracle/ChainlinkCompositePriceFeed.sol";
 import { UpgradeableProxy } from "../../src/utils/UpgradeableProxy.sol";
-import { UUPSProxy } from "../../src/UUPSProxy.sol";
-import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
 import { CashModuleTestSetup } from "../safe/modules/cash/CashModuleTestSetup.t.sol";
 import { AaveV4Fixture } from "./helpers/AaveV4Fixture.sol";
+import { ISpoke } from "aave-v4/spoke/interfaces/ISpoke.sol";
+import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
 
 /**
  * @title GatewayAaveV4Test
@@ -39,8 +40,8 @@ contract GatewayAaveV4Test is CashModuleTestSetup, AaveV4Fixture {
         //    - weETH: composite weETH/ETH x ETH/USD via the repo's ChainlinkCompositePriceFeed
         //    - USDC: the USDC/USD aggregator directly (it already exposes decimals/description/latestAnswer)
         address weethSource = address(new ChainlinkCompositePriceFeed(IAggregatorV3(weEthWethOracle), IAggregatorV3(ethUsdcOracle), 8, 30 days, 30 days, "weETH / USD"));
-        weethReserveId = _addAaveReserve(address(weETH), weethSource, 80_00, false);
-        usdcReserveId = _addAaveReserve(address(usdc), usdcUsdOracle, 80_00, true);
+        weethReserveId = _addAaveReserve(address(weETH), weethSource, 8000, false);
+        usdcReserveId = _addAaveReserve(address(usdc), usdcUsdOracle, 8000, true);
 
         // Seed borrowable USDC liquidity into the hub
         _seedAaveLiquidity(usdcReserveId, address(usdc), 1_000_000e6);
@@ -369,8 +370,24 @@ contract GatewayAaveV4Test is CashModuleTestSetup, AaveV4Fixture {
         vm.startPrank(driver);
         gw.supply(address(safe), address(weETH), 1 ether);
         gw.setUsingAsCollateral(address(safe), address(weETH), true);
-        vm.expectRevert(); // Aave health-factor / borrowing-power check
+        // Pinned to the health gate (not a bare revert): with 1M USDC seeded, a $50k borrow can only fail
+        // Aave's borrowing-power / health check, not liquidity.
+        vm.expectRevert(ISpoke.HealthFactorBelowThreshold.selector);
         gw.borrow(address(safe), address(usdc), 50_000e6, recipient);
+        vm.stopPrank();
+    }
+
+    /// @dev Withdrawing collateral that would break the position's health must trip Aave's liquidation-threshold gate.
+    function test_withdraw_breakingHealthReverts() public {
+        deal(address(weETH), address(safe), 5 ether);
+        vm.startPrank(driver);
+        gw.supply(address(safe), address(weETH), 5 ether);
+        gw.setUsingAsCollateral(address(safe), address(weETH), true);
+        gw.borrow(address(safe), address(usdc), 1000e6, recipient);
+
+        // Pulling all the collateral while $1000 of debt is open must trip Aave's liquidation-threshold gate.
+        vm.expectRevert(ISpoke.HealthFactorBelowThreshold.selector);
+        gw.withdraw(address(safe), address(weETH), 5 ether, recipient);
         vm.stopPrank();
     }
 

--- a/test/gateway/GatewayInvariant.t.sol
+++ b/test/gateway/GatewayInvariant.t.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-import { Test } from "forge-std/Test.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { Test } from "forge-std/Test.sol";
 
+import { UUPSProxy } from "../../src/UUPSProxy.sol";
 import { IAggregatorV3 } from "../../src/interfaces/IAggregatorV3.sol";
 import { Gateway } from "../../src/modules/gateway/Gateway.sol";
 import { ChainlinkCompositePriceFeed } from "../../src/oracle/ChainlinkCompositePriceFeed.sol";
-import { UUPSProxy } from "../../src/UUPSProxy.sol";
 import { CashModuleTestSetup } from "../safe/modules/cash/CashModuleTestSetup.t.sol";
 import { AaveV4Fixture } from "./helpers/AaveV4Fixture.sol";
 
@@ -89,8 +89,8 @@ contract GatewayInvariantTest is CashModuleTestSetup, AaveV4Fixture {
         _deployAaveV4();
 
         address weethSource = address(new ChainlinkCompositePriceFeed(IAggregatorV3(weEthWethOracle), IAggregatorV3(ethUsdcOracle), 8, 30 days, 30 days, "weETH / USD"));
-        weethReserveId = _addAaveReserve(address(weETH), weethSource, 80_00, false);
-        usdcReserveId = _addAaveReserve(address(usdc), usdcUsdOracle, 80_00, true);
+        weethReserveId = _addAaveReserve(address(weETH), weethSource, 8000, false);
+        usdcReserveId = _addAaveReserve(address(usdc), usdcUsdOracle, 8000, true);
         _seedAaveLiquidity(usdcReserveId, address(usdc), 5_000_000e6);
 
         address gwImpl = address(new Gateway(address(dataProvider), address(spoke)));

--- a/test/gateway/helpers/AaveV4Fixture.sol
+++ b/test/gateway/helpers/AaveV4Fixture.sol
@@ -1,24 +1,24 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-import { Test } from "forge-std/Test.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import { Test } from "forge-std/Test.sol";
 
+import { AccessManagerEnumerable } from "aave-v4/access/AccessManagerEnumerable.sol";
 import { IAccessManager } from "aave-v4/dependencies/openzeppelin/IAccessManager.sol";
 import { TransparentUpgradeableProxy } from "aave-v4/dependencies/openzeppelin/TransparentUpgradeableProxy.sol";
-import { AccessManagerEnumerable } from "aave-v4/access/AccessManagerEnumerable.sol";
 import { AssetInterestRateStrategy } from "aave-v4/hub/AssetInterestRateStrategy.sol";
+import { HubInstance } from "aave-v4/hub/instances/HubInstance.sol";
 import { IAssetInterestRateStrategy } from "aave-v4/hub/interfaces/IAssetInterestRateStrategy.sol";
 import { IHub } from "aave-v4/hub/interfaces/IHub.sol";
-import { HubInstance } from "aave-v4/hub/instances/HubInstance.sol";
+import { Roles } from "aave-v4/libraries/types/Roles.sol";
 import { AaveOracle } from "aave-v4/spoke/AaveOracle.sol";
+import { SpokeInstance } from "aave-v4/spoke/instances/SpokeInstance.sol";
+import { TreasurySpokeInstance } from "aave-v4/spoke/instances/TreasurySpokeInstance.sol";
 import { IAaveOracle } from "aave-v4/spoke/interfaces/IAaveOracle.sol";
 import { ISpoke } from "aave-v4/spoke/interfaces/ISpoke.sol";
 import { ITreasurySpoke } from "aave-v4/spoke/interfaces/ITreasurySpoke.sol";
-import { SpokeInstance } from "aave-v4/spoke/instances/SpokeInstance.sol";
-import { TreasurySpokeInstance } from "aave-v4/spoke/instances/TreasurySpokeInstance.sol";
-import { Roles } from "aave-v4/libraries/types/Roles.sol";
 
 /// @dev Minimal init interface shared by the hub/spoke/treasury proxy implementations
 interface IProxyInit {
@@ -100,7 +100,7 @@ abstract contract AaveV4Fixture is Test {
         accessManager.setTargetFunctionRole(address(hub), hubSelectors, Roles.HUB_ADMIN_ROLE);
 
         // A permissive liquidation config, so borrows/withdrawals are governed by collateral factors alone
-        spoke.updateLiquidationConfig(ISpoke.LiquidationConfig({ targetHealthFactor: 1.05e18, healthFactorForMaxBonus: 0.7e18, liquidationBonusFactor: 20_00 }));
+        spoke.updateLiquidationConfig(ISpoke.LiquidationConfig({ targetHealthFactor: 1.05e18, healthFactorForMaxBonus: 0.7e18, liquidationBonusFactor: 2000 }));
 
         vm.stopPrank();
     }
@@ -115,20 +115,14 @@ abstract contract AaveV4Fixture is Test {
     function _addAaveReserve(address token, address priceSource, uint16 collateralFactorBps, bool borrowable) internal returns (uint256 reserveId) {
         vm.startPrank(aaveAdmin);
 
-        bytes memory irData = abi.encode(IAssetInterestRateStrategy.InterestRateData({ optimalUsageRatio: 90_00, baseDrawnRate: 5_00, rateGrowthBeforeOptimal: 5_00, rateGrowthAfterOptimal: 5_00 }));
+        bytes memory irData = abi.encode(IAssetInterestRateStrategy.InterestRateData({ optimalUsageRatio: 9000, baseDrawnRate: 500, rateGrowthBeforeOptimal: 500, rateGrowthAfterOptimal: 500 }));
 
         uint256 assetId = hub.addAsset(token, IERC20Metadata(token).decimals(), address(treasurySpoke), address(irStrategy), irData);
-        hub.updateAssetConfig(assetId, IHub.AssetConfig({ feeReceiver: address(treasurySpoke), liquidityFee: 10_00, irStrategy: address(irStrategy), reinvestmentController: address(0) }), new bytes(0));
+        hub.updateAssetConfig(assetId, IHub.AssetConfig({ feeReceiver: address(treasurySpoke), liquidityFee: 1000, irStrategy: address(irStrategy), reinvestmentController: address(0) }), new bytes(0));
 
-        reserveId = spoke.addReserve(
-            address(hub),
-            assetId,
-            priceSource,
-            ISpoke.ReserveConfig({ paused: false, frozen: false, borrowable: borrowable, receiveSharesEnabled: true, collateralRisk: 0 }),
-            ISpoke.DynamicReserveConfig({ collateralFactor: collateralFactorBps, maxLiquidationBonus: 105_00, liquidationFee: 10_00 })
-        );
+        reserveId = spoke.addReserve(address(hub), assetId, priceSource, ISpoke.ReserveConfig({ paused: false, frozen: false, borrowable: borrowable, receiveSharesEnabled: true, collateralRisk: 0 }), ISpoke.DynamicReserveConfig({ collateralFactor: collateralFactorBps, maxLiquidationBonus: 10_500, liquidationFee: 1000 }));
 
-        hub.addSpoke(assetId, address(spoke), IHub.SpokeConfig({ addCap: type(uint40).max, drawCap: type(uint40).max, riskPremiumThreshold: 1000_00, active: true, halted: false }));
+        hub.addSpoke(assetId, address(spoke), IHub.SpokeConfig({ addCap: type(uint40).max, drawCap: type(uint40).max, riskPremiumThreshold: 100_000, active: true, halted: false }));
 
         vm.stopPrank();
     }

--- a/test/safe/modules/ModuleGatewaySandwich.t.sol
+++ b/test/safe/modules/ModuleGatewaySandwich.t.sol
@@ -90,4 +90,25 @@ contract ModuleGatewaySandwichTest is Test {
         vm.expectRevert(ModuleGatewaySandwich.OperationBreachesHealth.selector);
         harness.runSandwich(safe, asset, AMOUNT);
     }
+
+    // When lend is disabled for the safe, the withdraw bookend is a no-op: its assets already sit in the safe.
+    function test_withdraw_noOpWhenLendDisabled() public {
+        gateway.setLendEnabled(safe, false);
+        harness.withdrawFromGateway(safe, asset, AMOUNT);
+
+        (address s,, uint256 amount,) = gateway.lastWithdraw();
+        assertEq(s, address(0), "no withdraw call recorded");
+        assertEq(amount, 0);
+    }
+
+    // When lend is disabled, the resupply bookend is a no-op: the output stays in the safe, nothing goes to Aave.
+    function test_resupply_noOpWhenLendDisabled() public {
+        gateway.setLendEnabled(safe, false);
+        harness.resupplyToGateway(safe, asset, AMOUNT);
+
+        (address s,, uint256 amount,) = gateway.lastSupply();
+        assertEq(s, address(0), "no supply call recorded");
+        assertEq(amount, 0);
+        assertFalse(gateway.usingAsCollateral(safe, asset), "collateral flag untouched");
+    }
 }

--- a/test/upgrade-bytecode-verification/VerifyOPMainnet.t.sol
+++ b/test/upgrade-bytecode-verification/VerifyOPMainnet.t.sol
@@ -204,6 +204,9 @@ contract VerifyOPMainnetBytecode is ContractCodeChecker, Utils {
     }
 
     function test_verifyBytecode_CashEventEmitter() public {
+        // CashEventEmitter gains the Repay event (emitted when a migrated safe repays on Aave via the gateway)
+        // for Lend, so its bytecode no longer matches the deployed pre-Lend version. Re-enable after the Lend deployment.
+        vm.skip(true);
         address local = address(new CashEventEmitter(cashModuleProxy));
         _verify("CashEventEmitter", cashEventEmitterImpl, local);
     }

--- a/test/upgrade-bytecode-verification/VerifyOPMainnet.t.sol
+++ b/test/upgrade-bytecode-verification/VerifyOPMainnet.t.sol
@@ -188,6 +188,9 @@ contract VerifyOPMainnetBytecode is ContractCodeChecker, Utils {
     }
 
     function test_verifyBytecode_CashModuleSetters() public {
+        // CashModuleSetters gains the lend opt-out (setLendGateway/toggleLend) for Lend, so its bytecode no
+        // longer matches the deployed pre-Lend version. Re-enable after the Lend deployment.
+        vm.skip(true);
         address local = address(new CashModuleSetters(dataProviderProxy));
         _verify("CashModuleSetters", cashModuleSettersImpl, local);
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes core lending, migration ordering, and credit/repay routing across DebtManager, CashModule, and Aave gateway—mistakes could strand positions or mis-account debt.
> 
> **Overview**
> Adds an admin-driven **`migrateToAave`** path that moves a Safe’s legacy DebtManager debt and collateral onto Aave via the CashModule-configured gateway (clear legacy books first, then supply, LTV check, re-borrow to refill the pool), sets **`migratedToAave`**, and blocks further DebtManager **`borrow`/`repay`** with **`whenNotMigrated`**.
> 
> CashModule now wires **`setLendGateway`**, owner-signed **`toggleLend`** / delayed **`processLendDisable`** (withdraw all gateway-registered Aave collateral, force Debit, block Credit), and routes **credit spend** and **wallet repay** through the gateway when migrated. **`CashModuleLib`** delegatecalls cashback/repay logic to stay under the code-size limit.
> 
> Gateway gains **`whenLendEnabled`** on supply/borrow (withdraw/repay stay open), **`isLendEnabled`** / **`registeredAssets`**, and the module sandwich skips Aave bookends when lend is off. New fork tests cover migration, lend disable, and gateway behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccb9a146cba63d1d7fe281d78d5533f1c29ab1bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->