### PR TITLE
feat: resupply loose collateral to cover credit spend shortfalls

### DIFF
--- a/src/interfaces/ICashEventEmitter.sol
+++ b/src/interfaces/ICashEventEmitter.sol
@@ -132,6 +132,13 @@ interface ICashEventEmitter {
     function emitRepayDebtManager(address safe, address token, uint256 amount, uint256 amountInUsd) external;
 
     /**
+     * @notice Emits an event when loose collateral is supplied to cover a credit spend's borrowing shortfall
+     * @param token Collateral token supplied
+     * @param amount Token amount supplied
+     */
+    function emitCollateralResupplied(address safe, address token, uint256 amount) external;
+
+    /**
      * @notice Emits an event when spending limits are changed
      * @param oldLimit Previous spending limit
      * @param newLimit New spending limit

--- a/src/libraries/CreditSourcingLib.sol
+++ b/src/libraries/CreditSourcingLib.sol
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+
+import { ICashEventEmitter } from "../interfaces/ICashEventEmitter.sol";
+import { WithdrawalRequest } from "../interfaces/ICashModule.sol";
+import { IDebtManager } from "../interfaces/IDebtManager.sol";
+import { IGateway } from "../interfaces/IGateway.sol";
+import { IPriceProvider } from "../interfaces/IPriceProvider.sol";
+import { DebitSourcingLib } from "./DebitSourcingLib.sol";
+
+/**
+ * @title CreditSourcingLib
+ * @notice Sources borrowing capacity for a credit spend that no longer fits the safe's Aave position:
+ *         resupplies loose collateral to Aave so an auth approved before an instant
+ *         collateral withdrawal still lands. Only CashModuleCore calls it; CashLens must never count
+ *         this capacity, so it stays out of DebitSourcingLib's shared math.
+ * @dev Deployed as a linked library (public function) so the resupply machinery does not count against
+ *      CashModuleCore's EIP-170 size. It runs via delegatecall in the module's context.
+ * @author ether.fi
+ */
+library CreditSourcingLib {
+    /// @dev Pad on resupply sizing so Aave share rounding cannot leave the headroom short; excess supply is harmless
+    uint256 internal constant RESUPPLY_BUFFER_BPS = 10;
+
+    /**
+     * @notice Supplies loose collateral from the safe as Aave collateral to cover the part of a credit
+     *         spend that its borrowing capacity no longer covers
+     * @dev The first pass sizes only against balance not reserved by the pending withdrawal request; the
+     *      reserved remainder is taken only when the spend cannot be funded otherwise. Sizing finishes
+     *      before any supply, so it does not depend on the gateway's transfer timing. If loose collateral
+     *      cannot fully cover, it supplies what fits and the caller's subsequent borrow reverts the spend.
+     * @param gateway The Aave gateway
+     * @param debtManager The debt manager, for the collateral token list
+     * @param priceProvider The price provider
+     * @param emitter The cash event emitter
+     * @param pendingRequest The safe's pending withdrawal request
+     * @param safe Address of the EtherFi Safe
+     * @param spendUsd Credit spend amount in USD
+     * @return Whether sizing dipped into balance reserved by the pending withdrawal request, in which
+     *         case the caller must cancel the request
+     */
+    function resupplyCollateral(IGateway gateway, IDebtManager debtManager, IPriceProvider priceProvider, ICashEventEmitter emitter, WithdrawalRequest storage pendingRequest, address safe, uint256 spendUsd) public returns (bool) {
+        uint256 availableUsd = gateway.getAccountData(safe).availableBorrowsUsd;
+        if (spendUsd <= availableUsd) {
+            return false;
+        }
+        uint256 shortfallUsd = spendUsd - availableUsd;
+
+        address[] memory tokens = debtManager.getCollateralTokens();
+        uint256[] memory supplyAmounts = new uint256[](tokens.length);
+
+        bool dippedReserved = false;
+        shortfallUsd = _sizingPass(gateway, priceProvider, pendingRequest, safe, tokens, supplyAmounts, shortfallUsd, false);
+        if (shortfallUsd != 0) {
+            dippedReserved = true;
+            _sizingPass(gateway, priceProvider, pendingRequest, safe, tokens, supplyAmounts, shortfallUsd, true);
+        }
+
+        for (uint256 i = 0; i < tokens.length; i++) {
+            if (supplyAmounts[i] != 0) {
+                gateway.supply(safe, tokens[i], supplyAmounts[i]);
+                gateway.setUsingAsCollateral(safe, tokens[i], true);
+                emitter.emitCollateralResupplied(safe, tokens[i], supplyAmounts[i]);
+            }
+        }
+        return dippedReserved;
+    }
+
+    /**
+     * @dev One resupply sizing pass over the collateral tokens, accumulating into `supplyAmounts`. Skips the
+     *      balance reserved by the pending withdrawal unless `useReserved` is set.
+     * @return The USD shortfall left after the pass
+     */
+    function _sizingPass(IGateway gateway, IPriceProvider priceProvider, WithdrawalRequest storage pendingRequest, address safe, address[] memory tokens, uint256[] memory supplyAmounts, uint256 shortfallUsd, bool useReserved) private view returns (uint256) {
+        for (uint256 i = 0; i < tokens.length && shortfallUsd != 0; i++) {
+            uint256 tokenLtv = gateway.ltv(tokens[i]);
+            if (tokenLtv == 0) {
+                continue;
+            }
+            uint256 capacity = IERC20(tokens[i]).balanceOf(safe) - supplyAmounts[i];
+            if (!useReserved) {
+                uint256 pending = _pendingAmount(pendingRequest, tokens[i]);
+                capacity = capacity > pending ? capacity - pending : 0;
+            }
+            if (capacity == 0) {
+                continue;
+            }
+
+            uint256 needed = _supplyAmount(priceProvider, tokens[i], tokenLtv, shortfallUsd);
+            if (needed <= capacity) {
+                supplyAmounts[i] += needed;
+                return 0;
+            }
+            supplyAmounts[i] += capacity;
+            // Taking capacity of the needed amount covers the same fraction of the shortfall; floor keeps the remainder conservative
+            shortfallUsd -= (shortfallUsd * capacity) / needed;
+        }
+        return shortfallUsd;
+    }
+
+    /**
+     * @dev Amount of `token` to supply so its LTV-weighted USD value adds `neededUsd` of borrowing
+     *      headroom: inverts DebitSourcingLib.headroomConsumed in one ceil-div, padded by
+     *      RESUPPLY_BUFFER_BPS. Caller guarantees tokenLtv != 0.
+     */
+    function _supplyAmount(IPriceProvider priceProvider, address token, uint256 tokenLtv, uint256 neededUsd) private view returns (uint256) {
+        uint256 numerator = neededUsd * DebitSourcingLib.LTV_SCALE * (10 ** IERC20Metadata(token).decimals()) * (10_000 + RESUPPLY_BUFFER_BPS);
+        uint256 denominator = tokenLtv * priceProvider.price(token) * 10_000;
+        return (numerator + denominator - 1) / denominator;
+    }
+
+    /// @dev Amount of `token` in the pending withdrawal request, zero if absent
+    function _pendingAmount(WithdrawalRequest storage pendingRequest, address token) private view returns (uint256) {
+        uint256 len = pendingRequest.tokens.length;
+        for (uint256 i = 0; i < len; i++) {
+            if (pendingRequest.tokens[i] == token) {
+                return pendingRequest.amounts[i];
+            }
+        }
+        return 0;
+    }
+}

--- a/src/mocks/MockGateway.sol
+++ b/src/mocks/MockGateway.sol
@@ -33,6 +33,9 @@ contract MockGateway is IGateway {
     Call public lastBorrow;
     Call public lastRepay;
 
+    /// @notice Full supply-call history, for tests that assert more than the last call
+    Call[] public supplies;
+
     /// @notice When set, borrow reverts, to model a blocked borrow (e.g. insufficient Aave collateral)
     bool public borrowReverts;
 
@@ -68,6 +71,12 @@ contract MockGateway is IGateway {
 
     function supply(address safe, address asset, uint256 amount) external {
         lastSupply = Call(safe, asset, amount, address(0));
+        supplies.push(lastSupply);
+    }
+
+    /// @notice Number of recorded supply calls
+    function suppliesCount() external view returns (uint256) {
+        return supplies.length;
     }
 
     function withdraw(address safe, address asset, uint256 amount, address to) external {

--- a/src/modules/cash/CashEventEmitter.sol
+++ b/src/modules/cash/CashEventEmitter.sol
@@ -115,6 +115,14 @@ contract CashEventEmitter is UpgradeableProxy {
      * @param mode Operational mode in which the spending occurs
      */
     event Spend(address indexed safe, bytes32 indexed txId, BinSponsor indexed binSponsor, address[] tokens, uint256[] amounts, uint256[] amountInUsd, uint256 totalUsdAmt, Mode mode);
+
+    /**
+     * @notice Emitted when loose collateral is supplied to cover a credit spend's borrowing shortfall
+     * @param safe Address of the safe
+     * @param token Collateral token supplied
+     * @param amount Token amount supplied
+     */
+    event CollateralResupplied(address indexed safe, address indexed token, uint256 amount);
     
     /**
      * @notice Emitted when cashback is calculated and potentially distributed
@@ -391,6 +399,17 @@ contract CashEventEmitter is UpgradeableProxy {
      */
     function emitRepayDebtManager(address safe, address token, uint256 amount, uint256 amountInUsd) external onlyCashModule {
         emit RepayDebtManager(safe, token, amount, amountInUsd);
+    }
+
+    /**
+     * @notice Emits the CollateralResupplied event
+     * @dev Can only be called by the Cash Module
+     * @param safe Address of the safe
+     * @param token Collateral token supplied
+     * @param amount Token amount supplied
+     */
+    function emitCollateralResupplied(address safe, address token, uint256 amount) external onlyCashModule {
+        emit CollateralResupplied(safe, token, amount);
     }
 
     /**

--- a/src/modules/cash/CashModuleCore.sol
+++ b/src/modules/cash/CashModuleCore.sol
@@ -16,6 +16,7 @@ import { IGateway } from "../../interfaces/IGateway.sol";
 import { IPriceProvider } from "../../interfaces/IPriceProvider.sol";
 import { ArrayDeDupLib } from "../../libraries/ArrayDeDupLib.sol";
 import { CashVerificationLib } from "../../libraries/CashVerificationLib.sol";
+import { CreditSourcingLib } from "../../libraries/CreditSourcingLib.sol";
 import { DebitSourcingLib } from "../../libraries/DebitSourcingLib.sol";
 import { SignatureUtils } from "../../libraries/SignatureUtils.sol";
 import { SpendingLimit, SpendingLimitLib } from "../../libraries/SpendingLimitLib.sol";
@@ -220,16 +221,6 @@ contract CashModuleCore is CashModuleStorageContract {
     }
 
     /**
-     * @notice Processes a pending withdrawal request after the delay period
-     * @dev Executes the token transfers and clears the request
-     * @param safe Address of the EtherFi Safe
-     * @custom:throws CannotWithdrawYet if the withdrawal delay period hasn't passed
-     */
-    function processWithdrawal(address safe) public onlyEtherFiSafe(safe) nonReentrant {
-        _processWithdrawal(safe);
-    }
-
-    /**
      * @notice Retrieves cash configuration data for a Safe
      * @dev Only callable for valid EtherFi Safe addresses
      * @param safe Address of the EtherFi Safe
@@ -337,7 +328,10 @@ contract CashModuleCore is CashModuleStorageContract {
     }
 
     /**
-     * @dev Internal function to execute credit mode spending transaction (single token)
+     * @dev Internal function to execute credit mode spending transaction (single token). If the safe's
+     *      borrowing capacity does not cover the spend, loose collateral is first resupplied to Aave to
+     *      cover the shortfall, so an auth approved before an instant collateral withdrawal
+     *      still lands.
      * @param $ Storage reference to the CashModuleStorage
      * @param safe Address of the EtherFi Safe
      * @param binSponsor Bin sponsor used for spending
@@ -350,6 +344,13 @@ contract CashModuleCore is CashModuleStorageContract {
         if (!_isBorrowToken($.debtManager, tokens[0])) revert UnsupportedToken();
         uint256 amount = $.debtManager.convertUsdToCollateralToken(tokens[0], amountsInUsd[0]);
         if (amount == 0) revert AmountZero();
+
+        // The resupply runs from a linked library so its machinery does not count against this
+        // contract's EIP-170 size. A dip into withdrawal-reserved balance voids the request.
+        bool dippedReserved = CreditSourcingLib.resupplyCollateral($.gateway, $.debtManager, IPriceProvider(etherFiDataProvider.getPriceProvider()), $.cashEventEmitter, $.safeCashConfig[safe].pendingWithdrawalRequest, safe, amountsInUsd[0]);
+        if (dippedReserved) {
+            _cancelOldWithdrawal(safe);
+        }
 
         address dispatcher = getSettlementDispatcher(binSponsor);
 

--- a/src/modules/cash/CashModuleSetters.sol
+++ b/src/modules/cash/CashModuleSetters.sol
@@ -302,6 +302,17 @@ contract CashModuleSetters is CashModuleStorageContract {
     }
 
     /**
+     * @notice Processes a pending withdrawal request after the delay period
+     * @dev Executes the token transfers and clears the request. Lives here with the rest of the
+     *      withdrawal lifecycle; CashModuleCore's fallback routes calls through.
+     * @param safe Address of the EtherFi Safe
+     * @custom:throws CannotWithdrawYet if the withdrawal delay period hasn't passed
+     */
+    function processWithdrawal(address safe) public onlyEtherFiSafe(safe) nonReentrant {
+        _processWithdrawal(safe);
+    }
+
+    /**
      * @notice Updates the spending limits for a safe
      * @dev Can only be called by the safe itself with a valid admin signature
      * @param safe Address of the EtherFi Safe

--- a/test/safe/modules/cash/Spend.t.sol
+++ b/test/safe/modules/cash/Spend.t.sol
@@ -739,4 +739,199 @@ contract CashModuleSpendTest is CashModuleTestSetup {
         vm.expectRevert(ArrayDeDupLib.DuplicateElementFound.selector);
         cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
     }
+
+    // ========== Credit resupply: supply loose collateral when the borrow doesn't fit ==========
+
+    function _enterCreditMode() internal {
+        _setMode(Mode.Credit);
+        vm.warp(cashModule.incomingModeStartTime(address(safe)) + 1);
+    }
+
+    function _creditSpendUsdc(uint256 amountInUsd) internal {
+        address[] memory spendTokens = new address[](1);
+        spendTokens[0] = address(usdc);
+        uint256[] memory spendAmounts = new uint256[](1);
+        spendAmounts[0] = amountInUsd;
+        Cashback[] memory cashbacks;
+
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
+    }
+
+    function _setBorrowCapacity(uint256 availableBorrowsUsd) internal {
+        gateway.setAccountData(address(safe), IGateway.AccountData({ collateralUsd: 0, debtUsd: 0, availableBorrowsUsd: availableBorrowsUsd, healthFactor: type(uint256).max }));
+    }
+
+    /// @dev Mirrors CreditSourcingLib._supplyAmount: token amount whose LTV-weighted value covers neededUsd, ceil + 10 bps pad
+    function _resupplyAmount(address token, uint8 decimals, uint256 tokenLtv, uint256 neededUsd) internal view returns (uint256) {
+        uint256 num = neededUsd * 100e18 * (10 ** decimals) * 10_010;
+        uint256 den = tokenLtv * priceProvider.price(token) * 10_000;
+        return (num + den - 1) / den;
+    }
+
+    /// @dev Mirrors the partial-cover remainder: taking `capacity` of `needed` covers the same fraction of the shortfall
+    function _residualUsd(uint256 shortfallUsd, uint256 capacity, uint256 needed) internal pure returns (uint256) {
+        return shortfallUsd - (shortfallUsd * capacity) / needed;
+    }
+
+    /// Borrowing capacity covers the spend: nothing is supplied and the borrow just goes through
+    function test_spend_creditResupply_skipped_whenCapacityCovers() public {
+        deal(address(usdc), address(safe), 100e6);
+        _enterCreditMode();
+        gateway.setLtv(address(usdc), 80e18);
+        _setBorrowCapacity(80e6);
+
+        _creditSpendUsdc(10e6);
+
+        assertEq(gateway.suppliesCount(), 0);
+        (address s,, uint256 amt, address to) = gateway.lastBorrow();
+        assertEq(s, address(safe));
+        assertEq(amt, 10e6);
+        assertEq(to, address(settlementDispatcherReap));
+    }
+
+    /// A one-token shortfall supplies the exact buffered amount, flags it as collateral, and the borrow lands
+    function test_spend_creditResupply_suppliesOneToken() public {
+        deal(address(usdc), address(safe), 100e6);
+        _enterCreditMode();
+        gateway.setLtv(address(usdc), 80e18);
+        _setBorrowCapacity(4e6);
+
+        // Shortfall is 6e6; also the borrow-token == collateral-token case (USDC both)
+        uint256 expected = _resupplyAmount(address(usdc), 6, 80e18, 6e6);
+
+        vm.expectEmit(true, true, true, true);
+        emit CashEventEmitter.CollateralResupplied(address(safe), address(usdc), expected);
+        _creditSpendUsdc(10e6);
+
+        assertEq(gateway.suppliesCount(), 1);
+        (address s, address asset, uint256 amt,) = gateway.lastSupply();
+        assertEq(s, address(safe));
+        assertEq(asset, address(usdc));
+        assertEq(amt, expected);
+        assertTrue(gateway.usingAsCollateral(address(safe), address(usdc)));
+        (,, uint256 borrowed, address to) = gateway.lastBorrow();
+        assertEq(borrowed, 10e6);
+        assertEq(to, address(settlementDispatcherReap));
+    }
+
+    /// The unreserved loose balance covers the shortfall, so the pending withdrawal request survives
+    function test_spend_creditResupply_prefersUnreserved_keepsWithdrawal() public {
+        deal(address(usdc), address(safe), 100e6);
+        _enterCreditMode();
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 50e6;
+        _requestWithdrawal(tokens, amounts, withdrawRecipient);
+
+        gateway.setLtv(address(usdc), 80e18);
+        _setBorrowCapacity(4e6);
+
+        // Needed (~7.5e6) fits in the 50e6 unreserved balance, so the request survives
+        _creditSpendUsdc(10e6);
+
+        assertEq(cashModule.getPendingWithdrawalAmount(address(safe), address(usdc)), 50e6);
+        assertEq(gateway.suppliesCount(), 1);
+    }
+
+    /// Covering the shortfall needs withdrawal-reserved balance: the request is cancelled and the dip is supplied
+    function test_spend_creditResupply_dipsIntoReserved_cancelsWithdrawal() public {
+        deal(address(usdc), address(safe), 100e6);
+        _enterCreditMode();
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 95e6;
+        _requestWithdrawal(tokens, amounts, withdrawRecipient);
+
+        gateway.setLtv(address(usdc), 80e18);
+        _setBorrowCapacity(4e6);
+
+        // Unreserved is 5e6, needed ~7.5e6: pass one takes the 5e6, pass two cancels the request for the rest
+        uint256 residualUsd = _residualUsd(6e6, 5e6, _resupplyAmount(address(usdc), 6, 80e18, 6e6));
+        uint256 expected = 5e6 + _resupplyAmount(address(usdc), 6, 80e18, residualUsd);
+
+        vm.expectEmit(true, true, true, true);
+        emit CashEventEmitter.WithdrawalCancelled(address(safe), tokens, amounts, withdrawRecipient);
+        _creditSpendUsdc(10e6);
+
+        assertEq(cashModule.getPendingWithdrawalAmount(address(safe), address(usdc)), 0);
+        assertEq(gateway.suppliesCount(), 1);
+        (,, uint256 amt,) = gateway.lastSupply();
+        assertEq(amt, expected);
+    }
+
+    /// Another token's loose balance covers the shortfall, so the reserved token's request survives (two-pass order)
+    function test_spend_creditResupply_otherTokenCovers_keepsWithdrawal() public {
+        deal(address(usdc), address(safe), 50e6);
+        deal(address(weETH), address(safe), 1 ether);
+        _enterCreditMode();
+
+        // The whole USDC balance is reserved by the request; loose weETH must cover without touching it
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 50e6;
+        _requestWithdrawal(tokens, amounts, withdrawRecipient);
+
+        gateway.setLtv(address(usdc), 80e18);
+        gateway.setLtv(address(weETH), 50e18);
+        _setBorrowCapacity(4e6);
+
+        _creditSpendUsdc(10e6);
+
+        assertEq(cashModule.getPendingWithdrawalAmount(address(safe), address(usdc)), 50e6);
+        assertEq(gateway.suppliesCount(), 1);
+        (, address asset, uint256 amt,) = gateway.lastSupply();
+        assertEq(asset, address(weETH));
+        assertEq(amt, _resupplyAmount(address(weETH), 18, 50e18, 6e6));
+        assertTrue(gateway.usingAsCollateral(address(safe), address(weETH)));
+    }
+
+    /// With no eligible collateral nothing is supplied, and the failing borrow reverts the whole spend
+    function test_spend_creditResupply_noEligibleCollateral_borrowReverts() public {
+        deal(address(usdc), address(safe), 100e6);
+        _enterCreditMode();
+        // No LTVs set: every collateral token is ineligible, nothing is supplied, and the borrow is rejected
+        gateway.setBorrowReverts(true);
+
+        address[] memory spendTokens = new address[](1);
+        spendTokens[0] = address(usdc);
+        uint256[] memory spendAmounts = new uint256[](1);
+        spendAmounts[0] = 10e6;
+        Cashback[] memory cashbacks;
+
+        vm.prank(etherFiWallet);
+        vm.expectRevert(MockGateway.BorrowBlocked.selector);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
+    }
+
+    /// A shortfall spanning tokens exhausts the first and covers the proportional remainder from the next
+    function test_spend_creditResupply_multipleTokens_partialCover() public {
+        // Collateral order is [weETH, usdc]: the small weETH balance is exhausted first, USDC covers the rest
+        deal(address(weETH), address(safe), 0.001 ether);
+        deal(address(usdc), address(safe), 100e6);
+        _enterCreditMode();
+        gateway.setLtv(address(weETH), 50e18);
+        gateway.setLtv(address(usdc), 80e18);
+        _setBorrowCapacity(0);
+
+        uint256 residualUsd = _residualUsd(10e6, 0.001 ether, _resupplyAmount(address(weETH), 18, 50e18, 10e6));
+        uint256 expectedUsdc = _resupplyAmount(address(usdc), 6, 80e18, residualUsd);
+
+        _creditSpendUsdc(10e6);
+
+        assertEq(gateway.suppliesCount(), 2);
+        (, address asset0, uint256 amt0,) = gateway.supplies(0);
+        assertEq(asset0, address(weETH));
+        assertEq(amt0, 0.001 ether);
+        (, address asset1, uint256 amt1,) = gateway.supplies(1);
+        assertEq(asset1, address(usdc));
+        assertEq(amt1, expectedUsdc);
+        assertTrue(gateway.usingAsCollateral(address(safe), address(weETH)));
+        assertTrue(gateway.usingAsCollateral(address(safe), address(usdc)));
+    }
 }


### PR DESCRIPTION
Closes COR-1045

## What

Between a card auth approval and the spend tx landing (~5s), an instant Aave collateral withdrawal can drop the safe's borrowing power so the already-approved credit borrow fails on-chain (merchant paid, protocol not covered). This adds the spend-time fallback decided on COR-1045: if the borrow no longer fits, `_spendCredit` supplies loose collateral back to Aave for the shortfall (plus a 10 bps rounding buffer) and flags it as collateral, then borrows.

- Funds not reserved by a pending withdrawal request are used first; the request is cancelled only when the spend cannot be funded otherwise (mirrors the debit-side sourcing invariant).
- `canSpend` is untouched: resupply capacity is never advertised as headroom.
- If loose collateral cannot fully cover, it supplies what fits and the borrow revert unwinds the whole spend atomically.
- New `CollateralResupplied(safe, token, amount)` event per supplied token.

## Decisions worth a second pair of eyes

- **First linked library in the repo.** The sizing/supply machinery lives in `CreditSourcingLib` with a `public` function, so it deploys as a separate contract (delegatecall) and doesn't count against `CashModuleCore`'s EIP-170 limit. Core was 490 bytes over with the logic inline. Deploying a new `CashModuleCore` implementation now also deploys and links this library — forge handles it automatically in scripts/tests, but the deploy process should be aware.
- **`processWithdrawal` moved Core → Setters.** Required for size even with the library (Core is 440 bytes over without it), and coherent: Setters already holds `requestWithdrawal`/`cancelWithdrawal` and executes `_processWithdrawal` on the zero-delay path, so the whole withdrawal lifecycle now lives there. The selector still routes through Core's existing fallback. No other functions moved.
- **`WithdrawalCancelled` now emits after the `CollateralResupplied` events** (the cancel happens once the library returns), previously it would have come first. Same end state.

Contract size margins after this change: Core +1,074 B, Setters +2,367 B.

## How it was tested

7 new tests in `Spend.t.sol` covering: capacity-covers skip, exact buffered supply amount + event, unreserved-first (request survives), reserved dip (request cancelled), other-token cover (two-pass ordering), no eligible collateral (borrow reverts the spend), and multi-token partial cover with the proportional remainder math. Full cash-module suite green: 379 passed, 0 failed (`TEST_CHAIN=10`; flaky public-RPC suites rerun serially).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes on-chain credit settlement by auto-supplying collateral and optionally cancelling withdrawals; mistakes could mis-size borrows or strand user withdrawal intent, though failed borrows still revert atomically.
> 
> **Overview**
> Credit spends that no longer fit the safe’s Aave borrowing headroom (e.g. after an instant collateral withdrawal between auth and settlement) now **resupply loose collateral** before borrowing, instead of failing outright.
> 
> `_spendCredit` calls the new linked **`CreditSourcingLib`** to size and `gateway.supply` the USD shortfall (with a 10 bps rounding pad), enable collateral, then borrow as before. Sizing uses unreserved balances first and only dips into withdrawal-reserved funds—and **cancels the pending withdrawal**—when needed, mirroring debit sourcing. Partial coverage still supplies what it can; a failed borrow reverts the whole spend. **`canSpend` is unchanged**, so this capacity is not advertised as headroom.
> 
> Observability adds **`CollateralResupplied`** on the cash event emitter. **`processWithdrawal`** moves from `CashModuleCore` to `CashModuleSetters` (same selector via fallback) to stay under EIP-170. Tests extend `MockGateway` supply history and add seven credit-resupply scenarios in `Spend.t.sol`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a138bed7777d8ca80837b6c212f0b6378f9d2ff2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->