### PR TITLE
feat: add EnsoSwapModule for same-chain + cross-chain swaps

### DIFF
--- a/scripts/DeployEnsoModule.s.sol
+++ b/scripts/DeployEnsoModule.s.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { console } from "forge-std/console.sol";
+import { stdJson } from "forge-std/StdJson.sol";
+
+import { Utils } from "./utils/Utils.sol";
+import { UUPSProxy } from "../src/UUPSProxy.sol";
+import { EnsoSwapModule } from "../src/enso/EnsoSwapModule.sol";
+import { EtherFiDataProvider } from "../src/data-provider/EtherFiDataProvider.sol";
+import { ICashModule } from "../src/interfaces/ICashModule.sol";
+import { RoleRegistry } from "../src/role-registry/RoleRegistry.sol";
+
+/**
+ * @title DeployEnsoModule
+ * @notice Standalone deploy of the EnsoSwapModule against an already-live stack (read from
+ *         deployments.json). Whitelists it as a default module on the DataProvider and, where
+ *         the DataProvider exposes a CashModule (OP), registers it so it can place withdrawal
+ *         holds. Where `getCashModule() == 0` (e.g. the mainnet TradingSafe DataProvider) the
+ *         CashModule registration is skipped — the module then executes swaps immediately.
+ *
+ *         The Enso Router address is baked into initialize(); repoint it later via
+ *         `setEnsoRouter` (guarded by ENSO_SWAP_MODULE_ADMIN_ROLE) if Enso ships a new router.
+ *
+ * Run:
+ *   source .env && ENV=dev forge script scripts/DeployEnsoModule.s.sol --rpc-url optimism --broadcast -vvv --verify
+ */
+contract DeployEnsoModule is Utils {
+    // Enso Router V2 (same address on Ethereum and Optimism).
+    address constant ENSO_ROUTER = 0xF75584eF6673aD213a685a1B58Cc0330B8eA22Cf;
+
+    function run() public {
+        uint256 pk = vm.envUint("PRIVATE_KEY");
+        address deployer = vm.addr(pk);
+
+        string memory deployments = readDeploymentFile();
+        EtherFiDataProvider dataProvider = EtherFiDataProvider(
+            stdJson.readAddress(deployments, ".addresses.EtherFiDataProvider")
+        );
+        RoleRegistry roleRegistry = RoleRegistry(
+            stdJson.readAddress(deployments, ".addresses.RoleRegistry")
+        );
+
+        vm.startBroadcast(pk);
+
+        // Impl constructor reads getCashModule() off the DataProvider; the resulting immutable
+        // decides whether the hold path is active on this chain.
+        EnsoSwapModule module = new EnsoSwapModule(address(dataProvider));
+        EnsoSwapModule enso = EnsoSwapModule(address(new UUPSProxy(
+            address(module),
+            abi.encodeWithSelector(EnsoSwapModule.initialize.selector, address(roleRegistry), ENSO_ROUTER)
+        )));
+
+        address[] memory modules = new address[](1);
+        modules[0] = address(enso);
+        bool[] memory enable = new bool[](1);
+        enable[0] = true;
+
+        dataProvider.configureDefaultModules(modules, enable);
+
+        address cashModule = dataProvider.getCashModule();
+        if (cashModule != address(0)) {
+            ICashModule(cashModule).configureModulesCanRequestWithdraw(modules, enable);
+        }
+
+        roleRegistry.grantRole(enso.ENSO_SWAP_MODULE_ADMIN_ROLE(), deployer);
+
+        vm.stopBroadcast();
+
+        console.log("EnsoSwapModule:", address(enso));
+        console.log("CashModule (hold path):", cashModule);
+    }
+}

--- a/scripts/trading-account/DeployTradingAccountMainnet.s.sol
+++ b/scripts/trading-account/DeployTradingAccountMainnet.s.sol
@@ -7,6 +7,7 @@ import { stdJson } from "forge-std/StdJson.sol";
 import { Utils } from "../utils/Utils.sol";
 import { UUPSProxy } from "../../src/UUPSProxy.sol";
 import { AcrossSwapModule } from "../../src/across/AcrossSwapModule.sol";
+import { EnsoSwapModule } from "../../src/enso/EnsoSwapModule.sol";
 import { EtherFiDataProvider } from "../../src/data-provider/EtherFiDataProvider.sol";
 import { OwnershipBridgeReceiver } from "../../src/ownership-bridge/OwnershipBridgeReceiver.sol";
 import { PriceProviderV2 } from "../../src/oracle/PriceProviderV2.sol";
@@ -51,6 +52,10 @@ contract DeployTradingAccountMainnet is Utils {
     // Across SpokePoolPeriphery — origin-swap (anyToBridgeable) routes for the Sell flow.
     address constant PERIPHERY = 0x10D8b8DaA26d307489803e10477De69C0492B610;
 
+    // Enso Router V2 (same address on Ethereum and Optimism). Pinned target for the
+    // EnsoSwapModule's forward-calldata swaps.
+    address constant ENSO_ROUTER = 0xF75584eF6673aD213a685a1B58Cc0330B8eA22Cf;
+
     address constant RECOVERY_SIGNER_1 = 0xbfCe61CE31359267605F18dcE65Cb6c3cc9694A7;
     address constant RECOVERY_SIGNER_2 = 0xa265C271adbb0984EFd67310cfe85A77f449e291;
 
@@ -61,6 +66,7 @@ contract DeployTradingAccountMainnet is Utils {
     address internal predictedDataProvider;
     address internal predictedFactory;
     address internal predictedAcrossModule;
+    address internal predictedEnsoModule;
     RoleRegistry internal roleRegistry;
     PriceProviderV2 internal priceProvider;
     OwnershipBridgeReceiver internal receiver;
@@ -69,6 +75,7 @@ contract DeployTradingAccountMainnet is Utils {
     TradingLens internal lens;
     EtherFiDataProvider internal dataProvider;
     AcrossSwapModule internal acrossModule;
+    EnsoSwapModule internal ensoModule;
     // Existing TopUp source factory (not deployed here) — the `isTokenSupported` oracle the
     // factory's `redirectToTopUp` consults. Read from this chain's deployments.json.
     address internal topUpFactory;
@@ -88,6 +95,7 @@ contract DeployTradingAccountMainnet is Utils {
         predictedDataProvider = DEPLOYER.getDeterministicAddress(getSalt("TradingDataProviderProxyDev"));
         predictedFactory = DEPLOYER.getDeterministicAddress(getSalt("TradingSafeFactoryProxyDev"));
         predictedAcrossModule = DEPLOYER.getDeterministicAddress(getSalt("AcrossSwapModuleDev"));
+        predictedEnsoModule = DEPLOYER.getDeterministicAddress(getSalt("EnsoSwapModuleDev"));
 
         _deployCore();
         _deployBridgeAndFactory();
@@ -159,15 +167,16 @@ contract DeployTradingAccountMainnet is Utils {
         ));
     }
 
-    /// @dev DataProvider initialises atomically with full InitParams; the across module is
-    ///      referenced by prediction (stored only) and whitelisted + default so every
-    ///      TradingSafe deploys with it installed. AcrossSwapModule deploys LAST because
-    ///      its constructor CALLS dataProvider.getCashModule() (needs code there; returns 0
+    /// @dev DataProvider initialises atomically with full InitParams; the Across + Enso swap
+    ///      modules are referenced by prediction (stored only) and whitelisted + default so
+    ///      every TradingSafe deploys with both installed. Both modules deploy LAST because
+    ///      their constructors CALL dataProvider.getCashModule() (needs code there; returns 0
     ///      since InitParams set no cash module, permanently disabling the hold path —
     ///      correct for the mainnet TradingSafe: no card rail, no hold).
     function _deployDataProviderAndModule() internal {
-        address[] memory modules = new address[](1);
+        address[] memory modules = new address[](2);
         modules[0] = predictedAcrossModule;
+        modules[1] = predictedEnsoModule;
         address dataProviderImpl = _deploy("TradingDataProviderImplDev", type(EtherFiDataProvider).creationCode, "");
         dataProvider = EtherFiDataProvider(_deployProxy(
             "TradingDataProviderProxyDev",
@@ -204,6 +213,23 @@ contract DeployTradingAccountMainnet is Utils {
             )
         ));
         require(address(acrossModule) == predictedAcrossModule, "across module landed off-prediction");
+
+        // EnsoSwapModule — same forward-calldata lifecycle, targeting the pinned Enso Router.
+        // Its constructor reads getCashModule() (0 on the mainnet trading DataProvider), so the
+        // hold path is disabled and requestSwap executes immediately here.
+        address ensoImpl = _deploy(
+            "EnsoSwapModuleImplDev", type(EnsoSwapModule).creationCode, abi.encode(address(dataProvider))
+        );
+        ensoModule = EnsoSwapModule(_deployProxy(
+            "EnsoSwapModuleDev",
+            ensoImpl,
+            abi.encodeWithSelector(
+                EnsoSwapModule.initialize.selector,
+                address(roleRegistry),
+                ENSO_ROUTER
+            )
+        ));
+        require(address(ensoModule) == predictedEnsoModule, "enso module landed off-prediction");
     }
 
     /// @dev Wires roles + both redirect directions. Safe → TopUp: `setTopUpFactory` (the
@@ -215,6 +241,9 @@ contract DeployTradingAccountMainnet is Utils {
         roleRegistry.grantRole(acrossModule.ACROSS_SWAP_MODULE_ADMIN_ROLE(), deployer);
         // Periphery isn't part of initialize() — set it post-grant so origin-swap (Sell) routes work.
         acrossModule.setPeriphery(PERIPHERY);
+        // Enso router rides in initialize(); only the admin role is granted here so the router
+        // can be repointed later (e.g. an Enso V3 deployment).
+        roleRegistry.grantRole(ensoModule.ENSO_SWAP_MODULE_ADMIN_ROLE(), deployer);
         roleRegistry.grantRole(factory.TRADING_SAFE_FACTORY_ADMIN_ROLE(), keeper);
         roleRegistry.grantRole(lens.TRADING_LENS_ADMIN_ROLE(), deployer);
 
@@ -248,6 +277,7 @@ contract DeployTradingAccountMainnet is Utils {
         vm.serializeAddress(out, "TradingSafeImpl", tradingSafeImpl);
         vm.serializeAddress(out, "OwnershipBridgeReceiver", address(receiver));
         vm.serializeAddress(out, "AcrossSwapModule", address(acrossModule));
+        vm.serializeAddress(out, "EnsoSwapModule", address(ensoModule));
         vm.serializeAddress(out, "TopUpFactory", topUpFactory);
         string memory json = vm.serializeAddress(out, "TradingLens", address(lens));
         vm.writeJson(json, string.concat(
@@ -261,6 +291,7 @@ contract DeployTradingAccountMainnet is Utils {
         console.log("TradingSafeImpl:        ", tradingSafeImpl);
         console.log("OwnershipBridgeReceiver:", address(receiver));
         console.log("AcrossSwapModule:       ", address(acrossModule));
+        console.log("EnsoSwapModule:         ", address(ensoModule));
         console.log("TradingLens:            ", address(lens));
         console.log("TopUpFactory (wired):   ", topUpFactory);
     }

--- a/scripts/trading-account/DeployTradingAccountOptimism.s.sol
+++ b/scripts/trading-account/DeployTradingAccountOptimism.s.sol
@@ -7,6 +7,7 @@ import { stdJson } from "forge-std/StdJson.sol";
 import { Utils } from "../utils/Utils.sol";
 import { UUPSProxy } from "../../src/UUPSProxy.sol";
 import { AcrossSwapModule } from "../../src/across/AcrossSwapModule.sol";
+import { EnsoSwapModule } from "../../src/enso/EnsoSwapModule.sol";
 import { EtherFiDataProvider } from "../../src/data-provider/EtherFiDataProvider.sol";
 import { ICashModule } from "../../src/interfaces/ICashModule.sol";
 import { EtherFiSafe } from "../../src/safe/EtherFiSafe.sol";
@@ -44,6 +45,10 @@ contract DeployTradingAccountOptimism is Utils {
     address constant MULTICALL_HANDLER = 0x0F7Ae28dE1C8532170AD4ee566B5801485c13a0E;
     // Across SpokePoolPeriphery — origin-swap (anyToBridgeable) routes for the Sell flow.
     address constant PERIPHERY = 0x10D8b8DaA26d307489803e10477De69C0492B610;
+
+    // Enso Router V2 (same address on Ethereum and Optimism). Pinned target for the
+    // EnsoSwapModule's forward-calldata swaps.
+    address constant ENSO_ROUTER = 0xF75584eF6673aD213a685a1B58Cc0330B8eA22Cf;
 
     function run() public {
         uint256 pk = vm.envUint("PRIVATE_KEY");
@@ -114,6 +119,27 @@ contract DeployTradingAccountOptimism is Utils {
         // Periphery isn't part of initialize() — set it post-grant so origin-swap (Sell) routes work.
         acrossModule.setPeriphery(PERIPHERY);
 
+        // 4b. EnsoSwapModule — same forward-calldata lifecycle, targeting the pinned Enso Router.
+        //     Behind a UUPS proxy initialised atomically in its deployment tx. The impl
+        //     constructor reads getCashModule() from the OP data provider, so the CashModule
+        //     hold path is live here (same as Across on OP).
+        address ensoImpl = _deploy(
+            "EnsoSwapModuleImplDev", type(EnsoSwapModule).creationCode, abi.encode(address(dataProvider))
+        );
+        EnsoSwapModule ensoModule = EnsoSwapModule(_deploy(
+            "EnsoSwapModuleDev",
+            type(UUPSProxy).creationCode,
+            abi.encode(ensoImpl, abi.encodeWithSelector(
+                EnsoSwapModule.initialize.selector,
+                address(roleRegistry),
+                ENSO_ROUTER
+            ))
+        ));
+        modules[0] = address(ensoModule);
+        dataProvider.configureDefaultModules(modules, enable);
+        cashModule.configureModulesCanRequestWithdraw(modules, enable);
+        roleRegistry.grantRole(ensoModule.ENSO_SWAP_MODULE_ADMIN_ROLE(), deployer);
+
         // 5. Upgrade the DataProvider proxy to the bridge-aware impl — the deployed OP dev
         //    impl predates setOwnershipBridgeSender/getOwnershipBridgeSender. UUPS upgrade,
         //    gated on the roleRegistry owner (the dev key). No initializer re-run needed:
@@ -136,6 +162,7 @@ contract DeployTradingAccountOptimism is Utils {
         string memory out = "trading-account-optimism";
         vm.serializeAddress(out, "OwnershipBridgeSender", address(sender));
         vm.serializeAddress(out, "AcrossSwapModule", address(acrossModule));
+        vm.serializeAddress(out, "EnsoSwapModule", address(ensoModule));
         string memory json = vm.serializeAddress(out, "EtherFiSafeImpl", newSafeImpl);
         vm.writeJson(json, string.concat(
             vm.projectRoot(), "/deployments/", getEnv(), "/", vm.toString(block.chainid), "/trading-account.json"
@@ -143,6 +170,7 @@ contract DeployTradingAccountOptimism is Utils {
 
         console.log("OwnershipBridgeSender:", address(sender));
         console.log("AcrossSwapModule:     ", address(acrossModule));
+        console.log("EnsoSwapModule:       ", address(ensoModule));
         console.log("EtherFiSafeImpl:      ", newSafeImpl);
     }
 

--- a/src/enso/EnsoSwapModule.sol
+++ b/src/enso/EnsoSwapModule.sol
@@ -1,0 +1,379 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+
+import { IBridgeModule } from "../interfaces/IBridgeModule.sol";
+import { ICashModule } from "../interfaces/ICashModule.sol";
+import { IEtherFiDataProvider } from "../interfaces/IEtherFiDataProvider.sol";
+import { IEtherFiSafe } from "../interfaces/IEtherFiSafe.sol";
+import { IRoleRegistry } from "../interfaces/IRoleRegistry.sol";
+import { ModuleBase } from "../modules/ModuleBase.sol";
+import { UpgradeableProxy } from "../utils/UpgradeableProxy.sol";
+
+/**
+ * @title EnsoSwapModule
+ * @author ether.fi
+ * @notice Swap module that routes same-chain and cross-chain swaps through Enso. The user
+ *         signs ONE intent at `requestSwap`, which also stores the BE-supplied Enso
+ *         `router`-strategy calldata. After the CashModule withdrawal delay matures the
+ *         keeper calls `executeSwap(safe)` — taking only the safe address — which replays
+ *         the stored swap verbatim: it releases the solvency hold and drives the safe to
+ *         approve the pinned Enso Router and forward the calldata.
+ * @dev The Enso calldata (`swapData`) is built off-chain by the BE via the Enso Route/Bundle
+ *      API with the `router` routing strategy and stored at request time, then forwarded
+ *      verbatim — there is no on-chain min-out / balance enforcement. Slippage protection
+ *      lives entirely inside the Enso calldata; `order.minOut` is carried only for the
+ *      signed intent and events. Off-chain monitoring catches BE bugs or mis-routing.
+ *
+ *      The module always executes via `EtherFiSafe.execTransactionFromModule`, which is a
+ *      plain `call` (never `delegatecall`), so ONLY Enso's `router` strategy is usable here
+ *      (approve the router, then call it). The `delegate` strategy is not supported.
+ *
+ *      On the OP deploy the module hooks `CashModule.requestWithdrawalByModule` /
+ *      `cancelWithdrawalByModule` to place a solvency hold for the duration of the
+ *      CashModule withdrawal delay. Where the data provider's `cashModule` is the zero
+ *      address (e.g. the mainnet `TradingSafe`) the hold mechanic is skipped and the swap
+ *      executes immediately at request time.
+ *
+ *      The Enso Router address is admin-set (pinned) and every swap is forwarded only to it,
+ *      mirroring how `AcrossSwapModule` pins its periphery. Enso recommends using the API's
+ *      `tx.to`, so an admin must update `ensoRouter` if Enso ships a new router deployment.
+ */
+contract EnsoSwapModule is ModuleBase, UpgradeableProxy, IBridgeModule {
+    using MessageHashUtils for bytes32;
+
+    /// @notice User-signed swap intent. One per safe at a time.
+    /// @dev `dstChainId`, `dstToken` and `minOut` are carried for the signed intent and
+    ///      events only; they are not enforced on-chain (the Enso calldata owns slippage and
+    ///      routing). For a same-chain swap `dstChainId == block.chainid`.
+    struct Order {
+        address srcToken;
+        uint256 srcAmount;
+        uint256 dstChainId;
+        address dstToken;
+        address recipient;
+        uint256 minOut;
+        uint256 deadline;
+    }
+
+    /// @notice Everything `executeSwap` needs, captured at `requestSwap`: the user-signed
+    ///         order plus the BE-supplied Enso `router`-strategy calldata.
+    /// @dev `swapId` is the stable identifier minted at `requestSwap` and re-emitted at
+    ///      execute/cancel so off-chain consumers can link the three lifecycle events of a
+    ///      single swap.
+    struct StoredSwap {
+        Order order;
+        bytes swapData;
+        bytes32 swapId;
+    }
+
+    /// @custom:storage-location erc7201:etherfi.storage.EnsoSwapModule
+    struct EnsoSwapModuleStorage {
+        /// @notice Mapping of safe address to its single active stored swap.
+        mapping(address safe => StoredSwap swap) swaps;
+        /// @notice Pinned Enso Router address used on this chain; approved and called on every swap.
+        address ensoRouter;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("etherfi.storage.EnsoSwapModule")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant EnsoSwapModuleStorageLocation = 0x5a12820f7ccffa3b7965b81854504b7b9081737c3d6393e92a0a755ce6314400;
+
+    /// @notice Role allowed to configure the pinned Enso Router address.
+    bytes32 public constant ENSO_SWAP_MODULE_ADMIN_ROLE = keccak256("ENSO_SWAP_MODULE_ADMIN_ROLE");
+
+    /// @dev Domain-separator-style prefixes for the digest the user signs.
+    bytes32 private constant REQUEST_SWAP_SIG = keccak256("EnsoSwapModule.requestSwap");
+    bytes32 private constant CANCEL_SWAP_SIG = keccak256("EnsoSwapModule.cancelSwap");
+
+    /// @notice CashModule on the same chain. Zero where there is no card spending.
+    ICashModule public immutable cashModule;
+
+    /// @dev `swapId` is the second topic on every lifecycle event so consumers can filter or
+    ///      join a swap's request/execute/cancel by id.
+    event SwapRequested(
+        address indexed safe,
+        bytes32 indexed swapId,
+        address srcToken,
+        uint256 srcAmount,
+        uint256 dstChainId,
+        address dstToken,
+        address recipient,
+        uint256 minOut,
+        uint256 deadline
+    );
+    event SwapExecuted(
+        address indexed safe,
+        bytes32 indexed swapId,
+        uint256 dstChainId,
+        address indexed dstToken,
+        uint256 minOut
+    );
+    event SwapCancelled(address indexed safe, bytes32 indexed swapId);
+    event EnsoRouterSet(address oldEnsoRouter, address newEnsoRouter);
+
+    /// @notice Reverts when a non-admin tries to set the Enso Router.
+    error OnlyAdmin();
+    /// @notice Reverts when `requestSwap` is called on a safe with an active swap.
+    error OrderAlreadyActive();
+    /// @notice Reverts when `executeSwap` / `cancelSwap` finds no stored swap.
+    error NoActiveOrder();
+    /// @notice Reverts when the user's signature doesn't meet the safe's threshold.
+    error InvalidSignatures();
+    /// @notice Reverts when `executeSwap` runs after `order.deadline`.
+    error OrderExpired();
+    /// @notice Reverts when the admin-set `ensoRouter` is still zero.
+    error MissingConfig();
+    /// @notice Reverts when `executeSwap` runs before the CashModule withdrawal hold matures.
+    error WithdrawalDelayNotElapsed();
+    /// @notice Reverts when the BE-supplied Enso calldata is empty.
+    error EmptySwapData();
+
+    /// @dev Immutables (`etherFiDataProvider`, `cashModule`) live in the IMPLEMENTATION's
+    ///      code — every upgrade impl must be constructed with the same data provider.
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor(address _etherFiDataProvider) ModuleBase(_etherFiDataProvider) {
+        cashModule = ICashModule(IEtherFiDataProvider(_etherFiDataProvider).getCashModule());
+        _disableInitializers();
+    }
+
+    /**
+     * @notice Initialises the proxy.
+     * @param _roleRegistry Role registry used for upgrade authority + pause control.
+     * @param _ensoRouter Pinned Enso Router address used on this chain.
+     */
+    function initialize(address _roleRegistry, address _ensoRouter) external initializer {
+        __UpgradeableProxy_init(_roleRegistry);
+
+        if (_ensoRouter == address(0)) revert InvalidInput();
+        _getEnsoSwapModuleStorage().ensoRouter = _ensoRouter;
+    }
+
+    // ---- Admin config ----
+
+    /// @notice Sets the pinned Enso Router address used on this chain.
+    function setEnsoRouter(address _ensoRouter) external {
+        _onlyAdmin();
+        if (_ensoRouter == address(0)) revert InvalidInput();
+        EnsoSwapModuleStorage storage $ = _getEnsoSwapModuleStorage();
+        emit EnsoRouterSet($.ensoRouter, _ensoRouter);
+        $.ensoRouter = _ensoRouter;
+    }
+
+    // ---- Views ----
+
+    function getOrder(address safe) external view returns (Order memory) {
+        return _getEnsoSwapModuleStorage().swaps[safe].order;
+    }
+
+    function getSwap(address safe) external view returns (StoredSwap memory) {
+        return _getEnsoSwapModuleStorage().swaps[safe];
+    }
+
+    function getEnsoRouter() external view returns (address) {
+        return _getEnsoSwapModuleStorage().ensoRouter;
+    }
+
+    // ---- Lifecycle ----
+
+    /**
+     * @notice Stores a user-signed swap intent for `safe` together with the BE-supplied Enso
+     *         `router`-strategy calldata, and places a CashModule solvency hold for the source
+     *         amount (if cashModule is installed on this chain). `executeSwap` later replays
+     *         exactly what is stored here.
+     * @dev One active swap per safe; re-requesting requires cancel-or-execute first. The user
+     *      signs over the FULL request — `order` AND the Enso `swapData` — so the keeper cannot
+     *      substitute a different swap payload at `executeSwap` than the user authorised.
+     */
+    function requestSwap(
+        address safe,
+        Order calldata order,
+        bytes calldata swapData,
+        address[] calldata signers,
+        bytes[] calldata signatures
+    ) external whenNotPaused onlyEtherFiSafe(safe) {
+        _validateRequest(safe, order, swapData);
+
+        uint256 nonce = IEtherFiSafe(safe).useNonce();
+        _verifyRequestSignature(safe, order, swapData, nonce, signers, signatures);
+        _storeAndDispatch(safe, order, swapData, nonce);
+    }
+
+    /// @dev Shared request validation, split out to keep `requestSwap` under the legacy stack limit.
+    function _validateRequest(address safe, Order calldata order, bytes calldata swapData) internal view {
+        EnsoSwapModuleStorage storage $ = _getEnsoSwapModuleStorage();
+        if (swapData.length == 0) revert EmptySwapData();
+        if (
+            order.srcToken == address(0) || order.srcAmount == 0 ||
+            order.recipient == address(0) || order.deadline <= block.timestamp
+        ) revert InvalidInput();
+        if ($.swaps[safe].order.srcToken != address(0)) revert OrderAlreadyActive();
+        if ($.ensoRouter == address(0)) revert MissingConfig();
+    }
+
+    /// @dev Stores the verified swap and either places the CashModule hold (OP) or executes
+    ///      immediately (mainnet, where `cashModule == 0`).
+    function _storeAndDispatch(address safe, Order calldata order, bytes calldata swapData, uint256 nonce) internal {
+        EnsoSwapModuleStorage storage $ = _getEnsoSwapModuleStorage();
+        bytes32 swapId = keccak256(abi.encode(block.chainid, address(this), safe, nonce, order));
+        $.swaps[safe] = StoredSwap({ order: order, swapData: swapData, swapId: swapId });
+
+        _emitSwapRequested(safe, swapId, order);
+
+        if (address(cashModule) != address(0)) {
+            cashModule.requestWithdrawalByModule(safe, order.srcToken, order.srcAmount);
+        } else {
+            executeSwap(safe);
+        }
+    }
+
+    function _emitSwapRequested(address safe, bytes32 swapId, Order calldata order) internal {
+        emit SwapRequested(
+            safe,
+            swapId,
+            order.srcToken,
+            order.srcAmount,
+            order.dstChainId,
+            order.dstToken,
+            order.recipient,
+            order.minOut,
+            order.deadline
+        );
+    }
+
+    /**
+     * @notice Executes the stored swap for `safe`. Takes only the safe address: it reads the
+     *         order and Enso calldata captured at `requestSwap`, releases the solvency hold,
+     *         and drives the safe to approve the pinned Enso Router and forward the calldata.
+     * @dev Permissionless: it only replays the swap the user already signed at `requestSwap`
+     *      (order + swapData are both bound into that signature), so any caller can do no more
+     *      than execute exactly what the user authorised. Meant to be called after the
+     *      CashModule withdrawal delay matures.
+     */
+    function executeSwap(address safe) public nonReentrant whenNotPaused onlyEtherFiSafe(safe) {
+        EnsoSwapModuleStorage storage $ = _getEnsoSwapModuleStorage();
+        StoredSwap memory swap = $.swaps[safe];
+        if (swap.order.srcToken == address(0)) revert NoActiveOrder();
+        if (block.timestamp > swap.order.deadline) revert OrderExpired();
+        if ($.ensoRouter == address(0)) revert MissingConfig();
+
+        if (address(cashModule) != address(0)) {
+            if (block.timestamp < cashModule.getData(safe).pendingWithdrawalRequest.finalizeTime) {
+                revert WithdrawalDelayNotElapsed();
+            }
+        }
+
+        delete $.swaps[safe];
+        if (address(cashModule) != address(0)) cashModule.cancelWithdrawalByModule(safe);
+
+        _dispatchSwap(safe, swap);
+
+        emit SwapExecuted(safe, swap.swapId, swap.order.dstChainId, swap.order.dstToken, swap.order.minOut);
+    }
+
+    /// @dev Approve the pinned Enso Router for the input token, forward the signed Enso calldata
+    ///      verbatim, then reset the approval to zero. The safe is the router's caller, so it
+    ///      pulls the input token from the safe and (per the BE-built `swapData`) swaps and/or
+    ///      bridges to the recipient encoded in the calldata.
+    function _dispatchSwap(address safe, StoredSwap memory swap) internal {
+        address ensoRouter = _getEnsoSwapModuleStorage().ensoRouter;
+
+        address[] memory to = new address[](3);
+        uint256[] memory values = new uint256[](3);
+        bytes[] memory data = new bytes[](3);
+
+        to[0] = swap.order.srcToken;
+        data[0] = abi.encodeCall(IERC20.approve, (ensoRouter, swap.order.srcAmount));
+        to[1] = ensoRouter;
+        data[1] = swap.swapData;
+        to[2] = swap.order.srcToken;
+        data[2] = abi.encodeCall(IERC20.approve, (ensoRouter, 0));
+
+        IEtherFiSafe(safe).execTransactionFromModule(to, values, data);
+    }
+
+    /**
+     * @notice Cancels the stored swap for `safe`. Delegates to `cancelWithdrawalByModule` on
+     *         `cashModule` which calls back into `cancelBridgeByCashModule` — that callback
+     *         clears state and emits.
+     * @dev Signed by the safe's owners (same threshold as `requestSwap`). The user's BE-down
+     *      escape hatch. Where `cashModule == 0` clears state directly.
+     */
+    function cancelSwap(address safe, address[] calldata signers, bytes[] calldata signatures) external nonReentrant onlyEtherFiSafe(safe) {
+        EnsoSwapModuleStorage storage $ = _getEnsoSwapModuleStorage();
+        if ($.swaps[safe].order.srcToken == address(0)) revert NoActiveOrder();
+
+        bytes32 digest = keccak256(
+            abi.encodePacked(CANCEL_SWAP_SIG, block.chainid, address(this), IEtherFiSafe(safe).useNonce(), safe)
+        ).toEthSignedMessageHash();
+        if (!IEtherFiSafe(safe).checkSignatures(digest, signers, signatures)) revert InvalidSignatures();
+
+        bytes32 swapId = $.swaps[safe].swapId;
+        if (address(cashModule) != address(0)) {
+            cashModule.cancelWithdrawalByModule(safe);
+        } else {
+            // When cashModule is set, cancelWithdrawalByModule calls cancelBridgeByCashModule
+            // which clears the swap; where cashModule == 0 we clear it here directly.
+            delete $.swaps[safe];
+            emit SwapCancelled(safe, swapId);
+        }
+    }
+
+    /**
+     * @notice Hook called by `CashModule.cancelWithdrawalByModule` to keep our state in sync.
+     *         Clears the stored swap and emits if one is still present. No-op if already
+     *         cleared (`executeSwap` deletes its own swap before calling the cancel hook).
+     */
+    function cancelBridgeByCashModule(address safe) external override {
+        if (msg.sender != address(cashModule)) revert Unauthorized();
+        EnsoSwapModuleStorage storage $ = _getEnsoSwapModuleStorage();
+        if ($.swaps[safe].order.srcToken == address(0)) return;
+        bytes32 swapId = $.swaps[safe].swapId;
+        delete $.swaps[safe];
+        emit SwapCancelled(safe, swapId);
+    }
+
+    // ---- Internals ----
+
+    /// @dev Verifies the user's signature over the FULL request — the order AND the Enso
+    ///      `swapData` — consuming a safe nonce so a signed request can't replay. Binding
+    ///      `swapData` means the keeper cannot substitute a different swap payload than the
+    ///      user actually authorised.
+    function _verifyRequestSignature(
+        address safe,
+        Order calldata order,
+        bytes calldata swapData,
+        uint256 nonce,
+        address[] calldata signers,
+        bytes[] calldata signatures
+    ) internal view {
+        bytes32 digest = _requestDigest(safe, order, swapData, nonce);
+        if (!IEtherFiSafe(safe).checkSignatures(digest, signers, signatures)) revert InvalidSignatures();
+    }
+
+    /// @dev Digest the safe owners sign over the FULL request (order + swapData), bound to the safe nonce.
+    function _requestDigest(address safe, Order calldata order, bytes calldata swapData, uint256 nonce) internal view returns (bytes32) {
+        return keccak256(
+            abi.encodePacked(
+                REQUEST_SWAP_SIG,
+                block.chainid,
+                address(this),
+                nonce,
+                safe,
+                abi.encode(order),
+                keccak256(swapData)
+            )
+        ).toEthSignedMessageHash();
+    }
+
+    function _onlyAdmin() internal view {
+        if (!IRoleRegistry(etherFiDataProvider.roleRegistry()).hasRole(ENSO_SWAP_MODULE_ADMIN_ROLE, msg.sender)) revert OnlyAdmin();
+    }
+
+    function _getEnsoSwapModuleStorage() internal pure returns (EnsoSwapModuleStorage storage $) {
+        assembly {
+            $.slot := EnsoSwapModuleStorageLocation
+        }
+    }
+}

--- a/test/enso/EnsoSwapModule.t.sol
+++ b/test/enso/EnsoSwapModule.t.sol
@@ -1,0 +1,419 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { Vm } from "forge-std/Vm.sol";
+
+import { EnsoSwapModule } from "../../src/enso/EnsoSwapModule.sol";
+import { ModuleBase } from "../../src/modules/ModuleBase.sol";
+import { UpgradeableProxy } from "../../src/utils/UpgradeableProxy.sol";
+import { UUPSProxy } from "../../src/UUPSProxy.sol";
+import { SafeTestSetup } from "../safe/SafeTestSetup.t.sol";
+
+/// @dev Mock Enso Router for the forward-calldata path: when called with the encoded
+///      `swap(token, amount)`, it pulls `amount` of `token` from the caller (the safe),
+///      recording the pull so the test can assert the approve->call->reset flow.
+contract EnsoRouterStub {
+    address public lastCaller;
+    uint256 public pulled;
+    uint256 public callCount;
+
+    function swap(address token, uint256 amount) external {
+        lastCaller = msg.sender;
+        IERC20(token).transferFrom(msg.sender, address(this), amount);
+        pulled = amount;
+        callCount++;
+    }
+}
+
+contract EnsoSwapModuleTest is SafeTestSetup {
+    using MessageHashUtils for bytes32;
+
+    EnsoSwapModule internal module;
+    EnsoRouterStub internal ensoRouter;
+    address internal keeper = makeAddr("keeper");
+    address internal moduleAdmin = makeAddr("moduleAdmin");
+    address internal recipient = makeAddr("recipient");
+
+    uint256 internal constant DST_CHAIN = 1;
+    uint256 internal constant SRC_AMOUNT = 1_000e6;
+    uint256 internal constant MIN_OUT = 990_000_000_000_000;
+
+    function setUp() public override {
+        super.setUp();
+
+        ensoRouter = new EnsoRouterStub();
+        address moduleImpl = address(new EnsoSwapModule(address(dataProvider)));
+        module = EnsoSwapModule(address(new UUPSProxy(
+            moduleImpl,
+            abi.encodeWithSelector(
+                EnsoSwapModule.initialize.selector,
+                address(roleRegistry),
+                address(ensoRouter)
+            )
+        )));
+
+        address[] memory mods = new address[](1);
+        mods[0] = address(module);
+        bool[] memory shouldWhitelist = new bool[](1);
+        shouldWhitelist[0] = true;
+
+        vm.startPrank(owner);
+        dataProvider.configureModules(mods, shouldWhitelist);
+        cashModule.configureModulesCanRequestWithdraw(mods, shouldWhitelist);
+
+        roleRegistry.grantRole(module.ENSO_SWAP_MODULE_ADMIN_ROLE(), moduleAdmin);
+        vm.stopPrank();
+
+        bytes[] memory setupData = new bytes[](1);
+        _configureModules(mods, shouldWhitelist, setupData);
+
+        deal(address(usdc), address(safe), SRC_AMOUNT);
+    }
+
+    // ---- Admin setter ----
+
+    function test_setEnsoRouter_revertsForNonAdmin() public {
+        vm.expectRevert(EnsoSwapModule.OnlyAdmin.selector);
+        module.setEnsoRouter(address(ensoRouter));
+    }
+
+    function test_setEnsoRouter_revertsForZero() public {
+        vm.prank(moduleAdmin);
+        vm.expectRevert(ModuleBase.InvalidInput.selector);
+        module.setEnsoRouter(address(0));
+    }
+
+    function test_setEnsoRouter_storesAndEmits() public {
+        address newAddr = makeAddr("newEnsoRouter");
+        vm.expectEmit(false, false, false, true, address(module));
+        emit EnsoSwapModule.EnsoRouterSet(address(ensoRouter), newAddr);
+        vm.prank(moduleAdmin);
+        module.setEnsoRouter(newAddr);
+        assertEq(module.getEnsoRouter(), newAddr);
+    }
+
+    function test_initialize_revertsOnZeroConfig() public {
+        address impl = address(new EnsoSwapModule(address(dataProvider)));
+        vm.expectRevert(ModuleBase.InvalidInput.selector);
+        new UUPSProxy(impl, abi.encodeWithSelector(
+            EnsoSwapModule.initialize.selector,
+            address(roleRegistry), address(0)
+        ));
+    }
+
+    // ---- requestSwap ----
+
+    function test_requestSwap_storesSwapAndPlacesHold() public {
+        EnsoSwapModule.Order memory order = _baseOrder();
+        bytes memory swapData = _swapData(SRC_AMOUNT);
+        (address[] memory signers, bytes[] memory sigs) = _signRequest(order, swapData);
+        module.requestSwap(address(safe), order, swapData, signers, sigs);
+
+        assertEq(module.getOrder(address(safe)).srcAmount, SRC_AMOUNT);
+        // The Enso calldata is captured at request for executeSwap to replay verbatim.
+        assertEq(module.getSwap(address(safe)).swapData, swapData);
+        assertEq(cashModule.getData(address(safe)).pendingWithdrawalRequest.recipient, address(module));
+    }
+
+    function test_requestSwap_revertsOnEmptySwapData() public {
+        EnsoSwapModule.Order memory order = _baseOrder();
+        (address[] memory signers, bytes[] memory sigs) = _signRequest(order, "");
+        vm.expectRevert(EnsoSwapModule.EmptySwapData.selector);
+        module.requestSwap(address(safe), order, "", signers, sigs);
+    }
+
+    function test_requestSwap_revertsOnInvalidInput() public {
+        EnsoSwapModule.Order memory order = _baseOrder();
+        order.srcAmount = 0;
+        bytes memory swapData = _swapData(SRC_AMOUNT);
+        (address[] memory signers, bytes[] memory sigs) = _signRequest(order, swapData);
+        vm.expectRevert(ModuleBase.InvalidInput.selector);
+        module.requestSwap(address(safe), order, swapData, signers, sigs);
+    }
+
+    function test_requestSwap_revertsForExpiredDeadline() public {
+        EnsoSwapModule.Order memory order = _baseOrder();
+        order.deadline = block.timestamp;
+        bytes memory swapData = _swapData(SRC_AMOUNT);
+        (address[] memory signers, bytes[] memory sigs) = _signRequest(order, swapData);
+        vm.expectRevert(ModuleBase.InvalidInput.selector);
+        module.requestSwap(address(safe), order, swapData, signers, sigs);
+    }
+
+    function test_requestSwap_revertsForBadSignature() public {
+        EnsoSwapModule.Order memory order = _baseOrder();
+        EnsoSwapModule.Order memory tampered = _baseOrder();
+        tampered.srcAmount = SRC_AMOUNT + 1;
+        bytes memory swapData = _swapData(SRC_AMOUNT);
+        (address[] memory signers, bytes[] memory sigs) = _signRequest(tampered, swapData);
+        vm.expectRevert(EnsoSwapModule.InvalidSignatures.selector);
+        module.requestSwap(address(safe), order, swapData, signers, sigs);
+    }
+
+    function test_requestSwap_revertsWhenOrderAlreadyActive() public {
+        EnsoSwapModule.Order memory order = _baseOrder();
+        _request(order);
+
+        bytes memory swapData = _swapData(SRC_AMOUNT);
+        (address[] memory s2, bytes[] memory si2) = _signRequest(order, swapData);
+        vm.expectRevert(EnsoSwapModule.OrderAlreadyActive.selector);
+        module.requestSwap(address(safe), order, swapData, s2, si2);
+    }
+
+    // ---- executeSwap ----
+
+    function test_executeSwap_dispatchesApproveCallReset() public {
+        EnsoSwapModule.Order memory order = _baseOrder();
+        _request(order);
+        _warpPastDelay();
+
+        _executeAsKeeper();
+
+        assertEq(ensoRouter.callCount(), 1);
+        assertEq(ensoRouter.pulled(), SRC_AMOUNT);
+        assertEq(ensoRouter.lastCaller(), address(safe));
+        assertEq(module.getOrder(address(safe)).srcToken, address(0));
+        assertEq(cashModule.getData(address(safe)).pendingWithdrawalRequest.recipient, address(0));
+        // Approval is reset to zero after forwarding the swap.
+        assertEq(usdc.allowance(address(safe), address(ensoRouter)), 0);
+    }
+
+    function test_executeSwap_permissionless_anyCallerCanExecute() public {
+        _request(_baseOrder());
+        _warpPastDelay();
+
+        // No role required: an arbitrary caller can execute the user-signed stored swap.
+        vm.prank(makeAddr("randomCaller"));
+        module.executeSwap(address(safe));
+
+        assertEq(ensoRouter.callCount(), 1);
+        assertEq(module.getOrder(address(safe)).srcToken, address(0), "order not cleared");
+    }
+
+    function test_executeSwap_revertsForNoActiveOrder() public {
+        _expectExecuteRevert(EnsoSwapModule.NoActiveOrder.selector, keeper);
+    }
+
+    function test_executeSwap_revertsAfterDeadline() public {
+        EnsoSwapModule.Order memory order = _baseOrder();
+        _request(order);
+        vm.warp(order.deadline + 1);
+        _expectExecuteRevert(EnsoSwapModule.OrderExpired.selector, keeper);
+    }
+
+    function test_executeSwap_revertsBeforeWithdrawalDelayMatures() public {
+        _request(_baseOrder());
+        _expectExecuteRevert(EnsoSwapModule.WithdrawalDelayNotElapsed.selector, keeper);
+    }
+
+    // ---- cancelSwap ----
+
+    function test_cancelSwap_clearsOrderAndHold() public {
+        _request(_baseOrder());
+
+        (address[] memory signers, bytes[] memory sigs) = _signCancel();
+        // Match the safe topic only; swapId is asserted in the dedicated linking tests.
+        vm.expectEmit(true, false, false, false);
+        emit EnsoSwapModule.SwapCancelled(address(safe), bytes32(0));
+        module.cancelSwap(address(safe), signers, sigs);
+
+        assertEq(module.getOrder(address(safe)).srcToken, address(0));
+        assertEq(cashModule.getData(address(safe)).pendingWithdrawalRequest.recipient, address(0));
+    }
+
+    function test_cancelSwap_revertsForNoActiveOrder() public {
+        (address[] memory signers, bytes[] memory sigs) = _signCancel();
+        vm.expectRevert(EnsoSwapModule.NoActiveOrder.selector);
+        module.cancelSwap(address(safe), signers, sigs);
+    }
+
+    function test_cancelSwap_revertsForBadSig() public {
+        _request(_baseOrder());
+
+        address[] memory signers = new address[](2);
+        signers[0] = owner1;
+        signers[1] = owner2;
+        bytes[] memory sigs = new bytes[](2);
+        bytes32 baddigest = keccak256("not the right digest").toEthSignedMessageHash();
+        (uint8 v1, bytes32 r1, bytes32 s1) = vm.sign(owner1Pk, baddigest);
+        (uint8 v2, bytes32 r2, bytes32 s2) = vm.sign(owner2Pk, baddigest);
+        sigs[0] = abi.encodePacked(r1, s1, v1);
+        sigs[1] = abi.encodePacked(r2, s2, v2);
+
+        vm.expectRevert(EnsoSwapModule.InvalidSignatures.selector);
+        module.cancelSwap(address(safe), signers, sigs);
+    }
+
+    // ---- swapId linking ----
+
+    /// @dev The swapId committed at request time is `keccak256(chainid, module, safe, nonce, order)`.
+    function _expectedSwapId(EnsoSwapModule.Order memory order, uint256 nonce) internal view returns (bytes32) {
+        return keccak256(abi.encode(block.chainid, address(module), address(safe), nonce, order));
+    }
+
+    /// @dev Pull the `swapId` topic (topic[2]) of the first recorded log matching `sig`.
+    ///      Event topic layout is `[sig, safe, swapId]` for all three lifecycle events.
+    function _swapIdFromLogs(bytes32 sig) internal returns (bytes32) {
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].topics.length >= 3 && logs[i].topics[0] == sig) return logs[i].topics[2];
+        }
+        revert("event not found");
+    }
+
+    function test_requestSwap_storesAndEmitsSwapId() public {
+        EnsoSwapModule.Order memory order = _baseOrder();
+        bytes32 expected = _expectedSwapId(order, safe.nonce());
+
+        vm.recordLogs();
+        _request(order);
+
+        assertEq(module.getSwap(address(safe)).swapId, expected, "stored swapId");
+        assertEq(_swapIdFromLogs(EnsoSwapModule.SwapRequested.selector), expected, "emitted SwapRequested swapId");
+    }
+
+    function test_executeSwap_emitsSameSwapIdAsRequest() public {
+        _request(_baseOrder());
+        bytes32 stored = module.getSwap(address(safe)).swapId;
+        _warpPastDelay();
+
+        vm.recordLogs();
+        _executeAsKeeper();
+
+        assertEq(_swapIdFromLogs(EnsoSwapModule.SwapExecuted.selector), stored, "execute swapId links to request");
+    }
+
+    function test_cancelSwap_emitsSameSwapIdAsRequest() public {
+        _request(_baseOrder());
+        bytes32 stored = module.getSwap(address(safe)).swapId;
+
+        (address[] memory signers, bytes[] memory sigs) = _signCancel();
+        vm.recordLogs();
+        module.cancelSwap(address(safe), signers, sigs);
+
+        assertEq(_swapIdFromLogs(EnsoSwapModule.SwapCancelled.selector), stored, "cancel swapId links to request");
+    }
+
+    function test_cancelBridgeByCashModule_emitsSameSwapIdAsRequest() public {
+        _request(_baseOrder());
+        bytes32 stored = module.getSwap(address(safe)).swapId;
+
+        vm.recordLogs();
+        vm.prank(address(cashModule));
+        module.cancelBridgeByCashModule(address(safe));
+
+        assertEq(_swapIdFromLogs(EnsoSwapModule.SwapCancelled.selector), stored, "cancelBridge swapId links to request");
+    }
+
+    /// @dev Two sequential swaps for the same safe must get distinct ids (the nonce advances).
+    function test_swapId_distinctAcrossSequentialSwaps() public {
+        bytes32 firstId = _firstSwapIdThenCancel();
+        bytes32 secondId = _firstSwapIdThenCancel();
+        assertTrue(firstId != bytes32(0), "first id set");
+        assertTrue(firstId != secondId, "sequential swaps get distinct ids");
+    }
+
+    function _firstSwapIdThenCancel() internal returns (bytes32 id) {
+        _request(_baseOrder());
+        id = module.getSwap(address(safe)).swapId;
+        (address[] memory signers, bytes[] memory sigs) = _signCancel();
+        module.cancelSwap(address(safe), signers, sigs);
+    }
+
+    // ---- cancelBridgeByCashModule ----
+
+    function test_cancelBridgeByCashModule_clearsOrderOnly() public {
+        _request(_baseOrder());
+
+        vm.prank(address(cashModule));
+        module.cancelBridgeByCashModule(address(safe));
+
+        assertEq(module.getOrder(address(safe)).srcToken, address(0));
+    }
+
+    function test_cancelBridgeByCashModule_revertsForNonCashModule() public {
+        vm.expectRevert(UpgradeableProxy.Unauthorized.selector);
+        module.cancelBridgeByCashModule(address(safe));
+    }
+
+    // ---- Helpers ----
+
+    function _baseOrder() internal returns (EnsoSwapModule.Order memory) {
+        return EnsoSwapModule.Order({
+            srcToken: address(usdc),
+            srcAmount: SRC_AMOUNT,
+            dstChainId: DST_CHAIN,
+            dstToken: makeAddr("dstToken"),
+            recipient: recipient,
+            minOut: MIN_OUT,
+            deadline: block.timestamp + 1 hours
+        });
+    }
+
+    /// @dev Enso calldata the mock router understands: pull `amount` of usdc from the safe.
+    function _swapData(uint256 amount) internal view returns (bytes memory) {
+        return abi.encodeWithSelector(EnsoRouterStub.swap.selector, address(usdc), amount);
+    }
+
+    function _signRequest(EnsoSwapModule.Order memory order, bytes memory swapData)
+        internal view returns (address[] memory, bytes[] memory)
+    {
+        bytes32 digest = keccak256(abi.encodePacked(
+            keccak256("EnsoSwapModule.requestSwap"),
+            block.chainid,
+            address(module),
+            safe.nonce(),
+            address(safe),
+            abi.encode(order),
+            keccak256(swapData)
+        )).toEthSignedMessageHash();
+        return _twoSig(digest);
+    }
+
+    function _signCancel() internal view returns (address[] memory, bytes[] memory) {
+        bytes32 digest = keccak256(abi.encodePacked(
+            keccak256("EnsoSwapModule.cancelSwap"),
+            block.chainid,
+            address(module),
+            safe.nonce(),
+            address(safe)
+        )).toEthSignedMessageHash();
+        return _twoSig(digest);
+    }
+
+    function _twoSig(bytes32 digest) internal view returns (address[] memory, bytes[] memory) {
+        address[] memory signers = new address[](2);
+        signers[0] = owner1;
+        signers[1] = owner2;
+        bytes[] memory sigs = new bytes[](2);
+        (uint8 v1, bytes32 r1, bytes32 s1) = vm.sign(owner1Pk, digest);
+        (uint8 v2, bytes32 r2, bytes32 s2) = vm.sign(owner2Pk, digest);
+        sigs[0] = abi.encodePacked(r1, s1, v1);
+        sigs[1] = abi.encodePacked(r2, s2, v2);
+        return (signers, sigs);
+    }
+
+    function _request(EnsoSwapModule.Order memory order) internal {
+        bytes memory swapData = _swapData(SRC_AMOUNT);
+        (address[] memory signers, bytes[] memory sigs) = _signRequest(order, swapData);
+        module.requestSwap(address(safe), order, swapData, signers, sigs);
+    }
+
+    function _warpPastDelay() internal {
+        (uint64 withdrawalDelay, , ) = cashModule.getDelays();
+        vm.warp(block.timestamp + withdrawalDelay + 1);
+    }
+
+    function _executeAsKeeper() internal {
+        vm.prank(keeper);
+        module.executeSwap(address(safe));
+    }
+
+    function _expectExecuteRevert(bytes4 selector, address caller) internal {
+        vm.prank(caller);
+        vm.expectRevert(selector);
+        module.executeSwap(address(safe));
+    }
+}


### PR DESCRIPTION
## Summary
Adds an `EnsoSwapModule` alongside the existing `AcrossSwapModule`, mirroring its request/execute lifecycle but forwarding **BE-supplied Enso router calldata** verbatim. This unlocks **same-chain asset-to-asset swaps** (e.g. sell an ETH-mainnet asset for another ETH-mainnet asset), which Across cannot serve since `depositV3` reverts on same-chain routes. The Enso `router` strategy also still supports cross-chain, so this is a superset of the Across swap surface.