### PR TITLE
feat: route each safe between legacy and Aave gateway engines

### DIFF
--- a/scripts/DeployLiquidationHelper.s.sol
+++ b/scripts/DeployLiquidationHelper.s.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {stdJson} from "forge-std/StdJson.sol";
+
+import { CashLiquidationHelper } from "../src/modules/cash/CashLiquidationHelper.sol";
+import {Utils, ChainConfig} from "./utils/Utils.sol";
+
+contract DeployLiquidationHelper is Utils {
+    CashLiquidationHelper liquidationHelper;
+
+    address public eUsd = 0x939778D83b46B456224A33Fb59630B11DEC56663;
+
+    function run() public {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        string memory deployments = readDeploymentFile();
+
+        address debtManager = stdJson.readAddress(
+            deployments,
+            string.concat(".", "addresses", ".", "DebtManager")
+        );
+
+        
+        liquidationHelper = new CashLiquidationHelper(debtManager, eUsd);
+        vm.stopBroadcast();
+    }    
+}

--- a/src/debt-manager/DebtManagerCore.sol
+++ b/src/debt-manager/DebtManagerCore.sol
@@ -513,6 +513,79 @@ contract DebtManagerCore is DebtManagerStorageContract {
     }
 
     /**
+     * @notice Liquidates an unhealthy position
+     * @dev Can liquidate up to 50% of the debt in first attempt, and remainder if still unhealthy
+     * @param user Address of the user to liquidate
+     * @param borrowToken Address of the borrow token to repay
+     * @param collateralTokensPreference Order of preference for collateral tokens to liquidate
+     */
+    function liquidate(address user, address borrowToken, address[] memory collateralTokensPreference) external whenNotPaused nonReentrant whenNotMigrated(user) {
+        if (collateralTokensPreference.length == 0) revert CollateralPreferenceIsEmpty();
+        _updateInterestIndex(borrowToken);
+        uint256 interestIndex = _getDebtManagerStorage().borrowTokenConfig[borrowToken].interestIndexSnapshot;
+        if (!isBorrowToken(borrowToken)) revert UnsupportedBorrowToken();
+        if (!liquidatable(user)) revert CannotLiquidateYet();
+
+        _liquidateUser(user, borrowToken, collateralTokensPreference, interestIndex);
+    }
+
+    /**
+     * @dev Liquidates a user's position
+     * @param user Address of the user to liquidate
+     * @param borrowToken Address of the borrow token to repay
+     * @param collateralTokensPreference Order of preference for collateral tokens to liquidate
+     */
+    function _liquidateUser(address user, address borrowToken, address[] memory collateralTokensPreference, uint256 interestIndex) internal {
+        DebtManagerStorage storage $ = _getDebtManagerStorage();
+
+        uint256 debtAmountToLiquidateInUsd = _getActualBorrowAmount($.userNormalizedBorrowings[user][borrowToken].ceilDiv(2), interestIndex);
+        _liquidate(user, borrowToken, collateralTokensPreference, debtAmountToLiquidateInUsd, interestIndex);
+
+        uint256 remainingNormalizedBorrowAmt = $.userNormalizedBorrowings[user][borrowToken];
+        if (remainingNormalizedBorrowAmt > 0 && liquidatable(user)) {
+            debtAmountToLiquidateInUsd = _getActualBorrowAmount(remainingNormalizedBorrowAmt, interestIndex);
+            _liquidate(user, borrowToken, collateralTokensPreference, debtAmountToLiquidateInUsd, interestIndex);
+
+            // If there's still 1 wei left due to rounding, force it to zero
+            remainingNormalizedBorrowAmt = $.userNormalizedBorrowings[user][borrowToken];
+            if (remainingNormalizedBorrowAmt == 1) {
+                $.userNormalizedBorrowings[user][borrowToken] = 0;
+                $.borrowTokenConfig[borrowToken].totalNormalizedBorrowingAmount -= 1;
+            }
+        }
+    }
+
+    /**
+     * @dev Executes the liquidation process
+     * @param user Address of the user to liquidate
+     * @param borrowToken Address of the borrow token to repay
+     * @param collateralTokensPreference Order of preference for collateral tokens to liquidate
+     * @param debtAmountToLiquidateInUsd Amount of debt to liquidate in USD with 6 decimals
+     */
+    function _liquidate(address user, address borrowToken, address[] memory collateralTokensPreference, uint256 debtAmountToLiquidateInUsd, uint256 interestIndex) internal {
+        DebtManagerStorage storage $ = _getDebtManagerStorage();
+        ICashModule cashModule = ICashModule(etherFiDataProvider.getCashModule());
+
+        cashModule.preLiquidate(user);
+        if (debtAmountToLiquidateInUsd == 0) revert LiquidatableAmountIsZero();
+
+        uint256 beforeDebtAmount = _getActualBorrowAmount($.userNormalizedBorrowings[user][borrowToken], interestIndex);
+
+        (IDebtManager.LiquidationTokenData[] memory collateralTokensToSend, uint256 remainingDebt) = _getCollateralTokensForDebtAmount(user, debtAmountToLiquidateInUsd, collateralTokensPreference);
+
+        cashModule.postLiquidate(user, msg.sender, collateralTokensToSend);
+
+        uint256 liquidatedAmt = debtAmountToLiquidateInUsd - remainingDebt;
+        uint256 normalizedLiquidatedAmount = _getNormalizedAmount(liquidatedAmt, interestIndex, Math.Rounding.Floor);
+        $.userNormalizedBorrowings[user][borrowToken] -= normalizedLiquidatedAmount;
+        $.borrowTokenConfig[borrowToken].totalNormalizedBorrowingAmount -= normalizedLiquidatedAmount;
+
+        IERC20(borrowToken).safeTransferFrom(msg.sender, address(this), convertUsdToCollateralToken(borrowToken, liquidatedAmt));
+
+        emit Liquidated(msg.sender, user, borrowToken, collateralTokensToSend, beforeDebtAmount, liquidatedAmt);
+    }
+
+    /**
      * @dev Processes repayment with borrow token
      * @param token Address of the token being repaid
      * @param user Address of the user whose debt is being repaid
@@ -528,6 +601,61 @@ contract DebtManagerCore is DebtManagerStorageContract {
         IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
 
         emit Repaid(user, msg.sender, token, repayDebtusdAmount);
+    }
+
+    /**
+     * @dev Calculates collateral tokens needed to cover a debt amount
+     * @param user Address of the user being liquidated
+     * @param repayDebtUsdAmt Debt amount to cover in USD with 6 decimals
+     * @param collateralTokenPreference Order of preference for collateral tokens
+     * @return Array of liquidation token data
+     * @return Remaining debt that could not be covered
+     */
+    function _getCollateralTokensForDebtAmount(address user, uint256 repayDebtUsdAmt, address[] memory collateralTokenPreference) internal view returns (IDebtManager.LiquidationTokenData[] memory, uint256) {
+        DebtManagerStorage storage $ = _getDebtManagerStorage();
+        uint256 len = collateralTokenPreference.length;
+        IDebtManager.LiquidationTokenData[] memory collateral = new IDebtManager.LiquidationTokenData[](len);
+
+        for (uint256 i = 0; i < len;) {
+            address collateralToken = collateralTokenPreference[i];
+            if (!isCollateralToken(collateralToken)) revert NotACollateralToken();
+
+            uint256 collateralAmountForDebt = convertUsdToCollateralToken(collateralToken, repayDebtUsdAmt);
+            uint256 totalCollateral = IERC20(collateralToken).balanceOf(user);
+
+            uint256 netCollateralRepayValue = (totalCollateral * HUNDRED_PERCENT) / (HUNDRED_PERCENT + $.collateralTokenConfig[collateralToken].liquidationBonus);
+            uint256 maxBonus = totalCollateral - netCollateralRepayValue;
+
+            if (totalCollateral - maxBonus < collateralAmountForDebt) {
+                uint256 liquidationBonus = maxBonus;
+                collateral[i] = IDebtManager.LiquidationTokenData({ token: collateralToken, amount: totalCollateral, liquidationBonus: liquidationBonus });
+
+                uint256 usdValueOfCollateral = convertCollateralTokenToUsd(collateralToken, totalCollateral - liquidationBonus);
+
+                repayDebtUsdAmt -= usdValueOfCollateral;
+            } else {
+                uint256 liquidationBonus = (collateralAmountForDebt * $.collateralTokenConfig[collateralToken].liquidationBonus) / HUNDRED_PERCENT;
+
+                collateral[i] = IDebtManager.LiquidationTokenData({ token: collateralToken, amount: collateralAmountForDebt + liquidationBonus, liquidationBonus: liquidationBonus });
+
+                repayDebtUsdAmt = 0;
+            }
+
+            if (repayDebtUsdAmt == 0) {
+                uint256 arrLen = i + 1;
+                assembly ("memory-safe") {
+                    mstore(collateral, arrLen)
+                }
+
+                break;
+            }
+
+            unchecked {
+                ++i;
+            }
+        }
+
+        return (collateral, repayDebtUsdAmt);
     }
 
     /**
@@ -590,16 +718,18 @@ contract DebtManagerCore is DebtManagerStorageContract {
             }
         }
 
-        // 3. Supply all of the Safe's collateral into Aave, enabled as collateral (Safe is now debt-free on
+        // 3. Supply the Safe's collateral into Aave, enabled as collateral (Safe is now debt-free on
         //    DebtManager, so the hook's health check passes as the collateral moves). This runs even for a
         //    debt-free Safe: once migrated, credit spends borrow against the Aave position, so the collateral
         //    must actually move to Aave rather than sit idle in the Safe. Skipped for a lend-disabled safe,
-        //    which keeps its funds idle in the Safe by choice.
+        //    which keeps its funds idle in the Safe by choice. Amounts reserved by a pending withdrawal stay
+        //    loose in the Safe: the queued withdrawal is a plain transfer of the Safe's balance, so supplying
+        //    them would brick it. Pending withdrawals reserve funds; migration must not outrank them.
         if (lendEnabled) {
             address[] memory collateralTokens = getCollateralTokens();
             uint256 cLen = collateralTokens.length;
             for (uint256 i = 0; i < cLen;) {
-                uint256 bal = IERC20(collateralTokens[i]).balanceOf(safe);
+                uint256 bal = _suppliableBalance(cashModule, safe, collateralTokens[i]);
                 if (bal != 0) {
                     _gateway.supply(safe, collateralTokens[i], bal);
                     _gateway.setUsingAsCollateral(safe, collateralTokens[i], true);
@@ -625,7 +755,17 @@ contract DebtManagerCore is DebtManagerStorageContract {
         }
 
         $.migratedToAave[safe] = true;
+        // Flip the CashModule routing flag in the same tx, so the freeze latch here and the routing of
+        // spend/repay/lens can never disagree about which engine serves the Safe.
+        cashModule.markAaveGatewaySafe(safe);
         emit MigratedToAave(safe, totalDebtUsd);
+    }
+
+    /// @dev A Safe's balance of `token` minus what a pending withdrawal has reserved - the amount migration may supply
+    function _suppliableBalance(ICashModule cashModule, address safe, address token) internal view returns (uint256) {
+        uint256 bal = IERC20(token).balanceOf(safe);
+        uint256 reserved = cashModule.getPendingWithdrawalAmount(safe, token);
+        return bal > reserved ? bal - reserved : 0;
     }
 
     /**

--- a/src/debt-manager/DebtManagerCore.sol
+++ b/src/debt-manager/DebtManagerCore.sol
@@ -757,7 +757,7 @@ contract DebtManagerCore is DebtManagerStorageContract {
         $.migratedToAave[safe] = true;
         // Flip the CashModule routing flag in the same tx, so the freeze latch here and the routing of
         // spend/repay/lens can never disagree about which engine serves the Safe.
-        cashModule.markAaveGatewaySafe(safe);
+        cashModule.markUsesAave(safe);
         emit MigratedToAave(safe, totalDebtUsd);
     }
 

--- a/src/interfaces/ICashModule.sol
+++ b/src/interfaces/ICashModule.sol
@@ -141,6 +141,8 @@ struct SafeCashConfig {
     bool lendDisabled;
     /// @notice Timestamp after which a pending disable-lend request can be executed (0 if none)
     uint96 lendDisableFinalizeTime;
+    /// @notice True once the safe's borrow/collateral engine is the Aave gateway (set at onboarding or by migration; one-way)
+    bool onAaveGateway;
 }
 
 /**
@@ -211,6 +213,9 @@ interface ICashModule {
 
     /// @notice Error thrown when a balance is insufficient for an operation
     error InsufficientBalance();
+
+    /// @notice Error thrown when a non-DebtManager contract calls restricted functions
+    error OnlyDebtManager();
 
     /// @notice Error thrown when a recipient address is zero
     error RecipientCannotBeAddressZero();
@@ -360,6 +365,23 @@ interface ICashModule {
      * @return Address of the gateway (address(0) if not set)
      */
     function getLendGateway() external view returns (address);
+
+    /**
+     * @notice Whether the safe's borrow/collateral engine is the Aave gateway (vs the legacy DebtManager)
+     * @dev The canonical routing flag: every spend/repay/lens path branches on this. True for safes onboarded
+     *      after the gateway launch and for safes migrated via DebtManager.migrateToAave; false means legacy.
+     * @param safe The safe to query
+     * @return True if the safe uses the Aave gateway
+     */
+    function isAaveGatewaySafe(address safe) external view returns (bool);
+
+    /**
+     * @notice Marks a safe as using the Aave gateway engine
+     * @dev Only callable by the DebtManager, as the last step of migrateToAave. Idempotent and one-way.
+     * @param safe The safe to mark
+     * @custom:throws OnlyDebtManager if called by any address other than the DebtManager
+     */
+    function markAaveGatewaySafe(address safe) external;
 
     /**
      * @notice Gets the debt manager contract
@@ -627,6 +649,24 @@ interface ICashModule {
      * @custom:throws If spending would exceed limits or balances
      */
     function spend(address safe, bytes32 txId, BinSponsor binSponsor, address[] calldata tokens, uint256[] calldata amountsInUsd, Cashback[] calldata cashbacks) external;
+
+    /**
+     * @notice Prepares a safe for liquidation by canceling any pending withdrawals
+     * @dev Only callable by the DebtManager
+     * @param safe Address of the EtherFi Safe being liquidated
+     * @custom:throws OnlyDebtManager if called by any address other than the DebtManager
+     */
+    function preLiquidate(address safe) external;
+
+    /**
+     * @notice Executes post-liquidation logic to transfer tokens to the liquidator
+     * @dev Only callable by the DebtManager after a successful liquidation
+     * @param safe Address of the EtherFi Safe being liquidated
+     * @param liquidator Address that will receive the liquidated tokens
+     * @param tokensToSend Array of token data with amounts to send to the liquidator
+     * @custom:throws OnlyDebtManager if called by any address other than the DebtManager
+     */
+    function postLiquidate(address safe, address liquidator, IDebtManager.LiquidationTokenData[] memory tokensToSend) external;
 
     /**
      * @notice Clears pending cashback for users

--- a/src/interfaces/ICashModule.sol
+++ b/src/interfaces/ICashModule.sol
@@ -142,7 +142,7 @@ struct SafeCashConfig {
     /// @notice Timestamp after which a pending disable-lend request can be executed (0 if none)
     uint96 lendDisableFinalizeTime;
     /// @notice True once the safe's borrow/collateral engine is the Aave gateway (set at onboarding or by migration; one-way)
-    bool onAaveGateway;
+    bool usesAave;
 }
 
 /**
@@ -373,7 +373,7 @@ interface ICashModule {
      * @param safe The safe to query
      * @return True if the safe uses the Aave gateway
      */
-    function isAaveGatewaySafe(address safe) external view returns (bool);
+    function usesAave(address safe) external view returns (bool);
 
     /**
      * @notice Marks a safe as using the Aave gateway engine
@@ -381,7 +381,7 @@ interface ICashModule {
      * @param safe The safe to mark
      * @custom:throws OnlyDebtManager if called by any address other than the DebtManager
      */
-    function markAaveGatewaySafe(address safe) external;
+    function markUsesAave(address safe) external;
 
     /**
      * @notice Gets the debt manager contract

--- a/src/modules/cash/CashLendLib.sol
+++ b/src/modules/cash/CashLendLib.sol
@@ -2,7 +2,9 @@
 pragma solidity ^0.8.28;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { EnumerableSetLib } from "solady/utils/EnumerableSetLib.sol";
 
+import { IBridgeModule } from "../../interfaces/IBridgeModule.sol";
 import { BinSponsor, Mode, SafeCashConfig, WithdrawalRequest } from "../../interfaces/ICashModule.sol";
 import { IDebtManager } from "../../interfaces/IDebtManager.sol";
 import { IEtherFiDataProvider } from "../../interfaces/IEtherFiDataProvider.sol";
@@ -15,19 +17,26 @@ import { CashModuleStorageContract } from "./CashModuleStorageContract.sol";
 /**
  * @title CashLendLib
  * @notice The CashModule's lend logic: every module operation that touches the Aave gateway or the safe's
- *         position. It holds credit spending, debit-spend sourcing against the supplied balance, debt
- *         repayment, and the lend enable/disable lifecycle. CashModuleCore and CashModuleSetters keep only
- *         the thin entrypoints (access control, signature checks, events wiring) and delegate the work here.
+ *         position. It holds credit and debit spend execution, debt repayment, and the lend enable/disable
+ *         lifecycle. CashModuleCore and CashModuleSetters keep only the thin entrypoints (access control,
+ *         signature checks, events wiring) and delegate the work here.
  * @dev Deployed once and linked into CashModuleCore and CashModuleSetters, so this logic does not count
  *      against either implementation's EIP-170 runtime code-size limit. Every function is called via
  *      delegatecall and therefore runs in the CashModule's storage context: the caller passes its
  *      CashModuleStorage pointer and the library reads and writes the same namespaced storage the module
- *      would. Two consequences of the delegatecall shape: functions that need the module's
- *      etherFiDataProvider immutable take it as a parameter, and functions that would cancel the pending
- *      withdrawal request return a flag instead, since the cancel helper is module-internal.
+ *      would. One consequence of the delegatecall shape: functions that need the module's
+ *      etherFiDataProvider immutable take it as a parameter. The pending-withdrawal cancel lives here
+ *      (cancelOldWithdrawal) so the spend paths can cancel inline; the module's internal helper delegates
+ *      to it.
+ *
+ *      Engine convention: legacy DebtManager code always sits inside an `if (!_onGateway(...))` block (or a
+ *      legacy-named helper) that is deleted wholesale when the legacy engine is retired; the gateway path is
+ *      the unguarded fall-through, already in its final shape.
  * @author ether.fi
  */
 library CashLendLib {
+    using EnumerableSetLib for EnumerableSetLib.AddressSet;
+
     // These mirror CashModule's own errors selector-for-selector, so reverts from the library are
     // indistinguishable from reverts thrown in the module itself.
     error LendGatewayNotSet();
@@ -38,6 +47,7 @@ library CashLendLib {
     error LendNotDisabled();
     error LendDisabled();
     error AmountZero();
+    error SettlementDispatcherNotSetForBinSponsor();
 
     // Threads a debit spend's cross-token state through the sizing pass. Bundled into one struct so the
     // sizing frames stay well under the legacy stack limit (the price provider is a parameter here, where in
@@ -47,54 +57,109 @@ library CashLendLib {
         uint256[] fromLoose; // portion of each amount taken from the safe's loose balance
         uint256 borrowHeadroom; // remaining USD borrowing headroom, consumed as supplied balance is drawn
         bool hasDebt; // whether the safe carries debt (the headroom cap only applies then)
-        bool cancelWithdrawal; // sizing needs withdrawal-reserved balance: the caller cancels the request, and later tokens treat all loose balance as unreserved
+        bool cancelWithdrawal; // sizing needs withdrawal-reserved balance: the spend cancels the request, and later tokens treat all loose balance as unreserved
+    }
+
+    /// @dev The canonical engine check: true routes the safe to the Aave gateway, false to the legacy DebtManager.
+    ///      Every branch point in this library must read the flag through here and nothing else.
+    function _onGateway(CashModuleStorageContract.CashModuleStorage storage $, address safe) private view returns (bool) {
+        return $.safeCashConfig[safe].onAaveGateway;
     }
 
     /**
-     * @notice Executes a repayment on behalf of a safe, routing by migration state
+     * @notice The settlement dispatcher receiving a bin sponsor's spends
+     * @dev The module's getSettlementDispatcher delegates here; the spend paths read it directly.
+     * @param $ The CashModule storage (passed by the delegatecalling module)
+     * @param binSponsor Bin sponsor used for spending
+     * @return The settlement dispatcher address
+     * @custom:throws SettlementDispatcherNotSetForBinSponsor if none is configured for the bin sponsor
+     */
+    function settlementDispatcher(CashModuleStorageContract.CashModuleStorage storage $, BinSponsor binSponsor) public view returns (address) {
+        address dispatcher;
+        if (binSponsor == BinSponsor.Rain) dispatcher = $.settlementDispatcherRain;
+        else if (binSponsor == BinSponsor.PIX) dispatcher = $.settlementDispatcherPix;
+        else if (binSponsor == BinSponsor.CardOrder) dispatcher = $.settlementDispatcherCardOrder;
+        else dispatcher = $.settlementDispatcherReap;
+
+        if (dispatcher == address(0)) revert SettlementDispatcherNotSetForBinSponsor();
+        return dispatcher;
+    }
+
+    /**
+     * @notice Cancels the safe's pending withdrawal request, if any, and emits WithdrawalCancelled
+     * @dev The module's internal _cancelOldWithdrawal delegates here; the spend paths in this library call
+     *      it directly when a spend wins the competing claim over a reservation.
+     * @param $ The CashModule storage (passed by the delegatecalling module)
+     * @param dataProvider The module's data provider (to vet the recipient before the bridge-cancel call)
+     * @param safe Address of the EtherFi Safe
+     */
+    function cancelOldWithdrawal(CashModuleStorageContract.CashModuleStorage storage $, IEtherFiDataProvider dataProvider, address safe) public {
+        SafeCashConfig storage safeCashConfig = $.safeCashConfig[safe];
+        address recipient = safeCashConfig.pendingWithdrawalRequest.recipient;
+
+        if (safeCashConfig.pendingWithdrawalRequest.tokens.length > 0) {
+            if ($.whitelistedModulesCanRequestWithdraw.contains(recipient)) {
+                // Only call the function if the module is whitelisted on data provider
+                if (dataProvider.isWhitelistedModule(recipient)) IBridgeModule(recipient).cancelBridgeByCashModule(safe);
+            }
+
+            $.cashEventEmitter.emitWithdrawalCancelled(safe, safeCashConfig.pendingWithdrawalRequest.tokens, safeCashConfig.pendingWithdrawalRequest.amounts, recipient);
+            delete safeCashConfig.pendingWithdrawalRequest;
+        }
+    }
+
+    /**
+     * @notice Executes a repayment on behalf of a safe, routing by engine
      * @dev The caller must have already validated the amount and cancelled any conflicting withdrawal request.
-     *      A migrated safe repays on Aave via the gateway (which pulls the token from the safe, repays, refunds
-     *      dust, and emits Repaid); a legacy safe repays the DebtManager through the safe's module execution.
+     *      A legacy safe repays the DebtManager through the safe's module execution; an Aave-gateway safe
+     *      repays on Aave via the gateway (which pulls the token from the safe, repays, refunds dust, and
+     *      emits Repaid).
      * @param $ The CashModule storage (passed by the delegatecalling module)
      * @param safe The safe whose debt is repaid
      * @param token The token to repay
      * @param amount The token amount to repay
      * @param amountInUsd The USD value of the repayment (for the emitted DebtManager event)
-     * @custom:throws LendGatewayNotSet if the safe is migrated but no gateway is configured
+     * @custom:throws LendGatewayNotSet if the safe uses the gateway but none is configured
      */
     function repay(CashModuleStorageContract.CashModuleStorage storage $, address safe, address token, uint256 amount, uint256 amountInUsd) external {
-        if ($.debtManager.hasMigratedToAave(safe)) {
-            IGateway gateway = $.gateway;
-            if (address(gateway) == address(0)) revert LendGatewayNotSet();
-            // Full repays pass the max sentinel so no interest dust survives the exact-amount rounding.
-            uint256 debt = gateway.debtOf(safe, token);
-            uint256 repaid = gateway.repay(safe, token, amount >= debt ? type(uint256).max : amount);
-            // The gateway may repay less than requested (dust refund, or the live Aave debt being smaller than
-            // the quote), so report the USD value of what was actually repaid, not the requested amount.
-            uint256 repaidInUsd = repaid == amount ? amountInUsd : $.debtManager.convertCollateralTokenToUsd(token, repaid);
-            $.cashEventEmitter.emitRepay(safe, token, repaid, repaidInUsd);
+        if (!_onGateway($, safe)) {
+            address[] memory to = new address[](3);
+            bytes[] memory data = new bytes[](3);
+            uint256[] memory values = new uint256[](3);
+
+            to[0] = token;
+            to[1] = address($.debtManager);
+            to[2] = token;
+
+            data[0] = abi.encodeWithSelector(IERC20.approve.selector, address($.debtManager), amount);
+            data[1] = abi.encodeWithSelector(IDebtManager.repay.selector, safe, token, amount);
+            data[2] = abi.encodeWithSelector(IERC20.approve.selector, address($.debtManager), 0);
+
+            IEtherFiSafe(safe).execTransactionFromModule(to, values, data);
+            $.cashEventEmitter.emitRepayDebtManager(safe, token, amount, amountInUsd);
             return;
         }
 
-        address[] memory to = new address[](3);
-        bytes[] memory data = new bytes[](3);
-        uint256[] memory values = new uint256[](3);
-
-        to[0] = token;
-        to[1] = address($.debtManager);
-        to[2] = token;
-
-        data[0] = abi.encodeWithSelector(IERC20.approve.selector, address($.debtManager), amount);
-        data[1] = abi.encodeWithSelector(IDebtManager.repay.selector, safe, token, amount);
-        data[2] = abi.encodeWithSelector(IERC20.approve.selector, address($.debtManager), 0);
-
-        IEtherFiSafe(safe).execTransactionFromModule(to, values, data);
-        $.cashEventEmitter.emitRepayDebtManager(safe, token, amount, amountInUsd);
+        IGateway gateway = $.gateway;
+        if (address(gateway) == address(0)) revert LendGatewayNotSet();
+        // Full repays pass the max sentinel so no interest dust survives the exact-amount rounding.
+        uint256 debt = gateway.debtOf(safe, token);
+        uint256 repaid = gateway.repay(safe, token, amount >= debt ? type(uint256).max : amount);
+        // The gateway may repay less than requested (dust refund, or the live Aave debt being smaller than
+        // the quote), so report the USD value of what was actually repaid, not the requested amount.
+        uint256 repaidInUsd = repaid == amount ? amountInUsd : $.debtManager.convertCollateralTokenToUsd(token, repaid);
+        $.cashEventEmitter.emitRepay(safe, token, repaid, repaidInUsd);
     }
 
     /**
      * @notice Whether a safe has any open borrows (Aave debt via the gateway, or legacy DebtManager debt)
-     * @dev Checks raw per-asset debt, not getAccountData().debtUsd: the USD aggregate floors to 6 decimals,
+     * @dev Both engines are checked regardless of the safe's routing flag. In steady state debt can only
+     *      live on the safe's own engine, but disabling lend must never proceed with debt anywhere: a
+     *      gateway safe's disable withdraws all its Aave collateral, and an opted-out legacy safe with
+     *      DebtManager debt cannot be migrated (mark-only migration reverts with LendDisabledSafeHasDebt).
+     *      Checking both sides is cheap insurance instead of trusting the routing invariant.
+     *
+     *      Checks raw per-asset debt, not getAccountData().debtUsd: the USD aggregate floors to 6 decimals,
      *      so sub-$0.000001 dust reads as zero here and then reverts deep in Aave when disableLend tries to
      *      withdraw all collateral.
      * @param $ The CashModule storage (passed by the delegatecalling module)
@@ -139,22 +204,26 @@ library CashLendLib {
     /**
      * @notice Executes the disable-lend: withdraws ALL of the safe's Aave collateral back to the safe, marks
      *         lend disabled, and forces the safe into Debit mode
-     * @dev Iterates the gateway's registered assets, not DebtManager's collateral list, so a token delisted
-     *      from DebtManager while still supplied on Aave stays withdrawable. Reverts if the gateway is unset.
+     * @dev For a gateway safe, iterates the gateway's registered assets, not DebtManager's collateral list,
+     *      so a token delisted from DebtManager while still supplied on Aave stays withdrawable. A legacy
+     *      safe has nothing on Aave to unwind — its opt-out is just the flag plus forced Debit mode, and it
+     *      marks the safe to be left alone (funds kept loose) when the migration sweep reaches it.
      * @param $ The CashModule storage (passed by the delegatecalling module)
      * @param safe Address of the EtherFi Safe
      */
     function disableLend(CashModuleStorageContract.CashModuleStorage storage $, address safe) public {
-        IGateway gateway = $.gateway;
-        if (address(gateway) == address(0)) revert LendGatewayNotSet();
+        if (_onGateway($, safe)) {
+            IGateway gateway = $.gateway;
+            if (address(gateway) == address(0)) revert LendGatewayNotSet();
 
-        address[] memory collateralTokens = gateway.registeredAssets();
-        uint256 len = collateralTokens.length;
-        for (uint256 i = 0; i < len;) {
-            uint256 supplied = gateway.suppliedOf(safe, collateralTokens[i]);
-            if (supplied != 0) gateway.withdraw(safe, collateralTokens[i], supplied, safe);
-            unchecked {
-                ++i;
+            address[] memory collateralTokens = gateway.registeredAssets();
+            uint256 len = collateralTokens.length;
+            for (uint256 i = 0; i < len;) {
+                uint256 supplied = gateway.suppliedOf(safe, collateralTokens[i]);
+                if (supplied != 0) gateway.withdraw(safe, collateralTokens[i], supplied, safe);
+                unchecked {
+                    ++i;
+                }
             }
         }
 
@@ -186,66 +255,54 @@ library CashLendLib {
     }
 
     /**
-     * @notice Credit spend (single token): borrows against the safe's position and sends the borrowed
-     *         token to the settlement dispatcher
-     * @dev A migrated safe borrows on Aave via the gateway; a legacy safe borrows from the DebtManager,
-     *      executed by the safe itself. A blocked legacy borrow is not retried here: the retry first
-     *      cancels the pending withdrawal request, which is module-internal, so the caller cancels and
-     *      then calls legacyBorrow.
+     * @notice Credit spend (single token): borrows against the safe's position, sends the borrowed token
+     *         to the settlement dispatcher, and emits Spend
+     * @dev A legacy safe borrows from the DebtManager, executed by the safe itself; a gateway safe borrows
+     *      on Aave via the gateway. The caller has already validated the array shapes and the
+     *      one-token-in-credit rule.
      * @param $ The CashModule storage (passed by the delegatecalling module)
+     * @param dataProvider The module's data provider (to vet a legacy withdrawal cancel)
      * @param safe Address of the EtherFi Safe
+     * @param txId Transaction identifier
      * @param binSponsor Bin sponsor used for spending
-     * @param dispatcher Settlement dispatcher receiving the borrowed token
-     * @param token Address of the token to spend
-     * @param amountInUsd Amount to spend in USD
-     * @return The token amount spent
-     * @return Whether the caller must cancel the pending withdrawal request and retry via legacyBorrow
+     * @param tokens Address of the token to spend (single-element array)
+     * @param amountsInUsd Amount to spend in USD (single-element array)
+     * @param totalSpendingInUsd Total spend in USD, for the emitted event
      */
-    function spendCredit(CashModuleStorageContract.CashModuleStorage storage $, address safe, BinSponsor binSponsor, address dispatcher, address token, uint256 amountInUsd) external returns (uint256, bool) {
+    function spendCredit(CashModuleStorageContract.CashModuleStorage storage $, IEtherFiDataProvider dataProvider, address safe, bytes32 txId, BinSponsor binSponsor, address[] calldata tokens, uint256[] calldata amountsInUsd, uint256 totalSpendingInUsd) external {
         // Defense-in-depth: a safe that opted out of lend is forced to Debit and blocked from re-entering
         // Credit, so credit spending must never reach a lend-disabled safe.
         if ($.safeCashConfig[safe].lendDisabled) revert LendDisabled();
-        if (!$.debtManager.isBorrowToken(token)) revert UnsupportedToken();
-        uint256 amount = $.debtManager.convertUsdToCollateralToken(token, amountInUsd);
+        if (!$.debtManager.isBorrowToken(tokens[0])) revert UnsupportedToken();
+        uint256 amount = $.debtManager.convertUsdToCollateralToken(tokens[0], amountsInUsd[0]);
         if (amount == 0) revert AmountZero();
 
-        if ($.debtManager.hasMigratedToAave(safe)) {
-            // Migrated safe: its position lives on Aave. Borrow there via the gateway (the CashModule is
-            // always a gateway driver) and send the borrowed token straight to the settlement dispatcher.
-            // The legacy DebtManager.borrow path reverts for a migrated safe, and CashLens already sizes
-            // credit against the gateway, so routing here keeps the on-chain spend consistent with the
-            // precheck. Aave enforces the borrowing-power/health check on the borrow itself.
-            IGateway gateway = $.gateway;
-            if (address(gateway) == address(0)) revert LendGatewayNotSet();
-            gateway.borrow(safe, token, amount, dispatcher);
-            return (amount, false);
+        if (!_onGateway($, safe)) {
+            _spendLegacyCredit($, dataProvider, safe, binSponsor, tokens[0], amount);
+        } else {
+            _borrowOnGateway($, safe, binSponsor, tokens[0], amount);
         }
 
-        (address[] memory to, uint256[] memory values, bytes[] memory data) = _legacyBorrowCall($, binSponsor, token, amount);
-        try IEtherFiSafe(safe).execTransactionFromModule(to, values, data) {
-            return (amount, false);
-        } catch {
-            return (amount, true);
-        }
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = amount;
+        $.cashEventEmitter.emitSpend(safe, txId, binSponsor, tokens, amounts, amountsInUsd, totalSpendingInUsd, Mode.Credit);
     }
 
-    /**
-     * @notice Executes a legacy DebtManager borrow through the safe's module execution
-     * @dev The retry path after spendCredit signalled a blocked borrow and the caller cancelled the
-     *      pending withdrawal request
-     * @param $ The CashModule storage (passed by the delegatecalling module)
-     * @param safe Address of the EtherFi Safe
-     * @param binSponsor Bin sponsor used for spending
-     * @param token Address of the token to spend
-     * @param amount Token amount to borrow
-     */
-    function legacyBorrow(CashModuleStorageContract.CashModuleStorage storage $, address safe, BinSponsor binSponsor, address token, uint256 amount) public {
-        (address[] memory to, uint256[] memory values, bytes[] memory data) = _legacyBorrowCall($, binSponsor, token, amount);
-        IEtherFiSafe(safe).execTransactionFromModule(to, values, data);
+    /// @dev Gateway credit spend: the safe's position lives on Aave, so borrow there via the gateway (the
+    ///      CashModule is always a gateway driver) and send the borrowed token straight to the settlement
+    ///      dispatcher. The legacy DebtManager.borrow path reverts for a migrated safe, and CashLens sizes
+    ///      credit against the same engine flag, so routing here keeps the on-chain spend consistent with
+    ///      the precheck. Aave enforces the borrowing-power/health check on the borrow itself.
+    function _borrowOnGateway(CashModuleStorageContract.CashModuleStorage storage $, address safe, BinSponsor binSponsor, address token, uint256 amount) private {
+        IGateway gateway = $.gateway;
+        if (address(gateway) == address(0)) revert LendGatewayNotSet();
+        gateway.borrow(safe, token, amount, settlementDispatcher($, binSponsor));
     }
 
-    /// @dev Builds the safe-executed DebtManager.borrow call shared by spendCredit and legacyBorrow.
-    function _legacyBorrowCall(CashModuleStorageContract.CashModuleStorage storage $, BinSponsor binSponsor, address token, uint256 amount) private view returns (address[] memory, uint256[] memory, bytes[] memory) {
+    /// @dev Legacy credit spend: a DebtManager borrow executed by the safe itself. A blocked borrow means
+    ///      the pending withdrawal request holds the balance the borrow needs: the spend wins the competing
+    ///      claim (the debit path's rule), so cancel the request and retry.
+    function _spendLegacyCredit(CashModuleStorageContract.CashModuleStorage storage $, IEtherFiDataProvider dataProvider, address safe, BinSponsor binSponsor, address token, uint256 amount) private {
         address[] memory to = new address[](1);
         uint256[] memory values = new uint256[](1);
         bytes[] memory data = new bytes[](1);
@@ -253,27 +310,66 @@ library CashLendLib {
         to[0] = address($.debtManager);
         data[0] = abi.encodeWithSelector(IDebtManager.borrow.selector, binSponsor, token, amount);
 
-        return (to, values, data);
+        try IEtherFiSafe(safe).execTransactionFromModule(to, values, data) { }
+        catch {
+            cancelOldWithdrawal($, dataProvider, safe);
+            IEtherFiSafe(safe).execTransactionFromModule(to, values, data);
+        }
     }
 
     /**
-     * @notice Sizes a debit spend across tokens: the safe's loose balance is spent first, then the
-     *         Aave-supplied balance covers any shortfall
-     * @dev Per token, _sourceDebitToken sizes the loose/supplied split and threads the borrowing headroom
-     *      across tokens, so a debit cannot push a debt-carrying safe past its LTV max borrow. Pure sizing:
-     *      the caller cancels the pending withdrawal request when the returned flag is set (a delegatecalled
-     *      library cannot call the module's internal cancel), then runs executeDebits.
+     * @notice Debit spend (multiple tokens): sizes each token against the safe's balances, executes the
+     *         transfers to the settlement dispatcher, and emits Spend
+     * @dev A gateway safe spends its loose balance first, then its Aave-supplied balance covers any
+     *      shortfall; a legacy safe spends its loose balance only. When sizing needs balance reserved by
+     *      the pending withdrawal request, the spend wins the competing claim and the request is cancelled
+     *      before any transfer executes.
      * @param $ The CashModule storage (passed by the delegatecalling module)
-     * @param dataProvider The module's data provider (for the price provider)
+     * @param dataProvider The module's data provider (for the price provider and withdrawal cancels)
      * @param safe Address of the EtherFi Safe
+     * @param txId Transaction identifier
+     * @param binSponsor Bin sponsor used for spending
      * @param tokens Addresses of the tokens to spend
      * @param amountsInUsd Amounts to spend in USD
-     * @return Token amounts to spend
-     * @return Portion of each amount taken from the safe's loose balance
-     * @return Whether sizing needs balance reserved by the pending withdrawal request, in which case the
-     *         caller must cancel the request before executing
+     * @param totalSpendingInUsd Total spend in USD, for the emitted event
      */
-    function sourceDebits(CashModuleStorageContract.CashModuleStorage storage $, IEtherFiDataProvider dataProvider, address safe, address[] calldata tokens, uint256[] calldata amountsInUsd) external view returns (uint256[] memory, uint256[] memory, bool) {
+    function spendDebit(CashModuleStorageContract.CashModuleStorage storage $, IEtherFiDataProvider dataProvider, address safe, bytes32 txId, BinSponsor binSponsor, address[] calldata tokens, uint256[] calldata amountsInUsd, uint256 totalSpendingInUsd) external {
+        if (!_onGateway($, safe)) {
+            _spendLegacyDebit($, dataProvider, safe, txId, binSponsor, tokens, amountsInUsd, totalSpendingInUsd);
+            return;
+        }
+
+        DebitSpendState memory s = _sourceDebits($, dataProvider, safe, tokens, amountsInUsd);
+        if (s.cancelWithdrawal) cancelOldWithdrawal($, dataProvider, safe);
+        _executeDebits($, safe, settlementDispatcher($, binSponsor), tokens, s.amounts, s.fromLoose);
+        $.cashEventEmitter.emitSpend(safe, txId, binSponsor, tokens, s.amounts, amountsInUsd, totalSpendingInUsd, Mode.Debit);
+    }
+
+    /// @dev Legacy debit spend: every token comes from the loose balance (so _executeDebits performs pure
+    ///      transfers), reproducing the pre-gateway behavior exactly. Loose tokens are the legacy engine's
+    ///      collateral, so if the position is unhealthy after the spend, the pending withdrawal request
+    ///      loses the competing claim: cancel it and check again.
+    function _spendLegacyDebit(CashModuleStorageContract.CashModuleStorage storage $, IEtherFiDataProvider dataProvider, address safe, bytes32 txId, BinSponsor binSponsor, address[] calldata tokens, uint256[] calldata amountsInUsd, uint256 totalSpendingInUsd) private {
+        DebitSpendState memory s = _sourceLegacyDebits($, safe, tokens, amountsInUsd);
+        if (s.cancelWithdrawal) cancelOldWithdrawal($, dataProvider, safe);
+        _executeDebits($, safe, settlementDispatcher($, binSponsor), tokens, s.amounts, s.fromLoose);
+        $.cashEventEmitter.emitSpend(safe, txId, binSponsor, tokens, s.amounts, amountsInUsd, totalSpendingInUsd, Mode.Debit);
+
+        try $.debtManager.ensureHealth(safe) { }
+        catch {
+            cancelOldWithdrawal($, dataProvider, safe);
+            $.debtManager.ensureHealth(safe);
+        }
+    }
+
+    /**
+     * @dev Sizes a gateway debit spend across tokens: the safe's loose balance is spent first, then the
+     *      Aave-supplied balance covers any shortfall. Per token, _sourceDebitToken sizes the loose/supplied
+     *      split and threads the borrowing headroom across tokens, so a debit cannot push a debt-carrying
+     *      safe past its LTV max borrow. Pure sizing: the returned flag tells the caller to cancel the
+     *      pending withdrawal request before executing.
+     */
+    function _sourceDebits(CashModuleStorageContract.CashModuleStorage storage $, IEtherFiDataProvider dataProvider, address safe, address[] calldata tokens, uint256[] calldata amountsInUsd) private view returns (DebitSpendState memory) {
         DebitSpendState memory s;
         s.amounts = new uint256[](tokens.length);
         s.fromLoose = new uint256[](tokens.length);
@@ -288,20 +384,83 @@ library CashLendLib {
             _sourceDebitToken($, s, priceProvider, safe, tokens[i], amountsInUsd[i], i);
         }
 
-        return (s.amounts, s.fromLoose, s.cancelWithdrawal);
+        return s;
     }
 
     /**
-     * @notice Executes a sized debit spend: transfers the loose portions and withdraws the supplied
-     *         portions from Aave, both to the settlement dispatcher
+     * @notice Transfers liquidated collateral from the safe to the liquidator, skipping zero amounts
+     * @dev The execution half of CashModule.postLiquidate (the DebtManager-only auth stays in the module);
+     *      lives here purely for the module's code-size budget
+     * @param safe Address of the EtherFi Safe being liquidated
+     * @param liquidator Address receiving the liquidated tokens
+     * @param tokensToSend Token amounts to send, as computed by the DebtManager
+     */
+    function postLiquidateTransfers(address safe, address liquidator, IDebtManager.LiquidationTokenData[] memory tokensToSend) external {
+        uint256 len = tokensToSend.length;
+        address[] memory to = new address[](len);
+        bytes[] memory data = new bytes[](len);
+        uint256 counter = 0;
+
+        for (uint256 i = 0; i < len;) {
+            if (tokensToSend[i].amount > 0) {
+                to[counter] = tokensToSend[i].token;
+                data[counter] = abi.encodeWithSelector(IERC20.transfer.selector, liquidator, tokensToSend[i].amount);
+                unchecked {
+                    ++counter;
+                }
+            }
+
+            unchecked {
+                ++i;
+            }
+        }
+
+        assembly ("memory-safe") {
+            mstore(to, counter)
+            mstore(data, counter)
+        }
+
+        IEtherFiSafe(safe).execTransactionFromModule(to, new uint256[](counter), data);
+    }
+
+    /**
+     * @dev Sizes a legacy debit spend: every token is spent from the safe's loose balance, sized exactly as
+     *      the pre-gateway DebtManager-era module did. Pure sizing: the returned flag is set when a token's
+     *      spend plus its withdrawal reservation exceeds the loose balance (the spend wins the competing
+     *      claim); once set, later tokens treat the reservation as already void.
+     */
+    function _sourceLegacyDebits(CashModuleStorageContract.CashModuleStorage storage $, address safe, address[] calldata tokens, uint256[] calldata amountsInUsd) private view returns (DebitSpendState memory) {
+        DebitSpendState memory s;
+        s.amounts = new uint256[](tokens.length);
+        // Every token comes from the loose balance, so the execution pass performs pure transfers.
+        s.fromLoose = s.amounts;
+
+        for (uint256 i = 0; i < tokens.length; i++) {
+            if (!$.debtManager.isBorrowToken(tokens[i])) revert UnsupportedToken();
+            s.amounts[i] = $.debtManager.convertUsdToCollateralToken(tokens[i], amountsInUsd[i]);
+
+            uint256 balance = IERC20(tokens[i]).balanceOf(safe);
+            if (balance < s.amounts[i]) revert InsufficientBalance();
+
+            if (!s.cancelWithdrawal && s.amounts[i] + _pendingWithdrawalAmount($, safe, tokens[i]) > balance) {
+                s.cancelWithdrawal = true;
+            }
+        }
+
+        return s;
+    }
+
+    /**
+     * @dev Executes a sized debit spend: transfers the loose portions and withdraws the supplied portions
+     *      from Aave, both to the settlement dispatcher
      * @param $ The CashModule storage (passed by the delegatecalling module)
      * @param safe Address of the EtherFi Safe
      * @param dispatcher Settlement dispatcher receiving the tokens
      * @param tokens Addresses of the tokens to spend
-     * @param amounts Token amounts to spend, as sized by sourceDebits
+     * @param amounts Token amounts to spend, as sized by the sourcing pass
      * @param fromLoose Portion of each amount taken from the safe's loose balance
      */
-    function executeDebits(CashModuleStorageContract.CashModuleStorage storage $, address safe, address dispatcher, address[] calldata tokens, uint256[] memory amounts, uint256[] memory fromLoose) external {
+    function _executeDebits(CashModuleStorageContract.CashModuleStorage storage $, address safe, address dispatcher, address[] calldata tokens, uint256[] memory amounts, uint256[] memory fromLoose) private {
         _transferLoose(safe, dispatcher, tokens, fromLoose);
 
         // The headroom cap in the sizing pass already bounds the supplied withdrawals; no post-withdrawal health check is needed.

--- a/src/modules/cash/CashLendLib.sol
+++ b/src/modules/cash/CashLendLib.sol
@@ -29,7 +29,7 @@ import { CashModuleStorageContract } from "./CashModuleStorageContract.sol";
  *      (cancelOldWithdrawal) so the spend paths can cancel inline; the module's internal helper delegates
  *      to it.
  *
- *      Engine convention: legacy DebtManager code always sits inside an `if (!_onGateway(...))` block (or a
+ *      Engine convention: legacy DebtManager code always sits inside an `if (!_usesAave(...))` block (or a
  *      legacy-named helper) that is deleted wholesale when the legacy engine is retired; the gateway path is
  *      the unguarded fall-through, already in its final shape.
  * @author ether.fi
@@ -62,8 +62,8 @@ library CashLendLib {
 
     /// @dev The canonical engine check: true routes the safe to the Aave gateway, false to the legacy DebtManager.
     ///      Every branch point in this library must read the flag through here and nothing else.
-    function _onGateway(CashModuleStorageContract.CashModuleStorage storage $, address safe) private view returns (bool) {
-        return $.safeCashConfig[safe].onAaveGateway;
+    function _usesAave(CashModuleStorageContract.CashModuleStorage storage $, address safe) private view returns (bool) {
+        return $.safeCashConfig[safe].usesAave;
     }
 
     /**
@@ -122,7 +122,7 @@ library CashLendLib {
      * @custom:throws LendGatewayNotSet if the safe uses the gateway but none is configured
      */
     function repay(CashModuleStorageContract.CashModuleStorage storage $, address safe, address token, uint256 amount, uint256 amountInUsd) external {
-        if (!_onGateway($, safe)) {
+        if (!_usesAave($, safe)) {
             address[] memory to = new address[](3);
             bytes[] memory data = new bytes[](3);
             uint256[] memory values = new uint256[](3);
@@ -212,7 +212,7 @@ library CashLendLib {
      * @param safe Address of the EtherFi Safe
      */
     function disableLend(CashModuleStorageContract.CashModuleStorage storage $, address safe) public {
-        if (_onGateway($, safe)) {
+        if (_usesAave($, safe)) {
             IGateway gateway = $.gateway;
             if (address(gateway) == address(0)) revert LendGatewayNotSet();
 
@@ -277,7 +277,7 @@ library CashLendLib {
         uint256 amount = $.debtManager.convertUsdToCollateralToken(tokens[0], amountsInUsd[0]);
         if (amount == 0) revert AmountZero();
 
-        if (!_onGateway($, safe)) {
+        if (!_usesAave($, safe)) {
             _spendLegacyCredit($, dataProvider, safe, binSponsor, tokens[0], amount);
         } else {
             _borrowOnGateway($, safe, binSponsor, tokens[0], amount);
@@ -334,7 +334,7 @@ library CashLendLib {
      * @param totalSpendingInUsd Total spend in USD, for the emitted event
      */
     function spendDebit(CashModuleStorageContract.CashModuleStorage storage $, IEtherFiDataProvider dataProvider, address safe, bytes32 txId, BinSponsor binSponsor, address[] calldata tokens, uint256[] calldata amountsInUsd, uint256 totalSpendingInUsd) external {
-        if (!_onGateway($, safe)) {
+        if (!_usesAave($, safe)) {
             _spendLegacyDebit($, dataProvider, safe, txId, binSponsor, tokens, amountsInUsd, totalSpendingInUsd);
             return;
         }

--- a/src/modules/cash/CashLens.sol
+++ b/src/modules/cash/CashLens.sol
@@ -13,11 +13,20 @@ import { IPriceProvider } from "../../interfaces/IPriceProvider.sol";
 import { DebitSourcingLib } from "../../libraries/DebitSourcingLib.sol";
 import { SpendingLimit, SpendingLimitLib } from "../../libraries/SpendingLimitLib.sol";
 import { UpgradeableProxy } from "../../utils/UpgradeableProxy.sol";
+import { CashLensLegacyLib } from "./CashLensLegacyLib.sol";
 
 /**
  * @title CashLens
  * @notice Read-only contract providing views into a Safe's cash state
- * @dev Reads the Safe's position from the Aave gateway and the supported-token list from DebtManager.
+ * @dev Every engine-touching view branches on CashModule.isAaveGatewaySafe: gateway safes are read from the
+ *      Aave gateway (the logic in this contract), legacy safes from the DebtManager (preserved output-identical
+ *      in the linked CashLensLegacyLib). The check side of a spend must always agree with what the execution
+ *      side (CashLendLib) will do, so both read the same flag. Legacy code always sits inside an
+ *      `if (!isAaveGatewaySafe(safe))` block (routing to CashLensLegacyLib, or a couple of master-verbatim
+ *      lines inline), deleted wholesale when the legacy engine is retired; the gateway path is the unguarded
+ *      fall-through.
+ *
+ *      Gateway safes: the position is read from the Aave gateway; the supported-token list from DebtManager.
  *      Credit capacity comes straight from Aave. Debit spendable is the raw Safe balance plus the
  *      withdrawable supplied amount; when the Safe has debt, the withdrawable part is capped by the
  *      borrowing headroom (collateral weighted by LTV, minus debt) so the leftover position keeps
@@ -134,13 +143,13 @@ contract CashLens is UpgradeableProxy {
         amountsInUsd[0] = amountInUsd;
         address[] memory singleToken = new address[](1);
 
-        string memory firstError;
+        string memory firstReason;
 
         for (uint256 i = 0; i < tokenPreferences.length;) {
             singleToken[0] = tokenPreferences[i];
 
-            (bool success, string memory error) = canSpend(safe, txId, singleToken, amountsInUsd);
-            if (i == 0) firstError = error;
+            (bool success, string memory reason) = canSpend(safe, txId, singleToken, amountsInUsd);
+            if (i == 0) firstReason = reason;
 
             if (success) return (tokenPreferences[i], true, "");
 
@@ -149,7 +158,7 @@ contract CashLens is UpgradeableProxy {
             }
         }
 
-        return (tokenPreferences[0], false, firstError);
+        return (tokenPreferences[0], false, firstReason);
     }
 
     /// @notice Validates mode and spending limits, then runs the mode-specific check
@@ -167,6 +176,12 @@ contract CashLens is UpgradeableProxy {
         (bool withinLimit, string memory limitMessage) = safeData.spendingLimit.canSpend(totalSpendingInUsd);
         if (!withinLimit) {
             return (false, limitMessage);
+        }
+
+        // Route by engine, mirroring the spend execution: legacy safes get the pre-gateway DebtManager
+        // checks (and decline strings) exactly as before the gateway existed.
+        if (!cashModule.isAaveGatewaySafe(safe)) {
+            return CashLensLegacyLib.check(cashModule, safe, tokens, amountsInUsd, totalSpendingInUsd, safeData, mode);
         }
 
         if (mode == Mode.Credit) {
@@ -261,19 +276,24 @@ contract CashLens is UpgradeableProxy {
         IDebtManager debtManager = cashModule.getDebtManager();
         IPriceProvider priceProvider = IPriceProvider(dataProvider.getPriceProvider());
         SafeData memory safeData = cashModule.getData(safe);
-        IGateway.AccountData memory account = gateway().getAccountData(safe);
 
         SafeCashData memory data;
 
         address[] memory collateralTokens = debtManager.getCollateralTokens();
         address[] memory borrowTokens = debtManager.getBorrowTokens();
 
-        data.collateralBalances = _suppliedBalances(safe, collateralTokens);
-        data.borrows = _debtBalances(safe, borrowTokens);
-        data.totalCollateral = account.collateralUsd;
-        data.totalBorrow = account.debtUsd;
-        // Gross borrowing power (collateral weighted by LTV): the gateway headroom plus current debt
-        data.maxBorrow = account.availableBorrowsUsd + account.debtUsd;
+        if (!cashModule.isAaveGatewaySafe(safe)) {
+            (data.collateralBalances, data.totalCollateral, data.borrows, data.totalBorrow) = debtManager.getUserCurrentState(safe);
+            data.maxBorrow = debtManager.getMaxBorrowAmount(safe, true);
+        } else {
+            IGateway.AccountData memory account = gateway().getAccountData(safe);
+            data.collateralBalances = _suppliedBalances(safe, collateralTokens);
+            data.borrows = _debtBalances(safe, borrowTokens);
+            data.totalCollateral = account.collateralUsd;
+            data.totalBorrow = account.debtUsd;
+            // Gross borrowing power (collateral weighted by LTV): the gateway headroom plus current debt
+            data.maxBorrow = account.availableBorrowsUsd + account.debtUsd;
+        }
 
         uint256 len = collateralTokens.length;
         data.tokenPrices = new IDebtManager.TokenData[](len);
@@ -328,6 +348,10 @@ contract CashLens is UpgradeableProxy {
         if (len == 0) return DebitModeMaxSpend(new address[](0), new uint256[](0), new uint256[](0), 0);
         if (len > 1) debtServiceTokenPreference.checkDuplicates();
 
+        if (!cashModule.isAaveGatewaySafe(safe)) {
+            return CashLensLegacyLib.maxSpendDebit(cashModule, safe, debtServiceTokenPreference);
+        }
+
         IDebtManager debtManager = cashModule.getDebtManager();
         SafeData memory safeData = cashModule.getData(safe);
 
@@ -375,6 +399,10 @@ contract CashLens is UpgradeableProxy {
      * @return Maximum amount that can be spent in credit mode (USD, 6 decimals)
      */
     function getMaxSpendCredit(address safe) public view returns (uint256) {
+        if (!cashModule.isAaveGatewaySafe(safe)) {
+            return CashLensLegacyLib.maxSpendCredit(cashModule, safe);
+        }
+
         IGateway lendGateway = cashModule.getGateway();
         uint256 borrowPower = lendGateway.getAccountData(safe).availableBorrowsUsd;
 
@@ -430,8 +458,10 @@ contract CashLens is UpgradeableProxy {
 
     /**
      * @notice Gets the effective collateral amount for a specific token
-     * @dev Returns the raw Safe balance minus pending withdrawals. DebtManager reads this during its
-     *      retirement window, so it stays on the raw balance until the Aave cutover.
+     * @dev A gateway safe's collateral is its Aave-supplied balance (pending withdrawals reserve loose funds,
+     *      not the supplied position). A legacy safe's collateral is its raw balance minus pending
+     *      withdrawals — DebtManager reads this branch for its health and borrow checks, so it must keep the
+     *      exact pre-gateway semantics until the legacy engine is retired.
      * @param safe Address of the safe
      * @param token Address of the collateral token to check
      * @return Effective collateral amount
@@ -441,47 +471,34 @@ contract CashLens is UpgradeableProxy {
         IDebtManager debtManager = cashModule.getDebtManager();
 
         if (!debtManager.isCollateralToken(token)) revert NotACollateralToken();
-        uint256 balance = IERC20(token).balanceOf(safe);
-        uint256 pendingWithdrawalAmount = getPendingWithdrawalAmount(safe, token);
 
-        return balance > pendingWithdrawalAmount ? balance - pendingWithdrawalAmount : 0;
+        if (!cashModule.isAaveGatewaySafe(safe)) {
+            uint256 balance = IERC20(token).balanceOf(safe);
+            uint256 pendingWithdrawalAmount = getPendingWithdrawalAmount(safe, token);
+
+            return balance > pendingWithdrawalAmount ? balance - pendingWithdrawalAmount : 0;
+        }
+
+        return gateway().suppliedOf(safe, token);
     }
 
     /**
      * @notice Gets all effective collateral balances for a safe
-     * @dev Returns the raw Safe balances minus pending withdrawals. DebtManager reads this during its
-     *      retirement window, so it stays on the raw balance until the Aave cutover.
+     * @dev A gateway safe's collateral is its Aave-supplied balances; a legacy safe's is its raw balances
+     *      minus pending withdrawals. DebtManager reads the legacy branch for its health and borrow checks,
+     *      so that branch must keep the exact pre-gateway semantics until the legacy engine is retired.
      * @param safe Address of the safe
      * @return Array of token data with token addresses and effective amounts
      */
     function getUserTotalCollateral(address safe) public view returns (IDebtManager.TokenData[] memory) {
         IDebtManager debtManager = cashModule.getDebtManager();
         address[] memory collateralTokens = debtManager.getCollateralTokens();
-        uint256 len = collateralTokens.length;
-        IDebtManager.TokenData[] memory tokenAmounts = new IDebtManager.TokenData[](collateralTokens.length);
-        uint256 m = 0;
-        for (uint256 i = 0; i < len;) {
-            uint256 balance = IERC20(collateralTokens[i]).balanceOf(safe);
-            uint256 pendingWithdrawalAmount = getPendingWithdrawalAmount(safe, collateralTokens[i]);
-            if (balance != 0) {
-                balance = balance > pendingWithdrawalAmount ? balance - pendingWithdrawalAmount : 0;
-                if (balance != 0) {
-                    tokenAmounts[m] = IDebtManager.TokenData({ token: collateralTokens[i], amount: balance });
-                    unchecked {
-                        ++m;
-                    }
-                }
-            }
-            unchecked {
-                ++i;
-            }
+
+        if (!cashModule.isAaveGatewaySafe(safe)) {
+            return CashLensLegacyLib.userTotalCollateral(cashModule, safe, collateralTokens);
         }
 
-        assembly ("memory-safe") {
-            mstore(tokenAmounts, m)
-        }
-
-        return tokenAmounts;
+        return _suppliedBalances(safe, collateralTokens);
     }
 
     /**

--- a/src/modules/cash/CashLens.sol
+++ b/src/modules/cash/CashLens.sol
@@ -18,11 +18,11 @@ import { CashLensLegacyLib } from "./CashLensLegacyLib.sol";
 /**
  * @title CashLens
  * @notice Read-only contract providing views into a Safe's cash state
- * @dev Every engine-touching view branches on CashModule.isAaveGatewaySafe: gateway safes are read from the
+ * @dev Every engine-touching view branches on CashModule.usesAave: gateway safes are read from the
  *      Aave gateway (the logic in this contract), legacy safes from the DebtManager (preserved output-identical
  *      in the linked CashLensLegacyLib). The check side of a spend must always agree with what the execution
  *      side (CashLendLib) will do, so both read the same flag. Legacy code always sits inside an
- *      `if (!isAaveGatewaySafe(safe))` block (routing to CashLensLegacyLib, or a couple of master-verbatim
+ *      `if (!usesAave(safe))` block (routing to CashLensLegacyLib, or a couple of master-verbatim
  *      lines inline), deleted wholesale when the legacy engine is retired; the gateway path is the unguarded
  *      fall-through.
  *
@@ -180,7 +180,7 @@ contract CashLens is UpgradeableProxy {
 
         // Route by engine, mirroring the spend execution: legacy safes get the pre-gateway DebtManager
         // checks (and decline strings) exactly as before the gateway existed.
-        if (!cashModule.isAaveGatewaySafe(safe)) {
+        if (!cashModule.usesAave(safe)) {
             return CashLensLegacyLib.check(cashModule, safe, tokens, amountsInUsd, totalSpendingInUsd, safeData, mode);
         }
 
@@ -282,7 +282,7 @@ contract CashLens is UpgradeableProxy {
         address[] memory collateralTokens = debtManager.getCollateralTokens();
         address[] memory borrowTokens = debtManager.getBorrowTokens();
 
-        if (!cashModule.isAaveGatewaySafe(safe)) {
+        if (!cashModule.usesAave(safe)) {
             (data.collateralBalances, data.totalCollateral, data.borrows, data.totalBorrow) = debtManager.getUserCurrentState(safe);
             data.maxBorrow = debtManager.getMaxBorrowAmount(safe, true);
         } else {
@@ -348,7 +348,7 @@ contract CashLens is UpgradeableProxy {
         if (len == 0) return DebitModeMaxSpend(new address[](0), new uint256[](0), new uint256[](0), 0);
         if (len > 1) debtServiceTokenPreference.checkDuplicates();
 
-        if (!cashModule.isAaveGatewaySafe(safe)) {
+        if (!cashModule.usesAave(safe)) {
             return CashLensLegacyLib.maxSpendDebit(cashModule, safe, debtServiceTokenPreference);
         }
 
@@ -399,7 +399,7 @@ contract CashLens is UpgradeableProxy {
      * @return Maximum amount that can be spent in credit mode (USD, 6 decimals)
      */
     function getMaxSpendCredit(address safe) public view returns (uint256) {
-        if (!cashModule.isAaveGatewaySafe(safe)) {
+        if (!cashModule.usesAave(safe)) {
             return CashLensLegacyLib.maxSpendCredit(cashModule, safe);
         }
 
@@ -472,7 +472,7 @@ contract CashLens is UpgradeableProxy {
 
         if (!debtManager.isCollateralToken(token)) revert NotACollateralToken();
 
-        if (!cashModule.isAaveGatewaySafe(safe)) {
+        if (!cashModule.usesAave(safe)) {
             uint256 balance = IERC20(token).balanceOf(safe);
             uint256 pendingWithdrawalAmount = getPendingWithdrawalAmount(safe, token);
 
@@ -494,7 +494,7 @@ contract CashLens is UpgradeableProxy {
         IDebtManager debtManager = cashModule.getDebtManager();
         address[] memory collateralTokens = debtManager.getCollateralTokens();
 
-        if (!cashModule.isAaveGatewaySafe(safe)) {
+        if (!cashModule.usesAave(safe)) {
             return CashLensLegacyLib.userTotalCollateral(cashModule, safe, collateralTokens);
         }
 

--- a/src/modules/cash/CashLensLegacyLib.sol
+++ b/src/modules/cash/CashLensLegacyLib.sol
@@ -1,0 +1,382 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+
+import { DebitModeMaxSpend, ICashModule, Mode, SafeData } from "../../interfaces/ICashModule.sol";
+import { IDebtManager } from "../../interfaces/IDebtManager.sol";
+
+/**
+ * @title CashLensLegacyLib
+ * @notice CashLens's legacy-engine branches: the pre-gateway, DebtManager-based spend checks and max-spend
+ *         calculations, preserved output-identical (including decline strings) for safes still on the legacy
+ *         engine. CashLens routes here when a safe's engine flag is off; the gateway logic lives in CashLens
+ *         itself. Deployed as a linked external library so both engines' logic fits the lens under EIP-170.
+ * @dev Deleted wholesale when the legacy DebtManager engine is retired.
+ * @author ether.fi
+ */
+library CashLensLegacyLib {
+    using Math for uint256;
+
+    uint256 internal constant HUNDRED_PERCENT = 100e18;
+
+    /// @notice Mirrors CashLens.NotABorrowToken selector-for-selector
+    error NotABorrowToken();
+
+    /// @dev Result of walking the preference order to cover an underwater position's deficit
+    struct DeficitCoverage {
+        uint256[] spendableAmounts;
+        uint256[] spendableUsdValues;
+        uint256 remainingDeficit;
+        uint256 lastProcessedIndex;
+    }
+
+    /**
+     * @notice Mode-specific spend check for a legacy safe: validates tokens, converts amounts, and checks
+     *         DebtManager liquidity/borrowing power (credit) or post-spend health (debit)
+     * @dev The caller has already validated array shapes, the tx id, the spending limit, and the
+     *      one-token-in-credit rule; decline strings here are byte-identical to the pre-gateway lens.
+     * @param cashModule The CashModule (for the DebtManager reference)
+     * @param safe Address of the EtherFi Safe
+     * @param tokens Addresses of the tokens to spend
+     * @param amountsInUsd Amounts to spend in USD
+     * @param totalSpendingInUsd Total spend in USD
+     * @param safeData The safe's cash data (for pending withdrawal reservations)
+     * @param mode The applicable spend mode
+     * @return Whether the spend is allowed
+     * @return The decline reason when it is not
+     */
+    function check(ICashModule cashModule, address safe, address[] memory tokens, uint256[] memory amountsInUsd, uint256 totalSpendingInUsd, SafeData memory safeData, Mode mode) external view returns (bool, string memory) {
+        IDebtManager debtManager = cashModule.getDebtManager();
+        uint256[] memory amounts = new uint256[](tokens.length);
+
+        for (uint256 i = 0; i < tokens.length; i++) {
+            if (!debtManager.isBorrowToken(tokens[i])) {
+                return (false, "Not a supported stable token");
+            }
+
+            amounts[i] = debtManager.convertUsdToCollateralToken(tokens[i], amountsInUsd[i]);
+
+            if (mode == Mode.Debit && IERC20(tokens[i]).balanceOf(safe) < amounts[i]) {
+                return (false, "Insufficient token balance for debit mode spending");
+            }
+        }
+
+        if (mode == Mode.Credit) {
+            return _creditModeCheck(debtManager, safe, tokens, amounts, totalSpendingInUsd, safeData);
+        }
+        return _debitModeCheck(debtManager, safe, tokens, amounts, safeData);
+    }
+
+    /**
+     * @notice Maximum credit-mode spend for a legacy safe: borrowing power minus current borrowings on the
+     *         DebtManager, after reserving pending withdrawals from the collateral
+     * @param cashModule The CashModule (for the DebtManager reference)
+     * @param safe Address of the EtherFi Safe
+     * @return Maximum spendable in credit mode (USD, 6 decimals); 0 for an unhealthy or empty position
+     */
+    function maxSpendCredit(ICashModule cashModule, address safe) external view returns (uint256) {
+        IDebtManager debtManager = cashModule.getDebtManager();
+        SafeData memory safeData = cashModule.getData(safe);
+
+        (IDebtManager.TokenData[] memory collateralTokenAmounts, string memory declineReason) = _getCollateralBalanceWithTokensSubtracted(debtManager, safe, safeData, new address[](0), new uint256[](0), Mode.Credit);
+        if (bytes(declineReason).length != 0 || collateralTokenAmounts.length == 0) {
+            return 0;
+        }
+
+        (uint256 totalMaxBorrow, uint256 totalBorrowings) = debtManager.getBorrowingPowerAndTotalBorrowing(safe, collateralTokenAmounts);
+        if (totalBorrowings > totalMaxBorrow) {
+            return 0;
+        }
+
+        return totalMaxBorrow - totalBorrowings;
+    }
+
+    /**
+     * @notice Maximum debit-mode spend per token for a legacy safe, in preference order
+     * @dev When the position is underwater (borrowings exceed max borrow), earlier tokens are consumed as
+     *      collateral to restore health before later ones become spendable, exactly as the pre-gateway lens
+     *      calculated it. The caller has already validated a non-empty, duplicate-free preference array.
+     * @param cashModule The CashModule (for the DebtManager reference)
+     * @param safe Address of the EtherFi Safe
+     * @param debtServiceTokenPreference Ordered borrow-token preference; order determines deficit coverage
+     * @return Per-token spendable amounts and USD values with the aggregate total
+     */
+    function maxSpendDebit(ICashModule cashModule, address safe, address[] memory debtServiceTokenPreference) external view returns (DebitModeMaxSpend memory) {
+        uint256 len = debtServiceTokenPreference.length;
+        IDebtManager debtManager = cashModule.getDebtManager();
+        SafeData memory safeData = cashModule.getData(safe);
+
+        (uint256[] memory effectiveBalances, uint256[] memory tokenValuesInUsd, uint256 totalValueInUsd) = _calculateTokenValues(debtManager, safe, safeData, debtServiceTokenPreference, len);
+
+        if (totalValueInUsd == 0) {
+            return DebitModeMaxSpend(debtServiceTokenPreference, new uint256[](len), new uint256[](len), 0);
+        }
+
+        // Check collateral after theoretically spending all debit tokens
+        (IDebtManager.TokenData[] memory collateralTokenAmounts, string memory declineReason) = _getCollateralBalanceWithTokensSubtracted(debtManager, safe, safeData, debtServiceTokenPreference, effectiveBalances, Mode.Debit);
+        if (bytes(declineReason).length != 0) {
+            return DebitModeMaxSpend(new address[](0), new uint256[](0), new uint256[](0), 0);
+        }
+
+        (uint256 totalMaxBorrow, uint256 totalBorrowings) = debtManager.getBorrowingPowerAndTotalBorrowing(safe, collateralTokenAmounts);
+
+        // Healthy position: every effective balance is spendable
+        if (totalBorrowings == 0 || totalMaxBorrow >= totalBorrowings) {
+            return DebitModeMaxSpend(debtServiceTokenPreference, effectiveBalances, tokenValuesInUsd, totalValueInUsd);
+        }
+
+        return _processUnderwaterPosition(debtServiceTokenPreference, tokenValuesInUsd, effectiveBalances, debtManager, totalBorrowings - totalMaxBorrow);
+    }
+
+    /**
+     * @notice A legacy safe's effective collateral balances: raw loose balances minus pending withdrawals,
+     *         zero balances skipped
+     * @dev DebtManager reads this for its health and borrow checks; semantics must stay exactly pre-gateway.
+     * @param cashModule The CashModule (for the pending withdrawal request)
+     * @param safe Address of the EtherFi Safe
+     * @param collateralTokens The DebtManager's collateral token list
+     * @return Array of token data with token addresses and effective amounts
+     */
+    function userTotalCollateral(ICashModule cashModule, address safe, address[] memory collateralTokens) external view returns (IDebtManager.TokenData[] memory) {
+        SafeData memory safeData = cashModule.getData(safe);
+        uint256 len = collateralTokens.length;
+        IDebtManager.TokenData[] memory tokenAmounts = new IDebtManager.TokenData[](collateralTokens.length);
+        uint256 m = 0;
+        for (uint256 i = 0; i < len;) {
+            uint256 balance = IERC20(collateralTokens[i]).balanceOf(safe);
+            uint256 pendingWithdrawalAmount = _pendingWithdrawalAmount(safeData, collateralTokens[i]);
+            if (balance != 0) {
+                balance = balance > pendingWithdrawalAmount ? balance - pendingWithdrawalAmount : 0;
+                if (balance != 0) {
+                    tokenAmounts[m] = IDebtManager.TokenData({ token: collateralTokens[i], amount: balance });
+                    unchecked {
+                        ++m;
+                    }
+                }
+            }
+            unchecked {
+                ++i;
+            }
+        }
+
+        assembly ("memory-safe") {
+            mstore(tokenAmounts, m)
+        }
+
+        return tokenAmounts;
+    }
+
+    /// @dev Credit mode check: DebtManager liquidity, then borrowing power over the reserved collateral
+    function _creditModeCheck(IDebtManager debtManager, address safe, address[] memory tokens, uint256[] memory amounts, uint256 totalSpendingInUsd, SafeData memory safeData) private view returns (bool, string memory) {
+        if (IERC20(tokens[0]).balanceOf(address(debtManager)) < amounts[0]) {
+            return (false, "Insufficient liquidity in debt manager to cover the loan");
+        }
+
+        (IDebtManager.TokenData[] memory collateralTokenAmounts, string memory declineReason) = _getCollateralBalanceWithTokensSubtracted(debtManager, safe, safeData, tokens, amounts, Mode.Credit);
+        if (bytes(declineReason).length != 0) {
+            return (false, declineReason);
+        }
+
+        (uint256 totalMaxBorrow, uint256 totalBorrowings) = debtManager.getBorrowingPowerAndTotalBorrowing(safe, collateralTokenAmounts);
+        if (totalBorrowings > totalMaxBorrow) {
+            return (false, "Borrowings greater than max borrow");
+        }
+        if (totalSpendingInUsd > totalMaxBorrow - totalBorrowings) {
+            return (false, "Insufficient borrowing power");
+        }
+
+        return (true, "");
+    }
+
+    /// @dev Debit mode check: simulates the spend against the collateral and requires the position stays healthy
+    function _debitModeCheck(IDebtManager debtManager, address safe, address[] memory tokens, uint256[] memory amounts, SafeData memory safeData) private view returns (bool, string memory) {
+        (IDebtManager.TokenData[] memory collateralTokenAmounts, string memory declineReason) = _getCollateralBalanceWithTokensSubtracted(debtManager, safe, safeData, tokens, amounts, Mode.Debit);
+        if (bytes(declineReason).length != 0) {
+            return (false, declineReason);
+        }
+
+        (uint256 totalMaxBorrow, uint256 totalBorrowings) = debtManager.getBorrowingPowerAndTotalBorrowing(safe, collateralTokenAmounts);
+        if (totalBorrowings > totalMaxBorrow) {
+            return (false, "Borrowings greater than max borrow after spending");
+        }
+
+        return (true, "");
+    }
+
+    /// @dev Effective balance (loose minus pending withdrawal) and USD value per preference token
+    function _calculateTokenValues(IDebtManager debtManager, address safe, SafeData memory safeData, address[] memory tokens, uint256 len) private view returns (uint256[] memory, uint256[] memory, uint256) {
+        uint256[] memory effectiveBalances = new uint256[](len);
+        uint256[] memory tokenValuesInUsd = new uint256[](len);
+        uint256 totalValueInUsd = 0;
+
+        for (uint256 i = 0; i < len;) {
+            address token = tokens[i];
+            if (!debtManager.isBorrowToken(token)) revert NotABorrowToken();
+
+            effectiveBalances[i] = IERC20(token).balanceOf(safe) - _pendingWithdrawalAmount(safeData, token);
+
+            if (effectiveBalances[i] > 0) {
+                tokenValuesInUsd[i] = debtManager.convertCollateralTokenToUsd(token, effectiveBalances[i]);
+                totalValueInUsd += tokenValuesInUsd[i];
+            }
+
+            unchecked {
+                ++i;
+            }
+        }
+
+        return (effectiveBalances, tokenValuesInUsd, totalValueInUsd);
+    }
+
+    /// @dev Consumes tokens in preference order to cover the health deficit; the rest stays spendable
+    function _processUnderwaterPosition(address[] memory tokens, uint256[] memory tokenValuesInUsd, uint256[] memory effectiveBalances, IDebtManager debtManager, uint256 deficit) private view returns (DebitModeMaxSpend memory) {
+        DeficitCoverage memory c = _coverDeficitAndCalculateSpendable(tokens, tokenValuesInUsd, debtManager, deficit);
+
+        // If the deficit cannot be covered, nothing is spendable
+        if (c.remainingDeficit > 0) {
+            return DebitModeMaxSpend(new address[](0), new uint256[](0), new uint256[](0), 0);
+        }
+
+        uint256 totalSpendableUsd = _addRemainingTokens(c.spendableAmounts, c.spendableUsdValues, effectiveBalances, tokenValuesInUsd, c.lastProcessedIndex, tokens.length);
+
+        return DebitModeMaxSpend(tokens, c.spendableAmounts, c.spendableUsdValues, totalSpendableUsd);
+    }
+
+    /// @dev Walks the preference order covering the deficit with each token's borrowing power
+    function _coverDeficitAndCalculateSpendable(address[] memory tokens, uint256[] memory tokenValuesInUsd, IDebtManager debtManager, uint256 deficit) private view returns (DeficitCoverage memory) {
+        uint256 len = tokens.length;
+        DeficitCoverage memory c;
+        c.spendableAmounts = new uint256[](len);
+        c.spendableUsdValues = new uint256[](len);
+        c.remainingDeficit = deficit;
+
+        for (uint256 i = 0; i < len && c.remainingDeficit > 0;) {
+            uint256 tokenValue = tokenValuesInUsd[i];
+
+            if (tokenValue > 0) {
+                (uint256 spendableAmount, uint256 spendableUsd, uint256 deficitCovered) = _processTokenForDeficit(tokens[i], tokenValue, c.remainingDeficit, debtManager);
+
+                c.spendableAmounts[i] = spendableAmount;
+                c.spendableUsdValues[i] = spendableUsd;
+                c.remainingDeficit -= deficitCovered;
+                c.lastProcessedIndex = i;
+
+                if (c.remainingDeficit == 0) break;
+            }
+
+            unchecked {
+                ++i;
+            }
+        }
+
+        return c;
+    }
+
+    /// @dev How much of one token is spendable after it contributes borrowing power toward the deficit
+    function _processTokenForDeficit(address token, uint256 tokenValue, uint256 remainingDeficit, IDebtManager debtManager) private view returns (uint256, uint256, uint256) {
+        uint80 ltv = debtManager.collateralTokenConfig(token).ltv;
+        uint256 borrowingPower = tokenValue.mulDiv(ltv, HUNDRED_PERCENT, Math.Rounding.Floor);
+
+        if (borrowingPower >= remainingDeficit) {
+            // This token covers the remaining deficit; the excess stays spendable
+            uint256 collateralNeeded = remainingDeficit.mulDiv(HUNDRED_PERCENT, ltv, Math.Rounding.Ceil);
+            uint256 spendableUsd = tokenValue - collateralNeeded;
+            return (debtManager.convertUsdToCollateralToken(token, spendableUsd), spendableUsd, remainingDeficit);
+        }
+
+        // This token cannot cover the deficit alone: all of it is held back as collateral
+        return (0, 0, borrowingPower);
+    }
+
+    /// @dev Sums the deficit-phase spendables and marks every later token fully spendable
+    function _addRemainingTokens(uint256[] memory spendableAmounts, uint256[] memory spendableUsdValues, uint256[] memory effectiveBalances, uint256[] memory tokenValuesInUsd, uint256 lastProcessedIndex, uint256 len) private pure returns (uint256) {
+        uint256 totalSpendableUsd = 0;
+
+        for (uint256 i = 0; i <= lastProcessedIndex;) {
+            totalSpendableUsd += spendableUsdValues[i];
+            unchecked {
+                ++i;
+            }
+        }
+
+        for (uint256 i = lastProcessedIndex + 1; i < len;) {
+            if (tokenValuesInUsd[i] > 0) {
+                spendableAmounts[i] = effectiveBalances[i];
+                spendableUsdValues[i] = tokenValuesInUsd[i];
+                totalSpendableUsd += tokenValuesInUsd[i];
+            }
+            unchecked {
+                ++i;
+            }
+        }
+
+        return totalSpendableUsd;
+    }
+
+    /**
+     * @dev Collateral balances net of pending withdrawals, with the spend amounts subtracted for tokens
+     *      being spent (Debit mode simulation). Returns an error string when a spend amount exceeds the
+     *      post-reservation balance.
+     */
+    function _getCollateralBalanceWithTokensSubtracted(IDebtManager debtManager, address safe, SafeData memory safeData, address[] memory tokens, uint256[] memory amounts, Mode mode) private view returns (IDebtManager.TokenData[] memory, string memory) {
+        address[] memory collateralTokens = debtManager.getCollateralTokens();
+        uint256 len = collateralTokens.length;
+
+        IDebtManager.TokenData[] memory tokenAmounts = new IDebtManager.TokenData[](collateralTokens.length);
+        uint256 m = 0;
+
+        for (uint256 i = 0; i < len;) {
+            uint256 balance = IERC20(collateralTokens[i]).balanceOf(safe);
+            uint256 pendingWithdrawalAmount = _pendingWithdrawalAmount(safeData, collateralTokens[i]);
+
+            if (balance != 0) {
+                balance = balance - pendingWithdrawalAmount;
+
+                if (mode == Mode.Debit) {
+                    // Subtract the spend amount when this collateral token is being spent
+                    for (uint256 j = 0; j < tokens.length; j++) {
+                        if (collateralTokens[i] == tokens[j]) {
+                            if (balance < amounts[j]) {
+                                return (new IDebtManager.TokenData[](0), "Insufficient effective balance after withdrawal to spend with debit mode");
+                            }
+
+                            balance = balance - amounts[j];
+                            break;
+                        }
+                    }
+                }
+
+                tokenAmounts[m] = IDebtManager.TokenData({ token: collateralTokens[i], amount: balance });
+
+                unchecked {
+                    ++m;
+                }
+            }
+            unchecked {
+                ++i;
+            }
+        }
+
+        assembly ("memory-safe") {
+            mstore(tokenAmounts, m)
+        }
+
+        return (tokenAmounts, "");
+    }
+
+    /// @dev The amount of `token` reserved by the safe's pending withdrawal request, or 0 if none holds it
+    function _pendingWithdrawalAmount(SafeData memory safeData, address token) private pure returns (uint256) {
+        uint256 len = safeData.pendingWithdrawalRequest.tokens.length;
+        for (uint256 i = 0; i < len;) {
+            if (safeData.pendingWithdrawalRequest.tokens[i] == token) {
+                return safeData.pendingWithdrawalRequest.amounts[i];
+            }
+            unchecked {
+                ++i;
+            }
+        }
+        return 0;
+    }
+}

--- a/src/modules/cash/CashLiquidationHelper.sol
+++ b/src/modules/cash/CashLiquidationHelper.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { EnumerableSetLib } from "solady/utils/EnumerableSetLib.sol";
+import { IDebtManager } from "../../interfaces/IDebtManager.sol";
+
+contract CashLiquidationHelper {
+    using EnumerableSetLib for EnumerableSetLib.AddressSet;
+
+    IDebtManager public immutable debtManager;
+    EnumerableSetLib.AddressSet private stableAssets;
+
+    error InvalidInput();
+
+    constructor (address _debtManager,  address _eUsd) {
+        debtManager = IDebtManager(_debtManager);
+        stableAssets.add(_eUsd);
+        address[] memory borrowTokens = debtManager.getBorrowTokens();
+        for (uint256 i = 0; i < borrowTokens.length; i++) {
+            stableAssets.add(borrowTokens[i]);
+        }
+    }
+
+    struct CashLiquidationData {
+        address user;                   
+        bool isLiquidatable;
+        bool isMostlyStables;
+        uint256 maxBorrowAmount;           
+        uint256 totalBorrowing;            
+        uint256 liquidationBorrowAmount;   
+        uint256 remainingAmtToLiquidation; 
+    } 
+
+    function getStableAssets() external view returns (address[] memory) {                                                                                                       
+      return stableAssets.values();                                 
+    }
+
+    function updateStableAssets () external {
+        address[] memory stableAssetsFromDebtManager = debtManager.getBorrowTokens();
+        for (uint256 i = 0; i < stableAssetsFromDebtManager.length; i++) {
+            stableAssets.add(stableAssetsFromDebtManager[i]);
+        }
+    }
+
+    function getUserData(address user) external view returns (CashLiquidationData memory) {
+        return _getUserData(user);
+    }
+
+    function getUserDataBatch(address[] calldata users) external view returns (CashLiquidationData[] memory) {
+        uint256 len = users.length;
+        if (len == 0) revert InvalidInput();
+
+        CashLiquidationData[] memory data = new CashLiquidationData[](len);
+
+        for (uint256 i = 0; i < len; ) {
+            data[i] = _getUserData(users[i]);
+            unchecked {
+                ++i;
+            }
+        }
+
+        return data;
+    }
+
+    function _getUserData(address user) internal view returns (CashLiquidationData memory data) {
+        data.user = user;
+        
+        (IDebtManager.TokenData[] memory totalCollaterals, uint256 totalCollateralInUsd, , uint256 totalBorrowing) = debtManager.getUserCurrentState(user);
+        
+        uint256 stableCount = 0;
+        for (uint256 i = 0; i < totalCollaterals.length; i++) {
+            if (stableAssets.contains(totalCollaterals[i].token)) {
+                stableCount += debtManager.convertCollateralTokenToUsd(totalCollaterals[i].token, totalCollaterals[i].amount);
+            }
+        }
+
+        data.isMostlyStables = stableCount > (3 * totalCollateralInUsd) / 4;
+
+        data.isLiquidatable = debtManager.liquidatable(user);
+        data.maxBorrowAmount = debtManager.getMaxBorrowAmount(user, true);
+        data.totalBorrowing = totalBorrowing;
+        data.liquidationBorrowAmount = debtManager.getMaxBorrowAmount(user, false);
+
+        if (data.liquidationBorrowAmount > data.totalBorrowing) data.remainingAmtToLiquidation = data.liquidationBorrowAmount - data.totalBorrowing;
+    }                                                                                                                                                                 
+}

--- a/src/modules/cash/CashModuleCore.sol
+++ b/src/modules/cash/CashModuleCore.sol
@@ -82,7 +82,7 @@ contract CashModuleCore is CashModuleStorageContract {
         // New safes run on the Aave gateway. Guarded because setupModule is re-runnable: a legacy safe with
         // open DebtManager debt must keep routing to DebtManager until migrateToAave moves its position.
         (, uint256 legacyDebtUsd) = _getDebtManager().borrowingOf(msg.sender);
-        if (legacyDebtUsd == 0) $.onAaveGateway = true;
+        if (legacyDebtUsd == 0) $.usesAave = true;
     }
 
     /**
@@ -253,12 +253,12 @@ contract CashModuleCore is CashModuleStorageContract {
 
     /**
      * @notice Whether the safe's borrow/collateral engine is the Aave gateway (vs the legacy DebtManager)
-     * @dev The canonical routing flag; see ICashModule.isAaveGatewaySafe
+     * @dev The canonical routing flag; see ICashModule.usesAave
      * @param safe Address of the EtherFi Safe
      * @return True if the safe uses the Aave gateway
      */
-    function isAaveGatewaySafe(address safe) external view returns (bool) {
-        return _isAaveGatewaySafe(safe);
+    function usesAave(address safe) external view returns (bool) {
+        return _usesAave(safe);
     }
 
     /**

--- a/src/modules/cash/CashModuleCore.sol
+++ b/src/modules/cash/CashModuleCore.sol
@@ -78,6 +78,11 @@ contract CashModuleCore is CashModuleStorageContract {
         SafeCashConfig storage $ = _getCashModuleStorage().safeCashConfig[msg.sender];
         $.spendingLimit.initialize(dailyLimitInUsd, monthlyLimitInUsd, timezoneOffset);
         $.mode = Mode.Debit;
+
+        // New safes run on the Aave gateway. Guarded because setupModule is re-runnable: a legacy safe with
+        // open DebtManager debt must keep routing to DebtManager until migrateToAave moves its position.
+        (, uint256 legacyDebtUsd) = _getDebtManager().borrowingOf(msg.sender);
+        if (legacyDebtUsd == 0) $.onAaveGateway = true;
     }
 
     /**
@@ -185,13 +190,8 @@ contract CashModuleCore is CashModuleStorageContract {
      * @return settlementDispatcher The address of the settlement dispatcher
      * @custom:throws SettlementDispatcherNotSetForBinSponsor If the address of the settlement dispatcher is address(0) for bin sponsor
      */
-    function getSettlementDispatcher(BinSponsor binSponsor) public view returns (address settlementDispatcher) {
-        if (binSponsor == BinSponsor.Rain) settlementDispatcher = _getCashModuleStorage().settlementDispatcherRain;
-        else if (binSponsor == BinSponsor.PIX) settlementDispatcher = _getCashModuleStorage().settlementDispatcherPix;
-        else if (binSponsor == BinSponsor.CardOrder) settlementDispatcher = _getCashModuleStorage().settlementDispatcherCardOrder;
-        else settlementDispatcher = _getCashModuleStorage().settlementDispatcherReap;
-
-        if (settlementDispatcher == address(0)) revert SettlementDispatcherNotSetForBinSponsor();
+    function getSettlementDispatcher(BinSponsor binSponsor) public view returns (address) {
+        return CashLendLib.settlementDispatcher(_getCashModuleStorage(), binSponsor);
     }
 
     /**
@@ -218,6 +218,30 @@ contract CashModuleCore is CashModuleStorageContract {
     }
 
     /**
+     * @notice Prepares a safe for liquidation by canceling any pending withdrawals
+     * @dev Only callable by the DebtManager
+     * @param safe Address of the EtherFi Safe being liquidated
+     * @custom:throws OnlyDebtManager if called by any address other than the DebtManager
+     */
+    function preLiquidate(address safe) external {
+        if (msg.sender != address(getDebtManager())) revert OnlyDebtManager();
+        _cancelOldWithdrawal(safe);
+    }
+
+    /**
+     * @notice Executes post-liquidation logic to transfer tokens to the liquidator
+     * @dev Only callable by the DebtManager after a successful liquidation
+     * @param safe Address of the EtherFi Safe being liquidated
+     * @param liquidator Address that will receive the liquidated tokens
+     * @param tokensToSend Array of token data with amounts to send to the liquidator
+     * @custom:throws OnlyDebtManager if called by any address other than the DebtManager
+     */
+    function postLiquidate(address safe, address liquidator, IDebtManager.LiquidationTokenData[] memory tokensToSend) external {
+        if (msg.sender != address(getDebtManager())) revert OnlyDebtManager();
+        CashLendLib.postLiquidateTransfers(safe, liquidator, tokensToSend);
+    }
+
+    /**
      * @notice Returns whether lend (Aave auto-supply and borrow ops) is enabled for a safe
      * @dev Lend is enabled by default; a safe with no borrows may opt out via toggleLend(false) + processLendDisable
      * @param safe Address of the EtherFi Safe
@@ -225,6 +249,16 @@ contract CashModuleCore is CashModuleStorageContract {
      */
     function isLendEnabled(address safe) external view returns (bool) {
         return !_getCashModuleStorage().safeCashConfig[safe].lendDisabled;
+    }
+
+    /**
+     * @notice Whether the safe's borrow/collateral engine is the Aave gateway (vs the legacy DebtManager)
+     * @dev The canonical routing flag; see ICashModule.isAaveGatewaySafe
+     * @param safe Address of the EtherFi Safe
+     * @return True if the safe uses the Aave gateway
+     */
+    function isAaveGatewaySafe(address safe) external view returns (bool) {
+        return _isAaveGatewaySafe(safe);
     }
 
     /**
@@ -338,8 +372,12 @@ contract CashModuleCore is CashModuleStorageContract {
 
         uint256 totalSpendingInUsd = _validateSpend($.safeCashConfig[safe], txId, tokens, amountsInUsd);
 
-        if ($.safeCashConfig[safe].mode == Mode.Credit) _spendCredit($, safe, txId, binSponsor, tokens, amountsInUsd, totalSpendingInUsd);
-        else _spendDebit($, safe, txId, binSponsor, tokens, amountsInUsd, totalSpendingInUsd);
+        // CashLendLib routes each mode by engine (gateway vs legacy DebtManager) and emits Spend.
+        if ($.safeCashConfig[safe].mode == Mode.Credit) {
+            CashLendLib.spendCredit($, etherFiDataProvider, safe, txId, binSponsor, tokens, amountsInUsd, totalSpendingInUsd);
+        } else {
+            CashLendLib.spendDebit($, etherFiDataProvider, safe, txId, binSponsor, tokens, amountsInUsd, totalSpendingInUsd);
+        }
         _cashback($, safe, totalSpendingInUsd, cashbacks);
     }
 
@@ -370,49 +408,6 @@ contract CashModuleCore is CashModuleStorageContract {
         $$.spendingLimit.spend(totalSpendingInUsd);
 
         return totalSpendingInUsd;
-    }
-
-    /**
-     * @dev Internal function to execute credit mode spending transaction (single token), run in
-     *      CashLendLib; a blocked legacy borrow cancels the pending withdrawal request and retries
-     * @param $ Storage reference to the CashModuleStorage
-     * @param safe Address of the EtherFi Safe
-     * @param txId Transaction identifier
-     * @param tokens Addresses of the tokens to spend
-     * @param amountsInUsd Amounts to spend in USD
-     */
-    function _spendCredit(CashModuleStorage storage $, address safe, bytes32 txId, BinSponsor binSponsor, address[] memory tokens, uint256[] memory amountsInUsd, uint256 totalSpendingInUsd) internal {
-        (uint256 amount, bool retryAfterCancel) = CashLendLib.spendCredit($, safe, binSponsor, getSettlementDispatcher(binSponsor), tokens[0], amountsInUsd[0]);
-        if (retryAfterCancel) {
-            // The legacy borrow was blocked; cancel the pending withdrawal request and retry, matching the
-            // debit path's competing-claims rule (the spend wins over the reservation).
-            _cancelOldWithdrawal(safe);
-            CashLendLib.legacyBorrow($, safe, binSponsor, tokens[0], amount);
-        }
-
-        uint256[] memory amounts = new uint256[](1);
-        amounts[0] = amount;
-
-        $.cashEventEmitter.emitSpend(safe, txId, binSponsor, tokens, amounts, amountsInUsd, totalSpendingInUsd, Mode.Credit);
-    }
-
-    /**
-     * @dev Internal function to execute debit mode spending transactions (multiple tokens), sized and
-     *      executed in CashLendLib against the safe's loose and Aave-supplied balances
-     * @param $ Storage reference to the CashModuleStorage
-     * @param safe Address of the EtherFi Safe
-     * @param txId Transaction identifier
-     * @param tokens Array of addresses of the tokens to spend
-     * @param amountsInUsd Array of amounts to spend in USD
-     */
-    function _spendDebit(CashModuleStorage storage $, address safe, bytes32 txId, BinSponsor binSponsor, address[] calldata tokens, uint256[] calldata amountsInUsd, uint256 totalSpendingInUsd) internal {
-        (uint256[] memory amounts, uint256[] memory fromLoose, bool cancelWithdrawal) = CashLendLib.sourceDebits($, etherFiDataProvider, safe, tokens, amountsInUsd);
-        // Sizing needs balance reserved by the pending withdrawal request: the spend wins the
-        // competing claim and the request is cancelled before any transfer executes.
-        if (cancelWithdrawal) _cancelOldWithdrawal(safe);
-        CashLendLib.executeDebits($, safe, getSettlementDispatcher(binSponsor), tokens, amounts, fromLoose);
-
-        $.cashEventEmitter.emitSpend(safe, txId, binSponsor, tokens, amounts, amountsInUsd, totalSpendingInUsd, Mode.Debit);
     }
 
     /**

--- a/src/modules/cash/CashModuleSetters.sol
+++ b/src/modules/cash/CashModuleSetters.sol
@@ -94,6 +94,18 @@ contract CashModuleSetters is CashModuleStorageContract {
     }
 
     /**
+     * @notice Marks a safe as using the Aave gateway engine
+     * @dev Only callable by the DebtManager, as the last step of migrateToAave. Idempotent and one-way:
+     *      nothing ever clears the flag.
+     * @param safe Address of the EtherFi Safe
+     * @custom:throws OnlyDebtManager if called by any address other than the DebtManager
+     */
+    function markAaveGatewaySafe(address safe) external {
+        if (msg.sender != address(_getDebtManager())) revert OnlyDebtManager();
+        _getCashModuleStorage().safeCashConfig[safe].onAaveGateway = true;
+    }
+
+    /**
      * @notice Configures the withdraw assets whitelist
      * @dev Only callable by accounts with CASH_MODULE_CONTROLLER_ROLE
      * @param assets Array of asset addresses to configure
@@ -407,6 +419,8 @@ contract CashModuleSetters is CashModuleStorageContract {
         $$.pendingWithdrawalRequest = WithdrawalRequest({ tokens: tokens, amounts: amounts, recipient: recipient, finalizeTime: finalTime });
         $.cashEventEmitter.emitWithdrawalRequested(safe, tokens, amounts, recipient, finalTime);
 
+        // Deliberately unconditional: load-bearing for legacy safes (loose tokens are DebtManager collateral)
+        // and provably a no-op for gateway safes, whose DebtManager books are zero by construction.
         _getDebtManager().ensureHealth(safe);
 
         if ($.withdrawalDelay == 0) _processWithdrawal(safe);

--- a/src/modules/cash/CashModuleSetters.sol
+++ b/src/modules/cash/CashModuleSetters.sol
@@ -100,9 +100,9 @@ contract CashModuleSetters is CashModuleStorageContract {
      * @param safe Address of the EtherFi Safe
      * @custom:throws OnlyDebtManager if called by any address other than the DebtManager
      */
-    function markAaveGatewaySafe(address safe) external {
+    function markUsesAave(address safe) external {
         if (msg.sender != address(_getDebtManager())) revert OnlyDebtManager();
-        _getCashModuleStorage().safeCashConfig[safe].onAaveGateway = true;
+        _getCashModuleStorage().safeCashConfig[safe].usesAave = true;
     }
 
     /**

--- a/src/modules/cash/CashModuleStorageContract.sol
+++ b/src/modules/cash/CashModuleStorageContract.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.28;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-import { IBridgeModule } from "../../interfaces/IBridgeModule.sol";
 import { ICashEventEmitter } from "../../interfaces/ICashEventEmitter.sol";
 import { SafeCashConfig, SafeData, SafeTiers, WithdrawalRequest } from "../../interfaces/ICashModule.sol";
 import { ICashbackDispatcher } from "../../interfaces/ICashbackDispatcher.sol";
@@ -16,6 +15,7 @@ import { SignatureUtils } from "../../libraries/SignatureUtils.sol";
 import { SpendingLimit, SpendingLimitLib } from "../../libraries/SpendingLimitLib.sol";
 import { UpgradeableProxy } from "../../utils/UpgradeableProxy.sol";
 import { ModuleBase } from "../ModuleBase.sol";
+import { CashLendLib } from "./CashLendLib.sol";
 import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 import { EnumerableSetLib } from "solady/utils/EnumerableSetLib.sol";
 
@@ -104,6 +104,9 @@ contract CashModuleStorageContract is UpgradeableProxy, ModuleBase {
 
     /// @notice Error thrown when a balance is insufficient for an operation
     error InsufficientBalance();
+
+    /// @notice Error thrown when a non-DebtManager contract calls restricted functions
+    error OnlyDebtManager();
 
     /// @notice Error thrown when a recipient address is set to zero
     error RecipientCannotBeAddressZero();
@@ -198,26 +201,21 @@ contract CashModuleStorageContract is UpgradeableProxy, ModuleBase {
     }
 
     /**
-     * @dev Cancels pending withdrawal requests for a Safe
+     * @notice Whether the safe's borrow/collateral engine is the Aave gateway (vs the legacy DebtManager)
+     * @dev The canonical routing flag: every engine-touching path must branch on this and nothing else.
+     * @param safe Address of the EtherFi Safe
+     * @return True if the safe uses the Aave gateway
+     */
+    function _isAaveGatewaySafe(address safe) internal view returns (bool) {
+        return _getCashModuleStorage().safeCashConfig[safe].onAaveGateway;
+    }
+
+    /**
+     * @dev Cancels pending withdrawal requests for a Safe; the logic lives in CashLendLib for code size
      * @param safe Address of the EtherFi Safe
      */
     function _cancelOldWithdrawal(address safe) internal {
-        CashModuleStorage storage $ = _getCashModuleStorage();
-
-        ICashEventEmitter eventEmitter = $.cashEventEmitter;
-        SafeCashConfig storage safeCashConfig = $.safeCashConfig[safe];
-
-        address recipient = safeCashConfig.pendingWithdrawalRequest.recipient;
-
-        if (safeCashConfig.pendingWithdrawalRequest.tokens.length > 0) {
-            if ($.whitelistedModulesCanRequestWithdraw.contains(recipient)) {
-                // Only call the function if the module is whitelisted on data provider
-                if (etherFiDataProvider.isWhitelistedModule(recipient)) IBridgeModule(recipient).cancelBridgeByCashModule(safe);
-            }
-
-            eventEmitter.emitWithdrawalCancelled(safe, safeCashConfig.pendingWithdrawalRequest.tokens, safeCashConfig.pendingWithdrawalRequest.amounts, recipient);
-            delete safeCashConfig.pendingWithdrawalRequest;
-        }
+        CashLendLib.cancelOldWithdrawal(_getCashModuleStorage(), etherFiDataProvider, safe);
     }
 
     /**
@@ -342,6 +340,8 @@ contract CashModuleStorageContract is UpgradeableProxy, ModuleBase {
 
         delete $$.pendingWithdrawalRequest;
 
+        // Deliberately unconditional: load-bearing for legacy safes (loose tokens are DebtManager collateral)
+        // and provably a no-op for gateway safes, whose DebtManager books are zero by construction.
         $.debtManager.ensureHealth(safe);
     }
 }

--- a/src/modules/cash/CashModuleStorageContract.sol
+++ b/src/modules/cash/CashModuleStorageContract.sol
@@ -206,8 +206,8 @@ contract CashModuleStorageContract is UpgradeableProxy, ModuleBase {
      * @param safe Address of the EtherFi Safe
      * @return True if the safe uses the Aave gateway
      */
-    function _isAaveGatewaySafe(address safe) internal view returns (bool) {
-        return _getCashModuleStorage().safeCashConfig[safe].onAaveGateway;
+    function _usesAave(address safe) internal view returns (bool) {
+        return _getCashModuleStorage().safeCashConfig[safe].usesAave;
     }
 
     /**

--- a/test/Errors.t.sol
+++ b/test/Errors.t.sol
@@ -76,6 +76,7 @@ contract ErrorsTest is Test {
     error OnlyCashModuleController();
     error CannotWithdrawYet();
     error ModeAlreadySet();
+    error OnlyDebtManager();
     error AlreadyInSameTier();
     error CashbackPercentageGreaterThanMaxAllowed();
     error SplitAlreadyTheSame();
@@ -222,6 +223,7 @@ contract ErrorsTest is Test {
         emit log_named_bytes("OnlyCashModuleController", abi.encodePacked(OnlyCashModuleController.selector));
         emit log_named_bytes("CannotWithdrawYet", abi.encodePacked(CannotWithdrawYet.selector));
         emit log_named_bytes("ModeAlreadySet", abi.encodePacked(ModeAlreadySet.selector));
+        emit log_named_bytes("OnlyDebtManager", abi.encodePacked(OnlyDebtManager.selector));
         emit log_named_bytes("AlreadyInSameTier", abi.encodePacked(AlreadyInSameTier.selector));
         emit log_named_bytes("CashbackPercentageGreaterThanMaxAllowed", abi.encodePacked(CashbackPercentageGreaterThanMaxAllowed.selector));
         emit log_named_bytes("SplitAlreadyTheSame", abi.encodePacked(SplitAlreadyTheSame.selector));

--- a/test/gateway/CashLendDisable.t.sol
+++ b/test/gateway/CashLendDisable.t.sol
@@ -82,6 +82,7 @@ contract CashLendDisableTest is CashModuleTestSetup, AaveV4Fixture {
         cashModule.setGateway(address(gw));
     }
 
+    /// A fresh safe starts with lend enabled and no pending disable.
     function test_lendEnabledByDefault() public view {
         assertTrue(cashModule.isLendEnabled(address(safe)), "lend on by default (cash module)");
         assertTrue(gw.isLendEnabled(address(safe)), "lend on by default (gateway view)");
@@ -90,6 +91,7 @@ contract CashLendDisableTest is CashModuleTestSetup, AaveV4Fixture {
 
     // ----------------------------------------------------------------- happy path
 
+    /// Executing the opt-out pulls all Aave collateral into the safe, forces Debit, and blocks every later lend op.
     function test_disableLend_withdrawsCollateralForcesDebitAndBlocksLend() public {
         // Position: 5 weETH supplied as collateral on Aave, no debt
         deal(address(weETH), address(safe), 5 ether);
@@ -134,6 +136,7 @@ contract CashLendDisableTest is CashModuleTestSetup, AaveV4Fixture {
         vm.stopPrank();
     }
 
+    /// Opting out from Credit mode drops the safe back to Debit.
     function test_disableLend_forcesDebitFromCreditMode() public {
         // Move the safe into Credit mode first (no borrows), then opt out
         _setModeCredit();
@@ -146,6 +149,7 @@ contract CashLendDisableTest is CashModuleTestSetup, AaveV4Fixture {
         assertEq(uint8(cashModule.getMode(address(safe))), uint8(Mode.Debit), "credit dropped to debit");
     }
 
+    /// Opting out with no Aave position just flips the flag and forces Debit.
     function test_disableLend_noCollateral_marksDisabled() public {
         // No Aave position at all: opting out is still valid and just flips the flag
         _requestDisable();
@@ -156,8 +160,37 @@ contract CashLendDisableTest is CashModuleTestSetup, AaveV4Fixture {
         assertEq(uint8(cashModule.getMode(address(safe))), uint8(Mode.Debit));
     }
 
+    /// @dev A legacy-engine safe's opt-out is just the flag plus forced Debit: its funds are already loose,
+    ///      so nothing is unwound from Aave. This is the pre-migration opt-out lever.
+    function test_disableLend_legacySafe_disablesWithoutTouchingGateway() public {
+        _forceLegacyEngine(address(safe));
+        deal(address(weETH), address(safe), 5 ether);
+
+        _requestDisable();
+        vm.warp(block.timestamp + MODE_DELAY);
+        cashModule.processLendDisable(address(safe));
+
+        assertFalse(cashModule.isLendEnabled(address(safe)), "legacy safe disabled");
+        assertEq(uint8(cashModule.getMode(address(safe))), uint8(Mode.Debit), "forced to debit");
+        assertEq(weETH.balanceOf(address(safe)), 5 ether, "funds stayed loose in the safe");
+    }
+
+    /// @dev A legacy safe with open DebtManager debt cannot opt out: the borrow check counts both engines.
+    function test_toggleLendDisable_legacySafe_revertsWithOpenDebtManagerBorrow() public {
+        _forceLegacyEngine(address(safe));
+        deal(address(weETH), address(safe), 5 ether);
+        deal(address(usdc), address(debtManager), 100_000e6);
+        vm.prank(address(safe));
+        debtManager.borrow(BinSponsor.Reap, address(usdc), 100e6);
+
+        (address signer, bytes memory sig) = _toggleLendSig(false);
+        vm.expectRevert(ICashModule.HasOpenBorrows.selector);
+        cashModule.toggleLend(address(safe), false, signer, sig);
+    }
+
     // ----------------------------------------------------------------- disable-request guards
 
+    /// Requesting the opt-out reverts when the safe has an open Aave borrow.
     function test_toggleLendDisable_revertsWithOpenAaveBorrow() public {
         // Open an Aave borrow so the safe has debt
         deal(address(weETH), address(safe), 5 ether);
@@ -172,6 +205,7 @@ contract CashLendDisableTest is CashModuleTestSetup, AaveV4Fixture {
         cashModule.toggleLend(address(safe), false, signer, sig);
     }
 
+    /// A second opt-out request reverts while one is already pending.
     function test_toggleLendDisable_revertsWhenAlreadyPending() public {
         _requestDisable();
 
@@ -180,6 +214,7 @@ contract CashLendDisableTest is CashModuleTestSetup, AaveV4Fixture {
         cashModule.toggleLend(address(safe), false, signer, sig);
     }
 
+    /// Requesting the opt-out reverts when lend is already disabled.
     function test_toggleLendDisable_revertsWhenAlreadyDisabled() public {
         _requestDisable();
         vm.warp(block.timestamp + MODE_DELAY);
@@ -190,12 +225,14 @@ contract CashLendDisableTest is CashModuleTestSetup, AaveV4Fixture {
         cashModule.toggleLend(address(safe), false, signer, sig);
     }
 
+    /// toggleLend reverts when the named signer is not a safe admin.
     function test_toggleLend_rejectsNonAdminSigner() public {
         (, bytes memory sig) = _toggleLendSig(false);
         vm.expectRevert(ICashModule.OnlySafeAdmin.selector);
         cashModule.toggleLend(address(safe), false, makeAddr("notAdmin"), sig);
     }
 
+    /// toggleLend reverts when an admin is named but the signature is from the wrong key.
     function test_toggleLend_rejectsBadSignature() public {
         // Correct signer (an admin) but signed by the wrong key
         uint256 nonce = cashModule.getNonce(address(safe));
@@ -207,6 +244,7 @@ contract CashLendDisableTest is CashModuleTestSetup, AaveV4Fixture {
         cashModule.toggleLend(address(safe), false, owner1, sig);
     }
 
+    /// A signature for disable cannot be replayed to enable (the flag is bound into the digest).
     function test_toggleLend_signatureBindsEnableFlag() public {
         // A signature authorizing disable (enable=false) must not be accepted for enable (enable=true)
         (address signer, bytes memory sig) = _toggleLendSig(false);
@@ -216,11 +254,13 @@ contract CashLendDisableTest is CashModuleTestSetup, AaveV4Fixture {
 
     // ----------------------------------------------------------------- execute (processLendDisable) guards
 
+    /// processLendDisable reverts when there is no pending request.
     function test_processLendDisable_revertsWhenNoPending() public {
         vm.expectRevert(ICashModule.NoPendingLendDisable.selector);
         cashModule.processLendDisable(address(safe));
     }
 
+    /// processLendDisable reverts while still inside the mode-change delay.
     function test_processLendDisable_revertsWhenNotReady() public {
         _requestDisable();
         // Still inside the delay window
@@ -228,6 +268,7 @@ contract CashLendDisableTest is CashModuleTestSetup, AaveV4Fixture {
         cashModule.processLendDisable(address(safe));
     }
 
+    /// processLendDisable reverts if a borrow was opened during the delay window.
     function test_processLendDisable_revertsWhenBorrowTakenDuringDelay() public {
         // Request with no debt, then take an Aave borrow during the delay window
         _requestDisable();
@@ -278,6 +319,7 @@ contract CashLendDisableTest is CashModuleTestSetup, AaveV4Fixture {
 
     // ----------------------------------------------------------------- credit mode interaction
 
+    /// A lend-disabled safe cannot switch into Credit mode.
     function test_afterDisable_cannotEnterCreditMode() public {
         _requestDisable();
         vm.warp(block.timestamp + MODE_DELAY);
@@ -294,6 +336,7 @@ contract CashLendDisableTest is CashModuleTestSetup, AaveV4Fixture {
 
     // ----------------------------------------------------------------- re-enable (toggleLend true)
 
+    /// Re-enabling lend flips the flag back on and resumes auto-supply.
     function test_enableLend_reenablesAndResumesSupply() public {
         _requestDisable();
         vm.warp(block.timestamp + MODE_DELAY);
@@ -314,12 +357,14 @@ contract CashLendDisableTest is CashModuleTestSetup, AaveV4Fixture {
         assertApproxEqAbs(gw.suppliedOf(address(safe), address(weETH)), 2 ether, 2, "supply resumed");
     }
 
+    /// Re-enabling reverts when lend was never disabled.
     function test_enableLend_revertsWhenNotDisabled() public {
         (address signer, bytes memory sig) = _toggleLendSig(true);
         vm.expectRevert(ICashModule.LendNotDisabled.selector);
         cashModule.toggleLend(address(safe), true, signer, sig);
     }
 
+    /// Re-enabling cancels a pending disable so it can no longer be executed.
     function test_enableLend_cancelsPendingRequest() public {
         // A pending (not-yet-executed) request can be cancelled by re-enabling
         _requestDisable();

--- a/test/gateway/DebtManagerMigration.t.sol
+++ b/test/gateway/DebtManagerMigration.t.sol
@@ -8,7 +8,7 @@ import { UUPSProxy } from "../../src/UUPSProxy.sol";
 import { DebtManagerCore } from "../../src/debt-manager/DebtManagerCore.sol";
 import { DebtManagerStorageContract } from "../../src/debt-manager/DebtManagerStorageContract.sol";
 import { IAggregatorV3 } from "../../src/interfaces/IAggregatorV3.sol";
-import { BinSponsor, Cashback, Mode } from "../../src/interfaces/ICashModule.sol";
+import { BinSponsor, Cashback, ICashModule, Mode } from "../../src/interfaces/ICashModule.sol";
 import { CashVerificationLib } from "../../src/libraries/CashVerificationLib.sol";
 import { IGateway } from "../../src/interfaces/IGateway.sol";
 import { Gateway } from "../../src/modules/gateway/Gateway.sol";
@@ -65,6 +65,10 @@ contract DebtManagerMigrationTest is CashModuleTestSetup, AaveV4Fixture {
 
         _enableModule(address(gw));
         _activateAavePositionManager(address(gw));
+
+        // The safes in this suite model the pre-gateway population: route them to the legacy engine so
+        // migration is the thing that flips them (new safes onboard onto the gateway by default).
+        _forceLegacyEngine(address(safe));
     }
 
     /// @dev Empty on purpose: skips the base mock-gateway wiring so this suite's one-time setGateway(gw) above is
@@ -88,9 +92,10 @@ contract DebtManagerMigrationTest is CashModuleTestSetup, AaveV4Fixture {
         vm.prank(migrator);
         dm.migrateToAave(address(safe));
 
-        // Legacy debt closed and Safe flagged migrated
+        // Legacy debt closed and Safe flagged migrated; both latches flip in the same tx
         assertEq(debtManager.borrowingOf(address(safe), address(usdc)), 0, "legacy debt cleared");
         assertTrue(dm.hasMigratedToAave(address(safe)), "marked migrated");
+        assertTrue(cashModule.isAaveGatewaySafe(address(safe)), "CashModule routing flag flipped");
         // Position now lives on Aave: same collateral, same debt size
         assertApproxEqAbs(gw.suppliedOf(address(safe), address(weETH)), 10 ether, 3, "collateral on Aave");
         assertApproxEqAbs(gw.debtOf(address(safe), address(usdc)), borrowAmt, 1e6, "debt on Aave");
@@ -176,6 +181,45 @@ contract DebtManagerMigrationTest is CashModuleTestSetup, AaveV4Fixture {
         vm.prank(migrator);
         vm.expectRevert(DebtManagerStorageContract.LendDisabledSafeHasDebt.selector);
         dm.migrateToAave(address(safe));
+    }
+
+    /// @dev Pending withdrawals reserve loose funds; migration must not sweep them into Aave. The queued
+    ///      withdrawal is a plain transfer of the Safe's balance, so supplying it would brick processWithdrawal.
+    function test_migrateToAave_leavesPendingWithdrawalLoose() public {
+        _seedAaveLiquidity(usdcReserveId, address(usdc), 5_000_000e6);
+
+        deal(address(weETH), address(safe), 10 ether);
+        uint256 borrowAmt = dm.getMaxBorrowAmount(address(safe), true) / 8;
+        vm.prank(address(safe));
+        debtManager.borrow(BinSponsor.Reap, address(usdc), borrowAmt);
+
+        // Queue a withdrawal of 2 weETH, then migrate before the delay elapses
+        uint256 withdrawAmt = 2 ether;
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(weETH);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = withdrawAmt;
+        _requestWithdrawal(tokens, amounts, withdrawRecipient);
+
+        vm.prank(migrator);
+        dm.migrateToAave(address(safe));
+
+        // Reserved amount stayed loose; only the rest was supplied
+        assertEq(weETH.balanceOf(address(safe)), withdrawAmt, "reserved amount left loose in the safe");
+        assertApproxEqAbs(gw.suppliedOf(address(safe), address(weETH)), 10 ether - withdrawAmt, 3, "unreserved collateral supplied");
+
+        // The queued withdrawal still processes normally after the delay
+        (uint64 withdrawalDelay,,) = cashModule.getDelays();
+        vm.warp(block.timestamp + withdrawalDelay + 1);
+        cashModule.processWithdrawal(address(safe));
+        assertEq(weETH.balanceOf(withdrawRecipient), withdrawAmt, "withdrawal paid out post-migration");
+        assertEq(weETH.balanceOf(address(safe)), 0, "safe holds nothing loose afterwards");
+    }
+
+    function test_markAaveGatewaySafe_onlyDebtManager() public {
+        vm.prank(makeAddr("rando"));
+        vm.expectRevert(ICashModule.OnlyDebtManager.selector);
+        cashModule.markAaveGatewaySafe(address(safe));
     }
 
     function test_migrateToAave_onlyDebtManagerAdmin() public {
@@ -314,6 +358,97 @@ contract DebtManagerMigrationTest is CashModuleTestSetup, AaveV4Fixture {
         // Full repay leaves zero dust, and only the live debt was pulled from the safe (the excess is refunded).
         assertEq(gw.debtOf(address(safe), address(usdc)), 0, "Aave debt fully cleared, no dust");
         assertApproxEqAbs(safeBalBefore - usdc.balanceOf(address(safe)), liveDebt, 2, "only the live debt was pulled");
+    }
+
+    // ----------------------------------------------------------------- migration boundary
+    // A card auth is decided off-chain (CashLens.canSpend) seconds before the spend lands on-chain. If the
+    // migration sweep moves the safe in between, the auth was checked against the legacy engine but the
+    // spend executes on the gateway. These tests pin that hand-off.
+
+    /// A credit auth approved pre-migration (legacy check) lands post-migration as an Aave borrow.
+    function test_migrationBoundary_creditAuth_landsOnAave() public {
+        _seedAaveLiquidity(usdcReserveId, address(usdc), 5_000_000e6);
+        deal(address(weETH), address(safe), 10 ether);
+        deal(address(usdc), address(debtManager), 1000e6); // legacy credit check requires DebtManager liquidity
+
+        _setMode(Mode.Credit);
+        vm.warp(cashModule.incomingModeStartTime(address(safe)) + 1);
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 100e6;
+
+        (bool ok, string memory reason) = cashLens.canSpend(address(safe), keccak256("boundary-credit"), tokens, amounts);
+        assertTrue(ok, reason);
+
+        vm.prank(migrator);
+        dm.migrateToAave(address(safe));
+
+        Cashback[] memory cashbacks;
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), keccak256("boundary-credit"), BinSponsor.Reap, tokens, amounts, cashbacks);
+
+        assertApproxEqAbs(gw.debtOf(address(safe), address(usdc)), 100e6, 1e6, "borrowed on Aave, not the DebtManager");
+        assertEq(debtManager.borrowingOf(address(safe), address(usdc)), 0, "no legacy debt");
+    }
+
+    /// A debit auth approved pre-migration against the loose balance sources from the Aave-supplied
+    /// position post-migration (migration moved the funds there).
+    function test_migrationBoundary_debitAuth_sourcesFromAave() public {
+        deal(address(usdc), address(safe), 100e6);
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 50e6;
+
+        (bool ok, string memory reason) = cashLens.canSpend(address(safe), keccak256("boundary-debit"), tokens, amounts);
+        assertTrue(ok, reason);
+
+        vm.prank(migrator);
+        dm.migrateToAave(address(safe));
+        assertEq(usdc.balanceOf(address(safe)), 0, "migration supplied the loose balance");
+
+        address dispatcher = cashModule.getSettlementDispatcher(BinSponsor.Reap);
+        uint256 dispatcherBefore = usdc.balanceOf(dispatcher);
+
+        Cashback[] memory cashbacks;
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), keccak256("boundary-debit"), BinSponsor.Reap, tokens, amounts, cashbacks);
+
+        assertEq(usdc.balanceOf(dispatcher), dispatcherBefore + 50e6, "debit sourced from the supplied position");
+        assertApproxEqAbs(gw.suppliedOf(address(safe), address(usdc)), 50e6, 2, "supplied position reduced");
+    }
+
+    /// Gateway-credit declined-side parity: a check declined for borrowing power implies the Aave borrow
+    /// reverts (the mock gateway cannot model this; the real Aave instance enforces it).
+    function test_migrationBoundary_gatewayCreditDeclined_revertsOnSpend() public {
+        _seedAaveLiquidity(usdcReserveId, address(usdc), 5_000_000e6);
+        deal(address(weETH), address(safe), 1 ether);
+
+        vm.prank(migrator);
+        dm.migrateToAave(address(safe));
+
+        _setMode(Mode.Credit);
+        vm.warp(cashModule.incomingModeStartTime(address(safe)) + 1);
+
+        uint256 tooMuch = gw.getAccountData(address(safe)).availableBorrowsUsd + 100e6;
+        assertLt(tooMuch, dailyLimitInUsd, "test premise: declined by borrow power, not the limit");
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = tooMuch;
+
+        (bool ok, string memory reason) = cashLens.canSpend(address(safe), keccak256("boundary-declined"), tokens, amounts);
+        assertFalse(ok);
+        assertEq(reason, "Insufficient borrowing power");
+
+        Cashback[] memory cashbacks;
+        vm.prank(etherFiWallet);
+        vm.expectRevert(); // Aave enforces the borrowing power on the borrow itself
+        cashModule.spend(address(safe), keccak256("boundary-declined"), BinSponsor.Reap, tokens, amounts, cashbacks);
     }
 
     // ----------------------------------------------------------------- helpers

--- a/test/gateway/DebtManagerMigration.t.sol
+++ b/test/gateway/DebtManagerMigration.t.sol
@@ -95,7 +95,7 @@ contract DebtManagerMigrationTest is CashModuleTestSetup, AaveV4Fixture {
         // Legacy debt closed and Safe flagged migrated; both latches flip in the same tx
         assertEq(debtManager.borrowingOf(address(safe), address(usdc)), 0, "legacy debt cleared");
         assertTrue(dm.hasMigratedToAave(address(safe)), "marked migrated");
-        assertTrue(cashModule.isAaveGatewaySafe(address(safe)), "CashModule routing flag flipped");
+        assertTrue(cashModule.usesAave(address(safe)), "CashModule routing flag flipped");
         // Position now lives on Aave: same collateral, same debt size
         assertApproxEqAbs(gw.suppliedOf(address(safe), address(weETH)), 10 ether, 3, "collateral on Aave");
         assertApproxEqAbs(gw.debtOf(address(safe), address(usdc)), borrowAmt, 1e6, "debt on Aave");
@@ -216,10 +216,10 @@ contract DebtManagerMigrationTest is CashModuleTestSetup, AaveV4Fixture {
         assertEq(weETH.balanceOf(address(safe)), 0, "safe holds nothing loose afterwards");
     }
 
-    function test_markAaveGatewaySafe_onlyDebtManager() public {
+    function test_markUsesAave_onlyDebtManager() public {
         vm.prank(makeAddr("rando"));
         vm.expectRevert(ICashModule.OnlyDebtManager.selector);
-        cashModule.markAaveGatewaySafe(address(safe));
+        cashModule.markUsesAave(address(safe));
     }
 
     function test_migrateToAave_onlyDebtManagerAdmin() public {

--- a/test/safe/modules/cash/CashLens.t.sol
+++ b/test/safe/modules/cash/CashLens.t.sol
@@ -70,7 +70,9 @@ contract CashLensTest is CashModuleTestSetup {
         vm.stopPrank();
     }
 
+    /// A legacy safe's collateral is its raw balance minus pending withdrawals.
     function test_getUserCollateralForToken() public {
+        _forceLegacyEngine(address(safe));
         uint256 depositAmount = 5 ether;
         deal(address(weETH), address(safe), depositAmount);
         
@@ -97,7 +99,22 @@ contract CashLensTest is CashModuleTestSetup {
         cashLens.getUserCollateralForToken(address(safe), nonCollateralToken);
     }
 
+    /// A gateway safe's collateral is its Aave-supplied balance; loose funds and pending withdrawals don't count.
+    function test_getUserCollateralForToken_gatewaySafe_readsSuppliedBalance() public {
+        deal(address(weETH), address(safe), 5 ether); // loose, not collateral for a gateway safe
+        assertEq(cashLens.getUserCollateralForToken(address(safe), address(weETH)), 0, "loose balance is not collateral");
+
+        gateway.setSuppliedOf(address(safe), address(weETH), 3 ether);
+        assertEq(cashLens.getUserCollateralForToken(address(safe), address(weETH)), 3 ether, "supplied balance is the collateral");
+
+        IDebtManager.TokenData[] memory collateral = cashLens.getUserTotalCollateral(address(safe));
+        assertEq(collateral.length, 1, "only the supplied token shows up");
+        assertEq(collateral[0].token, address(weETH));
+        assertEq(collateral[0].amount, 3 ether);
+    }
+
     function test_getUserTotalCollateral() public {
+        _forceLegacyEngine(address(safe));
         // Add multiple collateral types
         deal(address(weETH), address(safe), 5 ether);
         deal(address(usdc), address(safe), 10000e6);

--- a/test/safe/modules/cash/CashModuleTestSetup.t.sol
+++ b/test/safe/modules/cash/CashModuleTestSetup.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.28;
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
 import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
-import { Test } from "forge-std/Test.sol";
+import { StdStorage, Test, stdStorage } from "forge-std/Test.sol";
 
 import { UUPSProxy } from "../../../../src/UUPSProxy.sol";
 import { CashbackDispatcher } from "../../../../src/cashback-dispatcher/CashbackDispatcher.sol";
@@ -26,6 +26,7 @@ import { ArrayDeDupLib, EtherFiDataProvider, EtherFiSafe, EtherFiSafeErrors, Saf
 contract CashModuleTestSetup is SafeTestSetup {
     using MessageHashUtils for bytes32;
     using TimeLib for uint256;
+    using stdStorage for StdStorage;
 
     address withdrawRecipient = makeAddr("withdrawRecipient");
     bytes32 txId = keccak256("txId");
@@ -154,6 +155,17 @@ contract CashModuleTestSetup is SafeTestSetup {
         vm.expectEmit(true, true, true, true);
         emit CashEventEmitter.SpendingLimitChanged(address(safe), oldLimit, newLimit);
         cashModule.updateSpendingLimit(address(safe), dailyLimit, monthlyLimit, owner1, signature);
+    }
+
+    /**
+     * @notice Flips a safe back to the legacy DebtManager engine, modeling a safe that predates the gateway
+     *         (new safes onboard onto the Aave gateway in setupModule).
+     * @dev Writes the packed onAaveGateway flag via stdstore, then asserts through the public getter so any
+     *      storage-layout drift fails loudly here instead of silently testing the wrong engine.
+     */
+    function _forceLegacyEngine(address _safe) internal {
+        stdstore.enable_packed_slots().target(address(cashModule)).sig(ICashModule.isAaveGatewaySafe.selector).with_key(_safe).checked_write(false);
+        assertFalse(cashModule.isAaveGatewaySafe(_safe), "forceLegacyEngine: flag still set");
     }
 
     /**

--- a/test/safe/modules/cash/CashModuleTestSetup.t.sol
+++ b/test/safe/modules/cash/CashModuleTestSetup.t.sol
@@ -160,12 +160,12 @@ contract CashModuleTestSetup is SafeTestSetup {
     /**
      * @notice Flips a safe back to the legacy DebtManager engine, modeling a safe that predates the gateway
      *         (new safes onboard onto the Aave gateway in setupModule).
-     * @dev Writes the packed onAaveGateway flag via stdstore, then asserts through the public getter so any
+     * @dev Writes the packed usesAave flag via stdstore, then asserts through the public getter so any
      *      storage-layout drift fails loudly here instead of silently testing the wrong engine.
      */
     function _forceLegacyEngine(address _safe) internal {
-        stdstore.enable_packed_slots().target(address(cashModule)).sig(ICashModule.isAaveGatewaySafe.selector).with_key(_safe).checked_write(false);
-        assertFalse(cashModule.isAaveGatewaySafe(_safe), "forceLegacyEngine: flag still set");
+        stdstore.enable_packed_slots().target(address(cashModule)).sig(ICashModule.usesAave.selector).with_key(_safe).checked_write(false);
+        assertFalse(cashModule.usesAave(_safe), "forceLegacyEngine: flag still set");
     }
 
     /**

--- a/test/safe/modules/cash/EngineParity.t.sol
+++ b/test/safe/modules/cash/EngineParity.t.sol
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
+
+import { BinSponsor, Cashback, ICashModule, Mode } from "../../../../src/interfaces/ICashModule.sol";
+import { IDebtManager } from "../../../../src/interfaces/IDebtManager.sol";
+import { IGateway } from "../../../../src/interfaces/IGateway.sol";
+import { EtherFiSafeErrors } from "../../../../src/safe/EtherFiSafeErrors.sol";
+import { CashModuleTestSetup } from "./CashModuleTestSetup.t.sol";
+
+/**
+ * @title EngineParityTest
+ * @notice The check side (CashLens.canSpend) and the execution side (CashModule.spend) must agree for every
+ *         (mode x engine) cell: an approved check implies the spend lands, and a declined check implies the
+ *         spend reverts with the matching error. These are the two on-chain halves of a card auth, so drift
+ *         between them declines good taps or, worse, lands taps the check already rejected.
+ * @dev Gateway-credit declined-side parity (borrow power) is enforced by Aave itself, which the mock gateway
+ *      cannot model; it runs in the fork suite (test/gateway/DebtManagerMigration.t.sol) instead.
+ */
+contract EngineParityTest is CashModuleTestSetup {
+    Cashback[] internal noCashback;
+
+    function _canSpend(bytes32 id, address token, uint256 amountUsd) internal view returns (bool, string memory) {
+        address[] memory tokens = new address[](1);
+        tokens[0] = token;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = amountUsd;
+        return cashLens.canSpend(address(safe), id, tokens, amounts);
+    }
+
+    function _spend(bytes32 id, address token, uint256 amountUsd) internal {
+        address[] memory tokens = new address[](1);
+        tokens[0] = token;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = amountUsd;
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), id, BinSponsor.Reap, tokens, amounts, noCashback);
+    }
+
+    // ----------------------------------------------------------------- legacy engine
+
+    /// Legacy debit: an approved balance-limited check lands, a declined one reverts InsufficientBalance.
+    function test_parity_legacyDebit_balance() public {
+        _forceLegacyEngine(address(safe));
+        deal(address(usdc), address(safe), 100e6);
+
+        (bool ok, string memory reason) = _canSpend(keccak256("ld1"), address(usdc), 60e6);
+        assertTrue(ok, reason);
+        uint256 dispatcherBefore = usdc.balanceOf(address(settlementDispatcherReap));
+        _spend(keccak256("ld1"), address(usdc), 60e6);
+        assertEq(usdc.balanceOf(address(settlementDispatcherReap)), dispatcherBefore + 60e6, "approved debit landed");
+
+        (ok, reason) = _canSpend(keccak256("ld2"), address(usdc), 200e6);
+        assertFalse(ok);
+        assertEq(reason, "Insufficient token balance for debit mode spending");
+        vm.expectRevert(ICashModule.InsufficientBalance.selector);
+        _spend(keccak256("ld2"), address(usdc), 200e6);
+    }
+
+    /// Legacy debit: a spend that fits the balance but breaks health is declined and reverts AccountUnhealthy.
+    function test_parity_legacyDebit_health() public {
+        _forceLegacyEngine(address(safe));
+        deal(address(usdc), address(safe), 100e6);
+        deal(address(usdc), address(debtManager), 1_000_000e6);
+
+        uint256 borrowAmt = debtManager.getMaxBorrowAmount(address(safe), true) / 2;
+        vm.prank(address(safe));
+        debtManager.borrow(BinSponsor.Reap, address(usdc), borrowAmt);
+
+        // The spend fits the balance but would leave the DebtManager position unhealthy
+        (bool ok, string memory reason) = _canSpend(keccak256("lh1"), address(usdc), 95e6);
+        assertFalse(ok);
+        assertEq(reason, "Borrowings greater than max borrow after spending");
+        vm.expectRevert(IDebtManager.AccountUnhealthy.selector);
+        _spend(keccak256("lh1"), address(usdc), 95e6);
+    }
+
+    /// Legacy credit: an approved borrow lands, and one beyond borrowing power is declined and reverts.
+    function test_parity_legacyCredit() public {
+        _forceLegacyEngine(address(safe));
+        deal(address(weETH), address(safe), 1 ether);
+        deal(address(usdc), address(debtManager), 1_000_000e6);
+        _setMode(Mode.Credit);
+        vm.warp(cashModule.incomingModeStartTime(address(safe)) + 1);
+
+        (bool ok, string memory reason) = _canSpend(keccak256("lc1"), address(usdc), 100e6);
+        assertTrue(ok, reason);
+        uint256 dispatcherBefore = usdc.balanceOf(address(settlementDispatcherReap));
+        _spend(keccak256("lc1"), address(usdc), 100e6);
+        assertEq(usdc.balanceOf(address(settlementDispatcherReap)), dispatcherBefore + 100e6, "approved credit landed");
+        assertApproxEqAbs(debtManager.borrowingOf(address(safe), address(usdc)), 100e6, 1, "borrowed on the DebtManager");
+
+        // More than the remaining borrowing power (but within the spending limit)
+        uint256 tooMuch = debtManager.getMaxBorrowAmount(address(safe), true);
+        assertLt(tooMuch, dailyLimitInUsd, "test premise: declined by borrow power, not the limit");
+        (ok, reason) = _canSpend(keccak256("lc2"), address(usdc), tooMuch);
+        assertFalse(ok);
+        assertEq(reason, "Insufficient borrowing power");
+        // The DebtManager's AccountUnhealthy surfaces wrapped by the safe's module execution
+        vm.expectRevert(abi.encodeWithSelector(EtherFiSafeErrors.CallFailed.selector, 0));
+        _spend(keccak256("lc2"), address(usdc), tooMuch);
+    }
+
+    // ----------------------------------------------------------------- gateway engine
+
+    /// Gateway debit: an approved check withdraws the shortfall from Aave and lands; an over-balance check reverts.
+    function test_parity_gatewayDebit() public {
+        deal(address(usdc), address(safe), 30e6);
+        gateway.setSuppliedOf(address(safe), address(usdc), 50e6);
+        gateway.setAvailableCash(address(usdc), type(uint128).max);
+        gateway.setAccountData(address(safe), IGateway.AccountData({ collateralUsd: 50e6, debtUsd: 0, availableBorrowsUsd: 40e6, healthFactor: type(uint256).max }));
+
+        // Loose (30) + supplied (50) cover the spend; the shortfall is withdrawn from Aave
+        (bool ok, string memory reason) = _canSpend(keccak256("gd1"), address(usdc), 60e6);
+        assertTrue(ok, reason);
+        uint256 dispatcherBefore = usdc.balanceOf(address(settlementDispatcherReap));
+        _spend(keccak256("gd1"), address(usdc), 60e6);
+        assertEq(usdc.balanceOf(address(settlementDispatcherReap)), dispatcherBefore + 30e6, "loose portion transferred");
+        (, address asset, uint256 amount, address to) = gateway.lastWithdraw();
+        assertEq(asset, address(usdc));
+        assertEq(amount, 30e6, "shortfall withdrawn from Aave");
+        assertEq(to, address(settlementDispatcherReap));
+
+        // Nothing loose left and only 50 supplied: both sides refuse a 100 spend
+        (ok, reason) = _canSpend(keccak256("gd2"), address(usdc), 100e6);
+        assertFalse(ok);
+        assertEq(reason, "Insufficient token balance for debit mode spending");
+        vm.expectRevert(ICashModule.InsufficientBalance.selector);
+        _spend(keccak256("gd2"), address(usdc), 100e6);
+    }
+
+    /// Gateway credit: an approved check borrows on the gateway and lands; one beyond borrow power is declined.
+    function test_parity_gatewayCredit_approvedLands() public {
+        _setMode(Mode.Credit);
+        vm.warp(cashModule.incomingModeStartTime(address(safe)) + 1);
+        gateway.setAvailableCash(address(usdc), type(uint128).max);
+        gateway.setAccountData(address(safe), IGateway.AccountData({ collateralUsd: 1000e6, debtUsd: 0, availableBorrowsUsd: 500e6, healthFactor: type(uint256).max }));
+
+        (bool ok, string memory reason) = _canSpend(keccak256("gc1"), address(usdc), 100e6);
+        assertTrue(ok, reason);
+        _spend(keccak256("gc1"), address(usdc), 100e6);
+        (, address asset, uint256 amount, address to) = gateway.lastBorrow();
+        assertEq(asset, address(usdc));
+        assertEq(amount, 100e6, "approved credit borrowed on the gateway");
+        assertEq(to, address(settlementDispatcherReap));
+
+        // Beyond the Aave borrowing power: declined by the check (the revert side is enforced by Aave and
+        // covered in the fork suite)
+        (ok, reason) = _canSpend(keccak256("gc2"), address(usdc), 600e6);
+        assertFalse(ok);
+        assertEq(reason, "Insufficient borrowing power");
+    }
+}

--- a/test/safe/modules/cash/LegacyCanSpend.t.sol
+++ b/test/safe/modules/cash/LegacyCanSpend.t.sol
@@ -1,0 +1,934 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
+import { IERC20Metadata } from "@openzeppelin/contracts/interfaces/IERC20Metadata.sol";
+import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+
+import { BinSponsor, Cashback, CashbackTokens, Mode } from "../../../../src/interfaces/ICashModule.sol";
+import { IDebtManager } from "../../../../src/interfaces/IDebtManager.sol";
+import { ArrayDeDupLib } from "../../../../src/libraries/ArrayDeDupLib.sol";
+import { IAggregatorV3, PriceProvider } from "../../../../src/oracle/PriceProvider.sol";
+import { CashModuleTestSetup } from "./CashModuleTestSetup.t.sol";
+
+contract LegacyCashLensCanSpendTest is CashModuleTestSetup {
+    using MessageHashUtils for bytes32;
+
+    IERC20 public liquidUsdScroll = IERC20(0x08c6F91e2B681FaF5e17227F2a44C307b3C1364C);
+
+    function setUp() public override {
+        super.setUp();
+
+        // These suites preserve the pre-gateway lens tests for legacy-engine safes (CashLensLegacyLib)
+        _forceLegacyEngine(address(safe));
+
+        vm.startPrank(owner);
+
+        PriceProvider.Config memory liquidUsdConfig = PriceProvider.Config({ oracle: usdcUsdOracle, priceFunctionCalldata: hex"", isChainlinkType: true, oraclePriceDecimals: IAggregatorV3(usdcUsdOracle).decimals(), maxStaleness: type(uint24).max, dataType: PriceProvider.ReturnType.Int256, isBaseTokenEth: false, isStableToken: true, isBaseTokenBtc: false });
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(liquidUsdScroll);
+
+        PriceProvider.Config[] memory tokensConfig = new PriceProvider.Config[](1);
+        tokensConfig[0] = liquidUsdConfig;
+
+        priceProvider.setTokenConfig(tokens, tokensConfig);
+
+        IDebtManager.CollateralTokenConfig[] memory collateralTokenConfig = new IDebtManager.CollateralTokenConfig[](1);
+
+        collateralTokenConfig[0].ltv = ltv;
+        collateralTokenConfig[0].liquidationThreshold = liquidationThreshold;
+        collateralTokenConfig[0].liquidationBonus = liquidationBonus;
+
+        debtManager.supportCollateralToken(address(liquidUsdScroll), collateralTokenConfig[0]);
+
+        minShares = uint128(10 * 10 ** IERC20Metadata(address(liquidUsdScroll)).decimals());
+        debtManager.supportBorrowToken(address(liquidUsdScroll), borrowApyPerSecond, minShares);
+
+        CashbackTokens[] memory cashbackTokens = new CashbackTokens[](1);
+        CashbackTokens memory scr = CashbackTokens({ token: address(cashbackToken), amountInUsd: 1e6, cashbackType: 0 });
+
+        cashbackTokens[0] = scr;
+
+        Cashback memory scrCashback = Cashback({ to: address(safe), cashbackTokens: cashbackTokens });
+
+        Cashback[] memory cashbacks = new Cashback[](1);
+        cashbacks[0] = scrCashback;
+
+        vm.stopPrank();
+    }
+
+    /// Debit spend passes when the safe holds enough token balance.
+    function test_canSpend_succeeds_inDebitMode_whenBalanceAvailable() public {
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 100e6;
+
+        deal(address(usdc), address(safe), amounts[0]);
+        (bool canSpend, string memory reason) = cashLens.canSpend(address(safe), txId, tokens, amounts);
+        assertEq(canSpend, true);
+        assertEq(reason, "");
+    }
+
+    /// Credit spend passes when collateral backs the borrow.
+    function test_canSpend_succeeds_inCreditMode_whenCollateralAvailable() public {
+        _setMode(Mode.Credit);
+        vm.warp(cashModule.incomingModeStartTime(address(safe)) + 1);
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 100e6;
+
+        deal(address(weETH), address(safe), 1 ether);
+        deal(address(usdc), address(debtManager), amounts[0]);
+        (bool canSpend, string memory reason) = cashLens.canSpend(address(safe), txId, tokens, amounts);
+        assertEq(canSpend, true);
+        assertEq(reason, "");
+    }
+
+    /// Debit spend fails when the requested amount exceeds the balance.
+    function test_canSpend_fails_inDebitMode_whenBalanceTooLow() public view {
+        uint256 bal = usdc.balanceOf(address(safe));
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = bal + 1;
+        (bool canSpend, string memory reason) = cashLens.canSpend(address(safe), txId, tokens, amounts);
+        assertEq(canSpend, false);
+        assertEq(reason, "Insufficient token balance for debit mode spending");
+    }
+
+    /// Credit spend fails when the debt manager lacks liquidity for the loan.
+    function test_canSpend_fails_inCreditMode_whenLiquidityUnavailableInDebtManager() public {
+        _setMode(Mode.Credit);
+        vm.warp(cashModule.incomingModeStartTime(address(safe)) + 1);
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 100e6;
+
+        deal(address(weETH), address(safe), 1 ether);
+        deal(address(usdc), address(debtManager), amounts[0] - 1);
+        (bool canSpend, string memory reason) = cashLens.canSpend(address(safe), txId, tokens, amounts);
+        assertEq(canSpend, false);
+        assertEq(reason, "Insufficient liquidity in debt manager to cover the loan");
+    }
+
+    /// Debit spend passes when the effective balance after a pending withdrawal still covers it.
+    function test_canSpend_succeeds_inDebitMode_whenWithdrawalIsLowerThanAmountRequested() public {
+        uint256 totalBal = 1000e6;
+        uint256 withdrawalBal = 900e6;
+        uint256 balToTransfer = totalBal - withdrawalBal;
+
+        deal(address(usdc), address(safe), totalBal);
+
+        address[] memory withdrawTokens = new address[](1);
+        withdrawTokens[0] = address(usdc);
+        uint256[] memory withdrawAmounts = new uint256[](1);
+        withdrawAmounts[0] = withdrawalBal;
+        _requestWithdrawal(withdrawTokens, withdrawAmounts, withdrawRecipient);
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = balToTransfer;
+
+        (bool canSpend, string memory reason) = cashLens.canSpend(address(safe), txId, tokens, amounts);
+        assertEq(canSpend, true);
+        assertEq(reason, "");
+    }
+
+    /// Credit spend passes when the collateral left after a withdrawal still supports the borrow.
+    function test_canSpend_succeeds_inCreditMode_whenAfterWithdrawalAmountIsStillBorrowable() public {
+        _setMode(Mode.Credit);
+        vm.warp(cashModule.incomingModeStartTime(address(safe)) + 1);
+
+        deal(address(usdc), address(debtManager), 1 ether);
+        uint256 totalBal = 1000e6;
+        uint256 withdrawalAmt = 200e6;
+        uint256 balToTransfer = 400e6; // still with 800 USDC after withdrawal we can borrow 400 USDC as ltv = 50%
+        deal(address(usdc), address(safe), totalBal);
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = withdrawalAmt;
+        _requestWithdrawal(tokens, amounts, withdrawRecipient);
+
+        amounts[0] = balToTransfer;
+
+        (bool canSpend, string memory reason) = cashLens.canSpend(address(safe), txId, tokens, amounts);
+        assertEq(canSpend, true);
+        assertEq(reason, "");
+    }
+
+    /// Debit spend fails when a pending withdrawal leaves too little effective balance.
+    function test_canSpend_fails_inDebitMode_whenWithdrawalRequestBlocksIt() public {
+        address token = address(usdc);
+        uint256 bal = 100e6;
+        deal(token, address(safe), bal);
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = token;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 10e6;
+        _requestWithdrawal(tokens, amounts, withdrawRecipient);
+
+        amounts[0] = bal;
+
+        (bool canSpend, string memory reason) = cashLens.canSpend(address(safe), txId, tokens, amounts);
+        assertEq(canSpend, false);
+        assertEq(reason, "Insufficient effective balance after withdrawal to spend with debit mode");
+    }
+
+    /// Credit spend fails when a pending withdrawal drops borrowing power below the amount.
+    function test_canSpend_fails_inCreditMode_whenWithdrawalRequestBlocksIt() public {
+        address token = address(usdc);
+        uint256 bal = 100e6;
+        deal(token, address(safe), bal);
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = token;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 10e6;
+        _requestWithdrawal(tokens, amounts, withdrawRecipient);
+
+        _setMode(Mode.Credit);
+
+        // since we have 100 USDC and 10 is in withdrawal, also incoming mode is credit
+        // with 90% ltv, max borrowable is (100 - 10) * 90% = 81 USDC
+        // if we want to borrow 82 USDC, it should fail
+        amounts[0] = 82e6;
+
+        (bool canSpend, string memory reason) = cashLens.canSpend(address(safe), txId, tokens, amounts);
+        assertEq(canSpend, false);
+        assertEq(reason, "Insufficient borrowing power");
+    }
+
+    /// Credit spend fails with zero collateral (no borrowing power).
+    function test_canSpend_fails_inCreditMode_whenCollateralBalanceIsZero() public {
+        _setMode(Mode.Credit);
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 50e6;
+
+        (bool canSpend, string memory reason) = cashLens.canSpend(address(safe), txId, tokens, amounts);
+        assertEq(canSpend, false);
+        assertEq(reason, "Insufficient borrowing power");
+    }
+
+    /// Debit spend fails when a multi-token withdrawal request blocks the spent token.
+    function test_canSpend_fails_inDebitMode_whenWithdrawalRequestBlocksItWithMultipleTokens() public {
+        address token = address(usdc);
+        uint256 bal = 100e6;
+        deal(token, address(safe), bal);
+        deal(address(weETH), address(safe), bal);
+
+        address[] memory tokens = new address[](2);
+        tokens[0] = address(weETH);
+        tokens[1] = token;
+        uint256[] memory amounts = new uint256[](2);
+        amounts[0] = 10e6;
+        amounts[1] = 10e6;
+        _requestWithdrawal(tokens, amounts, withdrawRecipient);
+
+        address[] memory spendTokens = new address[](1);
+        spendTokens[0] = address(usdc);
+        uint256[] memory spendAmounts = new uint256[](1);
+        spendAmounts[0] = bal;
+
+        (bool canSpend, string memory reason) = cashLens.canSpend(address(safe), txId, spendTokens, spendAmounts);
+        assertEq(canSpend, false);
+        assertEq(reason, "Insufficient effective balance after withdrawal to spend with debit mode");
+    }
+
+    /// Spend fails when the txId has already been cleared.
+    function test_canSpend_fails_whenTxIdIsAlreadyCleared() public {
+        deal(address(usdc), address(safe), 100 ether);
+        uint256 amountToSpend = 100e6;
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = amountToSpend;
+
+        Cashback[] memory cashbacks;
+
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, tokens, amounts, cashbacks);
+
+        (bool canSpend, string memory reason) = cashLens.canSpend(address(safe), txId, tokens, amounts);
+        assertEq(canSpend, false);
+        assertEq(reason, "Transaction already cleared");
+    }
+
+    /// Debit spend fails when the active daily spending limit is below the amount.
+    function test_canSpend_fails_inDebitMode_whenDailySpendingLimitIsTooLow() public {
+        uint256 amountToSpend = 100e6;
+        deal(address(usdc), address(safe), amountToSpend);
+        _updateSpendingLimit(amountToSpend - 1, 1 ether);
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = amountToSpend;
+
+        (, uint64 spendingLimitDelay,) = cashModule.getDelays();
+        vm.warp(block.timestamp + spendingLimitDelay + 1);
+        (bool canSpend, string memory reason) = cashLens.canSpend(address(safe), txId, tokens, amounts);
+        assertEq(canSpend, false);
+        assertEq(reason, "Daily available spending limit less than amount requested");
+    }
+
+    /// Debit spend fails when a prior spend has exhausted the daily limit.
+    function test_canSpend_fails_inDebitMode_whenDailySpendingLimitIsExhausted() public {
+        deal(address(usdc), address(safe), 100 ether);
+        uint256 amountToSpend = 100e6;
+
+        address[] memory spendTokens = new address[](1);
+        spendTokens[0] = address(usdc);
+        uint256[] memory spendAmounts = new uint256[](1);
+        spendAmounts[0] = dailyLimitInUsd - amountToSpend + 1;
+
+        Cashback[] memory cashbacks;
+
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = amountToSpend;
+
+        (bool canSpend, string memory reason) = cashLens.canSpend(address(safe), keccak256("newTxId"), tokens, amounts);
+        assertEq(canSpend, false);
+        assertEq(reason, "Daily available spending limit less than amount requested");
+    }
+
+    /// Debit spend passes again once the daily limit renews.
+    function test_canSpend_succeeds_inDebitMode_whenSpendingLimitRenews() public {
+        deal(address(usdc), address(safe), 100 ether);
+        uint256 amountToSpend = 100e6;
+
+        address[] memory spendTokens = new address[](1);
+        spendTokens[0] = address(usdc);
+        uint256[] memory spendAmounts = new uint256[](1);
+        spendAmounts[0] = dailyLimitInUsd - amountToSpend + 1;
+
+        Cashback[] memory cashbacks;
+
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = amountToSpend;
+
+        vm.warp(cashLens.applicableSpendingLimit(address(safe)).dailyRenewalTimestamp + 1);
+        (bool canSpend, string memory reason) = cashLens.canSpend(address(safe), keccak256("newTxId"), tokens, amounts);
+        assertEq(canSpend, true);
+        assertEq(reason, "");
+    }
+
+    /// Debit spend fails when the incoming (pending) daily limit is below the amount.
+    function test_canSpend_fails_inDebitMode_whenIncomingDailySpendingLimitIsTooLow() public {
+        uint256 amountToSpend = 100e6;
+        deal(address(usdc), address(safe), amountToSpend);
+        _updateSpendingLimit(amountToSpend - 1, 1 ether);
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = amountToSpend;
+
+        (bool canSpend, string memory reason) = cashLens.canSpend(address(safe), txId, tokens, amounts);
+        assertEq(canSpend, false);
+        assertEq(reason, "Incoming daily available spending limit less than amount requested");
+    }
+
+    /// Debit spend fails when the incoming daily limit is exhausted, even across a renewal.
+    function test_canSpend_fails_inDebitMode_whenIncomingDailySpendingLimitIsExhausted() public {
+        uint256 amountToSpend = 100e6;
+        deal(address(usdc), address(safe), 10 ether);
+        _updateSpendingLimit(amountToSpend - 1, 1 ether);
+
+        address[] memory spendTokens = new address[](1);
+        spendTokens[0] = address(usdc);
+        uint256[] memory spendAmounts = new uint256[](1);
+        spendAmounts[0] = 1;
+
+        Cashback[] memory cashbacks;
+
+        (, uint64 spendingLimitDelay,) = cashModule.getDelays();
+        vm.warp(block.timestamp + spendingLimitDelay + 1);
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = amountToSpend;
+
+        (bool canSpend, string memory reason) = cashLens.canSpend(address(safe), keccak256("newTxId"), tokens, amounts);
+        assertEq(canSpend, false);
+        assertEq(reason, "Daily available spending limit less than amount requested");
+
+        vm.warp(cashLens.applicableSpendingLimit(address(safe)).dailyRenewalTimestamp + 1);
+        (canSpend, reason) = cashLens.canSpend(address(safe), keccak256("newTxId"), tokens, amounts);
+        assertEq(canSpend, false);
+        assertEq(reason, "Daily available spending limit less than amount requested");
+    }
+
+    /// Debit spend passes once the incoming daily limit takes effect and renews.
+    function test_canSpend_succeeds_inDebitMode_whenIncomingDailySpendingLimitRenews() public {
+        uint256 amountToSpend = 100e6;
+        deal(address(usdc), address(safe), 10 ether);
+        _updateSpendingLimit(amountToSpend, 1 ether);
+
+        address[] memory spendTokens = new address[](1);
+        spendTokens[0] = address(usdc);
+        uint256[] memory spendAmounts = new uint256[](1);
+        spendAmounts[0] = 1;
+
+        Cashback[] memory cashbacks;
+
+        (, uint64 spendingLimitDelay,) = cashModule.getDelays();
+        vm.warp(block.timestamp + spendingLimitDelay + 1);
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
+
+        vm.warp(cashLens.applicableSpendingLimit(address(safe)).dailyRenewalTimestamp + 1);
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = amountToSpend;
+
+        (bool canSpend, string memory reason) = cashLens.canSpend(address(safe), keccak256("newTxId"), tokens, amounts);
+        assertEq(canSpend, true);
+        assertEq(reason, "");
+    }
+
+    /// Debit spend fails when a lowered daily limit is below the amount requested.
+    function test_canSpend_fails_inDebitMode_whenDailyLimitIsLowerThanAmountUsed() public {
+        deal(address(usdc), address(safe), 10 ether);
+
+        uint256 amount = 100e6;
+
+        _updateSpendingLimit(amount - 1, 1 ether);
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = amount;
+
+        (, uint64 spendingLimitDelay,) = cashModule.getDelays();
+        vm.warp(block.timestamp + spendingLimitDelay + 1);
+        (bool canSpend, string memory reason) = cashLens.canSpend(address(safe), keccak256("newTxId"), tokens, amounts);
+        assertEq(canSpend, false);
+        assertEq(reason, "Daily available spending limit less than amount requested");
+    }
+
+    /// Debit spend fails when an incoming lowered daily limit is already exhausted by prior use.
+    function test_canSpend_fails_inDebitMode_whenIncomingDailyLimitIsLowerThanAmountUsed() public {
+        deal(address(usdc), address(safe), 10 ether);
+
+        uint256 amount = 100e6;
+        address[] memory spendTokens = new address[](1);
+        spendTokens[0] = address(usdc);
+        uint256[] memory spendAmounts = new uint256[](1);
+        spendAmounts[0] = amount;
+
+        Cashback[] memory cashbacks;
+
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
+
+        _updateSpendingLimit(amount - 1, 1 ether);
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = amount;
+
+        (bool canSpend, string memory reason) = cashLens.canSpend(address(safe), keccak256("newTxId"), tokens, amounts);
+        assertEq(canSpend, false);
+        assertEq(reason, "Incoming daily spending limit already exhausted");
+    }
+
+    /// Rejects empty tokens, mismatched array lengths, and zero total amount.
+    function test_canSpend_inputValidation() public view {
+        // Test with empty tokens array
+        address[] memory tokens = new address[](0);
+        uint256[] memory amountsInUsd = new uint256[](0);
+
+        (bool canSpend, string memory message) = cashLens.canSpend(address(safe), txId, tokens, amountsInUsd);
+
+        assertFalse(canSpend, "Should not allow empty tokens array");
+        assertEq(message, "No tokens provided", "Error message should match");
+
+        // Test with mismatched array lengths
+        tokens = new address[](1);
+        tokens[0] = address(usdc);
+        amountsInUsd = new uint256[](2);
+        amountsInUsd[0] = 1000e6;
+        amountsInUsd[1] = 500e6;
+
+        (canSpend, message) = cashLens.canSpend(address(safe), txId, tokens, amountsInUsd);
+
+        assertFalse(canSpend, "Should not allow mismatched arrays");
+        assertEq(message, "Tokens and amounts arrays length mismatch", "Error message should match");
+
+        // Test with zero total amount
+        tokens = new address[](1);
+        tokens[0] = address(usdc);
+        amountsInUsd = new uint256[](1);
+        amountsInUsd[0] = 0;
+
+        (canSpend, message) = cashLens.canSpend(address(safe), txId, tokens, amountsInUsd);
+
+        assertFalse(canSpend, "Should not allow zero total amount");
+        assertEq(message, "Total amount zero in USD", "Error message should match");
+    }
+
+    /// Credit mode rejects spends that name more than one token.
+    function test_canSpend_creditModeValidation() public {
+        // Set to credit mode
+        _setMode(Mode.Credit);
+        vm.warp(cashModule.incomingModeStartTime(address(safe)) + 1);
+
+        // Try to spend multiple tokens in credit mode
+        address[] memory tokens = new address[](2);
+        tokens[0] = address(usdc);
+        tokens[1] = address(weETH);
+        uint256[] memory amountsInUsd = new uint256[](2);
+        amountsInUsd[0] = 1000e6;
+        amountsInUsd[1] = 500e6;
+
+        (bool canSpend, string memory message) = cashLens.canSpend(address(safe), txId, tokens, amountsInUsd);
+
+        assertFalse(canSpend, "Should not allow multiple tokens in credit mode");
+        assertEq(message, "Only one token allowed in Credit mode", "Error message should match");
+    }
+
+    /// Debit mode allows spending multiple tokens in one call.
+    function test_canSpend_debitMode() public {
+        vm.prank(owner);
+        debtManager.supportBorrowToken(address(weETH), borrowApyPerSecond, minShares);
+
+        // Setup test state with multiple tokens
+        deal(address(weETH), address(safe), 5 ether);
+        deal(address(usdc), address(safe), 10_000e6);
+
+        // Try to spend multiple tokens in debit mode
+        address[] memory tokens = new address[](2);
+        tokens[0] = address(usdc);
+        tokens[1] = address(weETH);
+        uint256[] memory amountsInUsd = new uint256[](2);
+
+        // Convert to actual token amounts in USD
+        uint256 usdcValueInUsd = debtManager.convertCollateralTokenToUsd(address(usdc), 1000e6);
+        uint256 weEthValueInUsd = debtManager.convertCollateralTokenToUsd(address(weETH), 1 ether);
+
+        amountsInUsd[0] = usdcValueInUsd;
+        amountsInUsd[1] = weEthValueInUsd;
+
+        (bool canSpend, string memory message) = cashLens.canSpend(address(safe), txId, tokens, amountsInUsd);
+
+        assertTrue(canSpend, "Should allow multiple tokens in debit mode");
+        assertEq(message, "", "Error message should be empty");
+    }
+
+    /// Debit spend fails when the USD amount exceeds the token balance.
+    function test_canSpend_exceedBalance() public {
+        // Setup test state with specific balance
+        deal(address(usdc), address(safe), 5000e6);
+
+        // Try to spend more than available balance
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amountsInUsd = new uint256[](1);
+        amountsInUsd[0] = debtManager.convertCollateralTokenToUsd(address(usdc), 10_000e6); // More than balance
+
+        (bool canSpend, string memory message) = cashLens.canSpend(address(safe), txId, tokens, amountsInUsd);
+
+        assertFalse(canSpend, "Should not allow spending more than balance in debit mode");
+        assertEq(message, "Insufficient token balance for debit mode spending", "Error message should match");
+    }
+
+    /// Debit spend is bounded by the balance remaining after a pending withdrawal.
+    function test_canSpend_withWithdrawalRequests() public {
+        // Setup test state with collateral
+        deal(address(weETH), address(safe), 5 ether);
+        deal(address(usdc), address(safe), 10_000e6);
+
+        // Create a withdrawal request
+        address[] memory withdrawTokens = new address[](1);
+        withdrawTokens[0] = address(usdc);
+        uint256[] memory withdrawAmounts = new uint256[](1);
+        withdrawAmounts[0] = 5000e6; // Withdraw half of USDC
+        _requestWithdrawal(withdrawTokens, withdrawAmounts, withdrawRecipient);
+
+        // Try to spend an amount under the remaining balance
+        address[] memory spendTokens = new address[](1);
+        spendTokens[0] = address(usdc);
+        uint256[] memory amountsInUsd = new uint256[](1);
+        amountsInUsd[0] = debtManager.convertCollateralTokenToUsd(address(usdc), 3000e6); // 3000 < (10000-5000)
+
+        (bool canSpend, string memory message) = cashLens.canSpend(address(safe), txId, spendTokens, amountsInUsd);
+
+        assertTrue(canSpend, "Should allow spending within remaining balance after withdrawal");
+        assertEq(message, "", "Error message should be empty");
+
+        // Try to spend more than the remaining balance
+        amountsInUsd[0] = debtManager.convertCollateralTokenToUsd(address(usdc), 6000e6); // 6000 > (10000-5000)
+
+        (canSpend, message) = cashLens.canSpend(address(safe), txId, spendTokens, amountsInUsd);
+
+        assertFalse(canSpend, "Should not allow spending more than remaining balance after withdrawal");
+        assertEq(message, "Insufficient effective balance after withdrawal to spend with debit mode", "Error message should match");
+    }
+
+    /// Debit spend fails when the amount exceeds the configured daily limit.
+    function test_canSpend_exceedsSpendingLimit() public {
+        // Setup test state with collateral
+        deal(address(usdc), address(safe), 50_000e6);
+
+        // Set up a smaller spending limit
+        _updateSpendingLimit(5000e6, 50_000e6); // Daily limit of 5000 USDC
+
+        // Try to spend more than daily limit
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amountsInUsd = new uint256[](1);
+        amountsInUsd[0] = 7000e6; // > 5000 daily limit
+
+        (bool canSpend, string memory message) = cashLens.canSpend(address(safe), txId, tokens, amountsInUsd);
+
+        assertFalse(canSpend, "Should not allow spending more than daily limit");
+        assertTrue(bytes(message).length > 0, "Error message should not be empty");
+    }
+
+    /// Spend fails for a token that is not a supported stable/borrow token.
+    function test_canSpend_nonBorrowToken() public {
+        // Create a mock token that's not a borrow token
+        address mockToken = makeAddr("mockToken");
+
+        // Try to spend a non-borrow token
+        address[] memory tokens = new address[](1);
+        tokens[0] = mockToken;
+        uint256[] memory amountsInUsd = new uint256[](1);
+        amountsInUsd[0] = 1000e6;
+
+        (bool canSpend, string memory message) = cashLens.canSpend(address(safe), txId, tokens, amountsInUsd);
+
+        assertFalse(canSpend, "Should not allow spending a non-borrow token");
+        assertEq(message, "Not a supported stable token", "Error message should match");
+    }
+
+    /// Spend fails when reusing a txId that a prior spend already cleared.
+    function test_canSpend_alreadyCleared() public {
+        // Setup a transaction and mark it as cleared
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 1000e6;
+
+        deal(address(usdc), address(safe), 10_000e6);
+
+        Cashback[] memory cashbacks;
+
+        // Spend to clear the transaction
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, tokens, amounts, cashbacks);
+
+        // Try to spend with the same txId
+        uint256[] memory amountsInUsd = new uint256[](1);
+        amountsInUsd[0] = 1000e6;
+
+        (bool canSpend, string memory message) = cashLens.canSpend(address(safe), txId, tokens, amountsInUsd);
+
+        assertFalse(canSpend, "Should not allow spending with already cleared txId");
+        assertEq(message, "Transaction already cleared", "Error message should match");
+    }
+
+    /// Spend reverts when the same token appears twice in the tokens array.
+    function test_canSpend_fails_whenDuplicateTokensArePassed() public {
+        uint256 bal = usdc.balanceOf(address(safe));
+
+        address[] memory tokens = new address[](2);
+        tokens[0] = address(usdc);
+        tokens[1] = address(usdc);
+        uint256[] memory amounts = new uint256[](2);
+        amounts[0] = bal + 1;
+        amounts[1] = bal + 1;
+        vm.expectRevert(ArrayDeDupLib.DuplicateElementFound.selector);
+        cashLens.canSpend(address(safe), txId, tokens, amounts);
+    }
+
+    /// Single-token debit picks the first preference token when it has balance.
+    function test_canSpendSingleToken_debitMode_firstTokenWorks() public {
+        deal(address(usdc), address(safe), 1000e6);
+        deal(address(liquidUsdScroll), address(safe), 1000e18);
+
+        address[] memory creditPrefs = new address[](1);
+        creditPrefs[0] = address(usdc);
+
+        address[] memory debitPrefs = new address[](2);
+        debitPrefs[0] = address(usdc);
+        debitPrefs[1] = address(liquidUsdScroll);
+
+        uint256 amountInUsd = 500e6; // 500 USD
+
+        (Mode mode, address token, bool canSpend, string memory message) = cashLens.canSpendSingleToken(address(safe), txId, creditPrefs, debitPrefs, amountInUsd);
+
+        assertEq(uint8(mode), uint8(Mode.Debit), "Should return debit mode");
+        assertEq(token, address(usdc), "Should return first preference token");
+        assertTrue(canSpend, "Should be able to spend");
+        assertEq(message, "", "Should have no error message");
+    }
+
+    /// Single-token debit falls back to the second preference when the first has no balance.
+    function test_canSpendSingleToken_debitMode_fallbackToSecondToken() public {
+        // Setup: safe only has LiquidUSD
+        deal(address(liquidUsdScroll), address(safe), 1000e18);
+
+        address[] memory creditPrefs = new address[](1);
+        creditPrefs[0] = address(usdc);
+
+        address[] memory debitPrefs = new address[](2);
+        debitPrefs[0] = address(usdc); // No balance
+        debitPrefs[1] = address(liquidUsdScroll); // Has balance
+
+        uint256 amountInUsd = 500e6; // 500 USD
+
+        (Mode mode, address token, bool canSpend, string memory message) = cashLens.canSpendSingleToken(address(safe), txId, creditPrefs, debitPrefs, amountInUsd);
+
+        assertEq(uint8(mode), uint8(Mode.Debit), "Should return debit mode");
+        assertEq(token, address(liquidUsdScroll), "Should return second preference token");
+        assertTrue(canSpend, "Should be able to spend with second token");
+        assertEq(message, "", "Should have no error message");
+    }
+
+    /// Single-token credit returns credit mode and the credit-preference token.
+    function test_canSpendSingleToken_creditMode_works() public {
+        _setMode(Mode.Credit);
+        vm.warp(cashModule.incomingModeStartTime(address(safe)) + 1);
+
+        deal(address(weETH), address(safe), 1 ether);
+        deal(address(usdc), address(debtManager), 10_000e6);
+
+        address[] memory creditPrefs = new address[](1);
+        creditPrefs[0] = address(usdc);
+
+        address[] memory debitPrefs = new address[](1);
+        debitPrefs[0] = address(usdc);
+
+        uint256 amountInUsd = 500e6; // 500 USD
+
+        (Mode mode, address token, bool canSpend, string memory message) = cashLens.canSpendSingleToken(address(safe), txId, creditPrefs, debitPrefs, amountInUsd);
+
+        assertEq(uint8(mode), uint8(Mode.Credit), "Should return credit mode");
+        assertEq(token, address(usdc), "Should return USDC");
+        assertTrue(canSpend, "Should be able to spend in credit mode");
+        assertEq(message, "", "Should have no error message");
+    }
+
+    /// Single-token debit returns the first token with its error when none can spend.
+    function test_canSpendSingleToken_noTokensWork() public {
+        deal(address(usdc), address(safe), 100e6);
+
+        address[] memory creditPrefs = new address[](1);
+        creditPrefs[0] = address(usdc);
+
+        address[] memory debitPrefs = new address[](2);
+        debitPrefs[0] = address(usdc);
+        debitPrefs[1] = address(liquidUsdScroll);
+
+        uint256 amountInUsd = 500e6;
+
+        (Mode mode, address token, bool canSpend, string memory message) = cashLens.canSpendSingleToken(address(safe), txId, creditPrefs, debitPrefs, amountInUsd);
+
+        assertEq(uint8(mode), uint8(Mode.Debit), "Should return debit mode");
+        assertEq(token, address(usdc), "Should return first preference token");
+        assertFalse(canSpend, "Should not be able to spend");
+        assertEq(message, "Insufficient token balance for debit mode spending", "Should return first token's error");
+    }
+
+    /// Single-token spend fails with no preferences provided.
+    function test_canSpendSingleToken_emptyPreferences() public view {
+        address[] memory creditPrefs = new address[](0);
+        address[] memory debitPrefs = new address[](0);
+
+        uint256 amountInUsd = 500e6;
+
+        (Mode mode, address token, bool canSpend, string memory message) = cashLens.canSpendSingleToken(address(safe), txId, creditPrefs, debitPrefs, amountInUsd);
+
+        assertEq(uint8(mode), uint8(Mode.Debit), "Should return current mode");
+        assertEq(token, address(0), "Should return zero address");
+        assertFalse(canSpend, "Should not be able to spend");
+        assertEq(message, "No token preferences provided", "Should indicate no preferences");
+    }
+
+    /// Single-token spend fails when the amount is zero.
+    function test_canSpendSingleToken_zeroAmount() public view {
+        address[] memory creditPrefs = new address[](1);
+        creditPrefs[0] = address(usdc);
+
+        address[] memory debitPrefs = new address[](1);
+        debitPrefs[0] = address(usdc);
+
+        uint256 amountInUsd = 0; // Zero amount
+
+        (Mode mode, address token, bool canSpend, string memory message) = cashLens.canSpendSingleToken(address(safe), txId, creditPrefs, debitPrefs, amountInUsd);
+
+        assertEq(uint8(mode), uint8(Mode.Debit), "Should return current mode");
+        assertEq(token, address(usdc), "Should return first preference");
+        assertFalse(canSpend, "Should not be able to spend");
+        assertEq(message, "Amount cannot be zero", "Should indicate zero amount");
+    }
+
+    /// Single-token spend fails when the txId was already cleared.
+    function test_canSpendSingleToken_transactionAlreadyCleared() public {
+        deal(address(usdc), address(safe), 10_000e6);
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 1000e6;
+
+        Cashback[] memory cashbacks;
+
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, tokens, amounts, cashbacks);
+
+        // Try canSpendSingleToken with cleared txId
+        address[] memory creditPrefs = new address[](1);
+        creditPrefs[0] = address(usdc);
+
+        address[] memory debitPrefs = new address[](1);
+        debitPrefs[0] = address(usdc);
+
+        uint256 amountInUsd = 500e6;
+
+        (Mode mode, address token, bool canSpend, string memory message) = cashLens.canSpendSingleToken(address(safe), txId, creditPrefs, debitPrefs, amountInUsd);
+
+        assertEq(uint8(mode), uint8(Mode.Debit), "Should return current mode");
+        assertEq(token, address(usdc), "Should return first preference");
+        assertFalse(canSpend, "Should not be able to spend");
+        assertEq(message, "Transaction already cleared", "Should indicate cleared transaction");
+    }
+
+    /// Single-token debit falls back past a token blocked by a pending withdrawal.
+    function test_canSpendSingleToken_withPendingWithdrawals() public {
+        // Setup balances
+        deal(address(usdc), address(safe), 1000e6);
+        deal(address(liquidUsdScroll), address(safe), 1000e18);
+
+        // Request withdrawal that affects USDC
+        address[] memory withdrawTokens = new address[](1);
+        withdrawTokens[0] = address(usdc);
+        uint256[] memory withdrawAmounts = new uint256[](1);
+        withdrawAmounts[0] = 800e6; // Leave only 200 USDC
+        _requestWithdrawal(withdrawTokens, withdrawAmounts, withdrawRecipient);
+
+        address[] memory creditPrefs = new address[](1);
+        creditPrefs[0] = address(usdc);
+
+        address[] memory debitPrefs = new address[](2);
+        debitPrefs[0] = address(usdc); // Will fail due to withdrawal
+        debitPrefs[1] = address(liquidUsdScroll); // Should work
+
+        uint256 amountInUsd = 500e6; // More than remaining USDC
+
+        (Mode mode, address token, bool canSpend, string memory message) = cashLens.canSpendSingleToken(address(safe), txId, creditPrefs, debitPrefs, amountInUsd);
+
+        assertEq(uint8(mode), uint8(Mode.Debit), "Should return debit mode");
+        assertEq(token, address(liquidUsdScroll), "Should fallback to LiquidUSD");
+        assertTrue(canSpend, "Should be able to spend with second token");
+        assertEq(message, "", "Should have no error message");
+    }
+
+    /// Single-token credit fails when there is no collateral to back the borrow.
+    function test_canSpendSingleToken_creditModeWithInsufficientCollateral() public {
+        // Switch to credit mode
+        _setMode(Mode.Credit);
+        vm.warp(cashModule.incomingModeStartTime(address(safe)) + 1);
+
+        // No collateral, but debt manager has liquidity
+        deal(address(usdc), address(debtManager), 10_000e6);
+
+        address[] memory creditPrefs = new address[](1);
+        creditPrefs[0] = address(usdc);
+
+        address[] memory debitPrefs = new address[](1);
+        debitPrefs[0] = address(usdc);
+
+        uint256 amountInUsd = 500e6;
+
+        (Mode mode, address token, bool canSpend, string memory message) = cashLens.canSpendSingleToken(address(safe), txId, creditPrefs, debitPrefs, amountInUsd);
+
+        assertEq(uint8(mode), uint8(Mode.Credit), "Should return credit mode");
+        assertEq(token, address(usdc), "Should return USDC");
+        assertFalse(canSpend, "Should not be able to spend without collateral");
+        assertEq(message, "Insufficient borrowing power", "Should indicate borrowing power issue");
+    }
+
+    /// Single-token debit fails when the amount exceeds the daily spending limit.
+    function test_canSpendSingleToken_spendingLimitExceeded() public {
+        // Setup balance
+        deal(address(usdc), address(safe), 10_000e6);
+
+        // Update spending limit to be lower
+        _updateSpendingLimit(100e6, 10_000e6); // Daily limit of 100 USD
+
+        address[] memory creditPrefs = new address[](1);
+        creditPrefs[0] = address(usdc);
+
+        address[] memory debitPrefs = new address[](1);
+        debitPrefs[0] = address(usdc);
+
+        uint256 amountInUsd = 200e6; // Exceeds daily limit
+
+        (, uint64 spendingLimitDelay,) = cashModule.getDelays();
+        vm.warp(block.timestamp + spendingLimitDelay + 1);
+
+        (Mode mode, address token, bool canSpend, string memory message) = cashLens.canSpendSingleToken(address(safe), txId, creditPrefs, debitPrefs, amountInUsd);
+
+        assertEq(uint8(mode), uint8(Mode.Debit), "Should return debit mode");
+        assertEq(token, address(usdc), "Should return first preference");
+        assertFalse(canSpend, "Should not be able to spend over limit");
+        assertEq(message, "Daily available spending limit less than amount requested", "Should indicate limit exceeded");
+    }
+
+    /// Single-token debit skips an unsupported preference token and uses the next valid one.
+    function test_canSpendSingleToken_unsupportedTokenInPreferences() public {
+        // Setup balance
+        deal(address(usdc), address(safe), 1000e6);
+
+        address unsupportedToken = makeAddr("unsupportedToken");
+
+        address[] memory creditPrefs = new address[](1);
+        creditPrefs[0] = address(usdc);
+
+        address[] memory debitPrefs = new address[](2);
+        debitPrefs[0] = unsupportedToken; // Not a borrow token
+        debitPrefs[1] = address(usdc);
+
+        uint256 amountInUsd = 500e6;
+
+        (Mode mode, address token, bool canSpend, string memory message) = cashLens.canSpendSingleToken(address(safe), txId, creditPrefs, debitPrefs, amountInUsd);
+
+        assertEq(uint8(mode), uint8(Mode.Debit), "Should return debit mode");
+        assertEq(token, address(usdc), "Should skip unsupported and use USDC");
+        assertTrue(canSpend, "Should be able to spend with valid token");
+        assertEq(message, "", "Should have no error message");
+    }
+}

--- a/test/safe/modules/cash/LegacyCashLensMaxSpend.t.sol
+++ b/test/safe/modules/cash/LegacyCashLensMaxSpend.t.sol
@@ -1,0 +1,455 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
+import { IERC20Metadata } from "@openzeppelin/contracts/interfaces/IERC20Metadata.sol";
+import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+
+import { BinSponsor, Cashback, CashbackTokens, DebitModeMaxSpend, Mode, SafeCashData, SafeData } from "../../../../src/interfaces/ICashModule.sol";
+import { IDebtManager } from "../../../../src/interfaces/IDebtManager.sol";
+import { IEtherFiSafeFactory } from "../../../../src/interfaces/IEtherFiSafeFactory.sol";
+import { AccountantWithRateProviders, ILayerZeroTeller } from "../../../../src/interfaces/ILayerZeroTeller.sol";
+import { ArrayDeDupLib } from "../../../../src/libraries/ArrayDeDupLib.sol";
+import { SpendingLimit } from "../../../../src/libraries/SpendingLimitLib.sol";
+import { CashLens } from "../../../../src/modules/cash/CashLens.sol";
+import { IAggregatorV3, PriceProvider } from "../../../../src/oracle/PriceProvider.sol";
+import { CashModuleTestSetup } from "./CashModuleTestSetup.t.sol";
+
+contract LegacyCashLensMaxSpendTest is CashModuleTestSetup {
+    using MessageHashUtils for bytes32;
+
+    IERC20 public liquidUsdScroll = IERC20(0x08c6F91e2B681FaF5e17227F2a44C307b3C1364C);
+    ILayerZeroTeller public liquidUsdTeller = ILayerZeroTeller(0x4DE413a26fC24c3FC27Cc983be70aA9c5C299387);
+
+    uint256 weETHBal = 10 ether;
+    uint256 usdcBal = 50_000e6;
+    uint256 liquidUsdBal = 30_000e6;
+    uint256 liquidUsdBorrowPower;
+    uint256 usdcBorrowPower;
+    uint256 weEthBorrowPower;
+    uint256 liquidAmtInUsd;
+
+    function setUp() public override {
+        super.setUp();
+
+        // These suites preserve the pre-gateway lens tests for legacy-engine safes (CashLensLegacyLib)
+        _forceLegacyEngine(address(safe));
+
+        vm.startPrank(owner);
+
+        // Setup liquidUSD price config
+        AccountantWithRateProviders liquidUsdAccountant = liquidUsdTeller.accountant();
+
+        PriceProvider.Config memory liquidUsdConfig = PriceProvider.Config({ oracle: address(liquidUsdAccountant), priceFunctionCalldata: abi.encodeWithSelector(AccountantWithRateProviders.getRate.selector), isChainlinkType: false, oraclePriceDecimals: liquidUsdAccountant.decimals(), maxStaleness: 2 days, dataType: PriceProvider.ReturnType.Uint256, isBaseTokenEth: false, isStableToken: true, isBaseTokenBtc: false });
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(liquidUsdScroll);
+
+        PriceProvider.Config[] memory tokensConfig = new PriceProvider.Config[](1);
+        tokensConfig[0] = liquidUsdConfig;
+
+        priceProvider.setTokenConfig(tokens, tokensConfig);
+
+        // Setup liquidUSD as collateral and borrow token
+        IDebtManager.CollateralTokenConfig[] memory collateralTokenConfig = new IDebtManager.CollateralTokenConfig[](1);
+        collateralTokenConfig[0].ltv = ltv;
+        collateralTokenConfig[0].liquidationThreshold = liquidationThreshold;
+        collateralTokenConfig[0].liquidationBonus = liquidationBonus;
+
+        debtManager.supportCollateralToken(address(liquidUsdScroll), collateralTokenConfig[0]);
+
+        minShares = uint128(10 * 10 ** IERC20Metadata(address(liquidUsdScroll)).decimals());
+        debtManager.supportBorrowToken(address(liquidUsdScroll), borrowApyPerSecond, minShares);
+
+        // Add liquidUSD to withdraw whitelist
+        address[] memory withdrawTokens = new address[](1);
+        withdrawTokens[0] = address(liquidUsdScroll);
+        bool[] memory whitelist = new bool[](1);
+        whitelist[0] = true;
+        cashModule.configureWithdrawAssets(withdrawTokens, whitelist);
+
+        // Add collateral to safe
+        deal(address(weETH), address(safe), weETHBal);
+        deal(address(usdc), address(safe), usdcBal);
+        deal(address(liquidUsdScroll), address(safe), liquidUsdBal);
+
+        // Ensure debt manager has sufficient liquidity
+        deal(address(usdc), address(debtManager), 100_000e6);
+        deal(address(liquidUsdScroll), address(debtManager), 100_000e6);
+
+        uint256 weEthInUsd = debtManager.convertCollateralTokenToUsd(address(weETH), weETHBal);
+        liquidAmtInUsd = debtManager.convertCollateralTokenToUsd(address(liquidUsdScroll), liquidUsdBal);
+        weEthBorrowPower = (weEthInUsd * ltv) / HUNDRED_PERCENT;
+        usdcBorrowPower = (usdcBal * ltv) / HUNDRED_PERCENT;
+        liquidUsdBorrowPower = (liquidAmtInUsd * ltv) / HUNDRED_PERCENT;
+
+        vm.stopPrank();
+    }
+
+    // ================ getMaxSpendDebit Tests ================
+
+    /// Empty token preference returns empty arrays and zero total.
+    function test_getMaxSpendDebit_emptyTokenPreference() public view {
+        address[] memory emptyPreference = new address[](0);
+
+        DebitModeMaxSpend memory result = cashLens.getMaxSpendDebit(address(safe), emptyPreference);
+
+        assertEq(result.spendableTokens.length, 0, "Should return empty tokens array");
+        assertEq(result.spendableAmounts.length, 0, "Should return empty amounts array");
+        assertEq(result.amountsInUsd.length, 0, "Should return empty USD amounts array");
+        assertEq(result.totalSpendableInUsd, 0, "Should return zero total");
+    }
+
+    /// Single USDC preference on a healthy position spends the full balance.
+    function test_getMaxSpendDebit_singleToken_USDC_healthyPosition() public view {
+        address[] memory tokenPreference = new address[](1);
+        tokenPreference[0] = address(usdc);
+
+        DebitModeMaxSpend memory result = cashLens.getMaxSpendDebit(address(safe), tokenPreference);
+
+        assertEq(result.spendableTokens.length, 1, "Should return one token");
+        assertEq(result.spendableTokens[0], address(usdc), "Token should be USDC");
+        assertEq(result.spendableAmounts[0], usdcBal, "Should be able to spend all USDC");
+        assertEq(result.amountsInUsd[0], usdcBal, "USD value should match");
+        assertEq(result.totalSpendableInUsd, usdcBal, "Total should match USDC value");
+    }
+
+    /// Single liquidUSD preference on a healthy position spends the full balance.
+    function test_getMaxSpendDebit_singleToken_liquidUSD_healthyPosition() public view {
+        address[] memory tokenPreference = new address[](1);
+        tokenPreference[0] = address(liquidUsdScroll);
+
+        DebitModeMaxSpend memory result = cashLens.getMaxSpendDebit(address(safe), tokenPreference);
+
+        assertEq(result.spendableTokens.length, 1, "Should return one token");
+        assertEq(result.spendableTokens[0], address(liquidUsdScroll), "Token should be liquidUSD");
+        assertEq(result.spendableAmounts[0], liquidUsdBal, "Should be able to spend all liquidUSD");
+        assertApproxEqRel(result.amountsInUsd[0], liquidAmtInUsd, 1, "USD value should match approximately"); // Allow 1% deviation for rate
+        assertApproxEqRel(result.totalSpendableInUsd, liquidAmtInUsd, 1, "Total should match liquidUSD value");
+    }
+
+    /// Both tokens on a healthy position spend fully and total to their sum.
+    function test_getMaxSpendDebit_bothTokens_healthyPosition() public view {
+        address[] memory tokenPreference = new address[](2);
+        tokenPreference[0] = address(usdc);
+        tokenPreference[1] = address(liquidUsdScroll);
+
+        DebitModeMaxSpend memory result = cashLens.getMaxSpendDebit(address(safe), tokenPreference);
+
+        assertEq(result.spendableTokens.length, 2, "Should return two tokens");
+        assertEq(result.spendableAmounts[0], usdcBal, "Should be able to spend all USDC");
+        assertEq(result.spendableAmounts[1], liquidUsdBal, "Should be able to spend all liquidUSD");
+        assertApproxEqRel(result.totalSpendableInUsd, usdcBal + liquidAmtInUsd, 1, "Total should be sum of both");
+    }
+
+    /// With debt, the first-preference USDC is drawn down to cover the deficit.
+    function test_getMaxSpendDebit_underwaterPosition_USDCFirst() public {
+        // Create debt by borrowing in credit mode
+        _setMode(Mode.Credit);
+        vm.warp(cashModule.incomingModeStartTime(address(safe)) + 1);
+
+        _updateSpendingLimit(1_000_000e6, 1_000_000e6);
+
+        // Borrow large % of collateral value to create underwater position
+        uint256 borrowAmount = weEthBorrowPower + usdcBorrowPower - 1e6;
+        address[] memory spendTokens = new address[](1);
+        spendTokens[0] = address(usdc);
+        uint256[] memory spendAmounts = new uint256[](1);
+        spendAmounts[0] = borrowAmount;
+
+        Cashback[] memory cashbacks = new Cashback[](1);
+        CashbackTokens[] memory cashbackTokens = new CashbackTokens[](1);
+
+        CashbackTokens memory scr = CashbackTokens({ token: address(cashbackToken), amountInUsd: 1e6, cashbackType: 0 });
+
+        cashbackTokens[0] = scr;
+
+        Cashback memory scrCashback = Cashback({ to: address(safe), cashbackTokens: cashbackTokens });
+
+        cashbacks[0] = scrCashback;
+
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
+
+        // Switch back to debit mode
+        _setMode(Mode.Debit);
+        vm.warp(block.timestamp + 1);
+
+        // Check max spend with USDC first preference
+        address[] memory tokenPreference = new address[](2);
+        tokenPreference[0] = address(usdc);
+        tokenPreference[1] = address(liquidUsdScroll);
+
+        DebitModeMaxSpend memory result = cashLens.getMaxSpendDebit(address(safe), tokenPreference);
+
+        // With debt, USDC should be used first to cover deficit
+        assertLt(result.spendableAmounts[0], usdcBal, "USDC spend should be restricted");
+        assertEq(result.spendableAmounts[1], liquidUsdBal, "liquidUSD should be fully spendable after USDC covers deficit");
+        assertGt(result.totalSpendableInUsd, 0, "Should still be able to spend something");
+    }
+
+    /// With debt, the first-preference liquidUSD is drawn down to cover the deficit.
+    function test_getMaxSpendDebit_underwaterPosition_liquidUSDFirst() public {
+        // Create debt
+        _setMode(Mode.Credit);
+        vm.warp(cashModule.incomingModeStartTime(address(safe)) + 1);
+        _updateSpendingLimit(1_000_000e6, 1_000_000e6);
+
+        uint256 borrowAmount = weEthBorrowPower + liquidUsdBorrowPower - 1e6;
+        address[] memory spendTokens = new address[](1);
+        spendTokens[0] = address(usdc);
+        uint256[] memory spendAmounts = new uint256[](1);
+        spendAmounts[0] = borrowAmount;
+
+        Cashback[] memory cashbacks = new Cashback[](1);
+        CashbackTokens[] memory cashbackTokens = new CashbackTokens[](1);
+
+        CashbackTokens memory scr = CashbackTokens({ token: address(cashbackToken), amountInUsd: 1e6, cashbackType: 0 });
+
+        cashbackTokens[0] = scr;
+
+        Cashback memory scrCashback = Cashback({ to: address(safe), cashbackTokens: cashbackTokens });
+
+        cashbacks[0] = scrCashback;
+
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
+
+        // Check max spend with liquidUSD first preference
+        address[] memory tokenPreference = new address[](2);
+        tokenPreference[0] = address(liquidUsdScroll);
+        tokenPreference[1] = address(usdc);
+
+        DebitModeMaxSpend memory result = cashLens.getMaxSpendDebit(address(safe), tokenPreference);
+
+        // With debt, liquidUSD should be used first to cover deficit
+        assertLt(result.spendableAmounts[0], liquidUsdBal, "liquidUSD spend should be restricted");
+        assertEq(result.spendableAmounts[1], usdcBal, "USDC should be fully spendable after liquidUSD covers deficit");
+        assertGt(result.totalSpendableInUsd, 0, "Should still be able to spend something");
+    }
+
+    /// A pending USDC withdrawal reduces spendable USDC by the requested amount.
+    function test_getMaxSpendDebit_withPendingWithdrawals_USDC() public {
+        // Create withdrawal request for USDC
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 20_000e6;
+        _requestWithdrawal(tokens, amounts, withdrawRecipient);
+
+        address[] memory tokenPreference = new address[](2);
+        tokenPreference[0] = address(usdc);
+        tokenPreference[1] = address(liquidUsdScroll);
+
+        DebitModeMaxSpend memory result = cashLens.getMaxSpendDebit(address(safe), tokenPreference);
+        uint256 effectiveUsdcBal = usdcBal - amounts[0];
+        assertEq(result.spendableAmounts[0], effectiveUsdcBal, "USDC should only spend effective balance");
+        assertEq(result.spendableAmounts[1], liquidUsdBal, "liquidUSD should be unaffected");
+        assertApproxEqRel(result.totalSpendableInUsd, effectiveUsdcBal + liquidAmtInUsd, 1, "Total should reflect reduced USDC");
+    }
+
+    /// A pending liquidUSD withdrawal reduces spendable liquidUSD by the requested amount.
+    function test_getMaxSpendDebit_withPendingWithdrawals_liquidUSD() public {
+        // Create withdrawal request for liquidUSD
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(liquidUsdScroll);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 15_000e6;
+        _requestWithdrawal(tokens, amounts, withdrawRecipient);
+
+        address[] memory tokenPreference = new address[](2);
+        tokenPreference[0] = address(usdc);
+        tokenPreference[1] = address(liquidUsdScroll);
+
+        DebitModeMaxSpend memory result = cashLens.getMaxSpendDebit(address(safe), tokenPreference);
+        uint256 effectiveLiquidUsdBal = liquidUsdBal - amounts[0];
+        uint256 liquidUsdAmtInUsd = debtManager.convertCollateralTokenToUsd(address(liquidUsdScroll), effectiveLiquidUsdBal);
+
+        assertEq(result.spendableAmounts[0], usdcBal, "USDC should be unaffected");
+        assertEq(result.spendableAmounts[1], effectiveLiquidUsdBal, "liquidUSD should only spend effective balance");
+        assertApproxEqRel(result.totalSpendableInUsd, usdcBal + liquidUsdAmtInUsd, 1, "Total should reflect reduced liquidUSD");
+    }
+
+    /// Duplicate tokens in the preference revert with DuplicateElementFound.
+    function test_getMaxSpendDebit_duplicateTokens() public {
+        address[] memory tokenPreference = new address[](2);
+        tokenPreference[0] = address(usdc);
+        tokenPreference[1] = address(usdc);
+
+        vm.expectRevert(ArrayDeDupLib.DuplicateElementFound.selector);
+        cashLens.getMaxSpendDebit(address(safe), tokenPreference);
+    }
+
+    /// A non-borrow token in the preference reverts with NotABorrowToken.
+    function test_getMaxSpendDebit_notBorrowToken() public {
+        address nonBorrowToken = makeAddr("nonBorrowToken");
+
+        address[] memory tokenPreference = new address[](1);
+        tokenPreference[0] = nonBorrowToken;
+
+        vm.expectRevert(CashLens.NotABorrowToken.selector);
+        cashLens.getMaxSpendDebit(address(safe), tokenPreference);
+    }
+
+    /// When collateral cannot cover the debt deficit, nothing is spendable.
+    function test_getMaxSpendDebit_cannotCoverDeficit() public {
+        // Create large debt
+        _setMode(Mode.Credit);
+        vm.warp(cashModule.incomingModeStartTime(address(safe)) + 1);
+
+        uint256 borrowAmount = 10_000e6;
+        address[] memory spendTokens = new address[](1);
+        spendTokens[0] = address(usdc);
+        uint256[] memory spendAmounts = new uint256[](1);
+        spendAmounts[0] = borrowAmount;
+
+        Cashback[] memory cashbacks = new Cashback[](1);
+        CashbackTokens[] memory cashbackTokens = new CashbackTokens[](1);
+
+        CashbackTokens memory scr = CashbackTokens({ token: address(cashbackToken), amountInUsd: 1e6, cashbackType: 0 });
+
+        cashbackTokens[0] = scr;
+
+        Cashback memory scrCashback = Cashback({ to: address(safe), cashbackTokens: cashbackTokens });
+
+        cashbacks[0] = scrCashback;
+
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
+
+        // Remove most collateral
+        deal(address(usdc), address(safe), 500e6);
+        deal(address(liquidUsdScroll), address(safe), 500e6);
+        deal(address(weETH), address(safe), 0);
+
+        // Try to get max spend - should return empty as deficit cannot be covered
+        address[] memory tokenPreference = new address[](2);
+        tokenPreference[0] = address(usdc);
+        tokenPreference[1] = address(liquidUsdScroll);
+
+        DebitModeMaxSpend memory result = cashLens.getMaxSpendDebit(address(safe), tokenPreference);
+
+        assertEq(result.spendableTokens.length, 0, "Should return empty when deficit cannot be covered");
+        assertEq(result.totalSpendableInUsd, 0, "Total should be zero");
+    }
+
+    /// A full-balance withdrawal leaves zero effective balance to spend.
+    function test_getMaxSpendDebit_zeroEffectiveBalance() public {
+        // Create withdrawal request for all USDC
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 50_000e6;
+        _requestWithdrawal(tokens, amounts, withdrawRecipient);
+
+        address[] memory tokenPreference = new address[](1);
+        tokenPreference[0] = address(usdc);
+
+        DebitModeMaxSpend memory result = cashLens.getMaxSpendDebit(address(safe), tokenPreference);
+
+        assertEq(result.spendableAmounts[0], 0, "Should have zero spendable with full withdrawal");
+        assertEq(result.totalSpendableInUsd, 0, "Total should be zero");
+    }
+
+    // ================ Updated getSafeCashData Tests ================
+
+    /// getSafeCashData honors a USDC-then-liquidUSD preference and populates the rest.
+    function test_getSafeCashData_withTokenPreference_USDC_liquidUSD() public view {
+        address[] memory tokenPreference = new address[](2);
+        tokenPreference[0] = address(usdc);
+        tokenPreference[1] = address(liquidUsdScroll);
+
+        SafeCashData memory data = cashLens.getSafeCashData(address(safe), tokenPreference);
+
+        // Verify debitMaxSpend uses the preference
+        assertEq(data.debitMaxSpend.spendableTokens.length, 2, "Should have two tokens in preference order");
+        assertEq(data.debitMaxSpend.spendableTokens[0], address(usdc), "First token should be USDC");
+        assertEq(data.debitMaxSpend.spendableTokens[1], address(liquidUsdScroll), "Second token should be liquidUSD");
+        assertGt(data.debitMaxSpend.totalSpendableInUsd, 0, "Should have spendable amount");
+
+        // Verify other data is still populated correctly
+        assertGt(data.totalCollateral, 0, "Should have collateral value");
+        assertEq(data.totalBorrow, 0, "Should have no borrows initially");
+    }
+
+    /// getSafeCashData honors a liquidUSD-then-USDC preference order.
+    function test_getSafeCashData_withTokenPreference_liquidUSD_USDC() public view {
+        address[] memory tokenPreference = new address[](2);
+        tokenPreference[0] = address(liquidUsdScroll);
+        tokenPreference[1] = address(usdc);
+
+        SafeCashData memory data = cashLens.getSafeCashData(address(safe), tokenPreference);
+
+        // Verify debitMaxSpend uses the preference
+        assertEq(data.debitMaxSpend.spendableTokens[0], address(liquidUsdScroll), "First token should be liquidUSD");
+        assertEq(data.debitMaxSpend.spendableTokens[1], address(usdc), "Second token should be USDC");
+    }
+
+    /// An empty preference falls back to all borrow tokens.
+    function test_getSafeCashData_emptyTokenPreference() public view {
+        address[] memory emptyPreference = new address[](0);
+
+        SafeCashData memory data = cashLens.getSafeCashData(address(safe), emptyPreference);
+
+        // Should use all borrow tokens when preference is empty
+        assertGt(data.debitMaxSpend.spendableTokens.length, 0, "Should have default borrow tokens");
+        assertGt(data.debitMaxSpend.totalSpendableInUsd, 0, "Should have spendable amount");
+
+        // Check that it includes both USDC and liquidUSD
+        bool hasUSDC = false;
+        bool hasLiquidUSD = false;
+        for (uint256 i = 0; i < data.debitMaxSpend.spendableTokens.length; i++) {
+            if (data.debitMaxSpend.spendableTokens[i] == address(usdc)) hasUSDC = true;
+            if (data.debitMaxSpend.spendableTokens[i] == address(liquidUsdScroll)) hasLiquidUSD = true;
+        }
+        assertTrue(hasUSDC && hasLiquidUSD, "Should include both USDC and liquidUSD");
+    }
+
+    /// A single-token preference restricts the result to that token.
+    function test_getSafeCashData_singleTokenPreference() public view {
+        address[] memory tokenPreference = new address[](1);
+        tokenPreference[0] = address(liquidUsdScroll);
+
+        SafeCashData memory data = cashLens.getSafeCashData(address(safe), tokenPreference);
+
+        assertEq(data.debitMaxSpend.spendableTokens.length, 1, "Should have only liquidUSD");
+        assertEq(data.debitMaxSpend.spendableTokens[0], address(liquidUsdScroll), "Token should be liquidUSD");
+        assertApproxEqRel(data.debitMaxSpend.totalSpendableInUsd, liquidAmtInUsd, 1, "Should match liquidUSD value");
+    }
+
+    /// getSafeCashData's debitMaxSpend matches a direct getMaxSpendDebit call.
+    function test_getSafeCashData_consistencyWithDirectCall() public view {
+        address[] memory tokenPreference = new address[](2);
+        tokenPreference[0] = address(usdc);
+        tokenPreference[1] = address(liquidUsdScroll);
+
+        // Get data through getSafeCashData
+        SafeCashData memory data = cashLens.getSafeCashData(address(safe), tokenPreference);
+
+        // Get data through direct getMaxSpendDebit call
+        DebitModeMaxSpend memory directResult = cashLens.getMaxSpendDebit(address(safe), tokenPreference);
+
+        // Compare results
+        assertEq(data.debitMaxSpend.totalSpendableInUsd, directResult.totalSpendableInUsd, "Total USD should match");
+        assertEq(data.debitMaxSpend.spendableTokens.length, directResult.spendableTokens.length, "Token count should match");
+
+        for (uint256 i = 0; i < data.debitMaxSpend.spendableTokens.length; i++) {
+            assertEq(data.debitMaxSpend.spendableTokens[i], directResult.spendableTokens[i], "Tokens should match");
+            assertEq(data.debitMaxSpend.spendableAmounts[i], directResult.spendableAmounts[i], "Amounts should match");
+            assertEq(data.debitMaxSpend.amountsInUsd[i], directResult.amountsInUsd[i], "USD amounts should match");
+        }
+    }
+
+    // ================ getMaxSpendCredit Tests ================
+
+    /// Credit max spend equals the debt manager's max borrow amount.
+    function test_getMaxSpendCredit_withUSDC_liquidUSD_collateral() public view {
+        uint256 creditMaxSpend = cashLens.getMaxSpendCredit(address(safe));
+
+        // Calculate expected based on collateral
+        uint256 expectedMaxBorrow = debtManager.getMaxBorrowAmount(address(safe), true);
+
+        assertEq(creditMaxSpend, expectedMaxBorrow, "Credit max spend should match max borrow");
+        assertGt(creditMaxSpend, 0, "Should have positive credit limit with collateral");
+    }
+}

--- a/test/safe/modules/cash/SetGateway.t.sol
+++ b/test/safe/modules/cash/SetGateway.t.sol
@@ -18,13 +18,13 @@ contract CashModuleSetGatewayTest is CashModuleTestSetup {
 
     /// @notice New safes onboard onto the Aave gateway engine; a debt-free re-setup also flips to the gateway.
     function test_setupModule_flagsNewSafeAsAaveGateway() public {
-        assertTrue(cashModule.isAaveGatewaySafe(address(safe)), "new safe defaults to the gateway engine");
+        assertTrue(cashModule.usesAave(address(safe)), "new safe defaults to the gateway engine");
 
         _forceLegacyEngine(address(safe));
 
         vm.prank(address(safe));
         cashModule.setupModule(abi.encode(dailyLimitInUsd, monthlyLimitInUsd, timezoneOffset));
-        assertTrue(cashModule.isAaveGatewaySafe(address(safe)), "debt-free re-setup flips to the gateway");
+        assertTrue(cashModule.usesAave(address(safe)), "debt-free re-setup flips to the gateway");
     }
 
     /// @notice A legacy safe with open DebtManager debt must keep routing to DebtManager if setup re-runs;
@@ -39,7 +39,7 @@ contract CashModuleSetGatewayTest is CashModuleTestSetup {
 
         vm.prank(address(safe));
         cashModule.setupModule(abi.encode(dailyLimitInUsd, monthlyLimitInUsd, timezoneOffset));
-        assertFalse(cashModule.isAaveGatewaySafe(address(safe)), "safe with legacy debt stays on the legacy engine");
+        assertFalse(cashModule.usesAave(address(safe)), "safe with legacy debt stays on the legacy engine");
     }
 
     /// @notice A controller can configure the first gateway during Lend bootstrap and the change is emitted.

--- a/test/safe/modules/cash/SetGateway.t.sol
+++ b/test/safe/modules/cash/SetGateway.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.28;
 import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
 import { UUPSProxy } from "../../../../src/UUPSProxy.sol";
-import { ICashModule, Mode, SafeCashData } from "../../../../src/interfaces/ICashModule.sol";
+import { BinSponsor, ICashModule, Mode, SafeCashData } from "../../../../src/interfaces/ICashModule.sol";
 import { IGateway } from "../../../../src/interfaces/IGateway.sol";
 import { CashVerificationLib } from "../../../../src/libraries/CashVerificationLib.sol";
 import { MockGateway } from "../../../../src/mocks/MockGateway.sol";
@@ -15,6 +15,32 @@ import { CashEventEmitter, CashModuleTestSetup } from "./CashModuleTestSetup.t.s
 
 contract CashModuleSetGatewayTest is CashModuleTestSetup {
     using MessageHashUtils for bytes32;
+
+    /// @notice New safes onboard onto the Aave gateway engine; a debt-free re-setup also flips to the gateway.
+    function test_setupModule_flagsNewSafeAsAaveGateway() public {
+        assertTrue(cashModule.isAaveGatewaySafe(address(safe)), "new safe defaults to the gateway engine");
+
+        _forceLegacyEngine(address(safe));
+
+        vm.prank(address(safe));
+        cashModule.setupModule(abi.encode(dailyLimitInUsd, monthlyLimitInUsd, timezoneOffset));
+        assertTrue(cashModule.isAaveGatewaySafe(address(safe)), "debt-free re-setup flips to the gateway");
+    }
+
+    /// @notice A legacy safe with open DebtManager debt must keep routing to DebtManager if setup re-runs;
+    ///         flipping it without migrating would strand the legacy debt behind gateway routing.
+    function test_setupModule_keepsLegacySafeWithDebtOnLegacyEngine() public {
+        _forceLegacyEngine(address(safe));
+
+        deal(address(weETH), address(safe), 10 ether);
+        deal(address(usdc), address(debtManager), 1_000_000e6);
+        vm.prank(address(safe));
+        debtManager.borrow(BinSponsor.Reap, address(usdc), 10e6);
+
+        vm.prank(address(safe));
+        cashModule.setupModule(abi.encode(dailyLimitInUsd, monthlyLimitInUsd, timezoneOffset));
+        assertFalse(cashModule.isAaveGatewaySafe(address(safe)), "safe with legacy debt stays on the legacy engine");
+    }
 
     /// @notice A controller can configure the first gateway during Lend bootstrap and the change is emitted.
     function test_setGateway_emitsAndUpdates() public {

--- a/test/safe/modules/cash/Spend.t.sol
+++ b/test/safe/modules/cash/Spend.t.sol
@@ -90,8 +90,9 @@ contract CashModuleSpendTest is CashModuleTestSetup {
         assertEq(weETH.balanceOf(address(settlementDispatcherReap)), settlementDispatcherWeETHBalBefore + weETHAmount);
     }
 
-    /// A non-migrated safe borrows credit from the DebtManager, leaving its own balance untouched.
+    /// A legacy-engine safe borrows credit from the DebtManager, leaving its own balance untouched.
     function test_spend_inCreditMode_borrowsFromDebtManager_whenNotMigrated() public {
+        _forceLegacyEngine(address(safe));
         uint256 initialBalance = 100e6;
         deal(address(usdc), address(safe), initialBalance);
 
@@ -253,6 +254,7 @@ contract CashModuleSpendTest is CashModuleTestSetup {
     // A failed gateway borrow propagates and reverts the whole credit spend (the old catch-and-retry is gone).
     /// A credit spend cancels a pending withdrawal when it would otherwise block the DebtManager borrow.
     function test_spend_inCreditMode_cancelsPendingWithdrawal_whenDebtManagerBorrowBlocked() public {
+        _forceLegacyEngine(address(safe));
         address[] memory tokens = new address[](1);
         uint256[] memory amounts = new uint256[](1);
         address recipient = withdrawRecipient;
@@ -659,6 +661,63 @@ contract CashModuleSpendTest is CashModuleTestSetup {
         assertEq(cashModule.getSettlementDispatcher(BinSponsor.Rain), address(settlementDispatcherRain));
     }
 
+    /// A legacy debit spend must leave the DebtManager position healthy: loose tokens are its collateral.
+    function test_spend_inDebitMode_legacySafe_revertsWhenPositionUnhealthy() public {
+        _forceLegacyEngine(address(safe));
+        deal(address(usdc), address(safe), 100e6);
+        deal(address(usdc), address(debtManager), 1 ether);
+
+        uint256 borrowAmt = debtManager.getMaxBorrowAmount(address(safe), true) / 2;
+        vm.prank(address(safe));
+        debtManager.borrow(BinSponsor.Reap, address(usdc), borrowAmt);
+
+        address[] memory spendTokens = new address[](1);
+        spendTokens[0] = address(usdc);
+        uint256[] memory spendAmounts = new uint256[](1);
+        spendAmounts[0] = 95e6; // leaves 5e6 backing the debt
+
+        Cashback[] memory cashbacks;
+
+        vm.prank(etherFiWallet);
+        vm.expectRevert(IDebtManager.AccountUnhealthy.selector);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
+    }
+
+    /// A legacy debit spend that is unhealthy only because of the withdrawal reservation cancels the pending
+    /// withdrawal (the spend wins the competing claim) and then succeeds.
+    function test_spend_inDebitMode_legacySafe_cancelsWithdrawalWhenUnhealthyWithReservation() public {
+        _forceLegacyEngine(address(safe));
+        deal(address(usdc), address(safe), 100e6);
+        deal(address(usdc), address(debtManager), 1 ether);
+
+        uint256 borrowAmt = debtManager.getMaxBorrowAmount(address(safe), true) / 4;
+        vm.prank(address(safe));
+        debtManager.borrow(BinSponsor.Reap, address(usdc), borrowAmt);
+
+        // Reserve 70e6 for withdrawal; the 25e6 spend fits the unreserved 30e6, but the post-spend position
+        // is unhealthy while the reservation stands (effective collateral 5e6 against the debt)
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 70e6;
+        _requestWithdrawal(tokens, amounts, withdrawRecipient);
+
+        address[] memory spendTokens = new address[](1);
+        spendTokens[0] = address(usdc);
+        uint256[] memory spendAmounts = new uint256[](1);
+        spendAmounts[0] = 25e6;
+
+        Cashback[] memory cashbacks;
+
+        uint256 dispatcherBefore = usdc.balanceOf(address(settlementDispatcherReap));
+
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
+
+        assertEq(usdc.balanceOf(address(settlementDispatcherReap)), dispatcherBefore + 25e6, "spend executed");
+        assertEq(cashModule.getPendingWithdrawalAmount(address(safe), address(usdc)), 0, "withdrawal cancelled to restore health");
+    }
+
     function test_spend_FundsGoToBinSponsorSettlementDispatcherAsSpecified_inDebitMode() public {
         uint256 amount = 100e6;
         deal(address(usdc), address(safe), 2 * amount);
@@ -701,6 +760,7 @@ contract CashModuleSpendTest is CashModuleTestSetup {
 
     /// The DebtManager credit borrow is forwarded to the settlement dispatcher of the chosen bin sponsor.
     function test_spend_inCreditMode_routesDebtManagerBorrowToBinSponsorDispatcher() public {
+        _forceLegacyEngine(address(safe));
         uint256 initialBalance = 100e6;
         deal(address(usdc), address(safe), initialBalance);
 

--- a/test/safe/modules/cash/Withdrawals.t.sol
+++ b/test/safe/modules/cash/Withdrawals.t.sol
@@ -212,6 +212,7 @@ contract CashModuleWithdrawalTest is CashModuleTestSetup {
 
     /// @notice A non-migrated safe borrows from the DebtManager, so withdrawing its backing collateral reverts as unhealthy.
     function test_processWithdrawals_fails_ifPositionUnhealthyAfterWithdrawal() external {
+        _forceLegacyEngine(address(safe));
         uint256 totalSafeBalance = 100e6;
         deal(address(usdc), address(safe), totalSafeBalance);
         deal(address(weETH), address(safe), 0);
@@ -277,6 +278,7 @@ contract CashModuleWithdrawalTest is CashModuleTestSetup {
 
     /// @notice Reserving all collateral for withdrawal while DebtManager debt is open makes the request unhealthy.
     function test_requestWithdrawal_fails_whenAccountBecomesUnhealthy() external {
+        _forceLegacyEngine(address(safe));
         address[] memory tokens = new address[](2);
         tokens[0] = address(usdc);
         tokens[1] = address(weETH);

--- a/test/safe/modules/cash/debt-manager/Borrow.t.sol
+++ b/test/safe/modules/cash/debt-manager/Borrow.t.sol
@@ -25,6 +25,9 @@ contract DebtManagerBorrowTest is CashModuleTestSetup {
     function setUp() public override {
         super.setUp();
 
+        // This suite tests the legacy DebtManager engine (new safes default to the Aave gateway)
+        _forceLegacyEngine(address(safe));
+
         collateralValueInUsdc = debtManager.convertCollateralTokenToUsd(address(weETH), collateralAmount);
 
         deal(address(weETH), address(safe), collateralAmount);

--- a/test/safe/modules/cash/debt-manager/DebtManagerViewFunctions.t.sol
+++ b/test/safe/modules/cash/debt-manager/DebtManagerViewFunctions.t.sol
@@ -23,6 +23,9 @@ contract DebtManagerViewFunctionTests is CashModuleTestSetup {
     function setUp() public override {
         super.setUp();
 
+        // This suite tests the legacy DebtManager engine (new safes default to the Aave gateway)
+        _forceLegacyEngine(address(safe));
+
         // remove all supplies from debt manager
         vm.startPrank(owner);
         debtManager.withdrawBorrowToken(address(usdc), debtManager.supplierBalance(owner, address(usdc)));

--- a/test/safe/modules/cash/debt-manager/InterestIndex.t.sol
+++ b/test/safe/modules/cash/debt-manager/InterestIndex.t.sol
@@ -38,6 +38,7 @@ contract DebtManagerInterestIndexTest is CashModuleTestSetup {
     }
 
     function test_getCurrentIndex_updatesCorrectly_afterBorrow() public {
+        _forceLegacyEngine(address(safe));
         deal(address(weETH), address(safe), 10 ether);
         // Borrow to trigger an index update
         uint256 borrowAmt = 1000e6; // 1000 USDC

--- a/test/safe/modules/cash/debt-manager/Invariant.t.sol
+++ b/test/safe/modules/cash/debt-manager/Invariant.t.sol
@@ -44,7 +44,10 @@ contract DebtManagerInvariantTest is CashModuleTestSetup {
 
             address deployedSafe = safeFactory.getDeterministicAddress(salt);
             safes.push(IEtherFiSafe(deployedSafe));
-            
+
+            // This suite tests the legacy DebtManager engine (new safes default to the Aave gateway)
+            _forceLegacyEngine(deployedSafe);
+
             // Setup borrower with sufficient collateral
             deal(address(weETH), deployedSafe, INITIAL_COLLATERAL_IN_WEETH);
             

--- a/test/safe/modules/cash/debt-manager/Liquidation.t.sol
+++ b/test/safe/modules/cash/debt-manager/Liquidation.t.sol
@@ -1,0 +1,664 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import { IDebtManager } from "../../../../../src/interfaces/IDebtManager.sol";
+import { BinSponsor, Cashback } from "../../../../../src/interfaces/ICashModule.sol";
+import { UpgradeableProxy } from "../../../../../src/utils/UpgradeableProxy.sol";
+import { CashEventEmitter, CashModuleTestSetup, Mode } from "../CashModuleTestSetup.t.sol";
+import { PriceProvider } from "../../../../../src/oracle/PriceProvider.sol";
+import { MockPriceProvider } from "../../../../../src/mocks/MockPriceProvider.sol";
+import { MockERC20 } from "../../../../../src/mocks/MockERC20.sol";
+
+contract DebtManagerLiquidationTest is CashModuleTestSetup {
+    uint256 collateralAmount = 0.01 ether;
+    uint256 collateralValueInUsdc;
+    uint256 borrowAmt;
+    uint256 mockWeETHPriceInUsd = 3000e6;
+
+    function setUp() public override {
+        super.setUp();
+
+        // This suite tests the legacy DebtManager engine (new safes default to the Aave gateway)
+        _forceLegacyEngine(address(safe));
+
+        vm.prank(owner);
+        cashModule.setDelays(60, 3600, 0); // set credit mode delay to 0
+
+        _setMode(Mode.Credit);
+
+        collateralValueInUsdc = debtManager.convertCollateralTokenToUsd(address(weETH), collateralAmount);
+
+        deal(address(weETH), address(safe), collateralAmount);
+        borrowAmt = debtManager.remainingBorrowingCapacityInUSD(address(safe));
+
+        address[] memory spendTokens = new address[](1);
+        spendTokens[0] = address(usdc);
+        uint256[] memory spendAmounts = new uint256[](1);
+        spendAmounts[0] = borrowAmt;
+
+        Cashback[] memory cashbacks;
+
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
+    }
+
+    function test_setCollateralTokenConfig_updatesLiquidationThreshold_whenCalledByAdmin() public {     
+        uint80 newThreshold = 70e18;
+
+        IDebtManager.CollateralTokenConfig memory collateralTokenConfig = debtManager.collateralTokenConfig(address(weETH));
+        collateralTokenConfig.liquidationThreshold = newThreshold;
+
+        vm.prank(owner);
+        debtManager.setCollateralTokenConfig(
+            address(weETH),
+            collateralTokenConfig
+        );
+
+        IDebtManager.CollateralTokenConfig memory configFromContract = debtManager.collateralTokenConfig(address(weETH));
+        assertEq(configFromContract.liquidationThreshold, newThreshold);
+    }
+
+    function test_setCollateralTokenConfig_reverts_whenCallerNotAdmin() public {
+        uint80 newThreshold = 70e18;
+        IDebtManager.CollateralTokenConfig memory collateralTokenConfig = debtManager.collateralTokenConfig(address(weETH));
+        collateralTokenConfig.liquidationThreshold = newThreshold;
+
+        vm.startPrank(notOwner);
+        vm.expectRevert(UpgradeableProxy.Unauthorized.selector);
+        debtManager.setCollateralTokenConfig(address(weETH), collateralTokenConfig);
+
+        vm.stopPrank();
+    }
+
+    function test_liquidate_succeeds_whenPositionLiquidatable() public {
+        vm.startPrank(owner);
+
+        // fast forward 10 days so the interest index also updates
+        vm.warp(block.timestamp + 10 days);
+
+        uint256 liquidatorWeEthBalBefore = weETH.balanceOf(owner);
+
+        IDebtManager.CollateralTokenConfig memory collateralTokenConfig;
+        collateralTokenConfig.ltv = 5e18;
+        collateralTokenConfig.liquidationThreshold = 10e18;
+        collateralTokenConfig.liquidationBonus = 5e18;
+
+        debtManager.setCollateralTokenConfig(address(weETH), collateralTokenConfig);
+        assertEq(debtManager.liquidatable(address(safe)), true);
+
+        address[] memory collateralTokenPreference = debtManager.getCollateralTokens();
+
+        uint256 currentBorrowAmt = debtManager.borrowingOf(address(safe), address(usdc));
+        deal(address(usdc), owner, currentBorrowAmt + 1);
+        IERC20(address(usdc)).approve(address(debtManager), currentBorrowAmt + 1);
+        debtManager.liquidate(address(safe), address(usdc), collateralTokenPreference);
+
+        vm.stopPrank();
+
+        // just to nullify any cashback effect on calculations
+        deal(address(usdc), address(safe), 0);
+
+        uint256 safeCollateralAfter = debtManager.getCollateralValueInUsd(address(safe));
+        uint256 safeDebtAfter = debtManager.borrowingOf(address(safe), address(usdc));
+        uint256 liquidatorWeEthBalAfter = weETH.balanceOf(owner);
+
+        uint256 liquidatedUsdcCollateralAmt = debtManager.convertUsdToCollateralToken(address(weETH), currentBorrowAmt);
+        uint256 liquidationBonusReceived = (liquidatedUsdcCollateralAmt * collateralTokenConfig.liquidationBonus) / HUNDRED_PERCENT;
+        uint256 liquidationBonusInUsdc = debtManager.convertCollateralTokenToUsd(address(weETH), liquidationBonusReceived);
+
+        assertApproxEqAbs(debtManager.convertCollateralTokenToUsd(address(weETH), liquidatorWeEthBalAfter - liquidatorWeEthBalBefore - liquidationBonusReceived), currentBorrowAmt, 10);
+        assertEq(safeDebtAfter, 0);
+        assertApproxEqAbs(safeCollateralAfter, collateralValueInUsdc - currentBorrowAmt - liquidationBonusInUsdc, 2);
+    }
+
+    function test_liquidate_cancelsPendingWithdrawals_whenWithdrawalsExist() public {
+        uint256 withdrawAmt = 0.001 ether;
+        deal(address(weETH), address(safe), collateralAmount + withdrawAmt);
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(weETH);
+
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = withdrawAmt;
+
+        _requestWithdrawal(tokens, amounts, withdrawRecipient);
+
+        vm.startPrank(owner);
+
+        IDebtManager.CollateralTokenConfig memory collateralTokenConfig;
+        collateralTokenConfig.ltv = 5e18;
+        collateralTokenConfig.liquidationThreshold = 10e18;
+        collateralTokenConfig.liquidationBonus = 5e18;
+
+        debtManager.setCollateralTokenConfig(address(weETH), collateralTokenConfig);
+        assertEq(debtManager.liquidatable(address(safe)), true);
+
+        address[] memory collateralTokenPreference = debtManager.getCollateralTokens();
+
+        deal(address(usdc), owner, borrowAmt);
+        IERC20(address(usdc)).approve(address(debtManager), borrowAmt);
+
+        vm.expectEmit(true, true, true, true);
+        emit CashEventEmitter.WithdrawalCancelled(address(safe), tokens, amounts, withdrawRecipient);
+        debtManager.liquidate(address(safe), address(usdc), collateralTokenPreference);
+
+        vm.stopPrank();
+
+        assertEq(cashModule.getPendingWithdrawalAmount(address(safe), address(weETH)), 0);
+    }
+
+    function test_liquidate_reverts_whenPositionNotLiquidatable() public {
+        vm.startPrank(owner);
+        assertEq(debtManager.liquidatable(address(safe)), false);
+        IERC20(address(usdc)).approve(address(debtManager), borrowAmt);
+
+        address[] memory collateralTokens = debtManager.getCollateralTokens();
+        vm.expectRevert(IDebtManager.CannotLiquidateYet.selector);
+        debtManager.liquidate(address(safe), address(usdc), collateralTokens);
+
+        vm.stopPrank();
+    }
+
+    function test_liquidate_reverts_whenInvalidCollateralTokensProvided() public {
+        deal(address(usdc), address(safe), borrowAmt);
+        vm.prank(etherFiWallet);
+        cashModule.repay(address(safe), address(usdc), borrowAmt);
+
+        priceProvider = PriceProvider(
+            address(new MockPriceProvider(mockWeETHPriceInUsd, address(usdc)))
+        );
+        vm.prank(owner);
+        dataProvider.setPriceProvider(address(priceProvider));
+
+        borrowAmt = debtManager.remainingBorrowingCapacityInUSD(address(safe));
+
+        address[] memory spendTokens = new address[](1);
+        spendTokens[0] = address(usdc);
+        uint256[] memory spendAmounts = new uint256[](1);
+        spendAmounts[0] = borrowAmt;
+
+        Cashback[] memory cashbacks;
+
+        // safe should borrow at new price for our calculations to be correct
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), keccak256("newTxId"), BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
+
+        vm.startPrank(owner);
+        uint256 newPrice = 1000e6; // 1000 USD per weETH
+        MockPriceProvider(address(priceProvider)).setPrice(newPrice);
+        
+        // Lower the thresholds for weETH as well
+        IDebtManager.CollateralTokenConfig memory collateralTokenConfigWeETH;
+        collateralTokenConfigWeETH.ltv = 5e18;
+        collateralTokenConfigWeETH.liquidationThreshold = 10e18;
+        collateralTokenConfigWeETH.liquidationBonus = 5e18;
+        debtManager.setCollateralTokenConfig(address(weETH), collateralTokenConfigWeETH);
+
+        address mockToken = address(new MockERC20("mockToken", "mock", 18));
+        address[] memory collateralTokenPreference = new address[](2);
+        collateralTokenPreference[0] = address(mockToken);
+        collateralTokenPreference[1] = address(weETH);
+
+        uint256 liquidationAmt = 5e6;
+
+        IERC20(address(usdc)).approve(address(debtManager), liquidationAmt);
+        vm.expectRevert(IDebtManager.NotACollateralToken.selector);
+        debtManager.liquidate(address(safe), address(usdc), collateralTokenPreference);
+
+        vm.stopPrank();
+    }
+
+    function test_liquidate_chargesCorrectAmount_whenPositionLiquidated() public {
+        deal(address(usdc), address(safe), borrowAmt);
+        vm.prank(etherFiWallet);
+        cashModule.repay(address(safe), address(usdc), borrowAmt);
+
+        priceProvider = PriceProvider(
+            address(new MockPriceProvider(mockWeETHPriceInUsd, address(usdc)))
+        );
+        vm.prank(owner);
+        dataProvider.setPriceProvider(address(priceProvider));
+
+        borrowAmt = debtManager.remainingBorrowingCapacityInUSD(address(safe));
+
+        address[] memory spendTokens = new address[](1);
+        spendTokens[0] = address(usdc);
+        uint256[] memory spendAmounts = new uint256[](1);
+        spendAmounts[0] = borrowAmt;
+
+        Cashback[] memory cashbacks;
+
+        // safe should borrow at new price for our calculations to be correct
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), keccak256("newTxId"), BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
+
+        vm.startPrank(owner);
+        uint256 newPrice = 1000e6; // 1000 USD per weETH
+        MockPriceProvider(address(priceProvider)).setPrice(newPrice);
+        
+        // Lower the thresholds for weETH as well
+        IDebtManager.CollateralTokenConfig memory collateralTokenConfigWeETH;
+        collateralTokenConfigWeETH.ltv = 5e18;
+        collateralTokenConfigWeETH.liquidationThreshold = 10e18;
+        collateralTokenConfigWeETH.liquidationBonus = 5e18;
+        debtManager.setCollateralTokenConfig(address(weETH), collateralTokenConfigWeETH);
+
+        // Now price of collateral token is 1000 USD per weETH
+        // total collateral = 0.01 weETH => 10 USD
+        // total debt = based on price 3000 USD per weETH and 50% LTV -> 15 USD
+        // So total collateral < total debt
+        // Also the user is liquidatable since liquidation threshold is 10% 
+        
+        // 50% liquidation -> 
+        // Debt is 15 USD -> 7.5 USD to liquidate first
+        // weETH amt -> 7.5 / 1000 = 0.0075 weETH
+        // bonus -> 5% -> 0.0075 * 5% = 0.000375 weETH
+        // total collateral gone -> 0.007875
+
+        // next 50% liquidation (since user is still liquidatable)
+        // collateral left -> 0.002125 weETH
+        // total value in USD -> 0.002125 * 1000 -> 2.125 USD
+        // total net repay value on this amount -> 0.002125 * 100% / (100 + 5)% = 0.002023809524 weETH = 0.002023809524 * 1000 = 2.023809524 USD
+        // total bonus -> 0.002125 (total collateral) - 0.002023809524 (total net repay) = 0.000101190476 weETH -> 0.101190476 USD
+        // total collateral liquidated -> 2.125 - 0.101190476 USD -> 2.023809524 USD
+
+        // total liquidated amount -> 7.5 + 2.023809524 USD = 9.523809524 USD
+
+        uint256 liquidationAmt = 9.523809 * 1e6;
+
+        address[] memory collateralTokenPreference = new address[](1);
+        collateralTokenPreference[0] = address(weETH);
+
+        uint256 ownerWeETHBalBefore = weETH.balanceOf(owner);
+        uint256 ownerUsdcBalBefore = IERC20(address(usdc)).balanceOf(owner);
+        uint256 aliceSafeDebtBefore = debtManager.borrowingOf(address(safe), address(usdc));
+        uint256 aliceSafeCollateralBefore = debtManager.getCollateralValueInUsd(address(safe));
+
+        IERC20(address(usdc)).approve(address(debtManager), liquidationAmt);
+        debtManager.liquidate(address(safe), address(usdc), collateralTokenPreference);
+
+        uint256 ownerWeETHBalAfter = weETH.balanceOf(owner);
+        uint256 ownerUsdcBalAfter = IERC20(address(usdc)).balanceOf(owner);
+        uint256 aliceSafeDebtAfter = debtManager.borrowingOf(address(safe), address(usdc));
+        uint256 aliceSafeCollateralAfter = debtManager.getCollateralValueInUsd(address(safe));
+
+        assertEq(ownerWeETHBalAfter - ownerWeETHBalBefore, collateralAmount);
+        assertEq(ownerUsdcBalBefore - ownerUsdcBalAfter, liquidationAmt);
+        assertEq(aliceSafeDebtBefore, borrowAmt);
+        assertEq(aliceSafeDebtAfter, borrowAmt - liquidationAmt);
+        assertEq(aliceSafeCollateralBefore, 10e6); // price dropped to 1000 USD and 0.01 weETH was collateral
+        assertEq(aliceSafeCollateralAfter, 0);
+
+        vm.stopPrank();
+    }
+
+    function test_liquidate_respectsCollateralPreference_whenMultipleCollateralsAvailable() public {
+        deal(address(usdc), address(safe), borrowAmt);
+        vm.prank(etherFiWallet);
+        cashModule.repay(address(safe), address(usdc), borrowAmt);
+                
+        priceProvider = PriceProvider(
+            address(new MockPriceProvider(mockWeETHPriceInUsd, address(usdc)))
+        );
+        vm.prank(owner);
+        dataProvider.setPriceProvider(address(priceProvider));
+
+        borrowAmt = debtManager.remainingBorrowingCapacityInUSD(address(safe));
+        // Alice should borrow at new price for our calculations to be correct
+
+        address[] memory spendTokens = new address[](1);
+        spendTokens[0] = address(usdc);
+        uint256[] memory spendAmounts = new uint256[](1);
+        spendAmounts[0] = borrowAmt;
+
+        Cashback[] memory cashbacks;
+
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), keccak256("newTxId"), BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
+        
+        address newCollateralToken = address(new MockERC20("collateral", "CTK", 18));
+        IDebtManager.CollateralTokenConfig memory collateralTokenConfigNewCollateralToken;
+        collateralTokenConfigNewCollateralToken.ltv = 5e18;
+        collateralTokenConfigNewCollateralToken.liquidationThreshold = 10e18;
+        collateralTokenConfigNewCollateralToken.liquidationBonus = 10e18;
+
+        vm.startPrank(owner);
+        debtManager.supportCollateralToken(
+            newCollateralToken,
+            collateralTokenConfigNewCollateralToken
+        );
+
+        uint256 collateralAmtNewToken = 0.005 ether;
+        deal(newCollateralToken, address(safe), collateralAmtNewToken);
+
+        // Lower the thresholds for weETH as well
+        IDebtManager.CollateralTokenConfig memory collateralTokenConfigWeETH;
+        collateralTokenConfigWeETH.ltv = 5e18;
+        collateralTokenConfigWeETH.liquidationThreshold = 10e18;
+        collateralTokenConfigWeETH.liquidationBonus = 5e18;
+        debtManager.setCollateralTokenConfig(address(weETH), collateralTokenConfigWeETH);
+
+        address[] memory collateralTokenPreference = new address[](2);
+        collateralTokenPreference[0] = newCollateralToken;
+        collateralTokenPreference[1] = address(weETH);
+
+        assertEq(debtManager.liquidatable(address(safe)), true);
+
+        // currently, alice collateral -> 
+        // 0.01 weETH + 0.005 newToken  => 30 + 15 = 45 USDC (since 3000 is the default price in mock price provider)
+        // alice debt -> 30 * 50% = 15 USD (initial collateral 30 USD, LTV: 50%)
+        // When we liquidate -> user should receive the following:
+        
+        // for a debt of 15 USD ->
+
+        // first liquidate 50% loan -> 7.5 USD
+
+        // new token is first in preference 
+        // total collateral in new token -> 0.005 * 3000 = 15 USDC
+        // debt amount in new collateral token -> 7.5 USD / 3000 USD = 0.0025 
+        // liquidation bonus -> 0.0025 * 10% bonus -> 0.00025 in collateral tokens -> 0.75 USDC 
+        // Collateral left in new token = 0.005 - 0.0025 - 0.00025 = 0.00225
+        
+        // After partial liquidation -> 
+        // user debt -> 7.5 USDC
+        // user collateral -> 0.01 weETH + 0.00225 newToken = 36.75
+        // user is still liquidatable as liquidation threshold is 10% 
+
+        // now we need to again liquidate the debt of 7.5 USDC which is left
+
+        // new token is first in preference 
+        // total collateral in new token -> 0.00225 * 3000 = 6.75 USDC
+        // total net repay value on this amount -> 0.00225 * 100% / (100 + 10)% = 0.002045454545 new token = 0.002045454545 * 3000 = 6.136363635 USD
+        // liquidation bonus -> 0.00225 (total collateral) - 0.002045454545 (total net repay) = 0.000204545455 new token = 0.000204545455 * 3000 = 0.613636365 USD
+        // so new token wipes off 6.136363635 USDC of debt
+        
+        // weETH is second in preference 
+        // total collateral in weETH -> 0.01 * 3000 = 30 USDC
+        // total debt left = 7.5 USDC - 6.136363635 USDC = 1.363636365 USDC
+        // total collateral worth 1.363636365 USDC in weETH -> 1.363636365 / 3000 -> 0.000454545455
+        // total bonus on 0.000454545455 weETH => 0.000454545455 * 5% = 0.00002272727275
+
+        // In total
+        // borrow wiped by new token -> 7.5 + 6.136363635 = 13.636363635 USDC
+        // borrow wiped by weETH -> 1.363636365 USDC
+        // total liquidation bonus new token -> 0.00025 + 0.000204545455 = 0.000454545455
+        // total liquidation bonus weETH -> 0.00002272727275
+
+        uint256 ownerWeETHBalBefore = weETH.balanceOf(owner);
+        uint256 ownerNewTokenBalBefore = IERC20(newCollateralToken).balanceOf(owner);
+        uint256 aliceSafeDebtBefore = debtManager.borrowingOf(address(safe), address(usdc));
+
+        IERC20(address(usdc)).approve(address(debtManager), borrowAmt);
+        debtManager.liquidate(address(safe), address(usdc), collateralTokenPreference);
+
+        vm.stopPrank();
+
+        _validate(newCollateralToken, ownerNewTokenBalBefore, ownerWeETHBalBefore, aliceSafeDebtBefore);
+    }
+
+    function _validate(
+        address newCollateralToken,
+        uint256 ownerNewTokenBalBefore,
+        uint256 ownerWeETHBalBefore,
+        uint256 aliceDebtBefore
+    ) internal view {
+        uint256 ownerWeETHBalAfter = weETH.balanceOf(owner);
+        uint256 ownerNewTokenBalAfter = IERC20(newCollateralToken).balanceOf(owner);
+        uint256 aliceDebtAfter = debtManager.borrowingOf(address(safe), address(usdc));
+
+        uint256 borrowWipedByNewToken =  13.636363 * 1e6;
+        uint256 borrowWipedByWeETH = 1.363636 * 1e6;
+        uint256 liquidationBonusNewToken =  0.000454545455 ether;
+        uint256 liquidationBonusWeETH = 0.00002272727275 ether;
+
+        assertApproxEqAbs(
+            debtManager.convertCollateralTokenToUsd(
+                address(newCollateralToken),
+                ownerNewTokenBalAfter - ownerNewTokenBalBefore - liquidationBonusNewToken
+            ),
+            borrowWipedByNewToken,
+            10
+        );
+        
+        assertApproxEqAbs(
+            debtManager.convertCollateralTokenToUsd(
+                address(weETH),
+                ownerWeETHBalAfter - ownerWeETHBalBefore - liquidationBonusWeETH
+            ),
+            borrowWipedByWeETH,
+            10
+        );
+
+        assertEq(aliceDebtBefore, borrowAmt);
+        assertEq(aliceDebtAfter, 0);
+    }
+
+    function test_liquidate_reverts_whenEmptyCollateralPreferenceProvided() public {
+        vm.startPrank(owner);
+        IDebtManager.CollateralTokenConfig memory collateralTokenConfig;
+        collateralTokenConfig.ltv = 5e18;
+        collateralTokenConfig.liquidationThreshold = 10e18;
+        collateralTokenConfig.liquidationBonus = 5e18;
+        debtManager.setCollateralTokenConfig(address(weETH), collateralTokenConfig);
+        
+        address[] memory emptyPreference = new address[](0);
+        
+        vm.expectRevert(IDebtManager.CollateralPreferenceIsEmpty.selector); 
+        debtManager.liquidate(address(safe), address(usdc), emptyPreference);
+        vm.stopPrank();
+    }
+
+    function test_liquidate_reverts_whenUnsupportedRepayToken() public {
+        vm.startPrank(owner);
+        IDebtManager.CollateralTokenConfig memory collateralTokenConfig;
+        collateralTokenConfig.ltv = 5e18;
+        collateralTokenConfig.liquidationThreshold = 10e18;
+        collateralTokenConfig.liquidationBonus = 5e18;
+        debtManager.setCollateralTokenConfig(address(weETH), collateralTokenConfig);
+        
+        address randomToken = address(new MockERC20("random", "RND", 18));        
+        address[] memory collateralTokenPreference = debtManager.getCollateralTokens();
+        
+        vm.expectRevert(IDebtManager.UnsupportedBorrowToken.selector);
+        debtManager.liquidate(address(safe), randomToken, collateralTokenPreference);
+        vm.stopPrank();
+    }
+
+    function test_liquidate_honorsChangedLiquidationBonus_withInsufficientCollateral() public {
+        deal(address(usdc), address(safe), borrowAmt);
+        vm.prank(etherFiWallet);
+        cashModule.repay(address(safe), address(usdc), borrowAmt);
+        
+        priceProvider = PriceProvider(
+            address(new MockPriceProvider(mockWeETHPriceInUsd, address(usdc)))
+        );
+        vm.prank(owner);
+        dataProvider.setPriceProvider(address(priceProvider));
+        
+        borrowAmt = debtManager.remainingBorrowingCapacityInUSD(address(safe));
+
+        address[] memory spendTokens = new address[](1);
+        spendTokens[0] = address(usdc);
+        uint256[] memory spendAmounts = new uint256[](1);
+        spendAmounts[0] = borrowAmt;
+
+        Cashback[] memory cashbacks;
+
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), keccak256("newTxId"), BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
+        
+        vm.startPrank(owner);
+        uint256 newPrice = 1000e6; // 1000 USD per weETH
+        MockPriceProvider(address(priceProvider)).setPrice(newPrice);
+        
+        // Set a very high liquidation bonus (30%)
+        IDebtManager.CollateralTokenConfig memory collateralTokenConfigWeETH;
+        collateralTokenConfigWeETH.ltv = 5e18;
+        collateralTokenConfigWeETH.liquidationThreshold = 10e18;
+        collateralTokenConfigWeETH.liquidationBonus = 30e18; // 30% bonus instead of 5%
+        debtManager.setCollateralTokenConfig(address(weETH), collateralTokenConfigWeETH);
+        
+        address[] memory collateralTokenPreference = new address[](1);
+        collateralTokenPreference[0] = address(weETH);
+        
+        uint256 ownerWeETHBalBefore = weETH.balanceOf(owner);
+        
+        IERC20(address(usdc)).approve(address(debtManager), borrowAmt);
+        debtManager.liquidate(address(safe), address(usdc), collateralTokenPreference);
+        
+        uint256 ownerWeETHBalAfter = weETH.balanceOf(owner);
+        
+        // Since the price dropped significantly and the total collateral is likely less than 
+        // the debt after the price change, the liquidator gets the entire collateral amount
+        uint256 expectedToReceive = collateralAmount; // 0.01 ether
+        
+        // The liquidator should receive the entire collateral
+        assertApproxEqAbs(
+            ownerWeETHBalAfter - ownerWeETHBalBefore,
+            expectedToReceive,
+            0.0001 ether
+        );
+        
+        vm.stopPrank();
+    }
+
+    function test_liquidate_honorsChangedLiquidationBonus_withSufficientCollateral() public {
+        deal(address(usdc), address(safe), borrowAmt);
+        vm.prank(etherFiWallet);
+        cashModule.repay(address(safe), address(usdc), borrowAmt);
+        
+        // Setup mock price provider with high initial price
+        priceProvider = PriceProvider(
+            address(new MockPriceProvider(mockWeETHPriceInUsd, address(usdc)))
+        );
+        vm.prank(owner);
+        dataProvider.setPriceProvider(address(priceProvider));
+        
+        // Set up a scenario with MORE collateral
+        uint256 largerCollateralAmount = 0.05 ether; // 5x more than the default 0.01 ether
+        deal(address(weETH), address(safe), largerCollateralAmount);
+        
+        // Borrow a smaller amount relative to collateral
+        uint256 smallerBorrowAmt = debtManager.remainingBorrowingCapacityInUSD(address(safe)) / 4; // Only borrow 25% of capacity
+
+        address[] memory spendTokens = new address[](1);
+        spendTokens[0] = address(usdc);
+        uint256[] memory spendAmounts = new uint256[](1);
+        spendAmounts[0] = smallerBorrowAmt;
+
+        Cashback[] memory cashbacks;
+
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), keccak256("newTxId"), BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
+        
+        vm.startPrank(owner);
+        
+        // Set a moderate price drop that makes user liquidatable but still leaves sufficient collateral
+        uint256 newPrice = 2000e6; // 2000 USD per weETH (33% drop instead of 66%)
+        MockPriceProvider(address(priceProvider)).setPrice(newPrice);
+        
+        // Set a high liquidation bonus (30%)
+        IDebtManager.CollateralTokenConfig memory collateralTokenConfigWeETH;
+        collateralTokenConfigWeETH.ltv = 5e18; // 5%
+        collateralTokenConfigWeETH.liquidationThreshold = 10e18; // 10%
+        collateralTokenConfigWeETH.liquidationBonus = 30e18; // 30% bonus
+        debtManager.setCollateralTokenConfig(address(weETH), collateralTokenConfigWeETH);
+        
+        // Confirm the position is liquidatable
+        assertTrue(debtManager.liquidatable(address(safe)), "Position should be liquidatable");
+        
+        address[] memory collateralTokenPreference = new address[](1);
+        collateralTokenPreference[0] = address(weETH);
+        
+        uint256 ownerWeETHBalBefore = weETH.balanceOf(owner);
+        
+        // Account for the fact that _liquidateUser liquidates in two steps
+        // Half in the first step, and potentially the rest in a second step if still liquidatable
+        uint256 debtToLiquidate = smallerBorrowAmt;
+        
+        // Amount of collateral needed to cover the debt (for both liquidation steps)
+        uint256 collateralNeededForDebt = debtManager.convertUsdToCollateralToken(address(weETH), debtToLiquidate);
+        
+        // Liquidation bonus (30% of collateral needed)
+        uint256 expectedBonus = (collateralNeededForDebt * collateralTokenConfigWeETH.liquidationBonus) / HUNDRED_PERCENT;
+        
+        // Expected total collateral to receive
+        uint256 expectedCollateralToReceive = collateralNeededForDebt + expectedBonus;
+        
+        // Approve more than needed USDC for liquidation
+        IERC20(address(usdc)).approve(address(debtManager), smallerBorrowAmt);
+        
+        // Execute liquidation
+        debtManager.liquidate(address(safe), address(usdc), collateralTokenPreference);
+        
+        uint256 ownerWeETHBalAfter = weETH.balanceOf(owner);
+        uint256 actualReceived = ownerWeETHBalAfter - ownerWeETHBalBefore;
+                
+        // The liquidator should receive exactly the debt plus the bonus
+        assertApproxEqAbs(
+            actualReceived,
+            expectedCollateralToReceive,
+            0.0001 ether
+        );
+        
+        vm.stopPrank();
+    }
+
+    function test_liquidate_reverts_afterPriceRecovery() public {
+        deal(address(usdc), address(safe), borrowAmt);
+        vm.prank(etherFiWallet);
+        cashModule.repay(address(safe), address(usdc), borrowAmt);
+        
+        // Setup mock price provider
+        priceProvider = PriceProvider(
+            address(new MockPriceProvider(mockWeETHPriceInUsd, address(usdc)))
+        );
+        vm.prank(owner);
+        dataProvider.setPriceProvider(address(priceProvider));
+        
+        borrowAmt = debtManager.remainingBorrowingCapacityInUSD(address(safe));
+
+        address[] memory spendTokens = new address[](1);
+        spendTokens[0] = address(usdc);
+        uint256[] memory spendAmounts = new uint256[](1);
+        spendAmounts[0] = borrowAmt;
+
+        Cashback[] memory cashbacks;
+
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), keccak256("newTxId"), BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
+        
+        vm.startPrank(owner);
+        // Drop price to make position liquidatable
+        uint256 lowPrice = 1000e6; // 1000 USD per weETH
+        MockPriceProvider(address(priceProvider)).setPrice(lowPrice);
+        
+        // Lower thresholds
+        IDebtManager.CollateralTokenConfig memory collateralTokenConfigWeETH;
+        collateralTokenConfigWeETH.ltv = 5e18;
+        collateralTokenConfigWeETH.liquidationThreshold = 10e18;
+        collateralTokenConfigWeETH.liquidationBonus = 5e18;
+        debtManager.setCollateralTokenConfig(address(weETH), collateralTokenConfigWeETH);
+        
+        // Verify position is liquidatable
+        assertTrue(debtManager.liquidatable(address(safe)));
+        
+        // Recover price
+        uint256 recoveredPrice = 20000e6; // Price jumped to 20000 USD per weETH
+        MockPriceProvider(address(priceProvider)).setPrice(recoveredPrice);
+        
+        // Position should no longer be liquidatable
+        assertFalse(debtManager.liquidatable(address(safe)));
+        
+        // Attempt to liquidate should fail
+        address[] memory collateralTokenPreference = new address[](1);
+        collateralTokenPreference[0] = address(weETH);
+        
+        vm.expectRevert(IDebtManager.CannotLiquidateYet.selector);
+        debtManager.liquidate(address(safe), address(usdc), collateralTokenPreference);
+        
+        vm.stopPrank();
+    }
+}

--- a/test/safe/modules/cash/debt-manager/Repay.t.sol
+++ b/test/safe/modules/cash/debt-manager/Repay.t.sol
@@ -12,6 +12,9 @@ contract DebtManagerRepayTest is CashModuleTestSetup {
     function setUp() public override {
         super.setUp();
 
+        // This suite tests the legacy DebtManager engine (new safes default to the Aave gateway)
+        _forceLegacyEngine(address(safe));
+
         vm.prank(owner);
         cashModule.setDelays(60, 3600, 0); // set credit mode delay to 0
 

--- a/test/safe/modules/cash/debt-manager/SupplyAndWithdraw.t.sol
+++ b/test/safe/modules/cash/debt-manager/SupplyAndWithdraw.t.sol
@@ -25,6 +25,9 @@ contract DebtManagerSupplyAndWithdrawTest is CashModuleTestSetup {
     function setUp() public override {
         super.setUp();
 
+        // This suite tests the legacy DebtManager engine (new safes default to the Aave gateway)
+        _forceLegacyEngine(address(safe));
+
         uint256 nonce = cashModule.getNonce(address(safe));
         bytes32 msgHash = keccak256(
             abi.encodePacked(


### PR DESCRIPTION
## What this does

Makes the CashModule serve each safe from one of two engines: the legacy DebtManager or the Aave gateway. A per-safe flag, `onAaveGateway`, decides which. Every spend, repay, and lens path branches on this one flag. New safes and safes migrated with `DebtManager.migrateToAave` use Aave; every existing safe stays on the legacy engine.

## Why

The gateway work so far moved everyone to Aave in one step. That leaves no path for the safes already live on the DebtManager. This lets both engines run side by side, so existing safes keep working unchanged and migrate to Aave one at a time.

## Main changes

- **Routing flag.** `onAaveGateway` on the safe config, with `isAaveGatewaySafe` to read it and `markAaveGatewaySafe` to set it. The flag is one way and only the DebtManager can set it, as the last step of migration.
- **Migration flips the flag in the same tx.** `migrateToAave` now calls `markAaveGatewaySafe`, so the DebtManager freeze latch and the CashModule routing can never disagree about which engine serves a safe. Migration also leaves funds reserved by a pending withdrawal loose in the safe instead of supplying them to Aave, since a queued withdrawal is a plain balance transfer and supplying those funds would break it.
- **Liquidation restored for legacy safes.** Brings back `CashLiquidationHelper` and the `preLiquidate` / `postLiquidate` hooks on the CashModule, plus the `DebtManager.liquidate` path. Gateway safes are liquidated by Aave itself.
- **Legacy lens split out.** `CashLensLegacyLib` holds the pre-gateway lens math so legacy safes still get correct `canSpend` and max-spend results. Kept in a separate lib for code size.

## Tests

- `EngineParity.t.sol`: the check side (`CashLens.canSpend`) and the execute side (`CashModule.spend`) agree for every mode and engine. An approved check lands, a declined check reverts with the matching error.
- `LegacyCanSpend.t.sol` and `LegacyCashLensMaxSpend.t.sol`: the full pre-gateway lens behavior on legacy-engine safes.
- `Liquidation.t.sol`: the restored legacy liquidation path.
- Updates to the migration and lend-disable suites for the dual-engine flag.

## Note for review

Migration is one way and sets the routing flag itself, so nothing else can flip a safe between engines. Please sanity check that no spend, repay, or lens path reads the engine from anywhere other than `isAaveGatewaySafe`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core borrow/spend/repay routing, one-way migration, and restored liquidation with cross-contract hooks; incorrect engine branching or migration/supply logic could mis-route funds or brick withdrawals.
> 
> **Overview**
> Introduces a per-safe **`usesAave`** flag so CashModule spend, repay, lend, and lens paths route to either the **legacy DebtManager** or the **Aave gateway**. New safes default to the gateway when they have no legacy debt; **`migrateToAave`** sets the flag in the same transaction via **`markUsesAave`** (DebtManager-only) and only supplies collateral not reserved by a **pending withdrawal**.
> 
> **Execution and reads** are split by engine: **`CashLendLib`** owns consolidated credit/debit spend, repay, withdrawal cancel, and liquidation transfers; **`CashLens`** delegates legacy **`canSpend`** / max-spend / collateral views to **`CashLensLegacyLib`** so pre-gateway behavior stays byte-identical on decline strings.
> 
> **Legacy liquidation** is restored on **`DebtManager.liquidate`** (up to ~50% debt per pass, collateral preference with bonus math), with **`CashModule.preLiquidate`** / **`postLiquidate`** (cancel pending withdrawal, transfer collateral to the liquidator). **`CashLiquidationHelper`** plus a Forge deploy script support off-chain liquidation discovery.
> 
> Tests add **check vs execute parity** (`EngineParity`), full legacy lens coverage, migration boundary cases, and lend-disable behavior for legacy vs gateway safes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fb844964619525fbefd13323fa23b156f87522d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->