### PR TITLE
feat: resupply loose collateral to cover credit spend shortfall

### DIFF
--- a/src/interfaces/ICashEventEmitter.sol
+++ b/src/interfaces/ICashEventEmitter.sol
@@ -136,6 +136,14 @@ interface ICashEventEmitter {
      */
     function emitRepay(address safe, address token, uint256 amount, uint256 amountInUsd) external;
 
+    /**
+     * @notice Emits an event when loose collateral is supplied to cover a credit spend's borrowing shortfall
+     * @param safe Address of the safe
+     * @param token Collateral token supplied
+     * @param amount Token amount supplied
+     */
+    function emitCollateralResupplied(address safe, address token, uint256 amount) external;
+
     /// @notice Emits the LendDisableRequested event
     function emitLendDisableRequested(address safe, uint256 finalizeTime) external;
 

--- a/src/mocks/MockGateway.sol
+++ b/src/mocks/MockGateway.sol
@@ -36,6 +36,9 @@ contract MockGateway is IGateway {
     Call public lastBorrow;
     Call public lastRepay;
 
+    /// @notice Full supply-call history, for tests that assert more than the last call
+    Call[] public supplies;
+
     /// @notice When set, borrow reverts, to model a blocked borrow (e.g. insufficient Aave collateral)
     bool public borrowReverts;
 
@@ -81,6 +84,12 @@ contract MockGateway is IGateway {
 
     function supply(address safe, address asset, uint256 amount) external {
         lastSupply = Call(safe, asset, amount, address(0));
+        supplies.push(lastSupply);
+    }
+
+    /// @notice Number of recorded supply calls
+    function suppliesCount() external view returns (uint256) {
+        return supplies.length;
     }
 
     function withdraw(address safe, address asset, uint256 amount, address to) external {

--- a/src/modules/cash/CashEventEmitter.sol
+++ b/src/modules/cash/CashEventEmitter.sol
@@ -139,7 +139,15 @@ contract CashEventEmitter is UpgradeableProxy {
      * @param mode Operational mode in which the spending occurs
      */
     event Spend(address indexed safe, bytes32 indexed txId, BinSponsor indexed binSponsor, address[] tokens, uint256[] amounts, uint256[] amountInUsd, uint256 totalUsdAmt, Mode mode);
-    
+
+    /**
+     * @notice Emitted when loose collateral is supplied to cover a credit spend's borrowing shortfall
+     * @param safe Address of the safe
+     * @param token Collateral token supplied
+     * @param amount Token amount supplied
+     */
+    event CollateralResupplied(address indexed safe, address indexed token, uint256 amount);
+
     /**
      * @notice Emitted when cashback is calculated and potentially distributed
      * @param safe Address of the safe 
@@ -412,6 +420,17 @@ contract CashEventEmitter is UpgradeableProxy {
 
     function emitRepay(address safe, address token, uint256 amount, uint256 amountInUsd) external onlyCashModule {
         emit Repay(safe, token, amount, amountInUsd);
+    }
+
+    /**
+     * @notice Emits the CollateralResupplied event
+     * @dev Can only be called by the Cash Module
+     * @param safe Address of the safe
+     * @param token Collateral token supplied
+     * @param amount Token amount supplied
+     */
+    function emitCollateralResupplied(address safe, address token, uint256 amount) external onlyCashModule {
+        emit CollateralResupplied(safe, token, amount);
     }
 
     /// @notice Emits the LendDisableRequested event

--- a/src/modules/cash/CashLendLib.sol
+++ b/src/modules/cash/CashLendLib.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.28;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import { EnumerableSetLib } from "solady/utils/EnumerableSetLib.sol";
 
 import { IBridgeModule } from "../../interfaces/IBridgeModule.sol";
@@ -48,6 +49,9 @@ library CashLendLib {
     error LendDisabled();
     error AmountZero();
     error SettlementDispatcherNotSetForBinSponsor();
+
+    /// @dev Pad on resupply sizing so Aave share rounding cannot leave the headroom short; excess supply is harmless
+    uint256 internal constant RESUPPLY_BUFFER_BPS = 10;
 
     // Threads a debit spend's cross-token state through the sizing pass. Bundled into one struct so the
     // sizing frames stay well under the legacy stack limit (the price provider is a parameter here, where in
@@ -258,7 +262,8 @@ library CashLendLib {
      * @notice Credit spend (single token): borrows against the safe's position, sends the borrowed token
      *         to the settlement dispatcher, and emits Spend
      * @dev A legacy safe borrows from the DebtManager, executed by the safe itself; a gateway safe borrows
-     *      on Aave via the gateway. The caller has already validated the array shapes and the
+     *      on Aave via the gateway, first resupplying loose collateral if the position's borrowing power no
+     *      longer covers the spend. The caller has already validated the array shapes and the
      *      one-token-in-credit rule.
      * @param $ The CashModule storage (passed by the delegatecalling module)
      * @param dataProvider The module's data provider (to vet a legacy withdrawal cancel)
@@ -280,7 +285,7 @@ library CashLendLib {
         if (!_usesAave($, safe)) {
             _spendLegacyCredit($, dataProvider, safe, binSponsor, tokens[0], amount);
         } else {
-            _borrowOnGateway($, safe, binSponsor, tokens[0], amount);
+            _borrowOnGateway($, dataProvider, safe, binSponsor, tokens[0], amount, amountsInUsd[0]);
         }
 
         uint256[] memory amounts = new uint256[](1);
@@ -292,11 +297,102 @@ library CashLendLib {
     ///      CashModule is always a gateway driver) and send the borrowed token straight to the settlement
     ///      dispatcher. The legacy DebtManager.borrow path reverts for a migrated safe, and CashLens sizes
     ///      credit against the same engine flag, so routing here keeps the on-chain spend consistent with
-    ///      the precheck. Aave enforces the borrowing-power/health check on the borrow itself.
-    function _borrowOnGateway(CashModuleStorageContract.CashModuleStorage storage $, address safe, BinSponsor binSponsor, address token, uint256 amount) private {
+    ///      the precheck. Aave enforces the borrowing-power/health check on the borrow itself; when the
+    ///      borrow no longer fits (an instant collateral withdrawal can land between the auth-time canSpend
+    ///      and the spend tx), loose collateral is first resupplied to cover the shortfall.
+    function _borrowOnGateway(CashModuleStorageContract.CashModuleStorage storage $, IEtherFiDataProvider dataProvider, address safe, BinSponsor binSponsor, address token, uint256 amount, uint256 amountInUsd) private {
         IGateway gateway = $.gateway;
         if (address(gateway) == address(0)) revert LendGatewayNotSet();
+        _resupplyCollateral($, dataProvider, gateway, safe, amountInUsd);
         gateway.borrow(safe, token, amount, settlementDispatcher($, binSponsor));
+    }
+
+    /**
+     * @dev Supplies loose collateral from the safe as Aave collateral to cover the part of a credit spend
+     *      that the position's borrowing power no longer covers. The first pass sizes only against balance
+     *      not reserved by the pending withdrawal request; the reserved remainder is taken only when the
+     *      spend cannot be funded otherwise, and then the spend wins the competing claim: the request is
+     *      cancelled before any supply executes (the debit path's rule). Sizing finishes before any supply,
+     *      so it does not depend on the gateway's transfer timing. If loose collateral cannot fully cover,
+     *      it supplies what fits and the caller's subsequent borrow reverts the spend. CashLens never
+     *      counts this capacity, so canSpend does not advertise it as headroom.
+     */
+    function _resupplyCollateral(CashModuleStorageContract.CashModuleStorage storage $, IEtherFiDataProvider dataProvider, IGateway gateway, address safe, uint256 spendUsd) private {
+        uint256 availableUsd = gateway.getAccountData(safe).availableBorrowsUsd;
+        if (spendUsd <= availableUsd) return;
+        uint256 shortfallUsd = spendUsd - availableUsd;
+
+        IPriceProvider priceProvider = IPriceProvider(dataProvider.getPriceProvider());
+        address[] memory tokens = gateway.registeredAssets();
+        uint256[] memory supplyAmounts = new uint256[](tokens.length);
+
+        shortfallUsd = _sizeResupply($, gateway, priceProvider, safe, tokens, supplyAmounts, shortfallUsd, false);
+        if (shortfallUsd != 0) {
+            _sizeResupply($, gateway, priceProvider, safe, tokens, supplyAmounts, shortfallUsd, true);
+            cancelOldWithdrawal($, dataProvider, safe);
+        }
+
+        for (uint256 i = 0; i < tokens.length; i++) {
+            if (supplyAmounts[i] != 0) {
+                gateway.supply(safe, tokens[i], supplyAmounts[i]);
+                gateway.setUsingAsCollateral(safe, tokens[i], true);
+                $.cashEventEmitter.emitCollateralResupplied(safe, tokens[i], supplyAmounts[i]);
+            }
+        }
+    }
+
+    /**
+     * @dev One resupply sizing pass over the gateway's registered assets, accumulating into `supplyAmounts`.
+     *      Skips the balance reserved by the pending withdrawal request unless `useReserved` is set.
+     * @return The USD shortfall left after the pass
+     */
+    function _sizeResupply(CashModuleStorageContract.CashModuleStorage storage $, IGateway gateway, IPriceProvider priceProvider, address safe, address[] memory tokens, uint256[] memory supplyAmounts, uint256 shortfallUsd, bool useReserved) private view returns (uint256) {
+        for (uint256 i = 0; i < tokens.length && shortfallUsd != 0; i++) {
+            // A zero-LTV asset adds no borrowing headroom, so supplying it cannot help
+            uint256 tokenLtv = gateway.ltv(tokens[i]);
+            if (tokenLtv == 0) continue;
+
+            // Loose balance still available for this token, net of what an earlier pass already claimed
+            uint256 capacity = IERC20(tokens[i]).balanceOf(safe) - supplyAmounts[i];
+            if (!useReserved) {
+                // First pass: leave the pending withdrawal's reservation untouched
+                uint256 pending = _pendingWithdrawalAmount($, safe, tokens[i]);
+                capacity = capacity > pending ? capacity - pending : 0;
+            }
+            if (capacity == 0) continue;
+
+            // Full cover fits in this token: take it and stop
+            uint256 needed = _resupplyAmount(priceProvider, tokens[i], tokenLtv, shortfallUsd);
+            if (needed <= capacity) {
+                supplyAmounts[i] += needed;
+                return 0;
+            }
+
+            // Partial cover: exhaust this token and carry the rest to the next one.
+            // Taking capacity of the needed amount covers the same fraction of the shortfall; floor keeps the remainder conservative
+            supplyAmounts[i] += capacity;
+            shortfallUsd -= (shortfallUsd * capacity) / needed;
+        }
+        return shortfallUsd;
+    }
+
+    /**
+     * @dev Amount of `token` to supply so the position gains `neededUsd` of borrowing headroom.
+     *      Collateral only counts toward borrowing power at its LTV: supplying $V adds
+     *      $V * tokenLtv / LTV_SCALE of headroom (DebitSourcingLib.headroomConsumed, in reverse), so
+     *      gaining neededUsd takes $ neededUsd * LTV_SCALE / tokenLtv of collateral (e.g. $7.50 of USDC
+     *      at 80% LTV for $6 of headroom). Converting that value into token units ($1 of token is
+     *      10^decimals / price tokens) and padding by RESUPPLY_BUFFER_BPS gives
+     *
+     *        amount = neededUsd * LTV_SCALE / tokenLtv * 10^decimals / price * 10_010 / 10_000
+     *
+     *      computed as a single fraction so truncation happens once, and rounded up (ceil-div) so the
+     *      error is always a hair of extra supply, never short headroom. Caller guarantees tokenLtv != 0.
+     */
+    function _resupplyAmount(IPriceProvider priceProvider, address token, uint256 tokenLtv, uint256 neededUsd) private view returns (uint256) {
+        uint256 numerator = neededUsd * DebitSourcingLib.LTV_SCALE * (10 ** IERC20Metadata(token).decimals()) * (10_000 + RESUPPLY_BUFFER_BPS);
+        uint256 denominator = tokenLtv * priceProvider.price(token) * 10_000;
+        return (numerator + denominator - 1) / denominator;
     }
 
     /// @dev Legacy credit spend: a DebtManager borrow executed by the safe itself. A blocked borrow means

--- a/test/safe/modules/cash/Spend.t.sol
+++ b/test/safe/modules/cash/Spend.t.sol
@@ -824,4 +824,226 @@ contract CashModuleSpendTest is CashModuleTestSetup {
         vm.expectRevert(ArrayDeDupLib.DuplicateElementFound.selector);
         cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
     }
+
+    // ========== Credit resupply: supply loose collateral when the borrow doesn't fit ==========
+
+    function _enterCreditMode() internal {
+        _setMode(Mode.Credit);
+        vm.warp(cashModule.incomingModeStartTime(address(safe)) + 1);
+    }
+
+    function _creditSpendUsdc(uint256 amountInUsd) internal {
+        address[] memory spendTokens = new address[](1);
+        spendTokens[0] = address(usdc);
+        uint256[] memory spendAmounts = new uint256[](1);
+        spendAmounts[0] = amountInUsd;
+        Cashback[] memory cashbacks;
+
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
+    }
+
+    function _setBorrowCapacity(uint256 availableBorrowsUsd) internal {
+        gateway.setAccountData(address(safe), IGateway.AccountData({ collateralUsd: 0, debtUsd: 0, availableBorrowsUsd: availableBorrowsUsd, healthFactor: type(uint256).max }));
+    }
+
+    /// @dev Registers the gateway's asset list; resupply sizes over it in order (empty by default in the mock)
+    function _registerGatewayAssets(address token) internal {
+        address[] memory assets = new address[](1);
+        assets[0] = token;
+        gateway.setRegisteredAssets(assets);
+    }
+
+    function _registerGatewayAssets(address tokenA, address tokenB) internal {
+        address[] memory assets = new address[](2);
+        assets[0] = tokenA;
+        assets[1] = tokenB;
+        gateway.setRegisteredAssets(assets);
+    }
+
+    /// @dev Mirrors CashLendLib._resupplyAmount: token amount whose LTV-weighted value covers neededUsd, ceil + 10 bps pad
+    function _resupplyAmount(address token, uint8 decimals, uint256 tokenLtv, uint256 neededUsd) internal view returns (uint256) {
+        uint256 num = neededUsd * 100e18 * (10 ** decimals) * 10_010;
+        uint256 den = tokenLtv * priceProvider.price(token) * 10_000;
+        return (num + den - 1) / den;
+    }
+
+    /// @dev Mirrors the partial-cover remainder: taking `capacity` of `needed` covers the same fraction of the shortfall
+    function _residualUsd(uint256 shortfallUsd, uint256 capacity, uint256 needed) internal pure returns (uint256) {
+        return shortfallUsd - (shortfallUsd * capacity) / needed;
+    }
+
+    /// Borrowing capacity covers the spend: nothing is supplied and the borrow just goes through
+    function test_spend_creditResupply_skipped_whenCapacityCovers() public {
+        deal(address(usdc), address(safe), 100e6);
+        _enterCreditMode();
+        _registerGatewayAssets(address(usdc));
+        gateway.setLtv(address(usdc), 80e18);
+        _setBorrowCapacity(80e6);
+
+        _creditSpendUsdc(10e6);
+
+        assertEq(gateway.suppliesCount(), 0);
+        (address s,, uint256 amt, address to) = gateway.lastBorrow();
+        assertEq(s, address(safe));
+        assertEq(amt, 10e6);
+        assertEq(to, address(settlementDispatcherReap));
+    }
+
+    /// A one-token shortfall supplies the exact buffered amount, flags it as collateral, and the borrow lands
+    function test_spend_creditResupply_suppliesOneToken() public {
+        deal(address(usdc), address(safe), 100e6);
+        _enterCreditMode();
+        _registerGatewayAssets(address(usdc));
+        gateway.setLtv(address(usdc), 80e18);
+        _setBorrowCapacity(4e6);
+
+        // Shortfall is 6e6; also the borrow-token == collateral-token case (USDC both)
+        uint256 expected = _resupplyAmount(address(usdc), 6, 80e18, 6e6);
+
+        vm.expectEmit(true, true, true, true);
+        emit CashEventEmitter.CollateralResupplied(address(safe), address(usdc), expected);
+        _creditSpendUsdc(10e6);
+
+        assertEq(gateway.suppliesCount(), 1);
+        (address s, address asset, uint256 amt,) = gateway.lastSupply();
+        assertEq(s, address(safe));
+        assertEq(asset, address(usdc));
+        assertEq(amt, expected);
+        assertTrue(gateway.usingAsCollateral(address(safe), address(usdc)));
+        (,, uint256 borrowed, address to) = gateway.lastBorrow();
+        assertEq(borrowed, 10e6);
+        assertEq(to, address(settlementDispatcherReap));
+    }
+
+    /// The unreserved loose balance covers the shortfall, so the pending withdrawal request survives
+    function test_spend_creditResupply_prefersUnreserved_keepsWithdrawal() public {
+        deal(address(usdc), address(safe), 100e6);
+        _enterCreditMode();
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 50e6;
+        _requestWithdrawal(tokens, amounts, withdrawRecipient);
+
+        _registerGatewayAssets(address(usdc));
+        gateway.setLtv(address(usdc), 80e18);
+        _setBorrowCapacity(4e6);
+
+        // Needed (~7.5e6) fits in the 50e6 unreserved balance, so the request survives
+        _creditSpendUsdc(10e6);
+
+        assertEq(cashModule.getPendingWithdrawalAmount(address(safe), address(usdc)), 50e6);
+        assertEq(gateway.suppliesCount(), 1);
+    }
+
+    /// Covering the shortfall needs withdrawal-reserved balance: the request is cancelled (before the
+    /// supply executes) and the dip is supplied
+    function test_spend_creditResupply_dipsIntoReserved_cancelsWithdrawal() public {
+        deal(address(usdc), address(safe), 100e6);
+        _enterCreditMode();
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 95e6;
+        _requestWithdrawal(tokens, amounts, withdrawRecipient);
+
+        _registerGatewayAssets(address(usdc));
+        gateway.setLtv(address(usdc), 80e18);
+        _setBorrowCapacity(4e6);
+
+        // Unreserved is 5e6, needed ~7.5e6: pass one takes the 5e6, pass two cancels the request for the rest
+        uint256 residualUsd = _residualUsd(6e6, 5e6, _resupplyAmount(address(usdc), 6, 80e18, 6e6));
+        uint256 expected = 5e6 + _resupplyAmount(address(usdc), 6, 80e18, residualUsd);
+
+        vm.expectEmit(true, true, true, true);
+        emit CashEventEmitter.WithdrawalCancelled(address(safe), tokens, amounts, withdrawRecipient);
+        vm.expectEmit(true, true, true, true);
+        emit CashEventEmitter.CollateralResupplied(address(safe), address(usdc), expected);
+        _creditSpendUsdc(10e6);
+
+        assertEq(cashModule.getPendingWithdrawalAmount(address(safe), address(usdc)), 0);
+        assertEq(gateway.suppliesCount(), 1);
+        (,, uint256 amt,) = gateway.lastSupply();
+        assertEq(amt, expected);
+    }
+
+    /// Another token's loose balance covers the shortfall, so the reserved token's request survives (two-pass order)
+    function test_spend_creditResupply_otherTokenCovers_keepsWithdrawal() public {
+        deal(address(usdc), address(safe), 50e6);
+        deal(address(weETH), address(safe), 1 ether);
+        _enterCreditMode();
+
+        // The whole USDC balance is reserved by the request; loose weETH must cover without touching it
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 50e6;
+        _requestWithdrawal(tokens, amounts, withdrawRecipient);
+
+        _registerGatewayAssets(address(usdc), address(weETH));
+        gateway.setLtv(address(usdc), 80e18);
+        gateway.setLtv(address(weETH), 50e18);
+        _setBorrowCapacity(4e6);
+
+        _creditSpendUsdc(10e6);
+
+        assertEq(cashModule.getPendingWithdrawalAmount(address(safe), address(usdc)), 50e6);
+        assertEq(gateway.suppliesCount(), 1);
+        (, address asset, uint256 amt,) = gateway.lastSupply();
+        assertEq(asset, address(weETH));
+        assertEq(amt, _resupplyAmount(address(weETH), 18, 50e18, 6e6));
+        assertTrue(gateway.usingAsCollateral(address(safe), address(weETH)));
+    }
+
+    /// With no eligible collateral (registered asset has zero LTV) nothing is supplied, and the failing
+    /// borrow reverts the whole spend
+    function test_spend_creditResupply_noEligibleCollateral_borrowReverts() public {
+        deal(address(usdc), address(safe), 100e6);
+        _enterCreditMode();
+        _registerGatewayAssets(address(usdc));
+        // No LTV set: the token is ineligible, nothing is supplied, and the borrow is rejected
+        gateway.setBorrowReverts(true);
+
+        address[] memory spendTokens = new address[](1);
+        spendTokens[0] = address(usdc);
+        uint256[] memory spendAmounts = new uint256[](1);
+        spendAmounts[0] = 10e6;
+        Cashback[] memory cashbacks;
+
+        vm.prank(etherFiWallet);
+        vm.expectRevert(MockGateway.BorrowBlocked.selector);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
+
+        assertEq(gateway.suppliesCount(), 0);
+    }
+
+    /// A shortfall spanning tokens exhausts the first and covers the proportional remainder from the next
+    function test_spend_creditResupply_multipleTokens_partialCover() public {
+        // Registered order is [weETH, usdc]: the small weETH balance is exhausted first, USDC covers the rest
+        deal(address(weETH), address(safe), 0.001 ether);
+        deal(address(usdc), address(safe), 100e6);
+        _enterCreditMode();
+        _registerGatewayAssets(address(weETH), address(usdc));
+        gateway.setLtv(address(weETH), 50e18);
+        gateway.setLtv(address(usdc), 80e18);
+        _setBorrowCapacity(0);
+
+        uint256 residualUsd = _residualUsd(10e6, 0.001 ether, _resupplyAmount(address(weETH), 18, 50e18, 10e6));
+        uint256 expectedUsdc = _resupplyAmount(address(usdc), 6, 80e18, residualUsd);
+
+        _creditSpendUsdc(10e6);
+
+        assertEq(gateway.suppliesCount(), 2);
+        (, address asset0, uint256 amt0,) = gateway.supplies(0);
+        assertEq(asset0, address(weETH));
+        assertEq(amt0, 0.001 ether);
+        (, address asset1, uint256 amt1,) = gateway.supplies(1);
+        assertEq(asset1, address(usdc));
+        assertEq(amt1, expectedUsdc);
+        assertTrue(gateway.usingAsCollateral(address(safe), address(weETH)));
+        assertTrue(gateway.usingAsCollateral(address(safe), address(usdc)));
+    }
 }


### PR DESCRIPTION
## What

On a credit spend routed through the Aave gateway, if the position's borrowing power no longer covers the spend, we now supply loose collateral from the safe to cover the shortfall before borrowing.

## Why

An instant collateral withdrawal can land between the auth-time `canSpend` check and the spend transaction. That leaves the borrow short and the spend would revert. Resupplying the loose balance closes that gap so a still-valid spend goes through.

Sizing runs in two passes. The first pass uses only balance not reserved by a pending withdrawal request. The reserved remainder is used only if the spend cannot be funded otherwise, and in that case the spend wins the competing claim and the withdrawal request is cancelled, matching the debit path's rule. Supply amounts are computed with a ceil-div and a small buffer so share rounding cannot leave the headroom short. `CashLens` never counts this capacity, so `canSpend` does not advertise it as headroom.

## Testing

Added unit tests in `Spend.t.sol` covering: capacity already covers (no supply), one-token shortfall, preferring unreserved balance, falling back to reserved balance and cancelling the withdrawal, multi-token sizing, and partial cover where the borrow still reverts.

Closes COR-1045

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the live credit-spend execution path on the Aave gateway (collateral supply, withdrawal cancellation, then borrow); well-tested but affects fund movement and position health timing.
> 
> **Overview**
> Gateway **credit spends** now call **`_resupplyCollateral`** before `gateway.borrow` when `availableBorrowsUsd` is below the spend USD—closing the gap when collateral moves between auth-time `canSpend` and execution.
> 
> Resupply **sizes** registered assets in two passes: unreserved loose balance first (respecting pending withdrawal reservations), then reserved balance with **`cancelOldWithdrawal`** if needed (same spend-wins rule as debit). Amounts use LTV-weighted USD math, ceil rounding, and a **10 bps** `RESUPPLY_BUFFER_BPS` pad; each supply sets collateral on the gateway and emits **`CollateralResupplied`**.
> 
> **`MockGateway`** records full supply history for tests; **`Spend.t.sol`** adds coverage for skip-when-covered, single/multi-token sizing, withdrawal preserve vs cancel, and borrow revert when collateral cannot cover.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af282ac0c77bedd5212438d2dbfeb7a2faf3f1e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->