### PR TITLE
refactor: rename gateway to lend gateway

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -16,7 +16,7 @@ dynamic_test_linking = true
 # The Aave v4 gateway tests need via_ir (Hub/Spoke instances) + the aave-v4 dependency. Keep them out of
 # the default profile so the default build/bytecode-verification settings are unchanged; run them under
 # FOUNDRY_PROFILE=aave (see [profile.aave] below).
-skip = ["test/gateway/**"]
+skip = ["test/lend-gateway/**"]
 
 # Profile for the Aave v4 gateway integration tests: compiles everything (our repo + aave-v4) with via_ir
 # so the Hub/Spoke instances build, and un-skips the gateway tests. Run: FOUNDRY_PROFILE=aave forge test.

--- a/src/debt-manager/DebtManagerCore.sol
+++ b/src/debt-manager/DebtManagerCore.sol
@@ -9,7 +9,7 @@ import { ICashLens } from "../interfaces/ICashLens.sol";
 import { BinSponsor, ICashModule } from "../interfaces/ICashModule.sol";
 import { IDebtManager } from "../interfaces/IDebtManager.sol";
 import { IEtherFiDataProvider } from "../interfaces/IEtherFiDataProvider.sol";
-import { IGateway } from "../interfaces/IGateway.sol";
+import { ILendGateway } from "../interfaces/ILendGateway.sol";
 import { IPriceProvider } from "../interfaces/IPriceProvider.sol";
 import { DebtManagerStorageContract } from "./DebtManagerStorageContract.sol";
 
@@ -662,8 +662,8 @@ contract DebtManagerCore is DebtManagerStorageContract {
      * @notice Whether a Safe's position has been migrated to Aave
      * @param safe The Safe to query
      */
-    function hasMigratedToAave(address safe) external view returns (bool) {
-        return _getDebtManagerStorage().migratedToAave[safe];
+    function hasMigratedToLendGateway(address safe) external view returns (bool) {
+        return _getDebtManagerStorage().migratedToLendGateway[safe];
     }
 
     /**
@@ -679,14 +679,14 @@ contract DebtManagerCore is DebtManagerStorageContract {
      *      driver; the gateway self-approves as the Safe's Aave position manager on its first op.
      * @param safe The Safe to migrate
      */
-    function migrateToAave(address safe) external whenNotPaused nonReentrant onlyRole(DEBT_MANAGER_ADMIN_ROLE) {
+    function migrateToLendGateway(address safe) external whenNotPaused nonReentrant onlyRole(DEBT_MANAGER_ADMIN_ROLE) {
         _onlyEtherFiSafe(safe);
         DebtManagerStorage storage $ = _getDebtManagerStorage();
 
         // Single source of truth: the gateway lives on CashModule (this contract already reaches it for the
         // settlement dispatcher), so migration reads it from there rather than keeping its own copy.
         ICashModule cashModule = ICashModule(etherFiDataProvider.getCashModule());
-        IGateway _gateway = IGateway(cashModule.getLendGateway());
+        ILendGateway _gateway = cashModule.getLendGateway();
         if (address(_gateway) == address(0)) revert GatewayNotSet();
 
         // 1. Snapshot the outstanding DebtManager debt. A debt-free Safe still migrates its collateral (below),
@@ -710,7 +710,7 @@ contract DebtManagerCore is DebtManagerStorageContract {
         for (uint256 i = 0; i < bLen;) {
             if (borrowings[i].amount != 0) {
                 uint256 debtTokenAmt = _clearLegacyDebt(safe, borrowings[i].token);
-                if (_gateway.availableCash(borrowings[i].token) < debtTokenAmt) revert InsufficientAaveLiquidity(borrowings[i].token);
+                if (_gateway.availableCash(borrowings[i].token) < debtTokenAmt) revert InsufficientLendGatewayLiquidity(borrowings[i].token);
                 debtTokenAmts[i] = debtTokenAmt;
             }
             unchecked {
@@ -744,7 +744,7 @@ contract DebtManagerCore is DebtManagerStorageContract {
         //      it — specific error so the runner can route positions that fit DebtManager's params but not Aave's —
         //      then borrow each debt from Aave into this contract, re-funding the debt cleared in step 2.
         if (totalDebtUsd != 0) {
-            if (_gateway.getAccountData(safe).availableBorrowsUsd < totalDebtUsd) revert PositionExceedsAaveLtv();
+            if (_gateway.getAccountData(safe).availableBorrowsUsd < totalDebtUsd) revert PositionExceedsLendGatewayLtv();
 
             for (uint256 i = 0; i < bLen;) {
                 if (debtTokenAmts[i] != 0) _gateway.borrow(safe, borrowings[i].token, debtTokenAmts[i], address(this));
@@ -754,11 +754,11 @@ contract DebtManagerCore is DebtManagerStorageContract {
             }
         }
 
-        $.migratedToAave[safe] = true;
+        $.migratedToLendGateway[safe] = true;
         // Flip the CashModule routing flag in the same tx, so the freeze latch here and the routing of
         // spend/repay/lens can never disagree about which engine serves the Safe.
-        cashModule.markUsesAave(safe);
-        emit MigratedToAave(safe, totalDebtUsd);
+        cashModule.markUsesLendGateway(safe);
+        emit MigratedToLendGateway(safe, totalDebtUsd);
     }
 
     /// @dev A Safe's balance of `token` minus what a pending withdrawal has reserved - the amount migration may supply
@@ -864,10 +864,10 @@ contract DebtManagerCore is DebtManagerStorageContract {
     /**
      * @dev Blocks legacy DebtManager operations for a Safe once it has migrated to Aave
      * @param safe The Safe to check
-     * @custom:throws AlreadyMigratedToAave if the Safe has been migrated
+     * @custom:throws AlreadyMigratedToLendGateway if the Safe has been migrated
      */
     modifier whenNotMigrated(address safe) {
-        if (_getDebtManagerStorage().migratedToAave[safe]) revert AlreadyMigratedToAave();
+        if (_getDebtManagerStorage().migratedToLendGateway[safe]) revert AlreadyMigratedToLendGateway();
         _;
     }
 

--- a/src/debt-manager/DebtManagerStorageContract.sol
+++ b/src/debt-manager/DebtManagerStorageContract.sol
@@ -125,7 +125,7 @@ contract DebtManagerStorageContract is UpgradeableProxy {
         mapping(address supplier => mapping(address borrowToken => uint256 shares)) sharesOfBorrowTokens;
 
         /// @notice Whether a Safe's position has been migrated to Aave (set once migrated, including Safes that had no debt)
-        mapping(address safe => bool migrated) migratedToAave;
+        mapping(address safe => bool migrated) migratedToLendGateway;
     }
 
     /// @notice Storage location for DebtManagerStorage (ERC-7201 compliant)
@@ -276,7 +276,7 @@ contract DebtManagerStorageContract is UpgradeableProxy {
     /// @notice Emitted when a Safe's position is migrated from DebtManager to the Aave instance
     /// @param safe The migrated Safe
     /// @param debtUsd The total debt migrated, in USD with 6 decimals
-    event MigratedToAave(address indexed safe, uint256 debtUsd);
+    event MigratedToLendGateway(address indexed safe, uint256 debtUsd);
 
     /**
      * @notice Error thrown when collateral token preference array is empty while liquidating
@@ -394,10 +394,10 @@ contract DebtManagerStorageContract is UpgradeableProxy {
     error InsufficientBorrowShares();
 
     /// @notice Thrown when the Aave reserve lacks the liquidity to fund the migration borrow
-    error InsufficientAaveLiquidity(address token);
+    error InsufficientLendGatewayLiquidity(address token);
 
     /// @notice Thrown when, after supplying its collateral, the Safe's debt does not fit Aave's LTVs
-    error PositionExceedsAaveLtv();
+    error PositionExceedsLendGatewayLtv();
 
     /// @notice Thrown when the migration gateway has not been configured
     error GatewayNotSet();
@@ -406,7 +406,7 @@ contract DebtManagerStorageContract is UpgradeableProxy {
     error LendDisabledSafeHasDebt();
 
     /// @notice Thrown when a legacy DebtManager operation (borrow/repay) is attempted on a Safe already migrated to Aave
-    error AlreadyMigratedToAave();
+    error AlreadyMigratedToLendGateway();
     
     /**
      * @notice Error thrown when user is still liquidatable

--- a/src/interfaces/IAaveV4Spoke.sol
+++ b/src/interfaces/IAaveV4Spoke.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.28;
 
 /**
  * @title IAaveV4Spoke
- * @notice The slice of the Aave v4 Spoke that the Gateway calls.
+ * @notice The slice of the Aave v4 Spoke that the LendGateway calls.
  * @author ether.fi
  */
 interface IAaveV4Spoke {

--- a/src/interfaces/ICashEventEmitter.sol
+++ b/src/interfaces/ICashEventEmitter.sol
@@ -25,8 +25,8 @@ interface ICashEventEmitter {
      */
     function emitSettlementDispatcherUpdated(BinSponsor binSponsor, address oldDispatcher, address newDispatcher) external;
 
-    /// @notice Emits the GatewaySet event
-    function emitGatewaySet(address gateway) external;
+    /// @notice Emits the LendGatewaySet event
+    function emitLendGatewaySet(address gateway) external;
 
     /**
      * @notice Emits an event when pending cashback is cleared

--- a/src/interfaces/ICashModule.sol
+++ b/src/interfaces/ICashModule.sol
@@ -5,7 +5,7 @@ import { EnumerableSetLib } from "solady/utils/EnumerableSetLib.sol";
 
 import { IDebtManager } from "../interfaces/IDebtManager.sol";
 import { IEtherFiDataProvider } from "../interfaces/IEtherFiDataProvider.sol";
-import { IGateway } from "../interfaces/IGateway.sol";
+import { ILendGateway } from "../interfaces/ILendGateway.sol";
 import { IPriceProvider } from "../interfaces/IPriceProvider.sol";
 import { SpendingLimit, SpendingLimitLib } from "../libraries/SpendingLimitLib.sol";
 
@@ -142,7 +142,7 @@ struct SafeCashConfig {
     /// @notice Timestamp after which a pending disable-lend request can be executed (0 if none)
     uint96 lendDisableFinalizeTime;
     /// @notice True once the safe's borrow/collateral engine is the Aave gateway (set at onboarding or by migration; one-way)
-    bool usesAave;
+    bool usesLendGateway;
 }
 
 /**
@@ -362,26 +362,26 @@ interface ICashModule {
 
     /**
      * @notice Returns the configured Aave gateway used for lend operations
-     * @return Address of the gateway (address(0) if not set)
+     * @return LendGateway instance (zero if not set)
      */
-    function getLendGateway() external view returns (address);
+    function getLendGateway() external view returns (ILendGateway);
 
     /**
      * @notice Whether the safe's borrow/collateral engine is the Aave gateway (vs the legacy DebtManager)
      * @dev The canonical routing flag: every spend/repay/lens path branches on this. True for safes onboarded
-     *      after the gateway launch and for safes migrated via DebtManager.migrateToAave; false means legacy.
+     *      after the gateway launch and for safes migrated via DebtManager.migrateToLendGateway; false means legacy.
      * @param safe The safe to query
      * @return True if the safe uses the Aave gateway
      */
-    function usesAave(address safe) external view returns (bool);
+    function usesLendGateway(address safe) external view returns (bool);
 
     /**
      * @notice Marks a safe as using the Aave gateway engine
-     * @dev Only callable by the DebtManager, as the last step of migrateToAave. Idempotent and one-way.
+     * @dev Only callable by the DebtManager, as the last step of migrateToLendGateway. Idempotent and one-way.
      * @param safe The safe to mark
      * @custom:throws OnlyDebtManager if called by any address other than the DebtManager
      */
-    function markUsesAave(address safe) external;
+    function markUsesLendGateway(address safe) external;
 
     /**
      * @notice Gets the debt manager contract
@@ -396,12 +396,6 @@ interface ICashModule {
      * @return settlementDispatcher The address of the settlement dispatcher
      */
     function getSettlementDispatcher(BinSponsor binSponsor) external view returns (address settlementDispatcher);
-
-    /**
-     * @notice Returns the Aave gateway contract
-     * @return Gateway instance
-     */
-    function getGateway() external view returns (IGateway);
 
     /**
      * @notice Returns the EtherFiDataProvider contract reference
@@ -556,7 +550,7 @@ interface ICashModule {
      * @custom:throws InvalidInput if gateway = address(0)
      * @custom:throws GatewayAlreadySet if the gateway has already been configured
      */
-    function setGateway(address gateway) external;
+    function setLendGateway(address gateway) external;
 
     /**
      * @notice Sets the tier for one or more safes

--- a/src/interfaces/IDebtManager.sol
+++ b/src/interfaces/IDebtManager.sol
@@ -306,7 +306,7 @@ interface IDebtManager {
      * @param safe Address of the EtherFi Safe.
      * @return True if the safe has migrated to Aave.
      */
-    function hasMigratedToAave(address safe) external view returns (bool);
+    function hasMigratedToLendGateway(address safe) external view returns (bool);
 
     /**
      * @notice Function to fetch the max borrow amount for ltv or liquidation purpose.

--- a/src/interfaces/ILendGateway.sol
+++ b/src/interfaces/ILendGateway.sol
@@ -2,17 +2,17 @@
 pragma solidity ^0.8.28;
 
 /**
- * @title IGateway
+ * @title ILendGateway
  * @notice Seam between the Cash contracts and the ether.fi-managed Aave v4 instance. The gateway
  *         acts as a safe's Aave position manager, performing supply / withdraw / borrow / repay on
  *         the safe's behalf (a card spend cannot wait for a user signature). Cash-side contracts
  *         (CashModule, CashLens, EtherFiHook) depend only on this interface; both the live gateway
- *         and a MockGateway satisfy it, so the two tracks can build in parallel.
+ *         and a MockLendGateway satisfy it, so the two tracks can build in parallel.
  * @dev v0 — expected to change. Locked to just enough surface to unblock both tracks. Borrow and
  *      withdraw take an explicit `to` because Aave pays the caller; the caller forwards atomically.
  * @author ether.fi
  */
-interface IGateway {
+interface ILendGateway {
     /// @notice A safe's Aave position summary. USD fields are 6 decimals (matching PriceProvider.DECIMALS); healthFactor is 1e18.
     struct AccountData {
         uint256 collateralUsd;

--- a/src/libraries/DebitSourcingLib.sol
+++ b/src/libraries/DebitSourcingLib.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.28;
 
 import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 
-import { IGateway } from "../interfaces/IGateway.sol";
+import { ILendGateway } from "../interfaces/ILendGateway.sol";
 import { IPriceProvider } from "../interfaces/IPriceProvider.sol";
 
 /**
@@ -14,7 +14,7 @@ import { IPriceProvider } from "../interfaces/IPriceProvider.sol";
  * @author ether.fi
  */
 library DebitSourcingLib {
-    /// @dev The gateway reports LTV on the 100e18 = 100% scale (see IGateway.ltv)
+    /// @dev The gateway reports LTV on the 100e18 = 100% scale (see ILendGateway.ltv)
     uint256 internal constant LTV_SCALE = 100e18;
 
     /**
@@ -22,7 +22,7 @@ library DebitSourcingLib {
      * @dev min(supplied, reserve cash); when the safe carries debt this is further capped by the borrowing
      *      headroom, and is zero for a zero-LTV reserve (no borrow weight, so it cannot be sized against debt).
      */
-    function withdrawableSupplied(IGateway gateway, IPriceProvider priceProvider, address safe, address token, uint256 borrowHeadroomUsd, bool hasDebt) internal view returns (uint256) {
+    function withdrawableSupplied(ILendGateway gateway, IPriceProvider priceProvider, address safe, address token, uint256 borrowHeadroomUsd, bool hasDebt) internal view returns (uint256) {
         uint256 supplied = gateway.suppliedOf(safe, token);
         uint256 cash = gateway.availableCash(token);
         uint256 cap = supplied < cash ? supplied : cash;
@@ -42,7 +42,7 @@ library DebitSourcingLib {
     }
 
     /// @notice Borrowing headroom (USD) consumed by withdrawing `amount` of `token`: its USD value weighted by the LTV
-    function headroomConsumed(IGateway gateway, IPriceProvider priceProvider, address token, uint256 amount) internal view returns (uint256) {
+    function headroomConsumed(ILendGateway gateway, IPriceProvider priceProvider, address token, uint256 amount) internal view returns (uint256) {
         return (_toUsd(priceProvider, token, amount) * gateway.ltv(token)) / LTV_SCALE;
     }
 

--- a/src/mocks/MockLendGateway.sol
+++ b/src/mocks/MockLendGateway.sol
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-import { IGateway } from "../interfaces/IGateway.sol";
+import { ILendGateway } from "../interfaces/ILendGateway.sol";
 
 /**
- * @title MockGateway
- * @notice Test double for IGateway. Lets cash-side tests drive a safe's position state directly,
+ * @title MockLendGateway
+ * @notice Test double for ILendGateway. Lets cash-side tests drive a safe's position state directly,
  *         with no live Aave v4 instance, and records the last call to each mutating op for
  *         assertions. Not for production.
  */
-contract MockGateway is IGateway {
+contract MockLendGateway is ILendGateway {
     /// @notice Thrown when the mock is configured to reject borrow calls
     error BorrowBlocked();
 

--- a/src/modules/ModuleGatewaySandwich.sol
+++ b/src/modules/ModuleGatewaySandwich.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-import { IGateway } from "../interfaces/IGateway.sol";
+import { ILendGateway } from "../interfaces/ILendGateway.sol";
 
 /**
  * @title ModuleGatewaySandwich
@@ -19,7 +19,7 @@ import { IGateway } from "../interfaces/IGateway.sol";
  */
 abstract contract ModuleGatewaySandwich {
     /// @notice The gateway that performs Aave ops on a safe's behalf
-    IGateway public immutable gateway;
+    ILendGateway public immutable gateway;
     /// @notice The lowest health factor the operation may leave the safe at once it completes
     uint256 public immutable minHealthFactor;
 
@@ -42,7 +42,7 @@ abstract contract ModuleGatewaySandwich {
 
     constructor(address _gateway, uint256 _minHealthFactor) {
         if (_gateway == address(0)) revert InvalidGateway();
-        gateway = IGateway(_gateway);
+        gateway = ILendGateway(_gateway);
         minHealthFactor = _minHealthFactor;
     }
 

--- a/src/modules/cash/CashEventEmitter.sol
+++ b/src/modules/cash/CashEventEmitter.sol
@@ -209,7 +209,7 @@ contract CashEventEmitter is UpgradeableProxy {
     event SettlementDispatcheUpdated(BinSponsor binSponsor, address oldDispatcher, address newDispatcher);
 
     /// @notice Emitted when the gateway is set during the one-time Lend bootstrap
-    event GatewaySet(address indexed gateway);
+    event LendGatewaySet(address indexed gateway);
     
     /**
      * @notice Emitted when the withdrawal tokens are updated
@@ -254,10 +254,10 @@ contract CashEventEmitter is UpgradeableProxy {
         emit SettlementDispatcheUpdated(binSponsor, oldDispatcher, newDispatcher);
     }
 
-    /// @notice Emits the GatewaySet event
+    /// @notice Emits the LendGatewaySet event
     /// @dev Can only be called by the Cash Module
-    function emitGatewaySet(address gateway) external onlyCashModule {
-        emit GatewaySet(gateway);
+    function emitLendGatewaySet(address gateway) external onlyCashModule {
+        emit LendGatewaySet(gateway);
     }
 
     /**

--- a/src/modules/cash/CashLendLib.sol
+++ b/src/modules/cash/CashLendLib.sol
@@ -10,7 +10,7 @@ import { BinSponsor, Mode, SafeCashConfig, WithdrawalRequest } from "../../inter
 import { IDebtManager } from "../../interfaces/IDebtManager.sol";
 import { IEtherFiDataProvider } from "../../interfaces/IEtherFiDataProvider.sol";
 import { IEtherFiSafe } from "../../interfaces/IEtherFiSafe.sol";
-import { IGateway } from "../../interfaces/IGateway.sol";
+import { ILendGateway } from "../../interfaces/ILendGateway.sol";
 import { IPriceProvider } from "../../interfaces/IPriceProvider.sol";
 import { DebitSourcingLib } from "../../libraries/DebitSourcingLib.sol";
 import { CashModuleStorageContract } from "./CashModuleStorageContract.sol";
@@ -30,7 +30,7 @@ import { CashModuleStorageContract } from "./CashModuleStorageContract.sol";
  *      (cancelOldWithdrawal) so the spend paths can cancel inline; the module's internal helper delegates
  *      to it.
  *
- *      Engine convention: legacy DebtManager code always sits inside an `if (!_usesAave(...))` block (or a
+ *      Engine convention: legacy DebtManager code always sits inside an `if (!_usesLendGateway(...))` block (or a
  *      legacy-named helper) that is deleted wholesale when the legacy engine is retired; the gateway path is
  *      the unguarded fall-through, already in its final shape.
  * @author ether.fi
@@ -66,8 +66,8 @@ library CashLendLib {
 
     /// @dev The canonical engine check: true routes the safe to the Aave gateway, false to the legacy DebtManager.
     ///      Every branch point in this library must read the flag through here and nothing else.
-    function _usesAave(CashModuleStorageContract.CashModuleStorage storage $, address safe) private view returns (bool) {
-        return $.safeCashConfig[safe].usesAave;
+    function _usesLendGateway(CashModuleStorageContract.CashModuleStorage storage $, address safe) private view returns (bool) {
+        return $.safeCashConfig[safe].usesLendGateway;
     }
 
     /**
@@ -126,7 +126,7 @@ library CashLendLib {
      * @custom:throws LendGatewayNotSet if the safe uses the gateway but none is configured
      */
     function repay(CashModuleStorageContract.CashModuleStorage storage $, address safe, address token, uint256 amount, uint256 amountInUsd) external {
-        if (!_usesAave($, safe)) {
+        if (!_usesLendGateway($, safe)) {
             address[] memory to = new address[](3);
             bytes[] memory data = new bytes[](3);
             uint256[] memory values = new uint256[](3);
@@ -144,7 +144,7 @@ library CashLendLib {
             return;
         }
 
-        IGateway gateway = $.gateway;
+        ILendGateway gateway = $.gateway;
         if (address(gateway) == address(0)) revert LendGatewayNotSet();
         // Full repays pass the max sentinel so no interest dust survives the exact-amount rounding.
         uint256 debt = gateway.debtOf(safe, token);
@@ -170,7 +170,7 @@ library CashLendLib {
      * @param safe Address of the EtherFi Safe
      */
     function hasOpenBorrows(CashModuleStorageContract.CashModuleStorage storage $, address safe) public view returns (bool) {
-        IGateway gateway = $.gateway;
+        ILendGateway gateway = $.gateway;
         if (address(gateway) != address(0)) {
             address[] memory assets = gateway.registeredAssets();
             uint256 aLen = assets.length;
@@ -216,8 +216,8 @@ library CashLendLib {
      * @param safe Address of the EtherFi Safe
      */
     function disableLend(CashModuleStorageContract.CashModuleStorage storage $, address safe) public {
-        if (_usesAave($, safe)) {
-            IGateway gateway = $.gateway;
+        if (_usesLendGateway($, safe)) {
+            ILendGateway gateway = $.gateway;
             if (address(gateway) == address(0)) revert LendGatewayNotSet();
 
             address[] memory collateralTokens = gateway.registeredAssets();
@@ -282,7 +282,7 @@ library CashLendLib {
         uint256 amount = $.debtManager.convertUsdToCollateralToken(tokens[0], amountsInUsd[0]);
         if (amount == 0) revert AmountZero();
 
-        if (!_usesAave($, safe)) {
+        if (!_usesLendGateway($, safe)) {
             _spendLegacyCredit($, dataProvider, safe, binSponsor, tokens[0], amount);
         } else {
             _borrowOnGateway($, dataProvider, safe, binSponsor, tokens[0], amount, amountsInUsd[0]);
@@ -293,7 +293,7 @@ library CashLendLib {
         $.cashEventEmitter.emitSpend(safe, txId, binSponsor, tokens, amounts, amountsInUsd, totalSpendingInUsd, Mode.Credit);
     }
 
-    /// @dev Gateway credit spend: the safe's position lives on Aave, so borrow there via the gateway (the
+    /// @dev LendGateway credit spend: the safe's position lives on Aave, so borrow there via the gateway (the
     ///      CashModule is always a gateway driver) and send the borrowed token straight to the settlement
     ///      dispatcher. The legacy DebtManager.borrow path reverts for a migrated safe, and CashLens sizes
     ///      credit against the same engine flag, so routing here keeps the on-chain spend consistent with
@@ -301,7 +301,7 @@ library CashLendLib {
     ///      borrow no longer fits (an instant collateral withdrawal can land between the auth-time canSpend
     ///      and the spend tx), loose collateral is first resupplied to cover the shortfall.
     function _borrowOnGateway(CashModuleStorageContract.CashModuleStorage storage $, IEtherFiDataProvider dataProvider, address safe, BinSponsor binSponsor, address token, uint256 amount, uint256 amountInUsd) private {
-        IGateway gateway = $.gateway;
+        ILendGateway gateway = $.gateway;
         if (address(gateway) == address(0)) revert LendGatewayNotSet();
         _resupplyCollateral($, dataProvider, gateway, safe, amountInUsd);
         gateway.borrow(safe, token, amount, settlementDispatcher($, binSponsor));
@@ -317,7 +317,7 @@ library CashLendLib {
      *      it supplies what fits and the caller's subsequent borrow reverts the spend. CashLens never
      *      counts this capacity, so canSpend does not advertise it as headroom.
      */
-    function _resupplyCollateral(CashModuleStorageContract.CashModuleStorage storage $, IEtherFiDataProvider dataProvider, IGateway gateway, address safe, uint256 spendUsd) private {
+    function _resupplyCollateral(CashModuleStorageContract.CashModuleStorage storage $, IEtherFiDataProvider dataProvider, ILendGateway gateway, address safe, uint256 spendUsd) private {
         uint256 availableUsd = gateway.getAccountData(safe).availableBorrowsUsd;
         if (spendUsd <= availableUsd) return;
         uint256 shortfallUsd = spendUsd - availableUsd;
@@ -346,7 +346,7 @@ library CashLendLib {
      *      Skips the balance reserved by the pending withdrawal request unless `useReserved` is set.
      * @return The USD shortfall left after the pass
      */
-    function _sizeResupply(CashModuleStorageContract.CashModuleStorage storage $, IGateway gateway, IPriceProvider priceProvider, address safe, address[] memory tokens, uint256[] memory supplyAmounts, uint256 shortfallUsd, bool useReserved) private view returns (uint256) {
+    function _sizeResupply(CashModuleStorageContract.CashModuleStorage storage $, ILendGateway gateway, IPriceProvider priceProvider, address safe, address[] memory tokens, uint256[] memory supplyAmounts, uint256 shortfallUsd, bool useReserved) private view returns (uint256) {
         for (uint256 i = 0; i < tokens.length && shortfallUsd != 0; i++) {
             // A zero-LTV asset adds no borrowing headroom, so supplying it cannot help
             uint256 tokenLtv = gateway.ltv(tokens[i]);
@@ -430,7 +430,7 @@ library CashLendLib {
      * @param totalSpendingInUsd Total spend in USD, for the emitted event
      */
     function spendDebit(CashModuleStorageContract.CashModuleStorage storage $, IEtherFiDataProvider dataProvider, address safe, bytes32 txId, BinSponsor binSponsor, address[] calldata tokens, uint256[] calldata amountsInUsd, uint256 totalSpendingInUsd) external {
-        if (!_usesAave($, safe)) {
+        if (!_usesLendGateway($, safe)) {
             _spendLegacyDebit($, dataProvider, safe, txId, binSponsor, tokens, amountsInUsd, totalSpendingInUsd);
             return;
         }
@@ -470,7 +470,7 @@ library CashLendLib {
         s.amounts = new uint256[](tokens.length);
         s.fromLoose = new uint256[](tokens.length);
         {
-            IGateway.AccountData memory account = $.gateway.getAccountData(safe);
+            ILendGateway.AccountData memory account = $.gateway.getAccountData(safe);
             s.hasDebt = account.debtUsd != 0;
             s.borrowHeadroom = s.hasDebt ? account.availableBorrowsUsd : 0;
         }

--- a/src/modules/cash/CashLens.sol
+++ b/src/modules/cash/CashLens.sol
@@ -8,7 +8,7 @@ import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/I
 import { DebitModeMaxSpend, ICashModule, Mode, SafeCashData, SafeData } from "../../interfaces/ICashModule.sol";
 import { IDebtManager } from "../../interfaces/IDebtManager.sol";
 import { IEtherFiDataProvider } from "../../interfaces/IEtherFiDataProvider.sol";
-import { IGateway } from "../../interfaces/IGateway.sol";
+import { ILendGateway } from "../../interfaces/ILendGateway.sol";
 import { IPriceProvider } from "../../interfaces/IPriceProvider.sol";
 import { DebitSourcingLib } from "../../libraries/DebitSourcingLib.sol";
 import { SpendingLimit, SpendingLimitLib } from "../../libraries/SpendingLimitLib.sol";
@@ -18,15 +18,15 @@ import { CashLensLegacyLib } from "./CashLensLegacyLib.sol";
 /**
  * @title CashLens
  * @notice Read-only contract providing views into a Safe's cash state
- * @dev Every engine-touching view branches on CashModule.usesAave: gateway safes are read from the
+ * @dev Every engine-touching view branches on CashModule.usesLendGateway: gateway safes are read from the
  *      Aave gateway (the logic in this contract), legacy safes from the DebtManager (preserved output-identical
  *      in the linked CashLensLegacyLib). The check side of a spend must always agree with what the execution
  *      side (CashLendLib) will do, so both read the same flag. Legacy code always sits inside an
- *      `if (!usesAave(safe))` block (routing to CashLensLegacyLib, or a couple of master-verbatim
+ *      `if (!usesLendGateway(safe))` block (routing to CashLensLegacyLib, or a couple of master-verbatim
  *      lines inline), deleted wholesale when the legacy engine is retired; the gateway path is the unguarded
  *      fall-through.
  *
- *      Gateway safes: the position is read from the Aave gateway; the supported-token list from DebtManager.
+ *      LendGateway safes: the position is read from the Aave gateway; the supported-token list from DebtManager.
  *      Credit capacity comes straight from Aave. Debit spendable is the raw Safe balance plus the
  *      withdrawable supplied amount; when the Safe has debt, the withdrawable part is capped by the
  *      borrowing headroom (collateral weighted by LTV, minus debt) so the leftover position keeps
@@ -79,8 +79,8 @@ contract CashLens is UpgradeableProxy {
     }
 
     /// @notice Returns the Aave gateway currently configured on CashModule
-    function gateway() public view returns (IGateway) {
-        return cashModule.getGateway();
+    function gateway() public view returns (ILendGateway) {
+        return cashModule.getLendGateway();
     }
 
     /**
@@ -180,7 +180,7 @@ contract CashLens is UpgradeableProxy {
 
         // Route by engine, mirroring the spend execution: legacy safes get the pre-gateway DebtManager
         // checks (and decline strings) exactly as before the gateway existed.
-        if (!cashModule.usesAave(safe)) {
+        if (!cashModule.usesLendGateway(safe)) {
             return CashLensLegacyLib.check(cashModule, safe, tokens, amountsInUsd, totalSpendingInUsd, safeData, mode);
         }
 
@@ -196,7 +196,7 @@ contract CashLens is UpgradeableProxy {
             return (false, "Not a supported borrow token");
         }
 
-        IGateway lendGateway = cashModule.getGateway();
+        ILendGateway lendGateway = cashModule.getLendGateway();
         if (lendGateway.availableCash(token) < _fromUsd(token, totalSpendingInUsd)) {
             return (false, "Insufficient liquidity to cover the loan");
         }
@@ -215,7 +215,7 @@ contract CashLens is UpgradeableProxy {
         bool hasDebt;
         uint256 borrowHeadroom;
         {
-            IGateway.AccountData memory account = gateway().getAccountData(safe);
+            ILendGateway.AccountData memory account = gateway().getAccountData(safe);
             hasDebt = account.debtUsd != 0;
             borrowHeadroom = hasDebt ? account.availableBorrowsUsd : 0;
         }
@@ -282,11 +282,11 @@ contract CashLens is UpgradeableProxy {
         address[] memory collateralTokens = debtManager.getCollateralTokens();
         address[] memory borrowTokens = debtManager.getBorrowTokens();
 
-        if (!cashModule.usesAave(safe)) {
+        if (!cashModule.usesLendGateway(safe)) {
             (data.collateralBalances, data.totalCollateral, data.borrows, data.totalBorrow) = debtManager.getUserCurrentState(safe);
             data.maxBorrow = debtManager.getMaxBorrowAmount(safe, true);
         } else {
-            IGateway.AccountData memory account = gateway().getAccountData(safe);
+            ILendGateway.AccountData memory account = gateway().getAccountData(safe);
             data.collateralBalances = _suppliedBalances(safe, collateralTokens);
             data.borrows = _debtBalances(safe, borrowTokens);
             data.totalCollateral = account.collateralUsd;
@@ -348,7 +348,7 @@ contract CashLens is UpgradeableProxy {
         if (len == 0) return DebitModeMaxSpend(new address[](0), new uint256[](0), new uint256[](0), 0);
         if (len > 1) debtServiceTokenPreference.checkDuplicates();
 
-        if (!cashModule.usesAave(safe)) {
+        if (!cashModule.usesLendGateway(safe)) {
             return CashLensLegacyLib.maxSpendDebit(cashModule, safe, debtServiceTokenPreference);
         }
 
@@ -358,7 +358,7 @@ contract CashLens is UpgradeableProxy {
         bool hasDebt;
         uint256 borrowHeadroom;
         {
-            IGateway.AccountData memory account = gateway().getAccountData(safe);
+            ILendGateway.AccountData memory account = gateway().getAccountData(safe);
             hasDebt = account.debtUsd != 0;
             if (hasDebt) {
                 borrowHeadroom = account.availableBorrowsUsd;
@@ -399,11 +399,11 @@ contract CashLens is UpgradeableProxy {
      * @return Maximum amount that can be spent in credit mode (USD, 6 decimals)
      */
     function getMaxSpendCredit(address safe) public view returns (uint256) {
-        if (!cashModule.usesAave(safe)) {
+        if (!cashModule.usesLendGateway(safe)) {
             return CashLensLegacyLib.maxSpendCredit(cashModule, safe);
         }
 
-        IGateway lendGateway = cashModule.getGateway();
+        ILendGateway lendGateway = cashModule.getLendGateway();
         uint256 borrowPower = lendGateway.getAccountData(safe).availableBorrowsUsd;
 
         address[] memory borrowTokens = cashModule.getDebtManager().getBorrowTokens();
@@ -472,7 +472,7 @@ contract CashLens is UpgradeableProxy {
 
         if (!debtManager.isCollateralToken(token)) revert NotACollateralToken();
 
-        if (!cashModule.usesAave(safe)) {
+        if (!cashModule.usesLendGateway(safe)) {
             uint256 balance = IERC20(token).balanceOf(safe);
             uint256 pendingWithdrawalAmount = getPendingWithdrawalAmount(safe, token);
 
@@ -494,7 +494,7 @@ contract CashLens is UpgradeableProxy {
         IDebtManager debtManager = cashModule.getDebtManager();
         address[] memory collateralTokens = debtManager.getCollateralTokens();
 
-        if (!cashModule.usesAave(safe)) {
+        if (!cashModule.usesLendGateway(safe)) {
             return CashLensLegacyLib.userTotalCollateral(cashModule, safe, collateralTokens);
         }
 
@@ -539,7 +539,7 @@ contract CashLens is UpgradeableProxy {
 
     /// @notice Per-token supplied position in the Safe's Aave account, skipping zero balances
     function _suppliedBalances(address safe, address[] memory tokens) internal view returns (IDebtManager.TokenData[] memory) {
-        IGateway lendGateway = cashModule.getGateway();
+        ILendGateway lendGateway = cashModule.getLendGateway();
         IDebtManager.TokenData[] memory out = new IDebtManager.TokenData[](tokens.length);
         uint256 m = 0;
         for (uint256 i = 0; i < tokens.length;) {
@@ -564,7 +564,7 @@ contract CashLens is UpgradeableProxy {
 
     /// @notice Per-token debt in the Safe's Aave account, skipping zero balances
     function _debtBalances(address safe, address[] memory tokens) internal view returns (IDebtManager.TokenData[] memory) {
-        IGateway lendGateway = cashModule.getGateway();
+        ILendGateway lendGateway = cashModule.getLendGateway();
         IDebtManager.TokenData[] memory out = new IDebtManager.TokenData[](tokens.length);
         uint256 m = 0;
         for (uint256 i = 0; i < tokens.length;) {

--- a/src/modules/cash/CashModuleCore.sol
+++ b/src/modules/cash/CashModuleCore.sol
@@ -12,6 +12,7 @@ import { ICashbackDispatcher } from "../../interfaces/ICashbackDispatcher.sol";
 import { IDebtManager } from "../../interfaces/IDebtManager.sol";
 import { IEtherFiDataProvider } from "../../interfaces/IEtherFiDataProvider.sol";
 import { IEtherFiSafe } from "../../interfaces/IEtherFiSafe.sol";
+import { ILendGateway } from "../../interfaces/ILendGateway.sol";
 import { ArrayDeDupLib } from "../../libraries/ArrayDeDupLib.sol";
 import { CashVerificationLib } from "../../libraries/CashVerificationLib.sol";
 import { SignatureUtils } from "../../libraries/SignatureUtils.sol";
@@ -80,9 +81,9 @@ contract CashModuleCore is CashModuleStorageContract {
         $.mode = Mode.Debit;
 
         // New safes run on the Aave gateway. Guarded because setupModule is re-runnable: a legacy safe with
-        // open DebtManager debt must keep routing to DebtManager until migrateToAave moves its position.
+        // open DebtManager debt must keep routing to DebtManager until migrateToLendGateway moves its position.
         (, uint256 legacyDebtUsd) = _getDebtManager().borrowingOf(msg.sender);
-        if (legacyDebtUsd == 0) $.usesAave = true;
+        if (legacyDebtUsd == 0) $.usesLendGateway = true;
     }
 
     /**
@@ -253,12 +254,12 @@ contract CashModuleCore is CashModuleStorageContract {
 
     /**
      * @notice Whether the safe's borrow/collateral engine is the Aave gateway (vs the legacy DebtManager)
-     * @dev The canonical routing flag; see ICashModule.usesAave
+     * @dev The canonical routing flag; see ICashModule.usesLendGateway
      * @param safe Address of the EtherFi Safe
      * @return True if the safe uses the Aave gateway
      */
-    function usesAave(address safe) external view returns (bool) {
-        return _usesAave(safe);
+    function usesLendGateway(address safe) external view returns (bool) {
+        return _usesLendGateway(safe);
     }
 
     /**
@@ -273,10 +274,10 @@ contract CashModuleCore is CashModuleStorageContract {
 
     /**
      * @notice Returns the configured Aave gateway used for lend operations
-     * @return Address of the gateway (address(0) if not set)
+     * @return LendGateway instance (zero if not set)
      */
-    function getLendGateway() external view returns (address) {
-        return address(_getCashModuleStorage().gateway);
+    function getLendGateway() external view returns (ILendGateway) {
+        return _getCashModuleStorage().gateway;
     }
 
     /**
@@ -532,7 +533,7 @@ contract CashModuleCore is CashModuleStorageContract {
     function _repay(address safe, IDebtManager debtManager, address token, uint256 amountInUsd) internal {
         uint256 amount = IDebtManager(debtManager).convertUsdToCollateralToken(token, amountInUsd);
         if (amount == 0) revert AmountZero();
-        _cancelWithdrawalRequestIfNecessary(safe, token, amount);
+        _cancelCompetingWithdrawal(safe, token, amount);
 
         // A migrated safe repays on Aave via the gateway; a legacy safe repays the DebtManager. Both paths run
         // in CashLendLib (extracted to keep this contract within the code-size limit).

--- a/src/modules/cash/CashModuleSetters.sol
+++ b/src/modules/cash/CashModuleSetters.sol
@@ -10,7 +10,7 @@ import { ICashbackDispatcher } from "../../interfaces/ICashbackDispatcher.sol";
 import { IDebtManager } from "../../interfaces/IDebtManager.sol";
 import { IEtherFiDataProvider } from "../../interfaces/IEtherFiDataProvider.sol";
 import { IEtherFiSafe } from "../../interfaces/IEtherFiSafe.sol";
-import { IGateway } from "../../interfaces/IGateway.sol";
+import { ILendGateway } from "../../interfaces/ILendGateway.sol";
 import { ArrayDeDupLib } from "../../libraries/ArrayDeDupLib.sol";
 import { CashVerificationLib } from "../../libraries/CashVerificationLib.sol";
 import { EnumerableAddressWhitelistLib } from "../../libraries/EnumerableAddressWhitelistLib.sol";
@@ -71,7 +71,7 @@ contract CashModuleSetters is CashModuleStorageContract {
      * @custom:throws InvalidInput if gateway has no contract code (also rejects address(0))
      * @custom:throws GatewayAlreadySet if the gateway has already been configured
      */
-    function setGateway(address gateway) external {
+    function setLendGateway(address gateway) external {
         if (!roleRegistry().hasRole(CASH_MODULE_CONTROLLER_ROLE, msg.sender)) revert OnlyCashModuleController();
         // One-time bootstrap that can't be repointed, so guard against a mistyped EOA or undeployed address.
         if (gateway.code.length == 0) revert InvalidInput();
@@ -81,28 +81,20 @@ contract CashModuleSetters is CashModuleStorageContract {
         // Repointing after positions exist can strand accounting and must use a dedicated migration flow.
         if (address($.gateway) != address(0)) revert GatewayAlreadySet();
 
-        $.gateway = IGateway(gateway);
-        $.cashEventEmitter.emitGatewaySet(gateway);
-    }
-
-    /**
-     * @notice Returns the Aave gateway contract
-     * @return Gateway instance
-     */
-    function getGateway() public view returns (IGateway) {
-        return _getCashModuleStorage().gateway;
+        $.gateway = ILendGateway(gateway);
+        $.cashEventEmitter.emitLendGatewaySet(gateway);
     }
 
     /**
      * @notice Marks a safe as using the Aave gateway engine
-     * @dev Only callable by the DebtManager, as the last step of migrateToAave. Idempotent and one-way:
+     * @dev Only callable by the DebtManager, as the last step of migrateToLendGateway. Idempotent and one-way:
      *      nothing ever clears the flag.
      * @param safe Address of the EtherFi Safe
      * @custom:throws OnlyDebtManager if called by any address other than the DebtManager
      */
-    function markUsesAave(address safe) external {
+    function markUsesLendGateway(address safe) external {
         if (msg.sender != address(_getDebtManager())) revert OnlyDebtManager();
-        _getCashModuleStorage().safeCashConfig[safe].usesAave = true;
+        _getCashModuleStorage().safeCashConfig[safe].usesLendGateway = true;
     }
 
     /**

--- a/src/modules/cash/CashModuleStorageContract.sol
+++ b/src/modules/cash/CashModuleStorageContract.sol
@@ -8,7 +8,7 @@ import { SafeCashConfig, SafeData, SafeTiers, WithdrawalRequest } from "../../in
 import { ICashbackDispatcher } from "../../interfaces/ICashbackDispatcher.sol";
 import { IDebtManager } from "../../interfaces/IDebtManager.sol";
 import { IEtherFiSafe } from "../../interfaces/IEtherFiSafe.sol";
-import { IGateway } from "../../interfaces/IGateway.sol";
+import { ILendGateway } from "../../interfaces/ILendGateway.sol";
 import { ArrayDeDupLib } from "../../libraries/ArrayDeDupLib.sol";
 import { CashVerificationLib } from "../../libraries/CashVerificationLib.sol";
 import { SignatureUtils } from "../../libraries/SignatureUtils.sol";
@@ -72,7 +72,7 @@ contract CashModuleStorageContract is UpgradeableProxy, ModuleBase {
         /// @notice Address of the SettlementDispatcher for CardOrder
         address settlementDispatcherCardOrder;
         /// @notice The Aave gateway that runs position operations (borrow/withdraw/repay) on a safe's behalf
-        IGateway gateway;
+        ILendGateway gateway;
     }
 
     // keccak256(abi.encode(uint256(keccak256("etherfi.storage.CashModuleStorage")) - 1)) & ~bytes32(uint256(0xff))
@@ -206,8 +206,8 @@ contract CashModuleStorageContract is UpgradeableProxy, ModuleBase {
      * @param safe Address of the EtherFi Safe
      * @return True if the safe uses the Aave gateway
      */
-    function _usesAave(address safe) internal view returns (bool) {
-        return _getCashModuleStorage().safeCashConfig[safe].usesAave;
+    function _usesLendGateway(address safe) internal view returns (bool) {
+        return _getCashModuleStorage().safeCashConfig[safe].usesLendGateway;
     }
 
     /**
@@ -219,13 +219,20 @@ contract CashModuleStorageContract is UpgradeableProxy, ModuleBase {
     }
 
     /**
-     * @dev Cancels withdrawal request if necessary based on available balance
+     * @dev Cancels the safe's pending withdrawal request when it competes with a repay/spend of `token`.
+     *      Reverts if `amount` exceeds the safe's loose balance. Otherwise, if `token` has a leg in the
+     *      pending request and `amount` plus that reserved leg exceeds the loose balance, the whole request
+     *      is cancelled: the repay/spend outranks the reservation. Conservative on purpose: the check uses
+     *      the quoted `amount`, but both engines cap the actual pull at the live debt (a full repay resolves
+     *      to the outstanding debt), so a repay quoted above the debt can cancel a request that the real,
+     *      smaller pull would have left intact. Only the repaid token's leg and the current balance are
+     *      considered.
      * @param safe Address of the EtherFi Safe
-     * @param token Address of the token to update
-     * @param amount Amount being processed
-     * @custom:throws InsufficientBalance if there is not enough balance for the operation
+     * @param token Address of the token being repaid/spent
+     * @param amount Quoted token amount for the operation
+     * @custom:throws InsufficientBalance if `amount` exceeds the safe's loose balance of `token`
      */
-    function _cancelWithdrawalRequestIfNecessary(address safe, address token, uint256 amount) internal {
+    function _cancelCompetingWithdrawal(address safe, address token, uint256 amount) internal {
         SafeCashConfig storage safeCashConfig = _getCashModuleStorage().safeCashConfig[safe];
         uint256 balance = IERC20(token).balanceOf(safe);
 

--- a/src/modules/lend-gateway/LendGateway.sol
+++ b/src/modules/lend-gateway/LendGateway.sol
@@ -9,13 +9,13 @@ import { EnumerableSetLib } from "solady/utils/EnumerableSetLib.sol";
 import { IAaveV4Spoke } from "../../interfaces/IAaveV4Spoke.sol";
 import { ICashModule } from "../../interfaces/ICashModule.sol";
 import { IEtherFiSafe } from "../../interfaces/IEtherFiSafe.sol";
-import { IGateway } from "../../interfaces/IGateway.sol";
+import { ILendGateway } from "../../interfaces/ILendGateway.sol";
 import { IPriceProvider } from "../../interfaces/IPriceProvider.sol";
 import { ModuleBase } from "../ModuleBase.sol";
 import { UpgradeableProxy } from "../../utils/UpgradeableProxy.sol";
 
 /**
- * @title Gateway
+ * @title LendGateway
  * @notice A safe's Aave v4 position manager. The gateway is registered on the Spoke by governance
  *         (updatePositionManager) and approved per-safe (setUserPositionManager); once both hold, it can
  *         supply/withdraw/borrow/repay on a safe's behalf without a per-op user signature.
@@ -26,13 +26,13 @@ import { UpgradeableProxy } from "../../utils/UpgradeableProxy.sol";
  *         break until re-approved). This is enforced by Aave, not re-implemented here.
  *      2. Cash side: only an authorized driver may call the mutating ops. The CashModule is always a driver
  *         (resolved live from the data provider); further drivers (auto-supply, migration) are added by a
- *         GATEWAY_ADMIN_ROLE holder. A position manager can move user funds, so who may drive it is the most
+ *         LEND_GATEWAY_ADMIN_ROLE holder. A position manager can move user funds, so who may drive it is the most
  *         security-critical surface in this contract.
  *
  *      Aave v4 addresses reserves by a uint256 reserveId, not by asset address. The gateway keeps its own
  *      asset -> reserveId registry, each entry validated against the Spoke's getReserve at registration time.
  *
- *      USD reads: IGateway's collateralUsd/debtUsd/availableBorrowsUsd are 6-decimal USD (PriceProvider
+ *      USD reads: ILendGateway's collateralUsd/debtUsd/availableBorrowsUsd are 6-decimal USD (PriceProvider
  *      scale). Aave reports position value in opaque "units of Value"/RAY, so the gateway does NOT consume
  *      those; it re-derives USD from ether.fi's PriceProvider over the registered assets (matching CashLens),
  *      applying each reserve's LTV for the borrow headroom, and takes only healthFactor (WAD == 1e18) from Aave.
@@ -45,7 +45,7 @@ import { UpgradeableProxy } from "../../utils/UpgradeableProxy.sol";
  *      on the Spoke, or pausing this gateway — not a per-safe opt-out.
  * @author ether.fi
  */
-contract Gateway is IGateway, UpgradeableProxy, ModuleBase {
+contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
     using SafeERC20 for IERC20;
     using EnumerableSetLib for EnumerableSetLib.AddressSet;
 
@@ -53,15 +53,15 @@ contract Gateway is IGateway, UpgradeableProxy, ModuleBase {
     IAaveV4Spoke public immutable spoke;
 
     /// @notice Role that registers reserves and manages the driver allowlist
-    bytes32 public constant GATEWAY_ADMIN_ROLE = keccak256("GATEWAY_ADMIN_ROLE");
+    bytes32 public constant LEND_GATEWAY_ADMIN_ROLE = keccak256("LEND_GATEWAY_ADMIN_ROLE");
 
-    /// @notice 100% in the IGateway ltv scale (100e18 == 100%)
+    /// @notice 100% in the ILendGateway ltv scale (100e18 == 100%)
     uint256 internal constant HUNDRED_PERCENT = 100e18;
     /// @notice Converts Aave's BPS collateralFactor to the 100e18 ltv scale (bps * 1e16; 10_000 * 1e16 == 100e18)
     uint256 internal constant BPS_TO_LTV_SCALE = 1e16;
 
-    /// @custom:storage-location erc7201:etherfi.storage.Gateway
-    struct GatewayStorage {
+    /// @custom:storage-location erc7201:etherfi.storage.LendGateway
+    struct LendGatewayStorage {
         /// @notice asset -> Aave reserveId (membership is tracked by `assets`, since reserveId 0 is valid)
         mapping(address asset => uint256 reserveId) reserveId;
         /// @notice The registered assets; membership doubles as the "is registered" check
@@ -70,8 +70,8 @@ contract Gateway is IGateway, UpgradeableProxy, ModuleBase {
         mapping(address driver => bool authorized) isDriver;
     }
 
-    // keccak256(abi.encode(uint256(keccak256("etherfi.storage.Gateway")) - 1)) & ~bytes32(uint256(0xff))
-    bytes32 private constant GatewayStorageLocation = 0xef6b7ff7f22dbe95f109f1722b6c4f5324bd342b000fbc132fbeb4f135815100;
+    // keccak256(abi.encode(uint256(keccak256("etherfi.storage.LendGateway")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant LendGatewayStorageLocation = 0x08cdfbb611f2a1b86b361fad47cf7e3d848e6642121a10c5da4ae64fe25c9800;
 
     /// @notice Emitted when an asset's reserveId is registered or updated
     event ReserveRegistered(address indexed asset, uint256 indexed reserveId);
@@ -129,7 +129,7 @@ contract Gateway is IGateway, UpgradeableProxy, ModuleBase {
 
     /// @dev Reverts unless the caller is the CashModule or an authorized driver
     function _onlyDriver() internal view {
-        if (msg.sender != etherFiDataProvider.getCashModule() && !_getGatewayStorage().isDriver[msg.sender]) revert OnlyDriver();
+        if (msg.sender != etherFiDataProvider.getCashModule() && !_getLendGatewayStorage().isDriver[msg.sender]) revert OnlyDriver();
     }
 
     modifier onlyDriver() {
@@ -157,11 +157,11 @@ contract Gateway is IGateway, UpgradeableProxy, ModuleBase {
      * the USD views then read the new reserve and miss the old, understating debt and 
      * inflating borrow headroom.
      */
-    function setReserveId(address asset, uint256 reserveId) external onlyRole(GATEWAY_ADMIN_ROLE) {
+    function setReserveId(address asset, uint256 reserveId) external onlyRole(LEND_GATEWAY_ADMIN_ROLE) {
         if (asset == address(0)) revert ZeroAddress();
         if (spoke.getReserve(reserveId).underlying != asset) revert ReserveAssetMismatch();
 
-        GatewayStorage storage $ = _getGatewayStorage();
+        LendGatewayStorage storage $ = _getLendGatewayStorage();
         $.assets.add(asset);
         $.reserveId[asset] = reserveId;
 
@@ -174,8 +174,8 @@ contract Gateway is IGateway, UpgradeableProxy, ModuleBase {
      * @dev Warning: do not remove an asset any safe still holds a position in; 
      * it drops from the USD views (debt reads 0), understating debt and inflating borrow headroom.
      */
-    function removeReserve(address asset) external onlyRole(GATEWAY_ADMIN_ROLE) {
-        GatewayStorage storage $ = _getGatewayStorage();
+    function removeReserve(address asset) external onlyRole(LEND_GATEWAY_ADMIN_ROLE) {
+        LendGatewayStorage storage $ = _getLendGatewayStorage();
         if (!$.assets.contains(asset)) revert AssetNotRegistered(asset);
 
         $.assets.remove(asset);
@@ -189,9 +189,9 @@ contract Gateway is IGateway, UpgradeableProxy, ModuleBase {
      * @param driver The driver contract (e.g. an auto-supply or migration module)
      * @param authorized True to authorize, false to revoke
      */
-    function setDriver(address driver, bool authorized) external onlyRole(GATEWAY_ADMIN_ROLE) {
+    function setDriver(address driver, bool authorized) external onlyRole(LEND_GATEWAY_ADMIN_ROLE) {
         if (driver == address(0)) revert ZeroAddress();
-        _getGatewayStorage().isDriver[driver] = authorized;
+        _getLendGatewayStorage().isDriver[driver] = authorized;
         emit DriverSet(driver, authorized);
     }
 
@@ -226,7 +226,7 @@ contract Gateway is IGateway, UpgradeableProxy, ModuleBase {
     }
 
     // ---------------------------------------------------------------------
-    // IGateway operations (drivers only)
+    // ILendGateway operations (drivers only)
     // ---------------------------------------------------------------------
 
     /**
@@ -360,7 +360,7 @@ contract Gateway is IGateway, UpgradeableProxy, ModuleBase {
     }
 
     // ---------------------------------------------------------------------
-    // IGateway reads
+    // ILendGateway reads
     // ---------------------------------------------------------------------
 
     /**
@@ -374,7 +374,7 @@ contract Gateway is IGateway, UpgradeableProxy, ModuleBase {
      */
     function getAccountData(address safe) external view returns (AccountData memory data) {
         IPriceProvider priceProvider = IPriceProvider(etherFiDataProvider.getPriceProvider());
-        GatewayStorage storage $ = _getGatewayStorage();
+        LendGatewayStorage storage $ = _getLendGatewayStorage();
 
         uint256 maxBorrowUsd;
         uint256 len = $.assets.length();
@@ -400,7 +400,7 @@ contract Gateway is IGateway, UpgradeableProxy, ModuleBase {
         }
 
         data.availableBorrowsUsd = maxBorrowUsd > data.debtUsd ? maxBorrowUsd - data.debtUsd : 0;
-        // healthFactor is WAD (1e18) on Aave, matching IGateway's 1e18 scale.
+        // healthFactor is WAD (1e18) on Aave, matching ILendGateway's 1e18 scale.
         data.healthFactor = spoke.getUserAccountData(safe).healthFactor;
     }
 
@@ -411,7 +411,7 @@ contract Gateway is IGateway, UpgradeableProxy, ModuleBase {
      * @return The supplied amount in asset units, or 0 if the asset is not registered
      */
     function suppliedOf(address safe, address asset) external view returns (uint256) {
-        GatewayStorage storage $ = _getGatewayStorage();
+        LendGatewayStorage storage $ = _getLendGatewayStorage();
         if (!$.assets.contains(asset)) return 0;
         return spoke.getUserSuppliedAssets($.reserveId[asset], safe);
     }
@@ -423,7 +423,7 @@ contract Gateway is IGateway, UpgradeableProxy, ModuleBase {
      * @return The debt amount in asset units, or 0 if the asset is not registered
      */
     function debtOf(address safe, address asset) external view returns (uint256) {
-        GatewayStorage storage $ = _getGatewayStorage();
+        LendGatewayStorage storage $ = _getLendGatewayStorage();
         if (!$.assets.contains(asset)) return 0;
         return spoke.getUserTotalDebt($.reserveId[asset], safe);
     }
@@ -434,7 +434,7 @@ contract Gateway is IGateway, UpgradeableProxy, ModuleBase {
      * @return The available liquidity in asset units, or 0 if the asset is not registered
      */
     function availableCash(address asset) external view returns (uint256) {
-        GatewayStorage storage $ = _getGatewayStorage();
+        LendGatewayStorage storage $ = _getLendGatewayStorage();
         if (!$.assets.contains(asset)) return 0;
         uint256 reserveId = $.reserveId[asset];
         uint256 supplied = spoke.getReserveSuppliedAssets(reserveId);
@@ -449,7 +449,7 @@ contract Gateway is IGateway, UpgradeableProxy, ModuleBase {
      * @return The LTV where 100e18 is 100%, or 0 if the asset is not registered
      */
     function ltv(address asset) external view returns (uint256) {
-        GatewayStorage storage $ = _getGatewayStorage();
+        LendGatewayStorage storage $ = _getLendGatewayStorage();
         if (!$.assets.contains(asset)) return 0;
         return _ltv($.reserveId[asset]);
     }
@@ -476,17 +476,17 @@ contract Gateway is IGateway, UpgradeableProxy, ModuleBase {
 
     /// @notice Whether `asset` has a registered reserveId
     function isRegistered(address asset) external view returns (bool) {
-        return _getGatewayStorage().assets.contains(asset);
+        return _getLendGatewayStorage().assets.contains(asset);
     }
 
     /// @notice The list of registered assets
     function registeredAssets() external view returns (address[] memory) {
-        return _getGatewayStorage().assets.values();
+        return _getLendGatewayStorage().assets.values();
     }
 
     /// @notice Whether `account` may drive the gateway (CashModule or an authorized driver)
     function isDriver(address account) external view returns (bool) {
-        return account == etherFiDataProvider.getCashModule() || _getGatewayStorage().isDriver[account];
+        return account == etherFiDataProvider.getCashModule() || _getLendGatewayStorage().isDriver[account];
     }
 
     /// @notice Whether `safe` currently approves this gateway as an (active) position manager on the Spoke
@@ -514,7 +514,7 @@ contract Gateway is IGateway, UpgradeableProxy, ModuleBase {
 
     /// @dev The registered reserveId for `asset`, reverting if unregistered
     function _reserveIdOf(address asset) internal view returns (uint256) {
-        GatewayStorage storage $ = _getGatewayStorage();
+        LendGatewayStorage storage $ = _getLendGatewayStorage();
         if (!$.assets.contains(asset)) revert AssetNotRegistered(asset);
         return $.reserveId[asset];
     }
@@ -532,9 +532,9 @@ contract Gateway is IGateway, UpgradeableProxy, ModuleBase {
     }
 
     /// @dev Returns the ERC-7201 storage struct
-    function _getGatewayStorage() internal pure returns (GatewayStorage storage $) {
+    function _getLendGatewayStorage() internal pure returns (LendGatewayStorage storage $) {
         assembly {
-            $.slot := GatewayStorageLocation
+            $.slot := LendGatewayStorageLocation
         }
     }
 }

--- a/test/lend-gateway/CashLendDisable.t.sol
+++ b/test/lend-gateway/CashLendDisable.t.sol
@@ -7,11 +7,11 @@ import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/Mes
 import { UUPSProxy } from "../../src/UUPSProxy.sol";
 import { IAggregatorV3 } from "../../src/interfaces/IAggregatorV3.sol";
 import { BinSponsor, ICashModule, Mode } from "../../src/interfaces/ICashModule.sol";
-import { IGateway } from "../../src/interfaces/IGateway.sol";
+import { ILendGateway } from "../../src/interfaces/ILendGateway.sol";
 import { CashVerificationLib } from "../../src/libraries/CashVerificationLib.sol";
 import { SignatureUtils } from "../../src/libraries/SignatureUtils.sol";
 import { CashEventEmitter } from "../../src/modules/cash/CashEventEmitter.sol";
-import { Gateway } from "../../src/modules/gateway/Gateway.sol";
+import { LendGateway } from "../../src/modules/lend-gateway/LendGateway.sol";
 import { ChainlinkCompositePriceFeed } from "../../src/oracle/ChainlinkCompositePriceFeed.sol";
 import { UpgradeableProxy } from "../../src/utils/UpgradeableProxy.sol";
 import { CashModuleTestSetup } from "../safe/modules/cash/CashModuleTestSetup.t.sol";
@@ -24,13 +24,13 @@ import { AaveV4Fixture } from "./helpers/AaveV4Fixture.sol";
  *         pulling ALL its collateral out of Aave back into the safe, forcing Debit mode, and blocking every
  *         further lend op (auto-supply / borrow) until it opts back in with toggleLend(true). Runs against a
  *         REAL Aave v4 instance deployed in-test on an Optimism fork, driven by the real ether.fi stack
- *         (CashModule, Gateway, EtherFiSafe) — no mocks.
- * @dev Run with: source .env && FOUNDRY_PROFILE=aave TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test --match-path test/gateway/CashLendDisable.t.sol
+ *         (CashModule, LendGateway, EtherFiSafe) — no mocks.
+ * @dev Run with: source .env && FOUNDRY_PROFILE=aave TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test --match-path test/lend-gateway/CashLendDisable.t.sol
  */
 contract CashLendDisableTest is CashModuleTestSetup, AaveV4Fixture {
     using MessageHashUtils for bytes32;
 
-    Gateway internal gw;
+    LendGateway internal gw;
     address internal driver = makeAddr("gwDriver"); // arranges Aave positions directly in tests
 
     uint256 internal usdcReserveId;
@@ -48,18 +48,18 @@ contract CashLendDisableTest is CashModuleTestSetup, AaveV4Fixture {
         usdcReserveId = _addAaveReserve(address(usdc), usdcUsdOracle, 8000, true);
         _seedAaveLiquidity(usdcReserveId, address(usdc), 1_000_000e6);
 
-        // Gateway proxy + wiring
-        address gwImpl = address(new Gateway(address(dataProvider), address(spoke)));
-        gw = Gateway(address(new UUPSProxy(gwImpl, abi.encodeWithSelector(Gateway.initialize.selector, address(roleRegistry)))));
+        // LendGateway proxy + wiring
+        address gwImpl = address(new LendGateway(address(dataProvider), address(spoke)));
+        gw = LendGateway(address(new UUPSProxy(gwImpl, abi.encodeWithSelector(LendGateway.initialize.selector, address(roleRegistry)))));
 
         vm.startPrank(owner);
-        roleRegistry.grantRole(gw.GATEWAY_ADMIN_ROLE(), owner);
+        roleRegistry.grantRole(gw.LEND_GATEWAY_ADMIN_ROLE(), owner);
         dataProvider.configureModules(_addr1(address(gw)), _bool1(true));
         gw.setReserveId(address(weETH), weethReserveId);
         gw.setReserveId(address(usdc), usdcReserveId);
         gw.setDriver(driver, true);
         // Wire the CashModule to the real gateway (source of the collateral-withdraw path) and give a real mode delay
-        cashModule.setGateway(address(gw));
+        cashModule.setLendGateway(address(gw));
         cashModule.setDelays(1, 3600, MODE_DELAY);
         vm.stopPrank();
 
@@ -67,19 +67,19 @@ contract CashLendDisableTest is CashModuleTestSetup, AaveV4Fixture {
         _activateAavePositionManager(address(gw));
     }
 
-    /// @dev Empty on purpose: skips the base mock-gateway wiring so this suite's one-time setGateway(gw) above is
+    /// @dev Empty on purpose: skips the base mock-gateway wiring so this suite's one-time setLendGateway(gw) above is
     ///      the first and only set. Without this, that call would revert GatewayAlreadySet.
     function _wireDefaultGateway() internal override { }
 
     // ----------------------------------------------------------------- wiring & defaults
 
-    /// @notice The gateway is wired once during setup and cannot be repointed (role/zero/codeless guards live in SetGateway.t.sol).
+    /// @notice The gateway is wired once during setup and cannot be repointed (role/zero/codeless guards live in SetLendGateway.t.sol).
     function test_lendGateway_wiredOnceAndImmutable() public {
-        assertEq(cashModule.getLendGateway(), address(gw));
+        assertEq(address(cashModule.getLendGateway()), address(gw));
 
         vm.prank(owner);
         vm.expectRevert(ICashModule.GatewayAlreadySet.selector);
-        cashModule.setGateway(address(gw));
+        cashModule.setLendGateway(address(gw));
     }
 
     /// A fresh safe starts with lend enabled and no pending disable.
@@ -127,11 +127,11 @@ contract CashLendDisableTest is CashModuleTestSetup, AaveV4Fixture {
         // Every lend op through the gateway is now rejected
         deal(address(weETH), address(safe), 1 ether);
         vm.startPrank(driver);
-        vm.expectRevert(Gateway.LendDisabled.selector);
+        vm.expectRevert(LendGateway.LendDisabled.selector);
         gw.supply(address(safe), address(weETH), 1 ether);
-        vm.expectRevert(Gateway.LendDisabled.selector);
+        vm.expectRevert(LendGateway.LendDisabled.selector);
         gw.borrow(address(safe), address(usdc), 1e6, driver);
-        vm.expectRevert(Gateway.LendDisabled.selector);
+        vm.expectRevert(LendGateway.LendDisabled.selector);
         gw.setUsingAsCollateral(address(safe), address(weETH), true);
         vm.stopPrank();
     }
@@ -290,7 +290,7 @@ contract CashLendDisableTest is CashModuleTestSetup, AaveV4Fixture {
     ///      deep in Aave when withdrawing the collateral. Injects 1 wei of raw debt via a mocked debtOf on the
     ///      wired gateway; there is no real Aave position, so the USD aggregate still floors to zero.
     function test_toggleLendDisable_revertsOnDustDebtBelowUsdFloor() public {
-        vm.mockCall(address(gw), abi.encodeWithSelector(IGateway.debtOf.selector, address(safe), address(weETH)), abi.encode(uint256(1)));
+        vm.mockCall(address(gw), abi.encodeWithSelector(ILendGateway.debtOf.selector, address(safe), address(weETH)), abi.encode(uint256(1)));
 
         // Premise of the test: the USD aggregate floors this dust to zero, so only the raw debtOf check catches it
         assertEq(gw.getAccountData(address(safe)).debtUsd, 0, "dust floors to zero USD");
@@ -312,7 +312,7 @@ contract CashLendDisableTest is CashModuleTestSetup, AaveV4Fixture {
 
         vm.startPrank(driver);
         gw.setUsingAsCollateral(address(safe), address(weETH), false); // must not revert
-        vm.expectRevert(Gateway.LendDisabled.selector);
+        vm.expectRevert(LendGateway.LendDisabled.selector);
         gw.setUsingAsCollateral(address(safe), address(weETH), true);
         vm.stopPrank();
     }

--- a/test/lend-gateway/DebtManagerMigration.t.sol
+++ b/test/lend-gateway/DebtManagerMigration.t.sol
@@ -10,8 +10,8 @@ import { DebtManagerStorageContract } from "../../src/debt-manager/DebtManagerSt
 import { IAggregatorV3 } from "../../src/interfaces/IAggregatorV3.sol";
 import { BinSponsor, Cashback, ICashModule, Mode } from "../../src/interfaces/ICashModule.sol";
 import { CashVerificationLib } from "../../src/libraries/CashVerificationLib.sol";
-import { IGateway } from "../../src/interfaces/IGateway.sol";
-import { Gateway } from "../../src/modules/gateway/Gateway.sol";
+import { ILendGateway } from "../../src/interfaces/ILendGateway.sol";
+import { LendGateway } from "../../src/modules/lend-gateway/LendGateway.sol";
 import { CashEventEmitter } from "../../src/modules/cash/CashEventEmitter.sol";
 import { ChainlinkCompositePriceFeed } from "../../src/oracle/ChainlinkCompositePriceFeed.sol";
 import { UpgradeableProxy } from "../../src/utils/UpgradeableProxy.sol";
@@ -20,17 +20,17 @@ import { AaveV4Fixture } from "./helpers/AaveV4Fixture.sol";
 
 /**
  * @title DebtManagerMigrationTest
- * @notice Fork tests for DebtManager.migrateToAave: a legacy Safe position (weETH collateral + USDC debt on
+ * @notice Fork tests for DebtManager.migrateToLendGateway: a legacy Safe position (weETH collateral + USDC debt on
  *         DebtManager) migrates atomically to a REAL Aave v4 instance (deployed in-test on an Optimism fork)
  *         via the gateway — no flash loan. Aave's weETH LTV is set below DebtManager's so the LTV-fit path
  *         is exercised.
- * @dev Run with: FOUNDRY_PROFILE=aave TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test --match-path test/gateway/DebtManagerMigration.t.sol
+ * @dev Run with: FOUNDRY_PROFILE=aave TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test --match-path test/lend-gateway/DebtManagerMigration.t.sol
  */
 contract DebtManagerMigrationTest is CashModuleTestSetup, AaveV4Fixture {
     using MessageHashUtils for bytes32;
 
     DebtManagerCore internal dm;
-    Gateway internal gw;
+    LendGateway internal gw;
     address internal migrator = makeAddr("migrationRunner");
 
     uint256 internal usdcReserveId;
@@ -48,18 +48,18 @@ contract DebtManagerMigrationTest is CashModuleTestSetup, AaveV4Fixture {
         weethReserveId = _addAaveReserve(address(weETH), weethSource, AAVE_WEETH_LTV, false);
         usdcReserveId = _addAaveReserve(address(usdc), usdcUsdOracle, 8000, true);
 
-        // Gateway proxy + wiring
-        address gwImpl = address(new Gateway(address(dataProvider), address(spoke)));
-        gw = Gateway(address(new UUPSProxy(gwImpl, abi.encodeWithSelector(Gateway.initialize.selector, address(roleRegistry)))));
+        // LendGateway proxy + wiring
+        address gwImpl = address(new LendGateway(address(dataProvider), address(spoke)));
+        gw = LendGateway(address(new UUPSProxy(gwImpl, abi.encodeWithSelector(LendGateway.initialize.selector, address(roleRegistry)))));
 
         vm.startPrank(owner);
-        roleRegistry.grantRole(gw.GATEWAY_ADMIN_ROLE(), owner);
+        roleRegistry.grantRole(gw.LEND_GATEWAY_ADMIN_ROLE(), owner);
         dataProvider.configureModules(_addr1(address(gw)), _bool1(true));
         gw.setReserveId(address(weETH), weethReserveId);
         gw.setReserveId(address(usdc), usdcReserveId);
         gw.setDriver(address(dm), true); // DebtManager drives the gateway during migration
         // Migration reads the gateway from CashModule (single source of truth); authorize the migration runner
-        cashModule.setGateway(address(gw));
+        cashModule.setLendGateway(address(gw));
         roleRegistry.grantRole(DEBT_MANAGER_ADMIN_ROLE, migrator);
         vm.stopPrank();
 
@@ -71,13 +71,13 @@ contract DebtManagerMigrationTest is CashModuleTestSetup, AaveV4Fixture {
         _forceLegacyEngine(address(safe));
     }
 
-    /// @dev Empty on purpose: skips the base mock-gateway wiring so this suite's one-time setGateway(gw) above is
+    /// @dev Empty on purpose: skips the base mock-gateway wiring so this suite's one-time setLendGateway(gw) above is
     ///      the first and only set. Without this, that call would revert GatewayAlreadySet.
     function _wireDefaultGateway() internal override { }
 
     // ----------------------------------------------------------------- happy path
 
-    function test_migrateToAave_atomic_noFlashLoan() public {
+    function test_migrateToLendGateway_atomic_noFlashLoan() public {
         _seedAaveLiquidity(usdcReserveId, address(usdc), 5_000_000e6);
 
         // Legacy position: 10 weETH collateral, borrow a modest fraction that fits Aave's 30% LTV
@@ -90,12 +90,12 @@ contract DebtManagerMigrationTest is CashModuleTestSetup, AaveV4Fixture {
         uint256 dmUsdcBefore = usdc.balanceOf(address(debtManager));
 
         vm.prank(migrator);
-        dm.migrateToAave(address(safe));
+        dm.migrateToLendGateway(address(safe));
 
         // Legacy debt closed and Safe flagged migrated; both latches flip in the same tx
         assertEq(debtManager.borrowingOf(address(safe), address(usdc)), 0, "legacy debt cleared");
-        assertTrue(dm.hasMigratedToAave(address(safe)), "marked migrated");
-        assertTrue(cashModule.usesAave(address(safe)), "CashModule routing flag flipped");
+        assertTrue(dm.hasMigratedToLendGateway(address(safe)), "marked migrated");
+        assertTrue(cashModule.usesLendGateway(address(safe)), "CashModule routing flag flipped");
         // Position now lives on Aave: same collateral, same debt size
         assertApproxEqAbs(gw.suppliedOf(address(safe), address(weETH)), 10 ether, 3, "collateral on Aave");
         assertApproxEqAbs(gw.debtOf(address(safe), address(usdc)), borrowAmt, 1e6, "debt on Aave");
@@ -110,7 +110,7 @@ contract DebtManagerMigrationTest is CashModuleTestSetup, AaveV4Fixture {
 
     // ----------------------------------------------------------------- reverts
 
-    function test_migrateToAave_revertsWhenExceedsAaveLtv() public {
+    function test_migrateToLendGateway_revertsWhenExceedsAaveLtv() public {
         _seedAaveLiquidity(usdcReserveId, address(usdc), 5_000_000e6);
 
         // Borrow ~90% of DebtManager's max: fits DebtManager's 50% LTV, exceeds Aave's 30%
@@ -120,11 +120,11 @@ contract DebtManagerMigrationTest is CashModuleTestSetup, AaveV4Fixture {
         debtManager.borrow(BinSponsor.Reap, address(usdc), borrowAmt);
 
         vm.prank(migrator);
-        vm.expectRevert(DebtManagerStorageContract.PositionExceedsAaveLtv.selector);
-        dm.migrateToAave(address(safe));
+        vm.expectRevert(DebtManagerStorageContract.PositionExceedsLendGatewayLtv.selector);
+        dm.migrateToLendGateway(address(safe));
     }
 
-    function test_migrateToAave_revertsWhenInsufficientAaveLiquidity() public {
+    function test_migrateToLendGateway_revertsWhenInsufficientLendGatewayLiquidity() public {
         // No Aave liquidity seeded → the reserve cannot fund the borrow
         deal(address(weETH), address(safe), 10 ether);
         uint256 borrowAmt = dm.getMaxBorrowAmount(address(safe), true) / 4;
@@ -132,18 +132,18 @@ contract DebtManagerMigrationTest is CashModuleTestSetup, AaveV4Fixture {
         debtManager.borrow(BinSponsor.Reap, address(usdc), borrowAmt);
 
         vm.prank(migrator);
-        vm.expectRevert(abi.encodeWithSelector(DebtManagerStorageContract.InsufficientAaveLiquidity.selector, address(usdc)));
-        dm.migrateToAave(address(safe));
+        vm.expectRevert(abi.encodeWithSelector(DebtManagerStorageContract.InsufficientLendGatewayLiquidity.selector, address(usdc)));
+        dm.migrateToLendGateway(address(safe));
     }
 
-    function test_migrateToAave_noDebt_suppliesCollateralAndMarksMigrated() public {
+    function test_migrateToLendGateway_noDebt_suppliesCollateralAndMarksMigrated() public {
         deal(address(weETH), address(safe), 10 ether); // collateral but no debt
-        assertFalse(dm.hasMigratedToAave(address(safe)));
+        assertFalse(dm.hasMigratedToLendGateway(address(safe)));
 
         vm.prank(migrator);
-        dm.migrateToAave(address(safe));
+        dm.migrateToLendGateway(address(safe));
 
-        assertTrue(dm.hasMigratedToAave(address(safe)), "marked migrated");
+        assertTrue(dm.hasMigratedToLendGateway(address(safe)), "marked migrated");
         // A debt-free migration still moves the collateral to Aave, so credit borrowing works post-migration
         // (marking migrated while leaving collateral idle in the Safe would break gateway-based credit spends).
         assertEq(weETH.balanceOf(address(safe)), 0, "collateral moved out of the Safe");
@@ -153,22 +153,22 @@ contract DebtManagerMigrationTest is CashModuleTestSetup, AaveV4Fixture {
 
     /// @dev A lend-disabled safe opted out of Aave, so migration must not force its collateral in: it just
     ///      gets marked migrated (freezing legacy borrow/repay) with its balance left idle in the safe.
-    function test_migrateToAave_lendDisabledSafe_marksMigratedWithoutSupplying() public {
+    function test_migrateToLendGateway_lendDisabledSafe_marksMigratedWithoutSupplying() public {
         deal(address(weETH), address(safe), 10 ether);
         _disableLendForSafe();
         assertFalse(cashModule.isLendEnabled(address(safe)), "lend disabled");
 
         vm.prank(migrator);
-        dm.migrateToAave(address(safe));
+        dm.migrateToLendGateway(address(safe));
 
-        assertTrue(dm.hasMigratedToAave(address(safe)), "marked migrated");
+        assertTrue(dm.hasMigratedToLendGateway(address(safe)), "marked migrated");
         assertEq(weETH.balanceOf(address(safe)), 10 ether, "collateral stayed in the safe");
         assertEq(gw.suppliedOf(address(safe), address(weETH)), 0, "nothing supplied to Aave");
     }
 
     /// @dev A lend-disabled safe should be debt-free (disabling requires zero borrows), but it can still borrow
     ///      on DebtManager directly afterward. Migration must reject that case rather than revert opaquely.
-    function test_migrateToAave_lendDisabledSafe_withDebt_reverts() public {
+    function test_migrateToLendGateway_lendDisabledSafe_withDebt_reverts() public {
         _seedAaveLiquidity(usdcReserveId, address(usdc), 5_000_000e6);
         deal(address(weETH), address(safe), 10 ether);
         _disableLendForSafe();
@@ -180,12 +180,12 @@ contract DebtManagerMigrationTest is CashModuleTestSetup, AaveV4Fixture {
 
         vm.prank(migrator);
         vm.expectRevert(DebtManagerStorageContract.LendDisabledSafeHasDebt.selector);
-        dm.migrateToAave(address(safe));
+        dm.migrateToLendGateway(address(safe));
     }
 
     /// @dev Pending withdrawals reserve loose funds; migration must not sweep them into Aave. The queued
     ///      withdrawal is a plain transfer of the Safe's balance, so supplying it would brick processWithdrawal.
-    function test_migrateToAave_leavesPendingWithdrawalLoose() public {
+    function test_migrateToLendGateway_leavesPendingWithdrawalLoose() public {
         _seedAaveLiquidity(usdcReserveId, address(usdc), 5_000_000e6);
 
         deal(address(weETH), address(safe), 10 ether);
@@ -202,7 +202,7 @@ contract DebtManagerMigrationTest is CashModuleTestSetup, AaveV4Fixture {
         _requestWithdrawal(tokens, amounts, withdrawRecipient);
 
         vm.prank(migrator);
-        dm.migrateToAave(address(safe));
+        dm.migrateToLendGateway(address(safe));
 
         // Reserved amount stayed loose; only the rest was supplied
         assertEq(weETH.balanceOf(address(safe)), withdrawAmt, "reserved amount left loose in the safe");
@@ -216,13 +216,13 @@ contract DebtManagerMigrationTest is CashModuleTestSetup, AaveV4Fixture {
         assertEq(weETH.balanceOf(address(safe)), 0, "safe holds nothing loose afterwards");
     }
 
-    function test_markUsesAave_onlyDebtManager() public {
+    function test_markUsesLendGateway_onlyDebtManager() public {
         vm.prank(makeAddr("rando"));
         vm.expectRevert(ICashModule.OnlyDebtManager.selector);
-        cashModule.markUsesAave(address(safe));
+        cashModule.markUsesLendGateway(address(safe));
     }
 
-    function test_migrateToAave_onlyDebtManagerAdmin() public {
+    function test_migrateToLendGateway_onlyDebtManagerAdmin() public {
         _seedAaveLiquidity(usdcReserveId, address(usdc), 5_000_000e6);
         deal(address(weETH), address(safe), 10 ether);
         uint256 borrowAmt = dm.getMaxBorrowAmount(address(safe), true) / 4;
@@ -231,7 +231,7 @@ contract DebtManagerMigrationTest is CashModuleTestSetup, AaveV4Fixture {
 
         vm.prank(makeAddr("notMigrator"));
         vm.expectRevert(UpgradeableProxy.Unauthorized.selector);
-        dm.migrateToAave(address(safe));
+        dm.migrateToLendGateway(address(safe));
     }
 
     function test_migratedSafe_cannotBorrowOrRepayOnDebtManager() public {
@@ -242,22 +242,22 @@ contract DebtManagerMigrationTest is CashModuleTestSetup, AaveV4Fixture {
         debtManager.borrow(BinSponsor.Reap, address(usdc), borrowAmt);
 
         vm.prank(migrator);
-        dm.migrateToAave(address(safe));
-        assertTrue(dm.hasMigratedToAave(address(safe)));
+        dm.migrateToLendGateway(address(safe));
+        assertTrue(dm.hasMigratedToLendGateway(address(safe)));
 
         // Legacy borrow is frozen for a migrated Safe
         vm.prank(address(safe));
-        vm.expectRevert(DebtManagerStorageContract.AlreadyMigratedToAave.selector);
+        vm.expectRevert(DebtManagerStorageContract.AlreadyMigratedToLendGateway.selector);
         debtManager.borrow(BinSponsor.Reap, address(usdc), 1e6);
 
         // Legacy repay is frozen for a migrated Safe
-        vm.expectRevert(DebtManagerStorageContract.AlreadyMigratedToAave.selector);
+        vm.expectRevert(DebtManagerStorageContract.AlreadyMigratedToLendGateway.selector);
         debtManager.repay(address(safe), address(usdc), 1e6);
     }
 
     /// @dev After migration, a credit-mode spend must borrow from Aave (via the gateway), not the frozen
     ///      DebtManager. Regression for: migrated safe passes CashLens (gateway-based) but reverts on spend
-    ///      with AlreadyMigratedToAave because _spendCredit still called DebtManager.borrow.
+    ///      with AlreadyMigratedToLendGateway because _spendCredit still called DebtManager.borrow.
     function test_migratedSafe_creditSpendBorrowsFromAave() public {
         _seedAaveLiquidity(usdcReserveId, address(usdc), 5_000_000e6);
 
@@ -268,8 +268,8 @@ contract DebtManagerMigrationTest is CashModuleTestSetup, AaveV4Fixture {
         debtManager.borrow(BinSponsor.Reap, address(usdc), borrowAmt);
 
         vm.prank(migrator);
-        dm.migrateToAave(address(safe));
-        assertTrue(dm.hasMigratedToAave(address(safe)), "safe migrated");
+        dm.migrateToLendGateway(address(safe));
+        assertTrue(dm.hasMigratedToLendGateway(address(safe)), "safe migrated");
 
         // Enter Credit mode (the gateway is wired to the CashModule in setUp)
         _setMode(Mode.Credit);
@@ -287,7 +287,7 @@ contract DebtManagerMigrationTest is CashModuleTestSetup, AaveV4Fixture {
         amounts[0] = spendUsd;
         Cashback[] memory cashbacks;
 
-        // Must NOT revert with AlreadyMigratedToAave
+        // Must NOT revert with AlreadyMigratedToLendGateway
         vm.prank(etherFiWallet);
         cashModule.spend(address(safe), keccak256("credit-after-migration"), BinSponsor.Reap, tokens, amounts, cashbacks);
 
@@ -309,7 +309,7 @@ contract DebtManagerMigrationTest is CashModuleTestSetup, AaveV4Fixture {
         debtManager.borrow(BinSponsor.Reap, address(usdc), borrowAmt);
 
         vm.prank(migrator);
-        dm.migrateToAave(address(safe));
+        dm.migrateToLendGateway(address(safe));
         uint256 aaveDebtBefore = gw.debtOf(address(safe), address(usdc));
         assertGt(aaveDebtBefore, 0, "has Aave debt");
 
@@ -317,7 +317,7 @@ contract DebtManagerMigrationTest is CashModuleTestSetup, AaveV4Fixture {
         deal(address(usdc), address(safe), 500e6);
         uint256 repayUsd = 200e6;
 
-        // Must NOT revert with AlreadyMigratedToAave, and must surface a gateway-repay event (indexed topics
+        // Must NOT revert with AlreadyMigratedToLendGateway, and must surface a gateway-repay event (indexed topics
         // checked; the exact repaid amount is left to the assertions below)
         vm.expectEmit(true, true, false, false);
         emit CashEventEmitter.Repay(address(safe), address(usdc), 0, 0);
@@ -341,7 +341,7 @@ contract DebtManagerMigrationTest is CashModuleTestSetup, AaveV4Fixture {
         debtManager.borrow(BinSponsor.Reap, address(usdc), borrowAmt);
 
         vm.prank(migrator);
-        dm.migrateToAave(address(safe));
+        dm.migrateToLendGateway(address(safe));
 
         vm.warp(block.timestamp + 30 days);
         uint256 liveDebt = gw.debtOf(address(safe), address(usdc));
@@ -383,7 +383,7 @@ contract DebtManagerMigrationTest is CashModuleTestSetup, AaveV4Fixture {
         assertTrue(ok, reason);
 
         vm.prank(migrator);
-        dm.migrateToAave(address(safe));
+        dm.migrateToLendGateway(address(safe));
 
         Cashback[] memory cashbacks;
         vm.prank(etherFiWallet);
@@ -407,7 +407,7 @@ contract DebtManagerMigrationTest is CashModuleTestSetup, AaveV4Fixture {
         assertTrue(ok, reason);
 
         vm.prank(migrator);
-        dm.migrateToAave(address(safe));
+        dm.migrateToLendGateway(address(safe));
         assertEq(usdc.balanceOf(address(safe)), 0, "migration supplied the loose balance");
 
         address dispatcher = cashModule.getSettlementDispatcher(BinSponsor.Reap);
@@ -421,14 +421,14 @@ contract DebtManagerMigrationTest is CashModuleTestSetup, AaveV4Fixture {
         assertApproxEqAbs(gw.suppliedOf(address(safe), address(usdc)), 50e6, 2, "supplied position reduced");
     }
 
-    /// Gateway-credit declined-side parity: a check declined for borrowing power implies the Aave borrow
+    /// LendGateway-credit declined-side parity: a check declined for borrowing power implies the Aave borrow
     /// reverts (the mock gateway cannot model this; the real Aave instance enforces it).
     function test_migrationBoundary_gatewayCreditDeclined_revertsOnSpend() public {
         _seedAaveLiquidity(usdcReserveId, address(usdc), 5_000_000e6);
         deal(address(weETH), address(safe), 1 ether);
 
         vm.prank(migrator);
-        dm.migrateToAave(address(safe));
+        dm.migrateToLendGateway(address(safe));
 
         _setMode(Mode.Credit);
         vm.warp(cashModule.incomingModeStartTime(address(safe)) + 1);

--- a/test/lend-gateway/LendGatewayAaveV4.t.sol
+++ b/test/lend-gateway/LendGatewayAaveV4.t.sol
@@ -5,8 +5,8 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import { UUPSProxy } from "../../src/UUPSProxy.sol";
 import { IAggregatorV3 } from "../../src/interfaces/IAggregatorV3.sol";
-import { IGateway } from "../../src/interfaces/IGateway.sol";
-import { Gateway } from "../../src/modules/gateway/Gateway.sol";
+import { ILendGateway } from "../../src/interfaces/ILendGateway.sol";
+import { LendGateway } from "../../src/modules/lend-gateway/LendGateway.sol";
 import { ChainlinkCompositePriceFeed } from "../../src/oracle/ChainlinkCompositePriceFeed.sol";
 import { UpgradeableProxy } from "../../src/utils/UpgradeableProxy.sol";
 import { CashModuleTestSetup } from "../safe/modules/cash/CashModuleTestSetup.t.sol";
@@ -15,14 +15,14 @@ import { ISpoke } from "aave-v4/spoke/interfaces/ISpoke.sol";
 import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
 
 /**
- * @title GatewayAaveV4Test
- * @notice End-to-end Gateway tests against a REAL Aave v4 instance deployed inside the test on an Optimism
+ * @title LendGatewayAaveV4Test
+ * @notice End-to-end LendGateway tests against a REAL Aave v4 instance deployed inside the test on an Optimism
  *         fork, driven by the REAL ether.fi stack (EtherFiSafe, EtherFiDataProvider, RoleRegistry,
  *         PriceProvider) — no mocks. Aave reserves are priced by live Optimism Chainlink feeds.
- * @dev Run with: source .env && FOUNDRY_PROFILE=aave TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test --match-path test/gateway/GatewayAaveV4.t.sol
+ * @dev Run with: source .env && FOUNDRY_PROFILE=aave TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test --match-path test/lend-gateway/LendGatewayAaveV4.t.sol
  */
-contract GatewayAaveV4Test is CashModuleTestSetup, AaveV4Fixture {
-    Gateway internal gw;
+contract LendGatewayAaveV4Test is CashModuleTestSetup, AaveV4Fixture {
+    LendGateway internal gw;
     address internal driver = makeAddr("gwDriver");
     address internal recipient = makeAddr("gwRecipient");
 
@@ -46,20 +46,20 @@ contract GatewayAaveV4Test is CashModuleTestSetup, AaveV4Fixture {
         // Seed borrowable USDC liquidity into the hub
         _seedAaveLiquidity(usdcReserveId, address(usdc), 1_000_000e6);
 
-        // 3. Deploy the Gateway proxy pointing at the fresh spoke
-        address gwImpl = address(new Gateway(address(dataProvider), address(spoke)));
-        gw = Gateway(address(new UUPSProxy(gwImpl, abi.encodeWithSelector(Gateway.initialize.selector, address(roleRegistry)))));
+        // 3. Deploy the LendGateway proxy pointing at the fresh spoke
+        address gwImpl = address(new LendGateway(address(dataProvider), address(spoke)));
+        gw = LendGateway(address(new UUPSProxy(gwImpl, abi.encodeWithSelector(LendGateway.initialize.selector, address(roleRegistry)))));
 
-        // 4. Wire the Gateway: roles, reserve registry, driver, whitelist as a module
+        // 4. Wire the LendGateway: roles, reserve registry, driver, whitelist as a module
         vm.startPrank(owner);
-        roleRegistry.grantRole(gw.GATEWAY_ADMIN_ROLE(), owner);
+        roleRegistry.grantRole(gw.LEND_GATEWAY_ADMIN_ROLE(), owner);
         dataProvider.configureModules(_addr1(address(gw)), _bool1(true));
         gw.setReserveId(address(weETH), weethReserveId);
         gw.setReserveId(address(usdc), usdcReserveId);
         gw.setDriver(driver, true);
         vm.stopPrank();
 
-        // Enable the Gateway as a module on the safe (owner-signed) and activate it as an Aave position manager
+        // Enable the LendGateway as a module on the safe (owner-signed) and activate it as an Aave position manager
         _enableModule(address(gw));
         _activateAavePositionManager(address(gw));
     }
@@ -73,12 +73,12 @@ contract GatewayAaveV4Test is CashModuleTestSetup, AaveV4Fixture {
 
         // A reserveId whose underlying != the asset is rejected
         vm.prank(owner);
-        vm.expectRevert(Gateway.ReserveAssetMismatch.selector);
+        vm.expectRevert(LendGateway.ReserveAssetMismatch.selector);
         gw.setReserveId(address(weETH), usdcReserveId);
     }
 
     function test_reads_ltvAndLiquidity() public view {
-        // 80_00 bps -> 80e18 in IGateway's 100e18 scale
+        // 80_00 bps -> 80e18 in ILendGateway's 100e18 scale
         assertEq(gw.ltv(address(usdc)), 80e18);
         assertEq(gw.ltv(address(weETH)), 80e18);
         // Seeded liquidity is withdrawable/borrowable cash
@@ -86,7 +86,7 @@ contract GatewayAaveV4Test is CashModuleTestSetup, AaveV4Fixture {
     }
 
     function test_getAccountData_freshSafeIsEmptyAndHealthy() public view {
-        IGateway.AccountData memory data = gw.getAccountData(address(safe));
+        ILendGateway.AccountData memory data = gw.getAccountData(address(safe));
         assertEq(data.collateralUsd, 0);
         assertEq(data.debtUsd, 0);
         assertEq(data.availableBorrowsUsd, 0);
@@ -124,7 +124,7 @@ contract GatewayAaveV4Test is CashModuleTestSetup, AaveV4Fixture {
         assertEq(usdc.balanceOf(recipient), 1000e6, "recipient receives borrow");
         assertApproxEqAbs(gw.debtOf(address(safe), address(usdc)), 1000e6, 2, "debt recorded");
 
-        IGateway.AccountData memory data = gw.getAccountData(address(safe));
+        ILendGateway.AccountData memory data = gw.getAccountData(address(safe));
         assertGt(data.collateralUsd, 0, "collateral valued");
         assertApproxEqAbs(data.debtUsd, 1000e6, 1e6, "debt in USD");
         assertGt(data.availableBorrowsUsd, 0, "headroom remains");
@@ -169,7 +169,7 @@ contract GatewayAaveV4Test is CashModuleTestSetup, AaveV4Fixture {
     function test_onlyDriverCanOperate() public {
         deal(address(weETH), address(safe), 1 ether);
         vm.prank(makeAddr("notADriver"));
-        vm.expectRevert(Gateway.OnlyDriver.selector);
+        vm.expectRevert(LendGateway.OnlyDriver.selector);
         gw.supply(address(safe), address(weETH), 1 ether);
     }
 
@@ -189,7 +189,7 @@ contract GatewayAaveV4Test is CashModuleTestSetup, AaveV4Fixture {
 
     function test_setReserveId_rejectsZeroAsset() public {
         vm.prank(owner);
-        vm.expectRevert(Gateway.ZeroAddress.selector);
+        vm.expectRevert(LendGateway.ZeroAddress.selector);
         gw.setReserveId(address(0), 0);
     }
 
@@ -203,14 +203,14 @@ contract GatewayAaveV4Test is CashModuleTestSetup, AaveV4Fixture {
         assertEq(gw.suppliedOf(address(safe), address(usdc)), 0);
         assertEq(gw.debtOf(address(safe), address(usdc)), 0);
 
-        vm.expectRevert(abi.encodeWithSelector(Gateway.AssetNotRegistered.selector, address(usdc)));
+        vm.expectRevert(abi.encodeWithSelector(LendGateway.AssetNotRegistered.selector, address(usdc)));
         gw.reserveIdOf(address(usdc));
     }
 
     function test_removeReserve_guards() public {
         address never = makeAddr("neverRegistered");
         vm.prank(owner);
-        vm.expectRevert(abi.encodeWithSelector(Gateway.AssetNotRegistered.selector, never));
+        vm.expectRevert(abi.encodeWithSelector(LendGateway.AssetNotRegistered.selector, never));
         gw.removeReserve(never);
 
         vm.prank(makeAddr("notAdmin"));
@@ -226,12 +226,12 @@ contract GatewayAaveV4Test is CashModuleTestSetup, AaveV4Fixture {
         gw.setDriver(driver, false);
         deal(address(weETH), address(safe), 1 ether);
         vm.prank(driver);
-        vm.expectRevert(Gateway.OnlyDriver.selector);
+        vm.expectRevert(LendGateway.OnlyDriver.selector);
         gw.supply(address(safe), address(weETH), 1 ether);
 
         // Zero address and role gating
         vm.prank(owner);
-        vm.expectRevert(Gateway.ZeroAddress.selector);
+        vm.expectRevert(LendGateway.ZeroAddress.selector);
         gw.setDriver(address(0), true);
 
         vm.prank(makeAddr("notAdmin"));
@@ -243,20 +243,20 @@ contract GatewayAaveV4Test is CashModuleTestSetup, AaveV4Fixture {
 
     function test_mutatingOps_onlyDriver() public {
         vm.startPrank(makeAddr("notADriver"));
-        vm.expectRevert(Gateway.OnlyDriver.selector);
+        vm.expectRevert(LendGateway.OnlyDriver.selector);
         gw.withdraw(address(safe), address(weETH), 1, recipient);
-        vm.expectRevert(Gateway.OnlyDriver.selector);
+        vm.expectRevert(LendGateway.OnlyDriver.selector);
         gw.borrow(address(safe), address(usdc), 1, recipient);
-        vm.expectRevert(Gateway.OnlyDriver.selector);
+        vm.expectRevert(LendGateway.OnlyDriver.selector);
         gw.repay(address(safe), address(usdc), 1);
-        vm.expectRevert(Gateway.OnlyDriver.selector);
+        vm.expectRevert(LendGateway.OnlyDriver.selector);
         gw.setUsingAsCollateral(address(safe), address(weETH), true);
         vm.stopPrank();
     }
 
     function test_mutatingOps_revertOnUnregisteredAsset() public {
         address unreg = makeAddr("unregisteredAsset");
-        bytes memory notRegistered = abi.encodeWithSelector(Gateway.AssetNotRegistered.selector, unreg);
+        bytes memory notRegistered = abi.encodeWithSelector(LendGateway.AssetNotRegistered.selector, unreg);
         vm.startPrank(driver);
         vm.expectRevert(notRegistered);
         gw.supply(address(safe), unreg, 1e18);
@@ -273,18 +273,18 @@ contract GatewayAaveV4Test is CashModuleTestSetup, AaveV4Fixture {
 
     function test_ops_revertOnZeroAmountAndRecipient() public {
         vm.startPrank(driver);
-        vm.expectRevert(Gateway.ZeroAmount.selector);
+        vm.expectRevert(LendGateway.ZeroAmount.selector);
         gw.supply(address(safe), address(weETH), 0);
-        vm.expectRevert(Gateway.ZeroAmount.selector);
+        vm.expectRevert(LendGateway.ZeroAmount.selector);
         gw.withdraw(address(safe), address(weETH), 0, recipient);
-        vm.expectRevert(Gateway.ZeroAmount.selector);
+        vm.expectRevert(LendGateway.ZeroAmount.selector);
         gw.borrow(address(safe), address(usdc), 0, recipient);
-        vm.expectRevert(Gateway.ZeroAddress.selector);
+        vm.expectRevert(LendGateway.ZeroAddress.selector);
         gw.withdraw(address(safe), address(weETH), 1, address(0));
-        vm.expectRevert(Gateway.ZeroAddress.selector);
+        vm.expectRevert(LendGateway.ZeroAddress.selector);
         gw.borrow(address(safe), address(usdc), 1, address(0));
         // repay(max) with no debt resolves to a zero pull amount
-        vm.expectRevert(Gateway.ZeroAmount.selector);
+        vm.expectRevert(LendGateway.ZeroAmount.selector);
         gw.repay(address(safe), address(usdc), type(uint256).max);
         vm.stopPrank();
     }
@@ -357,8 +357,8 @@ contract GatewayAaveV4Test is CashModuleTestSetup, AaveV4Fixture {
     }
 
     function test_constructor_revertsOnZeroSpoke() public {
-        vm.expectRevert(Gateway.ZeroAddress.selector);
-        new Gateway(address(dataProvider), address(0));
+        vm.expectRevert(LendGateway.ZeroAddress.selector);
+        new LendGateway(address(dataProvider), address(0));
     }
 
     // ----------------------------------------------------------------- proof the deployed Aave pool is live
@@ -438,7 +438,7 @@ contract GatewayAaveV4Test is CashModuleTestSetup, AaveV4Fixture {
         gw.setUsingAsCollateral(address(safe), address(weETH), false);
         vm.stopPrank();
 
-        IGateway.AccountData memory data = gw.getAccountData(address(safe));
+        ILendGateway.AccountData memory data = gw.getAccountData(address(safe));
         assertGt(data.collateralUsd, 0, "supplied value counted as collateralUsd");
         assertEq(data.availableBorrowsUsd, 0, "no borrow power without collateral enabled");
         assertEq(data.debtUsd, 0);

--- a/test/lend-gateway/LendGatewayInvariant.t.sol
+++ b/test/lend-gateway/LendGatewayInvariant.t.sol
@@ -6,20 +6,20 @@ import { Test } from "forge-std/Test.sol";
 
 import { UUPSProxy } from "../../src/UUPSProxy.sol";
 import { IAggregatorV3 } from "../../src/interfaces/IAggregatorV3.sol";
-import { Gateway } from "../../src/modules/gateway/Gateway.sol";
+import { LendGateway } from "../../src/modules/lend-gateway/LendGateway.sol";
 import { ChainlinkCompositePriceFeed } from "../../src/oracle/ChainlinkCompositePriceFeed.sol";
 import { CashModuleTestSetup } from "../safe/modules/cash/CashModuleTestSetup.t.sol";
 import { AaveV4Fixture } from "./helpers/AaveV4Fixture.sol";
 
 /**
- * @title GatewayHandler
- * @notice Drives random sequences of Gateway ops (as an authorized driver) for the invariant campaign.
+ * @title LendGatewayHandler
+ * @notice Drives random sequences of LendGateway ops (as an authorized driver) for the invariant campaign.
  *         Amounts are bounded to mostly succeed so the campaign exercises real Aave state transitions;
  *         residual reverts (e.g. a withdraw that would breach health) are tolerated (fail_on_revert=false).
- * @dev Run with: source .env && FOUNDRY_PROFILE=aave TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test --match-path "test/gateway/GatewayInvariant.t.sol"
+ * @dev Run with: source .env && FOUNDRY_PROFILE=aave TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test --match-path "test/lend-gateway/LendGatewayInvariant.t.sol"
  */
-contract GatewayHandler is Test {
-    Gateway internal immutable gw;
+contract LendGatewayHandler is Test {
+    LendGateway internal immutable gw;
     address internal immutable safe;
     address internal immutable recipient;
     IERC20 internal immutable weeth;
@@ -28,7 +28,7 @@ contract GatewayHandler is Test {
     /// @notice Count of fully-successful gateway ops (guards against a hollow, all-reverting campaign)
     uint256 public opsExecuted;
 
-    constructor(Gateway _gw, address _safe, address _recipient, IERC20 _weeth, IERC20 _usdc) {
+    constructor(LendGateway _gw, address _safe, address _recipient, IERC20 _weeth, IERC20 _usdc) {
         gw = _gw;
         safe = _safe;
         recipient = _recipient;
@@ -72,14 +72,14 @@ contract GatewayHandler is Test {
 }
 
 /**
- * @title GatewayInvariantTest
+ * @title LendGatewayInvariantTest
  * @notice Invariant: after any sequence of gateway operations the gateway holds no tokens — its custody
  *         flow (pull-from-safe -> supply, withdraw/borrow -> forward, repay -> refund dust) must never
  *         strand user funds in the gateway. Runs against a real Aave v4 instance on an Optimism fork.
  */
-contract GatewayInvariantTest is CashModuleTestSetup, AaveV4Fixture {
-    Gateway internal gw;
-    GatewayHandler internal handler;
+contract LendGatewayInvariantTest is CashModuleTestSetup, AaveV4Fixture {
+    LendGateway internal gw;
+    LendGatewayHandler internal handler;
     address internal recipient = makeAddr("invariantRecipient");
     uint256 internal usdcReserveId;
     uint256 internal weethReserveId;
@@ -93,13 +93,13 @@ contract GatewayInvariantTest is CashModuleTestSetup, AaveV4Fixture {
         usdcReserveId = _addAaveReserve(address(usdc), usdcUsdOracle, 8000, true);
         _seedAaveLiquidity(usdcReserveId, address(usdc), 5_000_000e6);
 
-        address gwImpl = address(new Gateway(address(dataProvider), address(spoke)));
-        gw = Gateway(address(new UUPSProxy(gwImpl, abi.encodeWithSelector(Gateway.initialize.selector, address(roleRegistry)))));
+        address gwImpl = address(new LendGateway(address(dataProvider), address(spoke)));
+        gw = LendGateway(address(new UUPSProxy(gwImpl, abi.encodeWithSelector(LendGateway.initialize.selector, address(roleRegistry)))));
 
-        handler = new GatewayHandler(gw, address(safe), recipient, weETH, usdc);
+        handler = new LendGatewayHandler(gw, address(safe), recipient, weETH, usdc);
 
         vm.startPrank(owner);
-        roleRegistry.grantRole(gw.GATEWAY_ADMIN_ROLE(), owner);
+        roleRegistry.grantRole(gw.LEND_GATEWAY_ADMIN_ROLE(), owner);
         dataProvider.configureModules(_addr1(address(gw)), _bool1(true));
         gw.setReserveId(address(weETH), weethReserveId);
         gw.setReserveId(address(usdc), usdcReserveId);

--- a/test/lend-gateway/helpers/AaveV4Fixture.sol
+++ b/test/lend-gateway/helpers/AaveV4Fixture.sol
@@ -28,7 +28,7 @@ interface IProxyInit {
 /**
  * @title AaveV4Fixture
  * @notice Deploys a real, self-owned Aave v4 instance inside a Foundry test (works on any fork), so the
- *         Gateway can be exercised against genuine Aave v4 code rather than a mock. This test contract
+ *         LendGateway can be exercised against genuine Aave v4 code rather than a mock. This test contract
  *         holds every admin role, so it can list reserves, set collateral factors, and activate position
  *         managers freely. Mirrors aave-v4 v0.5.11 `tests/Base.t.sol` deployFixtures/setUpRoles.
  * @dev The Hub/Spoke instances are compiled via_ir (foundry.toml compilation_restrictions) and their

--- a/test/safe/SafeTestSetup.t.sol
+++ b/test/safe/SafeTestSetup.t.sol
@@ -31,7 +31,7 @@ import { DebtManagerAdmin } from "../../src/debt-manager/DebtManagerAdmin.sol";
 import { CashbackDispatcher } from "../../src/cashback-dispatcher/CashbackDispatcher.sol";
 import { PriceProvider, IAggregatorV3 } from "../../src/oracle/PriceProvider.sol";
 import { SettlementDispatcherV2 } from "../../src/settlement-dispatcher/SettlementDispatcherV2.sol";
-import { MockGateway } from "../../src/mocks/MockGateway.sol";
+import { MockLendGateway } from "../../src/mocks/MockLendGateway.sol";
 import { Utils, ChainConfig } from "../utils/Utils.sol";
 
 contract SafeTestSetup is Utils {
@@ -47,7 +47,7 @@ contract SafeTestSetup is Utils {
     SettlementDispatcherV2 settlementDispatcherRain;
     SettlementDispatcherV2 settlementDispatcherReap;
     IDebtManager debtManager;
-    MockGateway gateway;
+    MockLendGateway gateway;
     address debtManagerAdminImpl;
     CashbackDispatcher cashbackDispatcher;
     ICashEventEmitter cashEventEmitter;
@@ -179,7 +179,7 @@ contract SafeTestSetup is Utils {
         address hookImpl = address(new EtherFiHook(address(dataProvider)));
         hook = EtherFiHook(address(new UUPSProxy(hookImpl, abi.encodeWithSelector(EtherFiHook.initialize.selector, address(roleRegistry)))));
 
-        gateway = new MockGateway();
+        gateway = new MockLendGateway();
         address cashLensImpl = address(new CashLens(address(cashModule), address(dataProvider)));
         cashLens = CashLens(address(new UUPSProxy(cashLensImpl, abi.encodeWithSelector(CashLens.initialize.selector, address(roleRegistry)))));
 
@@ -227,7 +227,7 @@ contract SafeTestSetup is Utils {
     /// @dev Wires the one-time gateway during setup. The gateway is set once and never repointed, so an Aave
     ///      suite that needs the real gateway overrides this to a no-op and sets it after deploying Aave.
     function _wireDefaultGateway() internal virtual {
-        cashModule.setGateway(address(gateway));
+        cashModule.setLendGateway(address(gateway));
     }
 
     function _setupWithdrawTokenWhitelist() internal {

--- a/test/safe/modules/ModuleGatewaySandwich.t.sol
+++ b/test/safe/modules/ModuleGatewaySandwich.t.sol
@@ -3,8 +3,8 @@ pragma solidity ^0.8.28;
 
 import { Test } from "forge-std/Test.sol";
 
-import { IGateway } from "../../../src/interfaces/IGateway.sol";
-import { MockGateway } from "../../../src/mocks/MockGateway.sol";
+import { ILendGateway } from "../../../src/interfaces/ILendGateway.sol";
+import { MockLendGateway } from "../../../src/mocks/MockLendGateway.sol";
 import { ModuleGatewaySandwich } from "../../../src/modules/ModuleGatewaySandwich.sol";
 
 /// @notice Exposes the base's internal bookends so they can be called directly in tests
@@ -27,7 +27,7 @@ contract SandwichHarness is ModuleGatewaySandwich {
 }
 
 contract ModuleGatewaySandwichTest is Test {
-    MockGateway gateway;
+    MockLendGateway gateway;
     SandwichHarness harness;
 
     uint256 constant MIN_HEALTH_FACTOR = 1e18;
@@ -36,12 +36,12 @@ contract ModuleGatewaySandwichTest is Test {
     address asset = makeAddr("asset");
 
     function setUp() public {
-        gateway = new MockGateway();
+        gateway = new MockLendGateway();
         harness = new SandwichHarness(address(gateway), MIN_HEALTH_FACTOR);
     }
 
     function _setHealthFactor(uint256 healthFactor) internal {
-        gateway.setAccountData(safe, IGateway.AccountData({ collateralUsd: 0, debtUsd: 0, availableBorrowsUsd: 0, healthFactor: healthFactor }));
+        gateway.setAccountData(safe, ILendGateway.AccountData({ collateralUsd: 0, debtUsd: 0, availableBorrowsUsd: 0, healthFactor: healthFactor }));
     }
 
     // A zero gateway address is rejected at deployment.

--- a/test/safe/modules/cash/CashLens.t.sol
+++ b/test/safe/modules/cash/CashLens.t.sol
@@ -7,7 +7,7 @@ import { IERC20Metadata } from "@openzeppelin/contracts/interfaces/IERC20Metadat
 
 import { Mode, SafeCashData, BinSponsor, SafeData, Cashback, CashbackTokens } from "../../../../src/interfaces/ICashModule.sol";
 import { IEtherFiSafeFactory } from "../../../../src/interfaces/IEtherFiSafeFactory.sol";
-import { IGateway } from "../../../../src/interfaces/IGateway.sol";
+import { ILendGateway } from "../../../../src/interfaces/ILendGateway.sol";
 import { CashLens } from "../../../../src/modules/cash/CashLens.sol";
 import { IDebtManager } from "../../../../src/interfaces/IDebtManager.sol";
 import { CashModuleTestSetup } from "./CashModuleTestSetup.t.sol";
@@ -227,9 +227,9 @@ contract CashLensTest is CashModuleTestSetup {
         // Mirror the current position (collateral only; no real borrow was executed, so debt is 0).
         _mirrorPositionToGateway(address(safe));
         // Layer a fabricated borrow on top for CashLens to read.
-        IGateway.AccountData memory account = gateway.getAccountData(address(safe));
+        ILendGateway.AccountData memory account = gateway.getAccountData(address(safe));
         gateway.setDebtOf(address(safe), address(usdc), spendAmount);
-        gateway.setAccountData(address(safe), IGateway.AccountData({
+        gateway.setAccountData(address(safe), ILendGateway.AccountData({
             collateralUsd: account.collateralUsd,
             debtUsd: spendAmount,
             availableBorrowsUsd: account.availableBorrowsUsd > spendAmount ? account.availableBorrowsUsd - spendAmount : 0,

--- a/test/safe/modules/cash/CashLensMaxSpend.t.sol
+++ b/test/safe/modules/cash/CashLensMaxSpend.t.sol
@@ -8,7 +8,7 @@ import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/Mes
 import { BinSponsor, Cashback, CashbackTokens, DebitModeMaxSpend, Mode, SafeCashData, SafeData } from "../../../../src/interfaces/ICashModule.sol";
 import { IDebtManager } from "../../../../src/interfaces/IDebtManager.sol";
 import { IEtherFiSafeFactory } from "../../../../src/interfaces/IEtherFiSafeFactory.sol";
-import { IGateway } from "../../../../src/interfaces/IGateway.sol";
+import { ILendGateway } from "../../../../src/interfaces/ILendGateway.sol";
 import { AccountantWithRateProviders, ILayerZeroTeller } from "../../../../src/interfaces/ILayerZeroTeller.sol";
 import { ArrayDeDupLib } from "../../../../src/libraries/ArrayDeDupLib.sol";
 import { SpendingLimit } from "../../../../src/libraries/SpendingLimitLib.sol";
@@ -143,7 +143,7 @@ contract CashLensMaxSpendTest is CashModuleTestSetup {
     /// @notice Sets the gateway account aggregate, deriving availableBorrowsUsd = collateralUsd x ltv - debtUsd (floored at 0). CashLens does not read healthFactor.
     function _setGatewayAccount(uint256 collateralUsd, uint256 debtUsd, uint256 ltv) internal {
         uint256 maxBorrowUsd = (collateralUsd * ltv) / HUNDRED_PERCENT;
-        gateway.setAccountData(address(safe), IGateway.AccountData({ collateralUsd: collateralUsd, debtUsd: debtUsd, availableBorrowsUsd: maxBorrowUsd > debtUsd ? maxBorrowUsd - debtUsd : 0, healthFactor: 1e18 }));
+        gateway.setAccountData(address(safe), ILendGateway.AccountData({ collateralUsd: collateralUsd, debtUsd: debtUsd, availableBorrowsUsd: maxBorrowUsd > debtUsd ? maxBorrowUsd - debtUsd : 0, healthFactor: 1e18 }));
     }
 
     /// @notice Sets a gateway debt position: both stables supplied with ample reserve cash, a uniform LTV, a debt, and zero raw safe balance. The borrowing headroom is derived as collateral x LTV - debt (stables valued at $1)
@@ -587,7 +587,7 @@ contract CashLensMaxSpendTest is CashModuleTestSetup {
         gateway.setAvailableCash(address(liquidUsd), type(uint128).max);
         gateway.setLtv(address(usdc), 50e18);
         gateway.setLtv(address(liquidUsd), 50e18);
-        gateway.setAccountData(address(safe), IGateway.AccountData({ collateralUsd: 1200e6, debtUsd: 500e6, availableBorrowsUsd: 100e6, healthFactor: 144e16 }));
+        gateway.setAccountData(address(safe), ILendGateway.AccountData({ collateralUsd: 1200e6, debtUsd: 500e6, availableBorrowsUsd: 100e6, healthFactor: 144e16 }));
 
         address[] memory withdrawTokens = new address[](1);
         withdrawTokens[0] = address(usdc);
@@ -642,7 +642,7 @@ contract CashLensMaxSpendTest is CashModuleTestSetup {
         gateway.setAvailableCash(address(liquidUsd), type(uint128).max);
         gateway.setLtv(address(usdc), 80e18);
         gateway.setLtv(address(liquidUsd), 50e18);
-        gateway.setAccountData(address(safe), IGateway.AccountData({ collateralUsd: 2200e6, debtUsd: 700e6, availableBorrowsUsd: 460e6, healthFactor: 1e18 }));
+        gateway.setAccountData(address(safe), ILendGateway.AccountData({ collateralUsd: 2200e6, debtUsd: 700e6, availableBorrowsUsd: 460e6, healthFactor: 1e18 }));
 
         address[] memory tokenPreference = new address[](2);
         tokenPreference[0] = address(usdc);
@@ -672,7 +672,7 @@ contract CashLensMaxSpendTest is CashModuleTestSetup {
         gateway.setAvailableCash(address(liquidUsd), type(uint128).max);
         gateway.setLtv(address(usdc), 90e18);
         gateway.setLtv(address(liquidUsd), 90e18);
-        gateway.setAccountData(address(safe), IGateway.AccountData({ collateralUsd: 13_340e6, debtUsd: 4000e6, availableBorrowsUsd: 7406e6, healthFactor: 1e18 }));
+        gateway.setAccountData(address(safe), ILendGateway.AccountData({ collateralUsd: 13_340e6, debtUsd: 4000e6, availableBorrowsUsd: 7406e6, healthFactor: 1e18 }));
 
         address[] memory tokenPreference = new address[](2);
         tokenPreference[0] = address(usdc);

--- a/test/safe/modules/cash/CashModuleTestSetup.t.sol
+++ b/test/safe/modules/cash/CashModuleTestSetup.t.sol
@@ -13,7 +13,7 @@ import { DebtManagerCore, DebtManagerStorageContract } from "../../../../src/deb
 import { ICashModule } from "../../../../src/interfaces/ICashModule.sol";
 import { Cashback, CashbackTokens, Mode, SafeTiers } from "../../../../src/interfaces/ICashModule.sol";
 import { IDebtManager } from "../../../../src/interfaces/IDebtManager.sol";
-import { IGateway } from "../../../../src/interfaces/IGateway.sol";
+import { ILendGateway } from "../../../../src/interfaces/ILendGateway.sol";
 import { IPriceProvider } from "../../../../src/interfaces/IPriceProvider.sol";
 import { CashVerificationLib } from "../../../../src/libraries/CashVerificationLib.sol";
 import { SpendingLimit } from "../../../../src/libraries/SpendingLimitLib.sol";
@@ -160,12 +160,12 @@ contract CashModuleTestSetup is SafeTestSetup {
     /**
      * @notice Flips a safe back to the legacy DebtManager engine, modeling a safe that predates the gateway
      *         (new safes onboard onto the Aave gateway in setupModule).
-     * @dev Writes the packed usesAave flag via stdstore, then asserts through the public getter so any
+     * @dev Writes the packed usesLendGateway flag via stdstore, then asserts through the public getter so any
      *      storage-layout drift fails loudly here instead of silently testing the wrong engine.
      */
     function _forceLegacyEngine(address _safe) internal {
-        stdstore.enable_packed_slots().target(address(cashModule)).sig(ICashModule.usesAave.selector).with_key(_safe).checked_write(false);
-        assertFalse(cashModule.usesAave(_safe), "forceLegacyEngine: flag still set");
+        stdstore.enable_packed_slots().target(address(cashModule)).sig(ICashModule.usesLendGateway.selector).with_key(_safe).checked_write(false);
+        assertFalse(cashModule.usesLendGateway(_safe), "forceLegacyEngine: flag still set");
     }
 
     /**
@@ -206,6 +206,6 @@ contract CashModuleTestSetup is SafeTestSetup {
             gateway.setAvailableCash(borrowTokens[i], type(uint128).max);
         }
 
-        gateway.setAccountData(_safe, IGateway.AccountData({ collateralUsd: totalCollateralUsd, debtUsd: totalBorrowUsd, availableBorrowsUsd: maxBorrowUsd > totalBorrowUsd ? maxBorrowUsd - totalBorrowUsd : 0, healthFactor: type(uint256).max }));
+        gateway.setAccountData(_safe, ILendGateway.AccountData({ collateralUsd: totalCollateralUsd, debtUsd: totalBorrowUsd, availableBorrowsUsd: maxBorrowUsd > totalBorrowUsd ? maxBorrowUsd - totalBorrowUsd : 0, healthFactor: type(uint256).max }));
     }
 }

--- a/test/safe/modules/cash/EngineParity.t.sol
+++ b/test/safe/modules/cash/EngineParity.t.sol
@@ -5,7 +5,7 @@ import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
 
 import { BinSponsor, Cashback, ICashModule, Mode } from "../../../../src/interfaces/ICashModule.sol";
 import { IDebtManager } from "../../../../src/interfaces/IDebtManager.sol";
-import { IGateway } from "../../../../src/interfaces/IGateway.sol";
+import { ILendGateway } from "../../../../src/interfaces/ILendGateway.sol";
 import { EtherFiSafeErrors } from "../../../../src/safe/EtherFiSafeErrors.sol";
 import { CashModuleTestSetup } from "./CashModuleTestSetup.t.sol";
 
@@ -15,8 +15,8 @@ import { CashModuleTestSetup } from "./CashModuleTestSetup.t.sol";
  *         (mode x engine) cell: an approved check implies the spend lands, and a declined check implies the
  *         spend reverts with the matching error. These are the two on-chain halves of a card auth, so drift
  *         between them declines good taps or, worse, lands taps the check already rejected.
- * @dev Gateway-credit declined-side parity (borrow power) is enforced by Aave itself, which the mock gateway
- *      cannot model; it runs in the fork suite (test/gateway/DebtManagerMigration.t.sol) instead.
+ * @dev LendGateway-credit declined-side parity (borrow power) is enforced by Aave itself, which the mock gateway
+ *      cannot model; it runs in the fork suite (test/lend-gateway/DebtManagerMigration.t.sol) instead.
  */
 contract EngineParityTest is CashModuleTestSetup {
     Cashback[] internal noCashback;
@@ -104,12 +104,12 @@ contract EngineParityTest is CashModuleTestSetup {
 
     // ----------------------------------------------------------------- gateway engine
 
-    /// Gateway debit: an approved check withdraws the shortfall from Aave and lands; an over-balance check reverts.
+    /// LendGateway debit: an approved check withdraws the shortfall from Aave and lands; an over-balance check reverts.
     function test_parity_gatewayDebit() public {
         deal(address(usdc), address(safe), 30e6);
         gateway.setSuppliedOf(address(safe), address(usdc), 50e6);
         gateway.setAvailableCash(address(usdc), type(uint128).max);
-        gateway.setAccountData(address(safe), IGateway.AccountData({ collateralUsd: 50e6, debtUsd: 0, availableBorrowsUsd: 40e6, healthFactor: type(uint256).max }));
+        gateway.setAccountData(address(safe), ILendGateway.AccountData({ collateralUsd: 50e6, debtUsd: 0, availableBorrowsUsd: 40e6, healthFactor: type(uint256).max }));
 
         // Loose (30) + supplied (50) cover the spend; the shortfall is withdrawn from Aave
         (bool ok, string memory reason) = _canSpend(keccak256("gd1"), address(usdc), 60e6);
@@ -130,12 +130,12 @@ contract EngineParityTest is CashModuleTestSetup {
         _spend(keccak256("gd2"), address(usdc), 100e6);
     }
 
-    /// Gateway credit: an approved check borrows on the gateway and lands; one beyond borrow power is declined.
+    /// LendGateway credit: an approved check borrows on the gateway and lands; one beyond borrow power is declined.
     function test_parity_gatewayCredit_approvedLands() public {
         _setMode(Mode.Credit);
         vm.warp(cashModule.incomingModeStartTime(address(safe)) + 1);
         gateway.setAvailableCash(address(usdc), type(uint128).max);
-        gateway.setAccountData(address(safe), IGateway.AccountData({ collateralUsd: 1000e6, debtUsd: 0, availableBorrowsUsd: 500e6, healthFactor: type(uint256).max }));
+        gateway.setAccountData(address(safe), ILendGateway.AccountData({ collateralUsd: 1000e6, debtUsd: 0, availableBorrowsUsd: 500e6, healthFactor: type(uint256).max }));
 
         (bool ok, string memory reason) = _canSpend(keccak256("gc1"), address(usdc), 100e6);
         assertTrue(ok, reason);

--- a/test/safe/modules/cash/MultiSpend.t.sol
+++ b/test/safe/modules/cash/MultiSpend.t.sol
@@ -9,7 +9,7 @@ import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
 import { UUPSProxy } from "../../../../src/UUPSProxy.sol";
 import { ICashModule, Mode, BinSponsor, Cashback, CashbackTokens } from "../../../../src/interfaces/ICashModule.sol";
 import { IDebtManager } from "../../../../src/interfaces/IDebtManager.sol";
-import { IGateway } from "../../../../src/interfaces/IGateway.sol";
+import { ILendGateway } from "../../../../src/interfaces/ILendGateway.sol";
 import { SpendingLimitLib } from "../../../../src/libraries/SpendingLimitLib.sol";
 import { CashEventEmitter, CashModuleTestSetup } from "./CashModuleTestSetup.t.sol";
 import { UpgradeableProxy } from "../../../../src/utils/UpgradeableProxy.sol";
@@ -637,7 +637,7 @@ contract CashModuleMultiSpendTest is CashModuleTestSetup {
         gateway.setAvailableCash(address(weETH), type(uint128).max);
 
         // Safe carries debt with ample borrowing headroom, so the weETH withdrawal is allowed.
-        gateway.setAccountData(address(safe), IGateway.AccountData({ collateralUsd: 500e6, debtUsd: 100e6, availableBorrowsUsd: 100e6, healthFactor: 1e18 }));
+        gateway.setAccountData(address(safe), ILendGateway.AccountData({ collateralUsd: 500e6, debtUsd: 100e6, availableBorrowsUsd: 100e6, healthFactor: 1e18 }));
 
         uint256 dispatcherUsdcBefore = usdc.balanceOf(address(settlementDispatcherReap));
         uint256 dispatcherWeETHBefore = weETH.balanceOf(address(settlementDispatcherReap));
@@ -688,7 +688,7 @@ contract CashModuleMultiSpendTest is CashModuleTestSetup {
 
         // $40 headroom at 80% LTV funds $50 of withdrawals in total. usdc's $30 draw spends $24 of it, leaving
         // room for only $20 of weETH, short of its $30 draw.
-        gateway.setAccountData(address(safe), IGateway.AccountData({ collateralUsd: 500e6, debtUsd: 100e6, availableBorrowsUsd: 40e6, healthFactor: 1e18 }));
+        gateway.setAccountData(address(safe), ILendGateway.AccountData({ collateralUsd: 500e6, debtUsd: 100e6, availableBorrowsUsd: 40e6, healthFactor: 1e18 }));
 
         address[] memory spendTokens = new address[](2);
         spendTokens[0] = address(usdc);

--- a/test/safe/modules/cash/SetLendGateway.t.sol
+++ b/test/safe/modules/cash/SetLendGateway.t.sol
@@ -5,26 +5,26 @@ import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/Mes
 
 import { UUPSProxy } from "../../../../src/UUPSProxy.sol";
 import { BinSponsor, ICashModule, Mode, SafeCashData } from "../../../../src/interfaces/ICashModule.sol";
-import { IGateway } from "../../../../src/interfaces/IGateway.sol";
+import { ILendGateway } from "../../../../src/interfaces/ILendGateway.sol";
 import { CashVerificationLib } from "../../../../src/libraries/CashVerificationLib.sol";
-import { MockGateway } from "../../../../src/mocks/MockGateway.sol";
+import { MockLendGateway } from "../../../../src/mocks/MockLendGateway.sol";
 import { CashLens } from "../../../../src/modules/cash/CashLens.sol";
 import { CashModuleCore } from "../../../../src/modules/cash/CashModuleCore.sol";
 import { CashModuleSetters } from "../../../../src/modules/cash/CashModuleSetters.sol";
 import { CashEventEmitter, CashModuleTestSetup } from "./CashModuleTestSetup.t.sol";
 
-contract CashModuleSetGatewayTest is CashModuleTestSetup {
+contract CashModuleSetLendGatewayTest is CashModuleTestSetup {
     using MessageHashUtils for bytes32;
 
     /// @notice New safes onboard onto the Aave gateway engine; a debt-free re-setup also flips to the gateway.
     function test_setupModule_flagsNewSafeAsAaveGateway() public {
-        assertTrue(cashModule.usesAave(address(safe)), "new safe defaults to the gateway engine");
+        assertTrue(cashModule.usesLendGateway(address(safe)), "new safe defaults to the gateway engine");
 
         _forceLegacyEngine(address(safe));
 
         vm.prank(address(safe));
         cashModule.setupModule(abi.encode(dailyLimitInUsd, monthlyLimitInUsd, timezoneOffset));
-        assertTrue(cashModule.usesAave(address(safe)), "debt-free re-setup flips to the gateway");
+        assertTrue(cashModule.usesLendGateway(address(safe)), "debt-free re-setup flips to the gateway");
     }
 
     /// @notice A legacy safe with open DebtManager debt must keep routing to DebtManager if setup re-runs;
@@ -39,27 +39,27 @@ contract CashModuleSetGatewayTest is CashModuleTestSetup {
 
         vm.prank(address(safe));
         cashModule.setupModule(abi.encode(dailyLimitInUsd, monthlyLimitInUsd, timezoneOffset));
-        assertFalse(cashModule.usesAave(address(safe)), "safe with legacy debt stays on the legacy engine");
+        assertFalse(cashModule.usesLendGateway(address(safe)), "safe with legacy debt stays on the legacy engine");
     }
 
     /// @notice A controller can configure the first gateway during Lend bootstrap and the change is emitted.
-    function test_setGateway_emitsAndUpdates() public {
+    function test_setLendGateway_emitsAndUpdates() public {
         (ICashModule unconfiguredCashModule,) = _deployUnconfiguredCashModule();
-        MockGateway newGateway = new MockGateway();
+        MockLendGateway newGateway = new MockLendGateway();
 
         vm.expectEmit(true, true, true, true);
-        emit CashEventEmitter.GatewaySet(address(newGateway));
+        emit CashEventEmitter.LendGatewaySet(address(newGateway));
 
         vm.prank(owner);
-        unconfiguredCashModule.setGateway(address(newGateway));
+        unconfiguredCashModule.setLendGateway(address(newGateway));
 
-        assertEq(address(unconfiguredCashModule.getGateway()), address(newGateway));
+        assertEq(address(unconfiguredCashModule.getLendGateway()), address(newGateway));
     }
 
     /// @notice CashLens should read the gateway configured during the one-time Lend bootstrap.
-    function test_setGateway_bootstrapUpdatesCashLensReads() public {
+    function test_setLendGateway_bootstrapUpdatesCashLensReads() public {
         (ICashModule unconfiguredCashModule, CashLens unconfiguredCashLens) = _deployUnconfiguredCashModule();
-        MockGateway newGateway = new MockGateway();
+        MockLendGateway newGateway = new MockLendGateway();
 
         vm.prank(address(safe));
         unconfiguredCashModule.setupModule(abi.encode(dailyLimitInUsd, monthlyLimitInUsd, timezoneOffset));
@@ -72,10 +72,10 @@ contract CashModuleSetGatewayTest is CashModuleTestSetup {
         amountsInUsd[0] = 100e6;
 
         newGateway.setAvailableCash(address(usdc), type(uint128).max);
-        newGateway.setAccountData(address(safe), IGateway.AccountData({ collateralUsd: 200e6, debtUsd: 0, availableBorrowsUsd: amountsInUsd[0], healthFactor: type(uint256).max }));
+        newGateway.setAccountData(address(safe), ILendGateway.AccountData({ collateralUsd: 200e6, debtUsd: 0, availableBorrowsUsd: amountsInUsd[0], healthFactor: type(uint256).max }));
 
         vm.prank(owner);
-        unconfiguredCashModule.setGateway(address(newGateway));
+        unconfiguredCashModule.setLendGateway(address(newGateway));
 
         assertEq(address(unconfiguredCashLens.gateway()), address(newGateway));
 
@@ -88,26 +88,26 @@ contract CashModuleSetGatewayTest is CashModuleTestSetup {
         assertEq(reason, "");
     }
 
-    /// @notice Gateway bootstrap rejects unauthorized callers, zero addresses, and attempts to overwrite a configured gateway.
-    function test_setGateway_revertsForInvalidCalls() public {
-        MockGateway newGateway = new MockGateway();
+    /// @notice LendGateway bootstrap rejects unauthorized callers, zero addresses, and attempts to overwrite a configured gateway.
+    function test_setLendGateway_revertsForInvalidCalls() public {
+        MockLendGateway newGateway = new MockLendGateway();
 
         vm.prank(notOwner);
         vm.expectRevert(ICashModule.OnlyCashModuleController.selector);
-        cashModule.setGateway(address(newGateway));
+        cashModule.setLendGateway(address(newGateway));
 
         vm.prank(owner);
         vm.expectRevert(ICashModule.InvalidInput.selector);
-        cashModule.setGateway(address(0));
+        cashModule.setLendGateway(address(0));
 
         // An address with no contract code is rejected by the deployed-contract check.
         vm.prank(owner);
         vm.expectRevert(ICashModule.InvalidInput.selector);
-        cashModule.setGateway(makeAddr("codelessGateway"));
+        cashModule.setLendGateway(makeAddr("codelessGateway"));
 
         vm.prank(owner);
         vm.expectRevert(ICashModule.GatewayAlreadySet.selector);
-        cashModule.setGateway(address(newGateway));
+        cashModule.setLendGateway(address(newGateway));
     }
 
     /// @dev Deploys a CashModule/CashLens pair with no gateway configured so tests can exercise first-time bootstrap.

--- a/test/safe/modules/cash/Spend.t.sol
+++ b/test/safe/modules/cash/Spend.t.sol
@@ -9,10 +9,10 @@ import { Test } from "forge-std/Test.sol";
 import { UUPSProxy } from "../../../../src/UUPSProxy.sol";
 import { ICashModule, Mode, BinSponsor, Cashback, CashbackTokens } from "../../../../src/interfaces/ICashModule.sol";
 import { IDebtManager } from "../../../../src/interfaces/IDebtManager.sol";
-import { IGateway } from "../../../../src/interfaces/IGateway.sol";
+import { ILendGateway } from "../../../../src/interfaces/ILendGateway.sol";
 import { IPriceProvider } from "../../../../src/interfaces/IPriceProvider.sol";
 import { CashVerificationLib } from "../../../../src/libraries/CashVerificationLib.sol";
-import { MockGateway } from "../../../../src/mocks/MockGateway.sol";
+import { MockLendGateway } from "../../../../src/mocks/MockLendGateway.sol";
 import { SpendingLimitLib } from "../../../../src/libraries/SpendingLimitLib.sol";
 import { ArrayDeDupLib, EtherFiDataProvider, EtherFiSafe, EtherFiSafeErrors, SafeTestSetup } from "../../SafeTestSetup.t.sol";
 import { CashEventEmitter, CashModuleTestSetup } from "./CashModuleTestSetup.t.sol";
@@ -367,7 +367,7 @@ contract CashModuleSpendTest is CashModuleTestSetup {
         gateway.setLtv(address(usdc), 80e18);
         gateway.setSuppliedOf(address(safe), address(usdc), 100e6);
         gateway.setAvailableCash(address(usdc), type(uint128).max);
-        gateway.setAccountData(address(safe), IGateway.AccountData({ collateralUsd: 200e6, debtUsd: 100e6, availableBorrowsUsd: 40e6, healthFactor: 1e18 }));
+        gateway.setAccountData(address(safe), ILendGateway.AccountData({ collateralUsd: 200e6, debtUsd: 100e6, availableBorrowsUsd: 40e6, healthFactor: 1e18 }));
 
         address[] memory spendTokens = new address[](1);
         spendTokens[0] = address(usdc);
@@ -387,7 +387,7 @@ contract CashModuleSpendTest is CashModuleTestSetup {
         gateway.setLtv(address(usdc), 80e18);
         gateway.setSuppliedOf(address(safe), address(usdc), 50e6);
         gateway.setAvailableCash(address(usdc), type(uint128).max);
-        gateway.setAccountData(address(safe), IGateway.AccountData({ collateralUsd: 200e6, debtUsd: 100e6, availableBorrowsUsd: 40e6, healthFactor: 1e18 }));
+        gateway.setAccountData(address(safe), ILendGateway.AccountData({ collateralUsd: 200e6, debtUsd: 100e6, availableBorrowsUsd: 40e6, healthFactor: 1e18 }));
 
         address[] memory spendTokens = new address[](1);
         spendTokens[0] = address(usdc);
@@ -413,7 +413,7 @@ contract CashModuleSpendTest is CashModuleTestSetup {
         gateway.setLtv(address(usdc), 0);
         gateway.setSuppliedOf(address(safe), address(usdc), 100e6);
         gateway.setAvailableCash(address(usdc), type(uint128).max);
-        gateway.setAccountData(address(safe), IGateway.AccountData({ collateralUsd: 200e6, debtUsd: 100e6, availableBorrowsUsd: 40e6, healthFactor: 1e18 }));
+        gateway.setAccountData(address(safe), ILendGateway.AccountData({ collateralUsd: 200e6, debtUsd: 100e6, availableBorrowsUsd: 40e6, healthFactor: 1e18 }));
 
         address[] memory spendTokens = new address[](1);
         spendTokens[0] = address(usdc);
@@ -432,7 +432,7 @@ contract CashModuleSpendTest is CashModuleTestSetup {
         deal(address(usdc), address(safe), amount);
 
         // Safe is already over its LTV-based borrow limit (headroom 0 with debt), e.g. after a price drop.
-        gateway.setAccountData(address(safe), IGateway.AccountData({ collateralUsd: 200e6, debtUsd: 100e6, availableBorrowsUsd: 0, healthFactor: 1e18 }));
+        gateway.setAccountData(address(safe), ILendGateway.AccountData({ collateralUsd: 200e6, debtUsd: 100e6, availableBorrowsUsd: 0, healthFactor: 1e18 }));
 
         uint256 dispatcherBalBefore = usdc.balanceOf(address(settlementDispatcherReap));
 
@@ -844,7 +844,7 @@ contract CashModuleSpendTest is CashModuleTestSetup {
     }
 
     function _setBorrowCapacity(uint256 availableBorrowsUsd) internal {
-        gateway.setAccountData(address(safe), IGateway.AccountData({ collateralUsd: 0, debtUsd: 0, availableBorrowsUsd: availableBorrowsUsd, healthFactor: type(uint256).max }));
+        gateway.setAccountData(address(safe), ILendGateway.AccountData({ collateralUsd: 0, debtUsd: 0, availableBorrowsUsd: availableBorrowsUsd, healthFactor: type(uint256).max }));
     }
 
     /// @dev Registers the gateway's asset list; resupply sizes over it in order (empty by default in the mock)
@@ -1014,7 +1014,7 @@ contract CashModuleSpendTest is CashModuleTestSetup {
         Cashback[] memory cashbacks;
 
         vm.prank(etherFiWallet);
-        vm.expectRevert(MockGateway.BorrowBlocked.selector);
+        vm.expectRevert(MockLendGateway.BorrowBlocked.selector);
         cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
 
         assertEq(gateway.suppliesCount(), 0);

--- a/test/upgrade-bytecode-verification/VerifyOPMainnet.t.sol
+++ b/test/upgrade-bytecode-verification/VerifyOPMainnet.t.sol
@@ -188,7 +188,7 @@ contract VerifyOPMainnetBytecode is ContractCodeChecker, Utils {
     }
 
     function test_verifyBytecode_CashModuleSetters() public {
-        // CashModuleSetters gains gateway wiring plus the lend opt-out (setGateway/toggleLend) for Lend, so
+        // CashModuleSetters gains gateway wiring plus the lend opt-out (setLendGateway/toggleLend) for Lend, so
         // its bytecode no longer matches the deployed pre-Lend OP implementation. Re-enable after the Lend deployment.
         vm.skip(true);
         address local = address(new CashModuleSetters(dataProviderProxy));


### PR DESCRIPTION
## What this does

Rename the Aave gateway to a lend gateway. The gateway is the layer the cash side uses for lending. It uses Aave v4 today, but the cash side should not name the backend in its own code.

The rename covers:
- the contract, interface, and mock: `Gateway` to `LendGateway`, `IGateway` to `ILendGateway`, `MockGateway` to `MockLendGateway`.
- the routing flag: `usesAave` to `usesLendGateway`, and `markUsesAave` to `markUsesLendGateway`.
- the setter, event, and role: `setGateway` to `setLendGateway`, `GatewaySet` to `LendGatewaySet`, `GATEWAY_ADMIN_ROLE` to `LEND_GATEWAY_ADMIN_ROLE`.
- the DebtManager migration function, event, and errors: `migrateToAave` to `migrateToLendGateway`, and the matching names.

Comments still say Aave where the backend is the point.

Two smaller changes are included:
- One getter instead of two. `getGateway()` returned the typed interface and `getLendGateway()` returned an address. Now there is one `getLendGateway()` that returns `ILendGateway`. Every caller used the typed value anyway.
- Rename `_cancelWithdrawalRequestIfNecessary` to `_cancelCompetingWithdrawal` and fix its comment. The behavior did not change. The old name promised more than the code does. The function decides whether to cancel a pending withdrawal from the quoted repay amount, but both engines cap the real repay at the live debt. So a full repay quoted above the live debt can cancel a request that the smaller real repay would have left alone.

## Why

The code used three names for one thing. The contract was `Gateway`, the cash side already said `getLendGateway` and `LendGatewayNotSet`, and the flag was `usesAave`. Nothing is deployed yet, so the rename is cheap now and costly later.

## Testing

- `forge build` passes on the default profile and the `aave` profile.
- The lend and cash test suites pass on an Optimism fork, with `TEST_CHAIN=10` and `FOUNDRY_PROFILE=aave` for the real Aave v4 fork tests. This covers the rename, the single getter, and the withdrawal cancel path.
- `forge fmt` and `forge lint` are clean on the changed files.

## Notes for review

- The gateway uses an ERC-7201 storage slot derived from a namespace string. The namespace changed to `etherfi.storage.LendGateway`, so I recomputed the slot constant. This is safe because nothing is deployed.
- The withdrawal cancel can still fire when it was not needed, when the quoted repay is larger than the live debt. I documented this rather than add logic to an audited path. The backend quotes from the live debt, so the gap is small in practice.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide rename of routing flags, migration entrypoints, and storage layout touches DebtManager migration and all spend/repay/lens paths; behavior is intended to be identical but integrators and off-chain indexers must adopt new names and events.
> 
> **Overview**
> **Renames the cash-side lending seam from “Gateway” / `usesAave` to `LendGateway` / `usesLendGateway`** so routing and APIs are backend-neutral while comments still refer to Aave where the v4 integration matters. That includes the implementation (`Gateway` → `LendGateway`), `IGateway` → `ILendGateway`, mock, admin role (`LEND_GATEWAY_ADMIN_ROLE`), storage namespace/slot, DebtManager **`migrateToLendGateway`** / **`hasMigratedToLendGateway`**, and matching events/errors (e.g. `InsufficientLendGatewayLiquidity`, `AlreadyMigratedToLendGateway`).
> 
> **CashModule / CashLens / CashLendLib** now branch on **`usesLendGateway`**, bootstrap via **`setLendGateway`**, and emit **`LendGatewaySet`**. **`getLendGateway()`** is the single typed accessor; **`getGateway()`** is removed. Foundry skips **`test/lend-gateway/**`** instead of **`test/gateway/**`** for the default profile.
> 
> Smaller follow-ons: **`_cancelWithdrawalRequestIfNecessary`** → **`_cancelCompetingWithdrawal`** (behavior unchanged; comment documents conservative cancel vs live debt cap). Bytecode verification tests stay skipped until post-Lend deploy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0fd505ac696148858efc1d6bce8e472aac1d145. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->