### PR TITLE
test: unify lend gateway tests under one dir and profile

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,6 @@ on:
   workflow_dispatch:
 
 env:
-  FOUNDRY_PROFILE: ci
   ENV: ${{ secrets.ENV || 'mainnet' }}
   TEST_CHAIN: ${{ secrets.TEST_CHAIN || '10' }}
   TEST_RPC: ${{ secrets.TEST_RPC || 'https://mainnet.optimism.io' }}
@@ -49,6 +48,8 @@ jobs:
       - name: Show Forge version
         run: forge --version
 
+      # Size-gate our own contracts. The lend tests (and aave-v4's SpokeInstance) are skipped by the default
+      # profile, so they never reach this size check.
       - name: Run Forge build
         run: forge build --sizes
         id: build
@@ -59,10 +60,10 @@ jobs:
           TS_NODE_COMPILER_OPTIONS: '{"module":"commonjs"}'
         id: test
 
-      # The Aave v4 gateway + gateway-path cash tests are skipped by the default profile (they need via_ir +
-      # the aave-v4 dependency). Run them under the aave profile against the Optimism fork.
-      - name: Run Aave gateway tests
-        run: FOUNDRY_PROFILE=aave forge test -vvv
+      # The lend (Aave v4) tests deploy a real Aave v4 instance on an Optimism fork, so they run under the
+      # lend profile against the fork rather than the default profile.
+      - name: Run lend tests
+        run: FOUNDRY_PROFILE=lend forge test -vvv
         env:
           TS_NODE_COMPILER_OPTIONS: '{"module":"commonjs"}'
-        id: test-aave
+        id: test-lend

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
 
 env:
+  FOUNDRY_PROFILE: ci
   ENV: ${{ secrets.ENV || 'mainnet' }}
   TEST_CHAIN: ${{ secrets.TEST_CHAIN || '10' }}
   TEST_RPC: ${{ secrets.TEST_RPC || 'https://mainnet.optimism.io' }}

--- a/README.md
+++ b/README.md
@@ -66,12 +66,12 @@ For specific test files:
 forge test --match-path test/path/to/file.t.sol -vvv
 ```
 
-The default profile skips the real-gateway tests (`test/lend-gateway/**` and
-`test/safe/modules/cash/aave/**`), which deploy a real Aave v4 instance and so need the
-`aave` profile (via_ir) and an Optimism fork. Run them with:
+The real-gateway tests (`test/safe/modules/cash/lend/**`) deploy a real Aave v4 instance in-test,
+so they are skipped by the default profile and run under the `lend` profile against an Optimism
+fork. Run them with:
 
 ```bash
-source .env && FOUNDRY_PROFILE=aave TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test
+source .env && FOUNDRY_PROFILE=lend TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test
 ```
 
 ### Deployment

--- a/foundry.toml
+++ b/foundry.toml
@@ -13,31 +13,22 @@ fs_permissions = [{ access = "read-write", path = "./" }]
 extra_output = ["storageLayout"]
 ffi = true
 dynamic_test_linking = true
-# The Aave v4 gateway tests pull in the aave-v4 source (Hub/Spoke) and a fork, so keep them out of the
-# default profile. That keeps the default build small and its bytecode-verification settings unchanged.
-# Run them under FOUNDRY_PROFILE=aave (see [profile.aave] below). test/safe/modules/cash/aave/** are
-# cash-flow tests against the real gateway, so they live behind the same profile.
-skip = ["test/lend-gateway/**", "test/safe/modules/cash/aave/**"]
+# The lend tests deploy a real Aave v4 instance (Hub/Spoke from the aave-v4 source) on an Optimism fork.
+# Keep them out of the default profile so the default build stays small and free of the aave-v4 dependency;
+# run them under FOUNDRY_PROFILE=lend (see [profile.lend] below).
+skip = ["test/safe/modules/cash/lend/**"]
 
-# Profile for the Aave v4 gateway integration tests: un-skips the gateway tests and links the aave-v4
-# LiquidationLogic library so the Hub/Spoke instances build. Run: FOUNDRY_PROFILE=aave forge test.
-# via_ir is intentionally not set. Our aave-v4 subset compiles under the legacy pipeline, and via_ir
-# roughly doubles the compile time. These are test-only, so there is no production bytecode concern.
-[profile.aave]
+# Profile for the lend (Aave v4) tests: un-skips them and links aave-v4's external LiquidationLogic library.
+# SpokeInstance links LiquidationLogic via an aave-rooted `src/` import forge can't resolve to an artifact,
+# so pin it to a fixed address; AaveV4Fixture etches the library's runtime code there before deploying.
+[profile.lend]
 skip = []
-# LiquidationLogic is linked via the `libraries` entry below (compile-time), so forge's runtime library
-# auto-linking is unneeded here and would noisily re-resolve aave-v4's `src/`-rooted imports.
-dynamic_test_linking = false
-# Aave's SpokeInstance links the external LiquidationLogic library. forge's dynamic linker can't
-# auto-deploy a library that lives under lib/, so link it to a fixed address; AaveV4Fixture etches the
-# library's runtime code there before deploying the spoke.
 libraries = ["src/spoke/libraries/LiquidationLogic.sol:LiquidationLogic:0x0000000000000000000000000000000000000A01"]
 
 # Modest bounds: each handler call drives real Aave ops on the fork, so keep the campaign small.
-[profile.aave.invariant]
+[profile.lend.invariant]
 runs = 12
 depth = 10
-fail_on_revert = false
 
 [fuzz]
 runs = 10000

--- a/src/mocks/MockLendGateway.sol
+++ b/src/mocks/MockLendGateway.sol
@@ -8,7 +8,7 @@ import { ILendGateway } from "../interfaces/ILendGateway.sol";
  * @notice Inert test double for ILendGateway. Non-lend safe suites wire it so the cash contracts have a codeful
  *         gateway that reports an empty position, and the SetLendGateway guard tests plus the ModuleGatewaySandwich
  *         call-order test drive it directly. Real gateway behavior is exercised against a live Aave v4 instance
- *         under the aave profile (test/safe/modules/cash/aave/**), so this mock no longer fabricates positions.
+ *         under the lend profile (test/safe/modules/cash/lend/**), so this mock no longer fabricates positions.
  *         Not for production.
  * @dev Records the last supply / withdraw call and the collateral flag for the sandwich test; the position
  *      aggregate (getAccountData) and reserve liquidity (availableCash) are settable for the guard tests. The

--- a/test/safe/modules/cash/lend/CanSpend.t.sol
+++ b/test/safe/modules/cash/lend/CanSpend.t.sol
@@ -11,7 +11,7 @@ import { CashGatewayTestSetup } from "./CashGatewayTestSetup.t.sol";
  *         an Aave-supplied balance, all built through real supply/borrow flows against a real Aave v4 instance.
  *         The debit-only / spending-limit / txId / validation canSpend tests that never read a gateway position
  *         stay in test/safe/modules/cash/CanSpend.t.sol (default profile, mock gateway as inert plumbing).
- * @dev Run with: source .env && FOUNDRY_PROFILE=aave TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test --match-path "test/safe/modules/cash/aave/CanSpend.t.sol"
+ * @dev Run with: source .env && FOUNDRY_PROFILE=lend TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test --match-path "test/safe/modules/cash/lend/CanSpend.t.sol"
  */
 contract CashLensCanSpendAaveTest is CashGatewayTestSetup {
     /// Debit spend succeeds when the stable is supplied to Aave rather than held loose, drawing on the withdrawable balance.

--- a/test/safe/modules/cash/lend/CashGatewayTestSetup.t.sol
+++ b/test/safe/modules/cash/lend/CashGatewayTestSetup.t.sol
@@ -7,7 +7,7 @@ import { UUPSProxy } from "../../../../../src/UUPSProxy.sol";
 import { IAggregatorV3 } from "../../../../../src/interfaces/IAggregatorV3.sol";
 import { LendGateway } from "../../../../../src/modules/lend-gateway/LendGateway.sol";
 import { ChainlinkCompositePriceFeed } from "../../../../../src/oracle/ChainlinkCompositePriceFeed.sol";
-import { AaveV4Fixture } from "../../../../lend-gateway/helpers/AaveV4Fixture.sol";
+import { AaveV4Fixture } from "./helpers/AaveV4Fixture.sol";
 import { CashModuleTestSetup } from "../CashModuleTestSetup.t.sol";
 
 /**
@@ -17,17 +17,17 @@ import { CashModuleTestSetup } from "../CashModuleTestSetup.t.sol";
  *         live lend engine. Positions are built through real supply / borrow flows, never injected via mock
  *         setters, so gateway-path behavior (borrowing power, declines, rounding, atomicity) is asserted
  *         against genuine Aave state.
- * @dev These tests run only under the aave profile (the default profile skips test/safe/modules/cash/aave/**,
- *      since a real Aave v4 build needs via_ir). Run with:
- *      source .env && FOUNDRY_PROFILE=aave TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test --match-path "test/safe/modules/cash/aave/**"
+ * @dev These tests run under the lend profile (the default profile skips test/safe/modules/cash/lend/**)
+ *      against an Optimism fork. Run with:
+ *      source .env && FOUNDRY_PROFILE=lend TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test --match-path "test/safe/modules/cash/lend/**"
  *
  *      Dual-engine test convention (functions that route on CashModule.usesLendGateway):
- *      1. The gateway is the default path. Tests of a flag-routed function live in this aave/ directory on a
+ *      1. The gateway is the default path. Tests of a flag-routed function live in this lend/ directory on a
  *         gateway safe, with positions built through the real supply / borrow helpers below.
- *      2. The legacy DebtManager path lives in its default-profile twin (a Legacy* file or debt-manager/*),
+ *      2. The legacy DebtManager path lives in its twin outside lend/ (a Legacy* file or debt-manager/*),
  *         opening with _forceLegacyEngine(safe); it may keep the mock gateway as inert plumbing but never sets
  *         gateway state.
- *      3. aave/EngineParity.t.sol is the drift detector: for every (mode x engine) cell it asserts canSpend and
+ *      3. lend/EngineParity.t.sol is the drift detector: for every (mode x engine) cell it asserts canSpend and
  *         spend agree, so the check side and the execution side never diverge.
  */
 abstract contract CashGatewayTestSetup is CashModuleTestSetup, AaveV4Fixture {

--- a/test/safe/modules/cash/lend/CashLendDisable.t.sol
+++ b/test/safe/modules/cash/lend/CashLendDisable.t.sol
@@ -3,13 +3,13 @@ pragma solidity ^0.8.28;
 
 import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
-import { BinSponsor, ICashModule, Mode } from "../../src/interfaces/ICashModule.sol";
-import { ILendGateway } from "../../src/interfaces/ILendGateway.sol";
-import { CashVerificationLib } from "../../src/libraries/CashVerificationLib.sol";
-import { SignatureUtils } from "../../src/libraries/SignatureUtils.sol";
-import { CashEventEmitter } from "../../src/modules/cash/CashEventEmitter.sol";
-import { LendGateway } from "../../src/modules/lend-gateway/LendGateway.sol";
-import { CashGatewayTestSetup } from "../safe/modules/cash/aave/CashGatewayTestSetup.t.sol";
+import { BinSponsor, ICashModule, Mode } from "../../../../../src/interfaces/ICashModule.sol";
+import { ILendGateway } from "../../../../../src/interfaces/ILendGateway.sol";
+import { CashVerificationLib } from "../../../../../src/libraries/CashVerificationLib.sol";
+import { SignatureUtils } from "../../../../../src/libraries/SignatureUtils.sol";
+import { CashEventEmitter } from "../../../../../src/modules/cash/CashEventEmitter.sol";
+import { LendGateway } from "../../../../../src/modules/lend-gateway/LendGateway.sol";
+import { CashGatewayTestSetup } from "./CashGatewayTestSetup.t.sol";
 
 /**
  * @title CashLendDisableTest
@@ -19,7 +19,7 @@ import { CashGatewayTestSetup } from "../safe/modules/cash/aave/CashGatewayTestS
  *         further lend op (auto-supply / borrow) until it opts back in with toggleLend(true). Runs against a
  *         REAL Aave v4 instance deployed in-test on an Optimism fork, driven by the real ether.fi stack
  *         (CashModule, LendGateway, EtherFiSafe) — no mocks.
- * @dev Run with: source .env && FOUNDRY_PROFILE=aave TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test --match-path test/lend-gateway/CashLendDisable.t.sol
+ * @dev Run with: source .env && FOUNDRY_PROFILE=lend TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test --match-path test/safe/modules/cash/lend/CashLendDisable.t.sol
  */
 contract CashLendDisableTest is CashGatewayTestSetup {
     using MessageHashUtils for bytes32;

--- a/test/safe/modules/cash/lend/CashLens.t.sol
+++ b/test/safe/modules/cash/lend/CashLens.t.sol
@@ -11,7 +11,7 @@ import { CashGatewayTestSetup } from "./CashGatewayTestSetup.t.sol";
  * @notice The gateway-path CashLens reads (collateral, safe cash data with and without borrows) built through
  *         real Aave supply/borrow flows. The legacy-engine and plumbing CashLens tests stay in
  *         test/safe/modules/cash/CashLens.t.sol (default profile).
- * @dev Run with: source .env && FOUNDRY_PROFILE=aave TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test --match-path "test/safe/modules/cash/aave/CashLens.t.sol"
+ * @dev Run with: source .env && FOUNDRY_PROFILE=lend TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test --match-path "test/safe/modules/cash/lend/CashLens.t.sol"
  */
 contract CashLensAaveTest is CashGatewayTestSetup {
     /// A gateway safe's collateral is its Aave-supplied balance; loose funds don't count.

--- a/test/safe/modules/cash/lend/CashLensMaxSpend.t.sol
+++ b/test/safe/modules/cash/lend/CashLensMaxSpend.t.sol
@@ -22,7 +22,7 @@ import { CashGatewayTestSetup } from "./CashGatewayTestSetup.t.sol";
  *      were written against); weETH keeps the base 80%. liquidUSD is priced off the USDC/USD feed so Aave and the
  *      PriceProvider agree at ~$1 (a test simplification; rate-based liquidUSD pricing keeps its own coverage in
  *      LiquidUSDLiquifier.t.sol). Run with:
- *      source .env && FOUNDRY_PROFILE=aave TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test --match-path "test/safe/modules/cash/aave/CashLensMaxSpend.t.sol"
+ *      source .env && FOUNDRY_PROFILE=lend TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test --match-path "test/safe/modules/cash/lend/CashLensMaxSpend.t.sol"
  */
 contract CashLensMaxSpendAaveTest is CashGatewayTestSetup {
     IERC20 public liquidUsd = IERC20(0x08c6F91e2B681FaF5e17227F2a44C307b3C1364C);

--- a/test/safe/modules/cash/lend/DebtManagerMigration.t.sol
+++ b/test/safe/modules/cash/lend/DebtManagerMigration.t.sol
@@ -3,13 +3,13 @@ pragma solidity ^0.8.28;
 
 import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
-import { DebtManagerCore } from "../../src/debt-manager/DebtManagerCore.sol";
-import { DebtManagerStorageContract } from "../../src/debt-manager/DebtManagerStorageContract.sol";
-import { BinSponsor, Cashback, ICashModule, Mode } from "../../src/interfaces/ICashModule.sol";
-import { CashVerificationLib } from "../../src/libraries/CashVerificationLib.sol";
-import { CashEventEmitter } from "../../src/modules/cash/CashEventEmitter.sol";
-import { UpgradeableProxy } from "../../src/utils/UpgradeableProxy.sol";
-import { CashGatewayTestSetup } from "../safe/modules/cash/aave/CashGatewayTestSetup.t.sol";
+import { DebtManagerCore } from "../../../../../src/debt-manager/DebtManagerCore.sol";
+import { DebtManagerStorageContract } from "../../../../../src/debt-manager/DebtManagerStorageContract.sol";
+import { BinSponsor, Cashback, ICashModule, Mode } from "../../../../../src/interfaces/ICashModule.sol";
+import { CashVerificationLib } from "../../../../../src/libraries/CashVerificationLib.sol";
+import { CashEventEmitter } from "../../../../../src/modules/cash/CashEventEmitter.sol";
+import { UpgradeableProxy } from "../../../../../src/utils/UpgradeableProxy.sol";
+import { CashGatewayTestSetup } from "./CashGatewayTestSetup.t.sol";
 
 /**
  * @title DebtManagerMigrationTest
@@ -17,7 +17,7 @@ import { CashGatewayTestSetup } from "../safe/modules/cash/aave/CashGatewayTestS
  *         DebtManager) migrates atomically to a REAL Aave v4 instance (deployed in-test on an Optimism fork)
  *         via the gateway — no flash loan. Aave's weETH LTV is set below DebtManager's so the LTV-fit path
  *         is exercised.
- * @dev Run with: FOUNDRY_PROFILE=aave TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test --match-path test/lend-gateway/DebtManagerMigration.t.sol
+ * @dev Run with: FOUNDRY_PROFILE=lend TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test --match-path test/safe/modules/cash/lend/DebtManagerMigration.t.sol
  */
 contract DebtManagerMigrationTest is CashGatewayTestSetup {
     using MessageHashUtils for bytes32;

--- a/test/safe/modules/cash/lend/EngineParity.t.sol
+++ b/test/safe/modules/cash/lend/EngineParity.t.sol
@@ -16,7 +16,7 @@ import { CashGatewayTestSetup } from "./CashGatewayTestSetup.t.sol";
  *         between them declines good taps or, worse, lands taps the check already rejected. The gateway cells run
  *         against a real Aave v4 instance, so the declined-credit revert side (enforced by Aave's borrowing-power
  *         check) is asserted here too; the legacy cells force the DebtManager engine.
- * @dev Run with: source .env && FOUNDRY_PROFILE=aave TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test --match-path "test/safe/modules/cash/aave/EngineParity.t.sol"
+ * @dev Run with: source .env && FOUNDRY_PROFILE=lend TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test --match-path "test/safe/modules/cash/lend/EngineParity.t.sol"
  */
 contract EngineParityAaveTest is CashGatewayTestSetup {
     Cashback[] internal noCashback;

--- a/test/safe/modules/cash/lend/LendGatewayAaveV4.t.sol
+++ b/test/safe/modules/cash/lend/LendGatewayAaveV4.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-import { ILendGateway } from "../../src/interfaces/ILendGateway.sol";
-import { LendGateway } from "../../src/modules/lend-gateway/LendGateway.sol";
-import { UpgradeableProxy } from "../../src/utils/UpgradeableProxy.sol";
-import { CashGatewayTestSetup } from "../safe/modules/cash/aave/CashGatewayTestSetup.t.sol";
+import { ILendGateway } from "../../../../../src/interfaces/ILendGateway.sol";
+import { LendGateway } from "../../../../../src/modules/lend-gateway/LendGateway.sol";
+import { UpgradeableProxy } from "../../../../../src/utils/UpgradeableProxy.sol";
+import { CashGatewayTestSetup } from "./CashGatewayTestSetup.t.sol";
 import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
 import { ISpoke } from "aave-v4/spoke/interfaces/ISpoke.sol";
 
@@ -13,7 +13,7 @@ import { ISpoke } from "aave-v4/spoke/interfaces/ISpoke.sol";
  * @notice End-to-end LendGateway tests against a REAL Aave v4 instance deployed inside the test on an Optimism
  *         fork, driven by the REAL ether.fi stack (EtherFiSafe, EtherFiDataProvider, RoleRegistry,
  *         PriceProvider) — no mocks. Aave reserves are priced by live Optimism Chainlink feeds.
- * @dev Run with: source .env && FOUNDRY_PROFILE=aave TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test --match-path test/lend-gateway/LendGatewayAaveV4.t.sol
+ * @dev Run with: source .env && FOUNDRY_PROFILE=lend TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test --match-path test/safe/modules/cash/lend/LendGatewayAaveV4.t.sol
  */
 contract LendGatewayAaveV4Test is CashGatewayTestSetup {
     // ----------------------------------------------------------------- registration & reads

--- a/test/safe/modules/cash/lend/LendGatewayInvariant.t.sol
+++ b/test/safe/modules/cash/lend/LendGatewayInvariant.t.sol
@@ -4,15 +4,15 @@ pragma solidity ^0.8.28;
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { Test } from "forge-std/Test.sol";
 
-import { LendGateway } from "../../src/modules/lend-gateway/LendGateway.sol";
-import { CashGatewayTestSetup } from "../safe/modules/cash/aave/CashGatewayTestSetup.t.sol";
+import { LendGateway } from "../../../../../src/modules/lend-gateway/LendGateway.sol";
+import { CashGatewayTestSetup } from "./CashGatewayTestSetup.t.sol";
 
 /**
  * @title LendGatewayHandler
  * @notice Drives random sequences of LendGateway ops (as an authorized driver) for the invariant campaign.
  *         Amounts are bounded to mostly succeed so the campaign exercises real Aave state transitions;
  *         residual reverts (e.g. a withdraw that would breach health) are tolerated (fail_on_revert=false).
- * @dev Run with: source .env && FOUNDRY_PROFILE=aave TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test --match-path "test/lend-gateway/LendGatewayInvariant.t.sol"
+ * @dev Run with: source .env && FOUNDRY_PROFILE=lend TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test --match-path "test/safe/modules/cash/lend/LendGatewayInvariant.t.sol"
  */
 contract LendGatewayHandler is Test {
     LendGateway internal immutable gw;

--- a/test/safe/modules/cash/lend/MultiSpend.t.sol
+++ b/test/safe/modules/cash/lend/MultiSpend.t.sol
@@ -10,7 +10,7 @@ import { CashGatewayTestSetup } from "./CashGatewayTestSetup.t.sol";
  *         its loose balance and partly from its Aave-supplied balance under debt, and the shared borrowing
  *         headroom binding across tokens. The loose-only multi-token spends (proportions, cashback, limits,
  *         pending) that never read a gateway position stay in test/safe/modules/cash/MultiSpend.t.sol.
- * @dev Run with: source .env && FOUNDRY_PROFILE=aave TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test --match-path "test/safe/modules/cash/aave/MultiSpend.t.sol"
+ * @dev Run with: source .env && FOUNDRY_PROFILE=lend TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test --match-path "test/safe/modules/cash/lend/MultiSpend.t.sol"
  */
 contract CashModuleMultiSpendAaveTest is CashGatewayTestSetup {
     function setUp() public override {

--- a/test/safe/modules/cash/lend/Spend.t.sol
+++ b/test/safe/modules/cash/lend/Spend.t.sol
@@ -17,7 +17,7 @@ import { CashGatewayTestSetup } from "./CashGatewayTestSetup.t.sol";
  *         dispatcher receipts, gw.suppliedOf / gw.debtOf, and events) rather than mock call recorders.
  * @dev Legacy-engine spend tests (_forceLegacyEngine) and the loose-balance / validation spend tests that never
  *      read a gateway position stay in test/safe/modules/cash/Spend.t.sol (default profile). Run with:
- *      source .env && FOUNDRY_PROFILE=aave TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test --match-path "test/safe/modules/cash/aave/Spend.t.sol"
+ *      source .env && FOUNDRY_PROFILE=lend TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test --match-path "test/safe/modules/cash/lend/Spend.t.sol"
  */
 contract CashModuleSpendAaveTest is CashGatewayTestSetup {
     /// @dev RESUPPLY_BUFFER_BPS in CashLendLib; keep in sync.

--- a/test/safe/modules/cash/lend/helpers/AaveV4Fixture.sol
+++ b/test/safe/modules/cash/lend/helpers/AaveV4Fixture.sol
@@ -31,8 +31,9 @@ interface IProxyInit {
  *         LendGateway can be exercised against genuine Aave v4 code rather than a mock. This test contract
  *         holds every admin role, so it can list reserves, set collateral factors, and activate position
  *         managers freely. Mirrors aave-v4 v0.5.11 `tests/Base.t.sol` deployFixtures/setUpRoles.
- * @dev The Hub/Spoke instances are compiled via_ir (foundry.toml compilation_restrictions) and their
- *      LiquidationLogic library is linked by dynamic_test_linking, so a plain `new` suffices.
+ * @dev SpokeInstance links the external LiquidationLogic library. forge can't resolve that aave-rooted
+ *      `src/` import to an artifact, so foundry.toml `[profile.lend]` libraries pins it to a fixed address and
+ *      `_deployAaveV4` etches the library code there before deploying the spoke.
  */
 abstract contract AaveV4Fixture is Test {
     /// @notice Admin of the Aave instance (holds AccessManager ADMIN + all granted roles)
@@ -45,7 +46,7 @@ abstract contract AaveV4Fixture is Test {
     AssetInterestRateStrategy internal irStrategy;
     ITreasurySpoke internal treasurySpoke;
 
-    /// @notice Fixed link address for LiquidationLogic (see foundry.toml [profile.aave] libraries)
+    /// @notice Fixed link address for LiquidationLogic (see foundry.toml `[profile.lend]` libraries)
     address internal constant LIQUIDATION_LOGIC = 0x0000000000000000000000000000000000000a01;
 
     /// @notice Deploys and wires a full Aave v4 instance (access manager, hub, spoke, oracle, treasury)


### PR DESCRIPTION
## What

Moves all the Aave v4 real-gateway tests into one directory, `test/safe/modules/cash/lend/`, next to the legacy engine's tests in `debt-manager/`. Before this they were split across `test/lend-gateway/` and `test/safe/modules/cash/aave/`, which imported each other in both directions.

Renames the test profile from `aave` to `lend` and points its skip glob at the new directory. The default profile still skips these tests, so a plain `forge build`/`forge test` stays small and free of the aave-v4 dependency. Run the lend tests with `FOUNDRY_PROFILE=lend`.

## Why

They are one test family, not two layers, and the old layout made that hard to see. The `lend` name matches how we talk about this work everywhere else.

## Decision worth a look

The old `aave` profile set `dynamic_test_linking = false` and hand-linked Aave's `LiquidationLogic` library. The `lend` profile keeps `dynamic_test_linking = true` and only pins that one library. It builds and links cleanly, so the extra setting was not needed.

## Testing

- `forge build --sizes` on the default profile: clean, exits 0.
- `FOUNDRY_PROFILE=lend forge build`: aave-v4 and the library link cleanly.
- `FOUNDRY_PROFILE=lend TEST_CHAIN=10 TEST_RPC=$OPTIMISM_RPC forge test --match-path "test/safe/modules/cash/lend/**"`: 125 tests, all pass.
