### PR TITLE
feat: repay from supplied balance and add the auto-supply entrypoints

### DIFF
--- a/src/interfaces/ICashEventEmitter.sol
+++ b/src/interfaces/ICashEventEmitter.sol
@@ -144,6 +144,23 @@ interface ICashEventEmitter {
      */
     function emitCollateralResupplied(address safe, address token, uint256 amount) external;
 
+    /**
+     * @notice Emits an event when a safe's loose balance is supplied into the lend market (auto-supply)
+     * @param safe Address of the safe
+     * @param token Token supplied
+     * @param amount Token amount supplied
+     */
+    function emitLendSupplied(address safe, address token, uint256 amount) external;
+
+    /**
+     * @notice Emits an event when a safe borrows from the lend market to itself (a borrow-page borrow)
+     * @param safe Address of the safe
+     * @param token Token borrowed
+     * @param amount Token amount borrowed
+     * @param amountInUsd USD value of the borrow
+     */
+    function emitLendBorrowed(address safe, address token, uint256 amount, uint256 amountInUsd) external;
+
     /// @notice Emits the LendDisableRequested event
     function emitLendDisableRequested(address safe, uint256 finalizeTime) external;
 

--- a/src/interfaces/ICashModule.sol
+++ b/src/interfaces/ICashModule.sol
@@ -214,6 +214,9 @@ interface ICashModule {
     /// @notice Error thrown when a balance is insufficient for an operation
     error InsufficientBalance();
 
+    /// @notice Error thrown when a lend-market operation targets a safe on the legacy DebtManager engine
+    error OnlyLendGatewaySafe();
+
     /// @notice Error thrown when a non-DebtManager contract calls restricted functions
     error OnlyDebtManager();
 
@@ -682,6 +685,29 @@ interface ICashModule {
      * @custom:throws InsufficientBalance if there is not enough balance for the operation
      */
     function repay(address safe, address token, uint256 amountInUsd) external;
+
+    /**
+     * @notice Supplies a safe's loose token balances into the Aave lend market (the auto-supply sweep)
+     * @dev Per token: supplies the loose balance net of any pending-withdrawal reservation and flags it
+     *      as collateral; zero and unregistered tokens are skipped. No-op for an opted-out safe; reverts
+     *      for a legacy safe.
+     * @param safe Address of the EtherFi Safe
+     * @param tokens Tokens to sweep
+     * @custom:throws OnlyLendGatewaySafe if the safe runs on the legacy DebtManager engine
+     */
+    function supplyToLend(address safe, address[] calldata tokens) external;
+
+    /**
+     * @notice Borrows a token against the safe's lend-market position; the proceeds land in the safe and
+     *         are immediately supplied back as collateral
+     * @param safe Address of the EtherFi Safe
+     * @param token Address of the token to borrow
+     * @param amountInUsd Amount to borrow in USD
+     * @custom:throws OnlyBorrowToken if token is not a valid borrow token
+     * @custom:throws AmountZero if the converted amount is zero
+     * @custom:throws OnlyLendGatewaySafe if the safe runs on the legacy DebtManager engine
+     */
+    function borrow(address safe, address token, uint256 amountInUsd) external;
 
     /**
      * @notice Requests a withdrawal of tokens to a recipient

--- a/src/libraries/DebitSourcingLib.sol
+++ b/src/libraries/DebitSourcingLib.sol
@@ -46,6 +46,18 @@ library DebitSourcingLib {
         return (_toUsd(priceProvider, token, amount) * gateway.ltv(token)) / LTV_SCALE;
     }
 
+    /**
+     * @notice Amount of `token` withdrawable from `safe`'s supplied balance to fund a repay whose loose leg
+     *         repays `fromLoose` first
+     * @dev Repaying the loose leg lowers the debt by its full USD value while the collateral is untouched,
+     *      so the withdraw leg sizes against that much extra headroom. Callers only get here with debt
+     *      remaining after the loose leg, so the headroom cap always applies.
+     */
+    function repayWithdrawable(ILendGateway gateway, IPriceProvider priceProvider, address safe, address token, uint256 fromLoose) public view returns (uint256) {
+        uint256 headroomUsd = gateway.getAccountData(safe).availableBorrowsUsd + _toUsd(priceProvider, token, fromLoose);
+        return withdrawableSupplied(gateway, priceProvider, safe, token, headroomUsd, true);
+    }
+
     /// @dev USD value of `amount` of `token` at its current price, on PriceProvider's USD scale
     function _toUsd(IPriceProvider priceProvider, address token, uint256 amount) private view returns (uint256) {
         return (amount * priceProvider.price(token)) / (10 ** IERC20Metadata(token).decimals());

--- a/src/modules/cash/CashEventEmitter.sol
+++ b/src/modules/cash/CashEventEmitter.sol
@@ -149,6 +149,23 @@ contract CashEventEmitter is UpgradeableProxy {
     event CollateralResupplied(address indexed safe, address indexed token, uint256 amount);
 
     /**
+     * @notice Emitted when a safe's loose balance is supplied into the lend market (auto-supply)
+     * @param safe Address of the safe
+     * @param token Token supplied
+     * @param amount Token amount supplied
+     */
+    event LendSupplied(address indexed safe, address indexed token, uint256 amount);
+
+    /**
+     * @notice Emitted when a safe borrows from the lend market to itself (a borrow-page borrow)
+     * @param safe Address of the safe
+     * @param token Token borrowed
+     * @param amount Token amount borrowed
+     * @param amountInUsd USD value of the borrow
+     */
+    event LendBorrowed(address indexed safe, address indexed token, uint256 amount, uint256 amountInUsd);
+
+    /**
      * @notice Emitted when cashback is calculated and potentially distributed
      * @param safe Address of the safe 
      * @param spendingInUsd USD value of the spending that generated the cashback
@@ -431,6 +448,29 @@ contract CashEventEmitter is UpgradeableProxy {
      */
     function emitCollateralResupplied(address safe, address token, uint256 amount) external onlyCashModule {
         emit CollateralResupplied(safe, token, amount);
+    }
+
+    /**
+     * @notice Emits the LendSupplied event
+     * @dev Can only be called by the Cash Module
+     * @param safe Address of the safe
+     * @param token Token supplied
+     * @param amount Token amount supplied
+     */
+    function emitLendSupplied(address safe, address token, uint256 amount) external onlyCashModule {
+        emit LendSupplied(safe, token, amount);
+    }
+
+    /**
+     * @notice Emits the LendBorrowed event
+     * @dev Can only be called by the Cash Module
+     * @param safe Address of the safe
+     * @param token Token borrowed
+     * @param amount Token amount borrowed
+     * @param amountInUsd USD value of the borrow
+     */
+    function emitLendBorrowed(address safe, address token, uint256 amount, uint256 amountInUsd) external onlyCashModule {
+        emit LendBorrowed(safe, token, amount, amountInUsd);
     }
 
     /// @notice Emits the LendDisableRequested event

--- a/src/modules/cash/CashLendLib.sol
+++ b/src/modules/cash/CashLendLib.sol
@@ -49,6 +49,7 @@ library CashLendLib {
     error LendDisabled();
     error AmountZero();
     error SettlementDispatcherNotSetForBinSponsor();
+    error OnlyLendGatewaySafe();
 
     /// @dev Pad on resupply sizing so Aave share rounding cannot leave the headroom short; excess supply is harmless
     uint256 internal constant RESUPPLY_BUFFER_BPS = 10;
@@ -114,18 +115,25 @@ library CashLendLib {
 
     /**
      * @notice Executes a repayment on behalf of a safe, routing by engine
-     * @dev The caller must have already validated the amount and cancelled any conflicting withdrawal request.
-     *      A legacy safe repays the DebtManager through the safe's module execution; an Aave-gateway safe
-     *      repays on Aave via the gateway (which pulls the token from the safe, repays, refunds dust, and
-     *      emits Repaid).
+     * @dev A legacy safe repays the DebtManager from its loose balance through the safe's module execution;
+     *      the caller has already validated the amount and cancelled any conflicting withdrawal request.
+     *      A gateway safe repays on Aave via the gateway, sourcing like a debit spend: unreserved loose
+     *      balance first, then the safe's Aave-supplied balance of the same token (Aave v4 has no
+     *      repay-with-aTokens, so the shortfall is withdrawn to the safe and repaid), and only as a last
+     *      resort the withdrawal-reserved loose balance, cancelling the request (the spend paths' rule).
+     *      The loose leg repays before the withdraw so the freed headroom sizes the supplied leg.
      * @param $ The CashModule storage (passed by the delegatecalling module)
+     * @param dataProvider The module's data provider (for the price provider and withdrawal cancels)
      * @param safe The safe whose debt is repaid
      * @param token The token to repay
-     * @param amount The token amount to repay
+     * @param amount The token amount to repay, capped at the open debt
      * @param amountInUsd The USD value of the repayment (for the emitted DebtManager event)
      * @custom:throws LendGatewayNotSet if the safe uses the gateway but none is configured
+     * @custom:throws AmountZero if the safe has no debt in the token
+     * @custom:throws InsufficientBalance if the safe cannot source the capped amount (the supplied leg is
+     *                bounded by borrowing headroom; a max-leveraged position unloops over multiple repays)
      */
-    function repay(CashModuleStorageContract.CashModuleStorage storage $, address safe, address token, uint256 amount, uint256 amountInUsd) external {
+    function repay(CashModuleStorageContract.CashModuleStorage storage $, IEtherFiDataProvider dataProvider, address safe, address token, uint256 amount, uint256 amountInUsd) external {
         if (!_usesLendGateway($, safe)) {
             address[] memory to = new address[](3);
             bytes[] memory data = new bytes[](3);
@@ -146,13 +154,128 @@ library CashLendLib {
 
         ILendGateway gateway = $.gateway;
         if (address(gateway) == address(0)) revert LendGatewayNotSet();
-        // Full repays pass the max sentinel so no interest dust survives the exact-amount rounding.
         uint256 debt = gateway.debtOf(safe, token);
-        uint256 repaid = gateway.repay(safe, token, amount >= debt ? type(uint256).max : amount);
+        if (amount > debt) amount = debt;
+        if (amount == 0) revert AmountZero();
+
+        (uint256 fromLoose, uint256 fromSupplied, bool cancelWithdrawal) = _sourceRepay($, gateway, dataProvider, safe, token, amount);
+        if (cancelWithdrawal) cancelOldWithdrawal($, dataProvider, safe);
+
+        // A full repay passes the max sentinel on its last leg so no interest dust survives the
+        // exact-amount rounding.
+        uint256 repaid;
+        if (fromSupplied == 0) {
+            // Loose covers the whole amount
+            repaid = gateway.repay(safe, token, amount == debt ? type(uint256).max : amount);
+        } else {
+            if (fromLoose != 0) repaid = gateway.repay(safe, token, fromLoose);
+            gateway.withdraw(safe, token, fromSupplied, safe);
+            repaid += gateway.repay(safe, token, amount == debt ? type(uint256).max : fromSupplied);
+        }
+
         // The gateway may repay less than requested (dust refund, or the live Aave debt being smaller than
         // the quote), so report the USD value of what was actually repaid, not the requested amount.
         uint256 repaidInUsd = repaid == amount ? amountInUsd : $.debtManager.convertCollateralTokenToUsd(token, repaid);
         $.cashEventEmitter.emitRepay(safe, token, repaid, repaidInUsd);
+    }
+
+    /**
+     * @dev Sizes a gateway repay across the safe's pots: unreserved loose balance, then Aave-supplied
+     *      balance capped by borrowing headroom (credited with the headroom the loose leg's repay frees),
+     *      then withdrawal-reserved loose balance. Returns the loose leg (reserved portion included), the
+     *      supplied leg, and whether the pending withdrawal request must be cancelled.
+     * @custom:throws InsufficientBalance if the three pots cannot cover `amount`
+     */
+    function _sourceRepay(CashModuleStorageContract.CashModuleStorage storage $, ILendGateway gateway, IEtherFiDataProvider dataProvider, address safe, address token, uint256 amount) private view returns (uint256, uint256, bool) {
+        // Split the safe's loose balance into what a pending withdrawal has reserved and what is free
+        uint256 loose = IERC20(token).balanceOf(safe);
+        uint256 reserved = _pendingWithdrawalAmount($, safe, token);
+        if (reserved > loose) reserved = loose;
+        uint256 unreserved = loose - reserved;
+
+        // Pot 1: unreserved loose balance
+        uint256 fromLoose = amount < unreserved ? amount : unreserved;
+        uint256 shortfall = amount - fromLoose;
+        if (shortfall == 0) return (fromLoose, 0, false);
+
+        // Pot 2: the safe's Aave-supplied balance, capped by borrowing headroom. The loose leg repays
+        // before the withdraw executes, so the sizing credits the headroom that repay frees.
+        uint256 fromSupplied = DebitSourcingLib.repayWithdrawable(gateway, IPriceProvider(dataProvider.getPriceProvider()), safe, token, fromLoose);
+        if (fromSupplied > shortfall) fromSupplied = shortfall;
+        shortfall -= fromSupplied;
+        if (shortfall == 0) return (fromLoose, fromSupplied, false);
+
+        // Pot 3: the reserved loose balance. The repay wins the competing claim, so the caller cancels
+        // the withdrawal request. Nothing left after that means the repay cannot be funded.
+        if (shortfall > reserved) revert InsufficientBalance();
+        return (fromLoose + shortfall, fromSupplied, true);
+    }
+
+    /**
+     * @notice Supplies a safe's loose balances into the lend market and flags them as collateral (the
+     *         auto-supply sweep)
+     * @dev Per token: supplies the loose balance net of the pending-withdrawal reservation, so a queued
+     *      withdrawal is never swept back into Aave. Zero and unregistered tokens are skipped, not
+     *      reverted, so a keeper batch never bricks. An opted-out safe is a no-op, since the keeper
+     *      legitimately races an opt-out; a legacy safe reverts, since routing one here is a keeper bug.
+     * @param $ The CashModule storage (passed by the delegatecalling module)
+     * @param safe Address of the EtherFi Safe
+     * @param tokens Tokens to sweep
+     * @custom:throws OnlyLendGatewaySafe if the safe runs on the legacy DebtManager engine
+     * @custom:throws LendGatewayNotSet if no gateway is configured
+     */
+    function supplyToLend(CashModuleStorageContract.CashModuleStorage storage $, address safe, address[] calldata tokens) external {
+        ILendGateway gateway = _requireGateway($, safe);
+        if ($.safeCashConfig[safe].lendDisabled) return;
+
+        for (uint256 i = 0; i < tokens.length; i++) {
+            if (!gateway.isRegistered(tokens[i])) continue;
+            uint256 amount = IERC20(tokens[i]).balanceOf(safe);
+            uint256 pending = _pendingWithdrawalAmount($, safe, tokens[i]);
+            amount = amount > pending ? amount - pending : 0;
+            if (amount == 0) continue;
+            _supplyAsCollateral($, gateway, safe, tokens[i], amount);
+        }
+    }
+
+    /**
+     * @notice Borrows `token` against the safe's lend-market position; the proceeds land in the safe and
+     *         are immediately supplied back as collateral (a borrow-page borrow with instant auto-supply)
+     * @dev The portfolio gains the borrowed asset as supplied collateral, so the borrowing power moves by
+     *      its LTV weight net of the new debt. Aave enforces the health check on the borrow itself, and the
+     *      gateway rejects a borrow for an opted-out safe; the lendDisabled check here is defense-in-depth,
+     *      mirroring spendCredit.
+     * @param $ The CashModule storage (passed by the delegatecalling module)
+     * @param safe Address of the EtherFi Safe
+     * @param token The token to borrow
+     * @param amount The token amount to borrow
+     * @param amountInUsd The USD value of the borrow (for the emitted event)
+     * @custom:throws OnlyLendGatewaySafe if the safe runs on the legacy DebtManager engine
+     * @custom:throws LendGatewayNotSet if no gateway is configured
+     * @custom:throws LendDisabled if the safe has opted out of the lend market
+     */
+    function borrow(CashModuleStorageContract.CashModuleStorage storage $, address safe, address token, uint256 amount, uint256 amountInUsd) external {
+        ILendGateway gateway = _requireGateway($, safe);
+        if ($.safeCashConfig[safe].lendDisabled) revert LendDisabled();
+
+        gateway.borrow(safe, token, amount, safe);
+        _supplyAsCollateral($, gateway, safe, token, amount);
+        $.cashEventEmitter.emitLendBorrowed(safe, token, amount, amountInUsd);
+    }
+
+    /// @dev The lend ops require the safe on the gateway engine and a configured gateway
+    function _requireGateway(CashModuleStorageContract.CashModuleStorage storage $, address safe) private view returns (ILendGateway) {
+        if (!_usesLendGateway($, safe)) revert OnlyLendGatewaySafe();
+        ILendGateway gateway = $.gateway;
+        if (address(gateway) == address(0)) revert LendGatewayNotSet();
+        return gateway;
+    }
+
+    /// @dev Supplies `amount` of `token` from the safe into the lend market and flags it as collateral
+    function _supplyAsCollateral(CashModuleStorageContract.CashModuleStorage storage $, ILendGateway gateway, address safe, address token, uint256 amount) private {
+        gateway.supply(safe, token, amount);
+        gateway.setUsingAsCollateral(safe, token, true);
+        $.cashEventEmitter.emitLendSupplied(safe, token, amount);
     }
 
     /**

--- a/src/modules/cash/CashModuleCore.sol
+++ b/src/modules/cash/CashModuleCore.sol
@@ -523,6 +523,39 @@ contract CashModuleCore is CashModuleStorageContract {
     }
 
     /**
+     * @notice Supplies a safe's loose token balances into the Aave lend market (the auto-supply sweep)
+     * @dev Only callable by the EtherFi wallet (the cash-be sweeper). Per token: supplies the loose balance
+     *      net of any pending-withdrawal reservation and flags it as collateral; zero and unregistered
+     *      tokens are skipped. No-op for an opted-out safe; reverts for a legacy safe.
+     * @param safe Address of the EtherFi Safe
+     * @param tokens Tokens to sweep
+     * @custom:throws OnlyLendGatewaySafe if the safe runs on the legacy DebtManager engine
+     */
+    function supplyToLend(address safe, address[] calldata tokens) external whenNotPaused nonReentrant onlyEtherFiWallet onlyEtherFiSafe(safe) {
+        CashLendLib.supplyToLend(_getCashModuleStorage(), safe, tokens);
+    }
+
+    /**
+     * @notice Borrows a token against the safe's lend-market position; the proceeds land in the safe and
+     *         are immediately supplied back as collateral
+     * @dev Only callable by the EtherFi wallet for valid EtherFi Safe addresses. Aave enforces the health
+     *      check on the borrow itself.
+     * @param safe Address of the EtherFi Safe
+     * @param token Address of the token to borrow
+     * @param amountInUsd Amount to borrow in USD
+     * @custom:throws OnlyBorrowToken if token is not a valid borrow token
+     * @custom:throws AmountZero if the converted amount is zero
+     * @custom:throws OnlyLendGatewaySafe if the safe runs on the legacy DebtManager engine
+     */
+    function borrow(address safe, address token, uint256 amountInUsd) external whenNotPaused nonReentrant onlyEtherFiWallet onlyEtherFiSafe(safe) {
+        IDebtManager debtManager = getDebtManager();
+        if (!_isBorrowToken(debtManager, token)) revert OnlyBorrowToken();
+        uint256 amount = debtManager.convertUsdToCollateralToken(token, amountInUsd);
+        if (amount == 0) revert AmountZero();
+        CashLendLib.borrow(_getCashModuleStorage(), safe, token, amount, amountInUsd);
+    }
+
+    /**
      * @dev Internal function to execute the repayment transaction
      * @param safe Address of the EtherFi Safe
      * @param debtManager Reference to the debt manager contract
@@ -533,11 +566,14 @@ contract CashModuleCore is CashModuleStorageContract {
     function _repay(address safe, IDebtManager debtManager, address token, uint256 amountInUsd) internal {
         uint256 amount = IDebtManager(debtManager).convertUsdToCollateralToken(token, amountInUsd);
         if (amount == 0) revert AmountZero();
-        _cancelCompetingWithdrawal(safe, token, amount);
+        // A legacy safe repays from its loose balance only, so a repay that needs withdrawal-reserved funds
+        // is resolved here. A gateway safe sources loose plus Aave-supplied balance in CashLendLib.repay,
+        // which owns the reservation handling for that engine.
+        if (!_usesLendGateway(safe)) _cancelCompetingWithdrawal(safe, token, amount);
 
         // A migrated safe repays on Aave via the gateway; a legacy safe repays the DebtManager. Both paths run
         // in CashLendLib (extracted to keep this contract within the code-size limit).
-        CashLendLib.repay(_getCashModuleStorage(), safe, token, amount, amountInUsd);
+        CashLendLib.repay(_getCashModuleStorage(), etherFiDataProvider, safe, token, amount, amountInUsd);
     }
 
     /**

--- a/src/modules/cash/CashModuleStorageContract.sol
+++ b/src/modules/cash/CashModuleStorageContract.sol
@@ -105,6 +105,9 @@ contract CashModuleStorageContract is UpgradeableProxy, ModuleBase {
     /// @notice Error thrown when a balance is insufficient for an operation
     error InsufficientBalance();
 
+    /// @notice Error thrown when a lend-market operation targets a safe on the legacy DebtManager engine
+    error OnlyLendGatewaySafe();
+
     /// @notice Error thrown when a non-DebtManager contract calls restricted functions
     error OnlyDebtManager();
 

--- a/test/safe/modules/cash/lend/AutoSupply.t.sol
+++ b/test/safe/modules/cash/lend/AutoSupply.t.sol
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+
+import { ICashModule } from "../../../../../src/interfaces/ICashModule.sol";
+import { CashVerificationLib } from "../../../../../src/libraries/CashVerificationLib.sol";
+import { CashEventEmitter } from "../../../../../src/modules/cash/CashEventEmitter.sol";
+import { CashGatewayTestSetup } from "./CashGatewayTestSetup.t.sol";
+
+/**
+ * @title AutoSupplyTest
+ * @notice Fork tests for the on-chain half of auto-supply: the sweep entrypoint (supplyToLend, called by the
+ *         cash-be cron via the EtherFi wallet) that moves a safe's loose balances into Aave as collateral,
+ *         and the borrow entrypoint whose proceeds land in the safe and are supplied back atomically.
+ * @dev Run with: source .env && FOUNDRY_PROFILE=lend TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test --match-path test/safe/modules/cash/lend/AutoSupply.t.sol
+ */
+contract AutoSupplyTest is CashGatewayTestSetup {
+    using MessageHashUtils for bytes32;
+
+    /// The sweep supplies each token's loose balance net of the pending-withdrawal reservation and flags
+    /// it as collateral; the reserved balance stays loose and the request survives.
+    function test_supplyToLend_sweepsLooseNetOfReservation() public {
+        uint256 looseUsdc = 1000e6;
+        uint256 reservedUsdc = 300e6;
+        uint256 looseWeeth = 2 ether;
+        deal(address(usdc), address(safe), looseUsdc);
+        deal(address(weETH), address(safe), looseWeeth);
+        _requestWithdrawal(_addr1(address(usdc)), _uint1(reservedUsdc), withdrawRecipient);
+
+        address[] memory tokens = new address[](2);
+        tokens[0] = address(usdc);
+        tokens[1] = address(weETH);
+
+        vm.expectEmit(true, true, true, true);
+        emit CashEventEmitter.LendSupplied(address(safe), address(usdc), looseUsdc - reservedUsdc);
+        vm.prank(etherFiWallet);
+        cashModule.supplyToLend(address(safe), tokens);
+
+        assertEq(gw.suppliedOf(address(safe), address(usdc)), looseUsdc - reservedUsdc, "swept loose minus the reservation");
+        assertEq(gw.suppliedOf(address(safe), address(weETH)), looseWeeth, "swept the full weETH balance");
+        assertEq(usdc.balanceOf(address(safe)), reservedUsdc, "reserved balance stays loose");
+        assertEq(cashModule.getPendingWithdrawalAmount(address(safe), address(usdc)), reservedUsdc, "withdrawal request survived");
+        assertGt(gw.getAccountData(address(safe)).availableBorrowsUsd, 0, "supplied balances count as collateral");
+    }
+
+    /// Zero-balance and unregistered tokens are skipped, not reverted, so a keeper batch never bricks.
+    function test_supplyToLend_skipsZeroAndUnregisteredTokens() public {
+        address[] memory tokens = new address[](2);
+        tokens[0] = makeAddr("unregistered");
+        tokens[1] = address(weETH); // zero balance
+
+        vm.prank(etherFiWallet);
+        cashModule.supplyToLend(address(safe), tokens);
+
+        assertEq(gw.suppliedOf(address(safe), address(weETH)), 0, "nothing supplied");
+    }
+
+    /// An opted-out safe is a no-op sweep (the keeper legitimately races an opt-out); its funds stay loose.
+    function test_supplyToLend_noopWhenOptedOut() public {
+        uint256 looseUsdc = 500e6;
+        _optOut();
+        deal(address(usdc), address(safe), looseUsdc);
+
+        vm.prank(etherFiWallet);
+        cashModule.supplyToLend(address(safe), _addr1(address(usdc)));
+
+        assertEq(usdc.balanceOf(address(safe)), looseUsdc, "opted-out safe keeps funds loose");
+        assertEq(gw.suppliedOf(address(safe), address(usdc)), 0, "nothing supplied");
+    }
+
+    /// Routing a legacy safe to the sweep is a keeper bug and reverts loudly.
+    function test_supplyToLend_revertsForLegacySafe() public {
+        _forceLegacyEngine(address(safe));
+        vm.prank(etherFiWallet);
+        vm.expectRevert(ICashModule.OnlyLendGatewaySafe.selector);
+        cashModule.supplyToLend(address(safe), _addr1(address(usdc)));
+    }
+
+    /// A borrow lands in the safe and is supplied back as collateral in the same tx: the portfolio gains
+    /// the asset, nothing stays loose, and the borrowing power moves by the asset's LTV weight net of debt.
+    function test_borrow_suppliesProceedsAsCollateral() public {
+        uint256 collateralWeeth = 5 ether;
+        uint256 borrowUsd = 500e6;
+        _supplyToGateway(address(safe), address(weETH), collateralWeeth);
+        uint256 availableBefore = gw.getAccountData(address(safe)).availableBorrowsUsd;
+
+        uint256 borrowAmt = debtManager.convertUsdToCollateralToken(address(usdc), borrowUsd);
+        vm.expectEmit(true, true, true, true);
+        emit CashEventEmitter.LendSupplied(address(safe), address(usdc), borrowAmt);
+        vm.expectEmit(true, true, true, true);
+        emit CashEventEmitter.LendBorrowed(address(safe), address(usdc), borrowAmt, borrowUsd);
+        vm.prank(etherFiWallet);
+        cashModule.borrow(address(safe), address(usdc), borrowUsd);
+
+        assertApproxEqAbs(gw.debtOf(address(safe), address(usdc)), borrowAmt, 2, "debt opened");
+        assertApproxEqAbs(gw.suppliedOf(address(safe), address(usdc)), borrowAmt, 2, "proceeds supplied back");
+        assertEq(usdc.balanceOf(address(safe)), 0, "nothing left loose");
+        // The borrow adds borrowUsd of debt, and supplying the proceeds back adds CF% of it as collateral
+        // weight, so the net borrowing-power cost is the remaining (100 - CF)%
+        uint256 powerConsumedUsd = borrowUsd - (borrowUsd * _usdcCollateralFactorBps()) / 10_000;
+        assertApproxEqAbs(availableBefore - gw.getAccountData(address(safe)).availableBorrowsUsd, powerConsumedUsd, 2e6, "borrow power moved by debt minus LTV-weighted supply");
+    }
+
+    /// An opted-out safe cannot borrow.
+    function test_borrow_revertsWhenOptedOut() public {
+        _optOut();
+
+        vm.prank(etherFiWallet);
+        vm.expectRevert(ICashModule.LendDisabled.selector);
+        cashModule.borrow(address(safe), address(usdc), 100e6);
+    }
+
+    /// A legacy safe has no gateway borrow flow.
+    function test_borrow_revertsForLegacySafe() public {
+        _forceLegacyEngine(address(safe));
+        vm.prank(etherFiWallet);
+        vm.expectRevert(ICashModule.OnlyLendGatewaySafe.selector);
+        cashModule.borrow(address(safe), address(usdc), 100e6);
+    }
+
+    /// @dev Opts the safe out of the lend market, riding out the mode-change delay.
+    function _optOut() internal {
+        (address signer, bytes memory sig) = _toggleLendSig(false);
+        cashModule.toggleLend(address(safe), false, signer, sig);
+        (,, uint64 modeDelay) = cashModule.getDelays();
+        if (modeDelay != 0) {
+            vm.warp(block.timestamp + modeDelay + 1);
+            cashModule.processLendDisable(address(safe));
+        }
+    }
+
+    function _toggleLendSig(bool enable) internal view returns (address, bytes memory) {
+        uint256 nonce = cashModule.getNonce(address(safe));
+        bytes32 digest = keccak256(abi.encodePacked(CashVerificationLib.TOGGLE_LEND_METHOD, block.chainid, address(safe), nonce, abi.encode(enable))).toEthSignedMessageHash();
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Pk, digest);
+        return (owner1, abi.encodePacked(r, s, v));
+    }
+
+    function _uint1(uint256 a) internal pure returns (uint256[] memory) {
+        uint256[] memory arr = new uint256[](1);
+        arr[0] = a;
+        return arr;
+    }
+}

--- a/test/safe/modules/cash/lend/RepaySourcing.t.sol
+++ b/test/safe/modules/cash/lend/RepaySourcing.t.sol
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+
+import { ICashModule } from "../../../../../src/interfaces/ICashModule.sol";
+import { CashEventEmitter } from "../../../../../src/modules/cash/CashEventEmitter.sol";
+import { CashGatewayTestSetup } from "./CashGatewayTestSetup.t.sol";
+
+/**
+ * @title RepaySourcingTest
+ * @notice Fork tests for the gateway repay's sourcing: unreserved loose balance first, then the safe's
+ *         Aave-supplied balance of the same token (withdrawn in the same tx, since Aave v4 has no
+ *         repay-with-aTokens), and only as a last resort the withdrawal-reserved loose balance. A fully
+ *         swept safe (all funds in Aave) must be able to repay, and a max-leveraged position unloops
+ *         because the loose leg repays before the supplied leg is sized.
+ * @dev Run with: source .env && FOUNDRY_PROFILE=lend TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test --match-path test/safe/modules/cash/lend/RepaySourcing.t.sol
+ */
+contract RepaySourcingTest is CashGatewayTestSetup {
+    using MessageHashUtils for bytes32;
+
+    /// A fully swept safe (borrowed USDC auto-supplied, zero loose) repays its whole debt from the
+    /// supplied balance; the sentinel path leaves no dust.
+    function test_repay_fullDebtFromSuppliedWhenSwept() public {
+        uint256 collateralWeeth = 5 ether;
+        uint256 borrowedUsdc = 1000e6;
+        _buildGatewayPosition(address(safe), address(weETH), collateralWeeth, address(usdc), borrowedUsdc);
+        // The sweep supplied the borrowed USDC back into Aave: the safe holds aUSDC, nothing loose
+        _supplyToGateway(address(safe), address(usdc), borrowedUsdc);
+        uint256 suppliedBefore = gw.suppliedOf(address(safe), address(usdc));
+        uint256 debt = gw.debtOf(address(safe), address(usdc));
+        assertEq(usdc.balanceOf(address(safe)), 0, "swept safe holds no loose USDC");
+
+        uint256 debtUsd = debtManager.convertCollateralTokenToUsd(address(usdc), debt);
+        vm.expectEmit(true, true, false, false);
+        emit CashEventEmitter.Repay(address(safe), address(usdc), 0, 0);
+        vm.prank(etherFiWallet);
+        cashModule.repay(address(safe), address(usdc), debtUsd + 1e6);
+
+        assertEq(gw.debtOf(address(safe), address(usdc)), 0, "debt fully cleared, no dust");
+        assertApproxEqAbs(suppliedBefore - gw.suppliedOf(address(safe), address(usdc)), debt, 2, "repay withdrew only the debt from the supplied pot");
+    }
+
+    /// A partial repay consumes the loose balance before touching the supplied pot.
+    function test_repay_sourcesLooseBeforeSupplied() public {
+        uint256 borrowedUsdc = 400e6;
+        uint256 suppliedUsdc = 1000e6;
+        uint256 looseUsdc = 250e6;
+        uint256 repayAmt = 300e6; // covered by all the loose plus (repayAmt - looseUsdc) from the supplied pot
+        _buildGatewayPosition(address(safe), address(weETH), 5 ether, address(usdc), borrowedUsdc);
+        _supplyToGateway(address(safe), address(usdc), suppliedUsdc);
+        deal(address(usdc), address(safe), looseUsdc);
+        uint256 suppliedBefore = gw.suppliedOf(address(safe), address(usdc));
+
+        uint256 repayUsd = debtManager.convertCollateralTokenToUsd(address(usdc), repayAmt);
+        vm.prank(etherFiWallet);
+        cashModule.repay(address(safe), address(usdc), repayUsd);
+
+        assertApproxEqAbs(gw.debtOf(address(safe), address(usdc)), borrowedUsdc - repayAmt, 3, "debt reduced by the repay");
+        assertApproxEqAbs(usdc.balanceOf(address(safe)), 0, 3, "loose consumed first");
+        assertApproxEqAbs(suppliedBefore - gw.suppliedOf(address(safe), address(usdc)), repayAmt - looseUsdc, 3, "only the shortfall left the supplied pot");
+    }
+
+    /// At max leverage the supplied pot alone cannot fund a repay (Aave's health check caps the withdraw),
+    /// but topping up loose unlocks more: the loose leg repays first and frees headroom for the withdraw.
+    function test_repay_unloopsAtMaxLeverageWithLooseTopUp() public {
+        uint256 suppliedUsdc = 1000e6;
+        uint256 borrowedUsdc = 799e6; // a hair under the 80% CF max: headroom ~0
+        _buildGatewayPosition(address(safe), address(usdc), suppliedUsdc, address(usdc), borrowedUsdc);
+
+        // Nothing loose and no headroom to withdraw against: the repay cannot be sourced
+        vm.prank(etherFiWallet);
+        vm.expectRevert(ICashModule.InsufficientBalance.selector);
+        cashModule.repay(address(safe), address(usdc), 100e6);
+
+        // The loose top-up funds twice its size: its repay frees that much USD of headroom, letting the
+        // supplied leg withdraw the other half
+        uint256 topUpUsdc = 100e6;
+        uint256 repayAmt = 2 * topUpUsdc;
+        deal(address(usdc), address(safe), topUpUsdc);
+        uint256 repayUsd = debtManager.convertCollateralTokenToUsd(address(usdc), repayAmt);
+        vm.prank(etherFiWallet);
+        cashModule.repay(address(safe), address(usdc), repayUsd);
+
+        assertApproxEqAbs(gw.debtOf(address(safe), address(usdc)), borrowedUsdc - repayAmt, 3, "unlooped by loose plus freed-headroom withdraw");
+        assertApproxEqAbs(usdc.balanceOf(address(safe)), 0, 3, "loose fully consumed");
+    }
+
+    /// When the supplied pot can fund the repay, the pending withdrawal request survives and its reserved
+    /// loose balance is untouched.
+    function test_repay_prefersSuppliedOverReservedLoose() public {
+        uint256 borrowedUsdc = 300e6;
+        uint256 suppliedUsdc = 1000e6; // covers the whole repay, so the reserved loose is never needed
+        uint256 reservedUsdc = 200e6;
+        _buildGatewayPosition(address(safe), address(weETH), 5 ether, address(usdc), borrowedUsdc);
+        _supplyToGateway(address(safe), address(usdc), suppliedUsdc);
+        deal(address(usdc), address(safe), reservedUsdc);
+        _requestWithdrawal(_addr1(address(usdc)), _uint1(reservedUsdc), withdrawRecipient);
+
+        uint256 repayUsd = debtManager.convertCollateralTokenToUsd(address(usdc), borrowedUsdc);
+        vm.prank(etherFiWallet);
+        cashModule.repay(address(safe), address(usdc), repayUsd);
+
+        assertApproxEqAbs(gw.debtOf(address(safe), address(usdc)), 0, 3, "debt repaid");
+        assertEq(usdc.balanceOf(address(safe)), reservedUsdc, "reserved loose untouched");
+        assertEq(cashModule.getPendingWithdrawalAmount(address(safe), address(usdc)), reservedUsdc, "withdrawal request survived");
+    }
+
+    /// With no supplied balance to draw on, the repay wins the competing claim: the withdrawal request is
+    /// cancelled and its reserved loose balance funds the repay.
+    function test_repay_cancelsWithdrawalAsLastResort() public {
+        uint256 borrowedUsdc = 300e6;
+        uint256 reservedUsdc = 200e6; // the safe's only USDC, all reserved; no supplied USDC to draw on
+        uint256 repayAmt = 150e6;
+        _buildGatewayPosition(address(safe), address(weETH), 5 ether, address(usdc), borrowedUsdc);
+        deal(address(usdc), address(safe), reservedUsdc);
+        _requestWithdrawal(_addr1(address(usdc)), _uint1(reservedUsdc), withdrawRecipient);
+
+        uint256 repayUsd = debtManager.convertCollateralTokenToUsd(address(usdc), repayAmt);
+        vm.prank(etherFiWallet);
+        cashModule.repay(address(safe), address(usdc), repayUsd);
+
+        assertApproxEqAbs(gw.debtOf(address(safe), address(usdc)), borrowedUsdc - repayAmt, 3, "repaid from the reserved balance");
+        assertEq(cashModule.getPendingWithdrawalAmount(address(safe), address(usdc)), 0, "withdrawal request cancelled");
+    }
+
+    function _uint1(uint256 a) internal pure returns (uint256[] memory) {
+        uint256[] memory arr = new uint256[](1);
+        arr[0] = a;
+        return arr;
+    }
+}


### PR DESCRIPTION
Closes COR-1070. Stacked on #177.

## What this does

A swept safe holds only aTokens, so repay could not find any funds to pull. Aave v4 cannot repay with aTokens, so the contract now withdraws the shortfall from the supplied balance and repays it in the same transaction.

- Repay sources funds in this order: unreserved loose balance, then the supplied balance capped by borrowing headroom, then the balance a pending withdrawal reserves. The last step cancels the request. See `CashLendLib.repay` and `_sourceRepay`.
- The loose part repays before the withdraw executes. That lowers the debt and gives the withdraw more headroom, so one transaction can repay more. The shared cap math is `DebitSourcingLib.repayWithdrawable`.
- `supplyToLend(safe, tokens)` is the on-chain half of the auto-supply cron (COR-939). It supplies each token's loose balance minus the pending withdrawal reservation and flags it as collateral.
- `borrow(safe, token, amountInUsd)` is the borrow page entrypoint. The proceeds land in the safe and are supplied back as collateral in the same transaction. Spending borrows are unchanged and still pay the settlement dispatcher directly.

## Decisions to double check

- The sweep does nothing for an opted-out safe but reverts for a legacy safe.
- A `getMaxRepayable` lens view was built and then cut. CashLens is about 162 bytes under the EIP-170 size limit and the view did not fit. The backend can compose min(per-token debt, `getMaxWithdrawable`) instead, which never quotes an amount that reverts. An exact view can ship later as a lens upgrade.
- The design call assumed Aave lets you repay with aTokens. That is a v3 feature and v4 does not have it. The user experience does not change, but the repay transaction does a withdraw under the hood.

## How it was tested

Fork tests on the lend profile, all passing:

- `RepaySourcing.t.sol`: swept safe full repay with no dust, loose before supplied, the unloop case at max leverage, withdrawal request survival, and last-resort cancellation.
- `AutoSupply.t.sol`: reservation-aware sweep, skip and no-op semantics, legacy reverts, and borrow proceeds ending up supplied with the borrow power moving by the collateral factor.

The legacy repay suite is unchanged and green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core repay funding, Aave withdraw/repay sequencing, and withdrawal cancellation on gateway safes—direct user funds and debt handling—with new keeper-driven supply/borrow paths gated only by `ETHER_FI_WALLET_ROLE`.
> 
> **Overview**
> **Gateway safes can repay when funds live only as Aave supply** (no loose balance). Because Aave v4 has no repay-with-aTokens, `CashLendLib.repay` now **sources** like debit spend: unreserved loose first, then withdraws from the same token’s supplied balance (capped by borrowing headroom via new `DebitSourcingLib.repayWithdrawable`), then withdrawal-reserved loose as a last resort (cancelling the pending withdrawal). The **loose leg repays before the withdraw** so freed headroom sizes the supplied leg; max-leveraged positions may need multiple repays.
> 
> Adds **EtherFi-wallet** entrypoints **`supplyToLend`** (cron auto-supply: sweep loose net of withdrawal reservations, skip zeros/unregistered, no-op if lend disabled, revert on legacy) and **`borrow`** (borrow to safe then supply back as collateral). New **`OnlyLendGatewaySafe`** guard and **`LendSupplied` / `LendBorrowed`** events. Legacy repay still uses loose-only cancellation in the module; gateway reservation handling moves into `CashLendLib`.
> 
> Fork tests in `AutoSupply.t.sol` and `RepaySourcing.t.sol` cover sweep, borrow, sourcing order, unloop, and withdrawal competition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 528e3cc24c1317d9072a8bb0622ddcfbdfddb004. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->