### PR TITLE
feat: pull the withdrawal shortfall from the lend market at request time

### DIFF
--- a/src/modules/cash/CashLendLib.sol
+++ b/src/modules/cash/CashLendLib.sol
@@ -212,6 +212,39 @@ library CashLendLib {
     }
 
     /**
+     * @notice Pulls each requested token's shortfall out of the lend market into the safe, so a
+     *         withdrawal request is funded even while the balance sits supplied (the pull-first step
+     *         of the withdrawal flow)
+     * @dev A legacy safe skips the pull: its balances never sit in the lend market. The caller has
+     *      already cancelled any pending withdrawal, so the whole loose balance counts. Per token, the
+     *      pull is capped at the safe's supplied balance and the caller's balance check still rejects a
+     *      request the two pots cannot fund; Aave enforces the position's health on the pull itself, so
+     *      a withdrawal that would leave the safe unhealthy reverts here. The pulled funds sit loose
+     *      through the withdrawal delay; the auto-supply sweep nets out the pending reservation, so it
+     *      never sweeps them back.
+     * @param $ The CashModule storage (passed by the delegatecalling module)
+     * @param safe Address of the EtherFi Safe
+     * @param tokens Tokens in the withdrawal request
+     * @param amounts Requested token amounts
+     * @custom:throws LendGatewayNotSet if the safe uses the gateway but none is configured
+     */
+    function sourceWithdrawal(CashModuleStorageContract.CashModuleStorage storage $, address safe, address[] memory tokens, uint256[] memory amounts) external {
+        if (!_usesLendGateway($, safe)) return;
+        ILendGateway gateway = $.gateway;
+        if (address(gateway) == address(0)) revert LendGatewayNotSet();
+
+        for (uint256 i = 0; i < tokens.length; i++) {
+            if (!gateway.isRegistered(tokens[i])) continue;
+            uint256 loose = IERC20(tokens[i]).balanceOf(safe);
+            if (amounts[i] <= loose) continue;
+            uint256 shortfall = amounts[i] - loose;
+            uint256 supplied = gateway.suppliedOf(safe, tokens[i]);
+            if (supplied == 0) continue;
+            gateway.withdraw(safe, tokens[i], shortfall > supplied ? supplied : shortfall, safe);
+        }
+    }
+
+    /**
      * @notice Supplies a safe's loose balances into the lend market and flags them as collateral (the
      *         auto-supply sweep)
      * @dev Per token: supplies the loose balance net of the pending-withdrawal reservation, so a queued

--- a/src/modules/cash/CashLendLib.sol
+++ b/src/modules/cash/CashLendLib.sol
@@ -221,7 +221,8 @@ library CashLendLib {
      *      request the two pots cannot fund; Aave enforces the position's health on the pull itself, so
      *      a withdrawal that would leave the safe unhealthy reverts here. The pulled funds sit loose
      *      through the withdrawal delay; the auto-supply sweep nets out the pending reservation, so it
-     *      never sweeps them back.
+     *      never sweeps them back. A cancel leaves them loose on purpose (re-supplying there would let
+     *      a paused reserve block the cancel); the next sweep restores them as collateral.
      * @param $ The CashModule storage (passed by the delegatecalling module)
      * @param safe Address of the EtherFi Safe
      * @param tokens Tokens in the withdrawal request

--- a/src/modules/cash/CashModuleSetters.sol
+++ b/src/modules/cash/CashModuleSetters.sol
@@ -387,7 +387,8 @@ contract CashModuleSetters is CashModuleStorageContract {
 
     /**
      * @notice Internal implementation of withdrawal request logic
-     * @dev Creates a pending withdrawal request and emits events
+     * @dev For a gateway safe, first pulls any lend-market shortfall into the safe (Aave enforces the
+     *      position's health on that pull), then creates a pending withdrawal request and emits events
      * @param safe Address of the EtherFi Safe
      * @param tokens Array of token addresses to withdraw
      * @param amounts Array of token amounts to withdraw
@@ -406,6 +407,7 @@ contract CashModuleSetters is CashModuleStorageContract {
 
         uint96 finalTime = uint96(block.timestamp) + $.withdrawalDelay;
 
+        CashLendLib.sourceWithdrawal($, safe, tokens, amounts);
         _checkBalance(safe, tokens, amounts);
 
         $$.pendingWithdrawalRequest = WithdrawalRequest({ tokens: tokens, amounts: amounts, recipient: recipient, finalizeTime: finalTime });

--- a/test/safe/modules/cash/lend/WithdrawalSourcing.t.sol
+++ b/test/safe/modules/cash/lend/WithdrawalSourcing.t.sol
@@ -98,6 +98,36 @@ contract WithdrawalSourcingTest is CashGatewayTestSetup {
         assertEq(gw.suppliedOf(address(safe), address(usdc)), suppliedAfterPull, "nothing swept back");
     }
 
+    /// A full exit at the getMaxWithdrawable quote pays out exactly, even after interest accrual has
+    /// moved the share rate: the pull is capped at the same preview the spoke itself caps with, and the
+    /// hub transfers the capped amount exactly, so no rounding dust can undercut the balance check.
+    function test_requestWithdrawal_fullExitAtQuoteAfterAccrual() public {
+        _supplyToGateway(address(safe), address(usdc), 5000e6);
+
+        // An independent borrower drives USDC utilization so the supplied balance accrues interest
+        address borrower = makeAddr("dustBorrower");
+        deal(address(weETH), borrower, 400 ether);
+        vm.startPrank(borrower);
+        weETH.approve(address(spoke), 400 ether);
+        spoke.supply(weethReserveId, 400 ether, borrower);
+        spoke.setUsingAsCollateral(weethReserveId, true, borrower);
+        spoke.borrow(usdcReserveId, 500_000e6, borrower);
+        vm.stopPrank();
+
+        vm.warp(block.timestamp + 7 days);
+
+        uint256 max = cashLens.getMaxWithdrawable(address(safe), address(usdc));
+        assertGt(max, 5000e6, "interest accrued on the supplied balance");
+
+        _requestWithdrawal(_addr1(address(usdc)), _uint1(max), withdrawRecipient);
+        assertEq(usdc.balanceOf(address(safe)), max, "full exit lands in the safe exactly");
+
+        (uint64 withdrawalDelay,,) = cashModule.getDelays();
+        vm.warp(block.timestamp + withdrawalDelay + 1);
+        cashModule.processWithdrawal(address(safe));
+        assertEq(usdc.balanceOf(withdrawRecipient), max, "recipient paid the full quote");
+    }
+
     /// Builds the owner signatures for a withdrawal request, so revert-path tests can place expectRevert
     /// immediately before the module call.
     function _signRequestWithdrawal(address[] memory tokens, uint256[] memory amounts, address recipient_) internal view returns (address[] memory, bytes[] memory) {

--- a/test/safe/modules/cash/lend/WithdrawalSourcing.t.sol
+++ b/test/safe/modules/cash/lend/WithdrawalSourcing.t.sol
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+
+import { ICashModule } from "../../../../../src/interfaces/ICashModule.sol";
+import { CashVerificationLib } from "../../../../../src/libraries/CashVerificationLib.sol";
+import { CashGatewayTestSetup } from "./CashGatewayTestSetup.t.sol";
+
+/**
+ * @title WithdrawalSourcingTest
+ * @notice Fork tests for the withdrawal request's pull-first step: a gateway safe's shortfall is withdrawn
+ *         from Aave into the safe at request time, then the existing delayed queue runs on the loose
+ *         balance. Aave enforces the position's health on the pull, so a request that would leave the safe
+ *         unhealthy reverts, and the quote side (CashLens.getMaxWithdrawable) is exactly requestable. The
+ *         legacy path is untouched (the pull is skipped), covered by the default-profile withdrawal tests.
+ * @dev Run with: source .env && FOUNDRY_PROFILE=lend TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test --match-path test/safe/modules/cash/lend/WithdrawalSourcing.t.sol
+ */
+contract WithdrawalSourcingTest is CashGatewayTestSetup {
+    using MessageHashUtils for bytes32;
+
+    /// A request larger than the loose balance pulls only the shortfall out of Aave, queues, and pays out
+    /// the full amount after the delay.
+    function test_requestWithdrawal_pullsShortfallFromSupplied() public {
+        _supplyToGateway(address(safe), address(weETH), 3 ether);
+        deal(address(weETH), address(safe), 1 ether);
+        uint256 suppliedBefore = gw.suppliedOf(address(safe), address(weETH));
+
+        _requestWithdrawal(_addr1(address(weETH)), _uint1(3 ether), withdrawRecipient);
+
+        assertEq(weETH.balanceOf(address(safe)), 3 ether, "shortfall pulled into the safe");
+        assertApproxEqAbs(suppliedBefore - gw.suppliedOf(address(safe), address(weETH)), 2 ether, 2, "only the shortfall left the supplied pot");
+        assertEq(cashModule.getPendingWithdrawalAmount(address(safe), address(weETH)), 3 ether, "request queued for the full amount");
+
+        (uint64 withdrawalDelay,,) = cashModule.getDelays();
+        vm.warp(block.timestamp + withdrawalDelay + 1);
+        cashModule.processWithdrawal(address(safe));
+        assertEq(weETH.balanceOf(withdrawRecipient), 3 ether, "recipient paid the full amount");
+    }
+
+    /// A fully swept safe (zero loose) can withdraw: the whole amount is pulled from the supplied pot.
+    function test_requestWithdrawal_fullySweptSafe() public {
+        _supplyToGateway(address(safe), address(usdc), 5000e6);
+        assertEq(usdc.balanceOf(address(safe)), 0, "swept safe holds no loose USDC");
+
+        _requestWithdrawal(_addr1(address(usdc)), _uint1(4000e6), withdrawRecipient);
+
+        assertEq(usdc.balanceOf(address(safe)), 4000e6, "pulled from Aave into the safe");
+        assertApproxEqAbs(gw.suppliedOf(address(safe), address(usdc)), 1000e6, 2, "the rest stays supplied");
+    }
+
+    /// The lens quote is exactly requestable with debt open: getMaxWithdrawable succeeds and one weETH-cent
+    /// more reverts on Aave's health check.
+    function test_requestWithdrawal_maxWithdrawableIsRequestableWithDebt() public {
+        _buildGatewayPosition(address(safe), address(weETH), 10 ether, address(usdc), 5000e6);
+        uint256 max = cashLens.getMaxWithdrawable(address(safe), address(weETH));
+        assertLt(max, 10 ether, "debt caps the withdrawable balance");
+
+        (address[] memory signers, bytes[] memory signatures) = _signRequestWithdrawal(_addr1(address(weETH)), _uint1(max + 0.01 ether), withdrawRecipient);
+        vm.expectRevert();
+        cashModule.requestWithdrawal(address(safe), _addr1(address(weETH)), _uint1(max + 0.01 ether), withdrawRecipient, signers, signatures);
+
+        _requestWithdrawal(_addr1(address(weETH)), _uint1(max), withdrawRecipient);
+        assertEq(cashModule.getPendingWithdrawalAmount(address(safe), address(weETH)), max, "max quote is requestable");
+    }
+
+    /// When both pots together cannot fund the request, it reverts with the module's own error.
+    function test_requestWithdrawal_revertsWhenBothPotsShort() public {
+        _supplyToGateway(address(safe), address(weETH), 1 ether);
+
+        (address[] memory signers, bytes[] memory signatures) = _signRequestWithdrawal(_addr1(address(weETH)), _uint1(2 ether), withdrawRecipient);
+        vm.expectRevert(ICashModule.InsufficientBalance.selector);
+        cashModule.requestWithdrawal(address(safe), _addr1(address(weETH)), _uint1(2 ether), withdrawRecipient, signers, signatures);
+    }
+
+    /// A request the loose balance already covers never touches the gateway.
+    function test_requestWithdrawal_looseCoversSkipsPull() public {
+        _supplyToGateway(address(safe), address(weETH), 3 ether);
+        deal(address(weETH), address(safe), 2 ether);
+        uint256 suppliedBefore = gw.suppliedOf(address(safe), address(weETH));
+
+        _requestWithdrawal(_addr1(address(weETH)), _uint1(2 ether), withdrawRecipient);
+
+        assertEq(gw.suppliedOf(address(safe), address(weETH)), suppliedBefore, "supplied pot untouched");
+    }
+
+    /// The auto-supply sweep nets out the pending reservation, so the pulled funds are never swept back
+    /// into Aave during the delay.
+    function test_autoSupply_neverSweepsThePulledFundsBack() public {
+        _supplyToGateway(address(safe), address(usdc), 5000e6);
+        _requestWithdrawal(_addr1(address(usdc)), _uint1(4000e6), withdrawRecipient);
+        uint256 suppliedAfterPull = gw.suppliedOf(address(safe), address(usdc));
+
+        vm.prank(etherFiWallet);
+        cashModule.supplyToLend(address(safe), _addr1(address(usdc)));
+
+        assertEq(usdc.balanceOf(address(safe)), 4000e6, "reserved funds stay loose");
+        assertEq(gw.suppliedOf(address(safe), address(usdc)), suppliedAfterPull, "nothing swept back");
+    }
+
+    /// Builds the owner signatures for a withdrawal request, so revert-path tests can place expectRevert
+    /// immediately before the module call.
+    function _signRequestWithdrawal(address[] memory tokens, uint256[] memory amounts, address recipient_) internal view returns (address[] memory, bytes[] memory) {
+        bytes32 digestHash = keccak256(abi.encodePacked(CashVerificationLib.REQUEST_WITHDRAWAL_METHOD, block.chainid, address(safe), safe.nonce(), abi.encode(tokens, amounts, recipient_))).toEthSignedMessageHash();
+
+        (uint8 v1, bytes32 r1, bytes32 s1) = vm.sign(owner1Pk, digestHash);
+        (uint8 v2, bytes32 r2, bytes32 s2) = vm.sign(owner2Pk, digestHash);
+
+        address[] memory signers = new address[](2);
+        signers[0] = owner1;
+        signers[1] = owner2;
+
+        bytes[] memory signatures = new bytes[](2);
+        signatures[0] = abi.encodePacked(r1, s1, v1);
+        signatures[1] = abi.encodePacked(r2, s2, v2);
+
+        return (signers, signatures);
+    }
+
+    function _uint1(uint256 a) internal pure returns (uint256[] memory) {
+        uint256[] memory arr = new uint256[](1);
+        arr[0] = a;
+        return arr;
+    }
+}


### PR DESCRIPTION
A withdrawal request now works when the safe's balance is supplied to Aave. The safe pulls the shortfall out of Aave at request time, and the existing delayed withdrawal flow runs unchanged after that.

## What it does

- On requestWithdrawal, a gateway safe pulls each token's shortfall out of Aave into the safe (CashLendLib.sourceWithdrawal). The existing delay, queue, and off-chain holds check then run unchanged on the loose balance.
- Aave checks the position's health on the pull, so a request that would leave the safe unhealthy reverts.
- The existing balance check still rejects a request that both pots cannot fund.
- A legacy safe skips the pull. Its path is unchanged.

## Why

Once auto-supply is on, most of a user's balance sits in Aave. Without this, a bank transfer or a withdrawal to a wallet reverts on the loose balance check even though the user has the money.

## Notes for review

- The pull-at-request design still needs security sign-off. That gates the merge.
- requestWithdrawalByModule goes through the same path, so module withdrawal requests also get the pull. Uniform and looks harmless, but please check.
- The auto-supply sweep nets out the pending reservation, so it never supplies the pulled funds back during the delay. A test pins this.

## Testing

- 6 fork tests in test/safe/modules/cash/lend/WithdrawalSourcing.t.sol. They cover the shortfall pull and payout, a fully swept safe, getMaxWithdrawable being exactly requestable with debt open, both pots short reverting, a loose covered request skipping the gateway, and the sweep not undoing the pull.
- The full lend suite passes. The one failure is a missing OPENOCEAN_API_KEY in the local env, unrelated. The 38 legacy withdrawal tests pass.

Closes COR-958

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches withdrawal funding and Aave gateway withdraws at request time with health checks; incorrect sourcing or reservation logic could block withdrawals or affect collateral during the delay.
> 
> **Overview**
> Gateway safes can request withdrawals when most funds sit in Aave auto-supply. **`requestWithdrawal`** (and **`requestWithdrawalByModule`**, via **`_requestWithdrawal`**) now runs **`CashLendLib.sourceWithdrawal`** before the loose-balance check: for each token, any gap between the requested amount and loose balance is withdrawn from the lend gateway into the safe (capped by supplied balance; unregistered tokens skipped). Legacy safes no-op; the existing delay, queue, and finalize flow are unchanged.
> 
> **Aave health** applies on that pull, so over-withdrawable amounts revert at the gateway rather than only at **`InsufficientBalance`**. **`_checkBalance`** still enforces that loose + supplied can fund the request. Pulled tokens stay loose during the delay; auto-supply already reserves pending withdrawals so keepers do not sweep them back.
> 
> Adds fork tests in **`WithdrawalSourcing.t.sol`** (shortfall pull, fully swept safe, **`getMaxWithdrawable`** alignment with debt, insufficient combined pots, skip when loose covers, sweep behavior, accrual/rounding full exit).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61d94bf39b149042d61b80c9b0852bb0264bb955. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->