### PR TITLE
feat: permissionless cancelExpiredSwap for stuck trading orders

### DIFF
--- a/src/across/AcrossSwapModule.sol
+++ b/src/across/AcrossSwapModule.sol
@@ -134,6 +134,8 @@ contract AcrossSwapModule is ModuleBase, UpgradeableProxy {
     error InvalidSignatures();
     /// @notice Reverts when `executeSwap` runs after `order.deadline`.
     error OrderExpired();
+    /// @notice Reverts when `cancelExpiredSwap` runs at or before `order.deadline`.
+    error OrderNotExpired();
     /// @notice Reverts when `depositArgs.outputAmount < order.minOut`.
     error InsufficientOutputAmount();
     /// @notice Reverts when admin-set `spokePool` / `multicallHandler` is still zero.
@@ -447,6 +449,31 @@ contract AcrossSwapModule is ModuleBase, UpgradeableProxy {
             // and cancels the swap already, so we need to delete the swap only in else block
             delete $.swaps[safe];
             emit SwapCancelled(safe, swapId);
+        }
+    }
+
+    /**
+     * @notice Permissionlessly cancels an EXPIRED stored swap for `safe`, releasing its
+     *         CashModule solvency hold WITHOUT an owner signature.
+     * @dev Once `block.timestamp > order.deadline`, `executeSwap` can never succeed again (it
+     *      reverts `OrderExpired`), so the stored swap and its hold would otherwise sit until an
+     *      owner signs `cancelSwap`. Authorization is purely the elapsed deadline: this can only
+     *      run after expiry, and it merely refunds the safe's own funds back to the safe (via
+     *      `cancelWithdrawalByModule`) and clears state — there is no fund-movement authority to
+     *      abuse, so it is safe to let the backend keeper (or anyone) call it. Mirrors
+     *      `cancelSwap`'s clearing path; where `cashModule == 0` state is cleared directly.
+     */
+    function cancelExpiredSwap(address safe) external nonReentrant onlyEtherFiSafe(safe) {
+        AcrossSwapModuleStorage storage $ = _getAcrossSwapModuleStorage();
+        StoredSwap memory swap = $.swaps[safe];
+        if (swap.order.srcToken == address(0)) revert NoActiveOrder();
+        if (block.timestamp <= swap.order.deadline) revert OrderNotExpired();
+
+        if (address(cashModule) != address(0)) {
+            cashModule.cancelWithdrawalByModule(safe);
+        } else {
+            delete $.swaps[safe];
+            emit SwapCancelled(safe, swap.swapId);
         }
     }
 

--- a/src/enso/EnsoSwapModule.sol
+++ b/src/enso/EnsoSwapModule.sol
@@ -123,6 +123,8 @@ contract EnsoSwapModule is ModuleBase, UpgradeableProxy, IBridgeModule {
     error InvalidSignatures();
     /// @notice Reverts when `executeSwap` runs after `order.deadline`.
     error OrderExpired();
+    /// @notice Reverts when `cancelExpiredSwap` runs at or before `order.deadline`.
+    error OrderNotExpired();
     /// @notice Reverts when the admin-set `ensoRouter` is still zero.
     error MissingConfig();
     /// @notice Reverts when `executeSwap` runs before the CashModule withdrawal hold matures.
@@ -317,6 +319,31 @@ contract EnsoSwapModule is ModuleBase, UpgradeableProxy, IBridgeModule {
             // which clears the swap; where cashModule == 0 we clear it here directly.
             delete $.swaps[safe];
             emit SwapCancelled(safe, swapId);
+        }
+    }
+
+    /**
+     * @notice Permissionlessly cancels an EXPIRED stored swap for `safe`, releasing its
+     *         CashModule solvency hold WITHOUT an owner signature.
+     * @dev Once `block.timestamp > order.deadline`, `executeSwap` can never succeed again (it
+     *      reverts `OrderExpired`), so the stored swap and its hold would otherwise sit until an
+     *      owner signs `cancelSwap`. Authorization is purely the elapsed deadline: this can only
+     *      run after expiry, and it merely refunds the safe's own funds back to the safe (via
+     *      `cancelWithdrawalByModule`) and clears state — there is no fund-movement authority to
+     *      abuse, so it is safe to let the backend keeper (or anyone) call it. Mirrors
+     *      `cancelSwap`'s clearing path; where `cashModule == 0` state is cleared directly.
+     */
+    function cancelExpiredSwap(address safe) external nonReentrant onlyEtherFiSafe(safe) {
+        EnsoSwapModuleStorage storage $ = _getEnsoSwapModuleStorage();
+        StoredSwap memory swap = $.swaps[safe];
+        if (swap.order.srcToken == address(0)) revert NoActiveOrder();
+        if (block.timestamp <= swap.order.deadline) revert OrderNotExpired();
+
+        if (address(cashModule) != address(0)) {
+            cashModule.cancelWithdrawalByModule(safe);
+        } else {
+            delete $.swaps[safe];
+            emit SwapCancelled(safe, swap.swapId);
         }
     }
 

--- a/test/across/AcrossSwapModule.t.sol
+++ b/test/across/AcrossSwapModule.t.sol
@@ -268,6 +268,42 @@ contract AcrossSwapModuleTest is SafeTestSetup {
         module.cancelSwap(address(safe), signers, sigs);
     }
 
+    // ---- cancelExpiredSwap ----
+
+    function test_cancelExpiredSwap_clearsOrderAndHold_permissionlessAfterDeadline() public {
+        AcrossSwapModule.Order memory order = _baseOrder();
+        _request(order);
+        vm.warp(order.deadline + 1);
+
+        // No signature and no role: any caller can clean up an expired order.
+        vm.expectEmit(true, false, false, false);
+        emit AcrossSwapModule.SwapCancelled(address(safe), bytes32(0));
+        vm.prank(makeAddr("randomCaller"));
+        module.cancelExpiredSwap(address(safe));
+
+        assertEq(module.getOrder(address(safe)).srcToken, address(0), "order not cleared");
+        assertEq(
+            cashModule.getData(address(safe)).pendingWithdrawalRequest.recipient,
+            address(0),
+            "hold not cleared"
+        );
+    }
+
+    function test_cancelExpiredSwap_revertsForNoActiveOrder() public {
+        vm.expectRevert(AcrossSwapModule.NoActiveOrder.selector);
+        module.cancelExpiredSwap(address(safe));
+    }
+
+    function test_cancelExpiredSwap_revertsBeforeDeadline() public {
+        AcrossSwapModule.Order memory order = _baseOrder();
+        _request(order);
+
+        // At the deadline (inclusive) it is not yet expired.
+        vm.warp(order.deadline);
+        vm.expectRevert(AcrossSwapModule.OrderNotExpired.selector);
+        module.cancelExpiredSwap(address(safe));
+    }
+
     // ---- swapId linking ----
 
     /// @dev The swapId committed at request time is `keccak256(chainid, module, safe, nonce, order)`.

--- a/test/enso/EnsoSwapModule.t.sol
+++ b/test/enso/EnsoSwapModule.t.sol
@@ -246,6 +246,42 @@ contract EnsoSwapModuleTest is SafeTestSetup {
         module.cancelSwap(address(safe), signers, sigs);
     }
 
+    // ---- cancelExpiredSwap ----
+
+    function test_cancelExpiredSwap_clearsOrderAndHold_permissionlessAfterDeadline() public {
+        EnsoSwapModule.Order memory order = _baseOrder();
+        _request(order);
+        vm.warp(order.deadline + 1);
+
+        // No signature and no role: any caller can clean up an expired order.
+        vm.expectEmit(true, false, false, false);
+        emit EnsoSwapModule.SwapCancelled(address(safe), bytes32(0));
+        vm.prank(makeAddr("randomCaller"));
+        module.cancelExpiredSwap(address(safe));
+
+        assertEq(module.getOrder(address(safe)).srcToken, address(0), "order not cleared");
+        assertEq(
+            cashModule.getData(address(safe)).pendingWithdrawalRequest.recipient,
+            address(0),
+            "hold not cleared"
+        );
+    }
+
+    function test_cancelExpiredSwap_revertsForNoActiveOrder() public {
+        vm.expectRevert(EnsoSwapModule.NoActiveOrder.selector);
+        module.cancelExpiredSwap(address(safe));
+    }
+
+    function test_cancelExpiredSwap_revertsBeforeDeadline() public {
+        EnsoSwapModule.Order memory order = _baseOrder();
+        _request(order);
+
+        // At the deadline (inclusive) it is not yet expired.
+        vm.warp(order.deadline);
+        vm.expectRevert(EnsoSwapModule.OrderNotExpired.selector);
+        module.cancelExpiredSwap(address(safe));
+    }
+
     // ---- swapId linking ----
 
     /// @dev The swapId committed at request time is `keccak256(chainid, module, safe, nonce, order)`.


### PR DESCRIPTION
## Summary
Stacked on #124 (`feat/eth-asset-support`). Lets the backend keeper clear an expired trading order **without a user signature**, releasing the stuck CashModule solvency hold and freeing the one-active-order-per-safe slot.

- Adds `cancelExpiredSwap(address safe)` to **both** `EnsoSwapModule` and `AcrossSwapModule` (covers all trading order types: buy / sell / swap).
- Permissionless (same trust model as `executeSwap`) and gated on `block.timestamp > order.deadline`. Once past the deadline `executeSwap` can only revert `OrderExpired`, so the order is already dead — this just cleans it up.
- Mirrors `cancelSwap`'s clearing path: `cashModule.cancelWithdrawalByModule(safe)` on OP, or a direct `delete` + `SwapCancelled` where `cashModule == 0` (mainnet trading).
- New `OrderNotExpired` error for calls at/before the deadline; `NoActiveOrder` when nothing is stored.

### Why it's safe
- Can only run **after** expiry, i.e. when execution is already impossible.
- It only refunds the safe's **own** funds back to the safe and clears state — there is no fund-movement authority a caller could abuse, and no destination/recipient input.
- A stored swap only exists while the order is still `requested` (`executeSwap` deletes it before dispatching), so this can never race a partially-executed/bridged order.

### Motivation
Today a quote can expire (deadline passes) before the keeper executes — e.g. route slippage moves — leaving the order permanently un-executable. The only recovery was the owner signing `cancelSwap`, which blocked the next trade and left the withdrawal hold in place. This gives the BE reaper a signature-less way to release it.
