### PR TITLE
feat: supply topups into Aave via the lend gateway driver

### DIFF
--- a/src/top-up/TopUpDest.sol
+++ b/src/top-up/TopUpDest.sol
@@ -3,7 +3,9 @@ pragma solidity ^0.8.28;
 
 import { IERC20, SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
+import { ICashModule } from "../interfaces/ICashModule.sol";
 import { IEtherFiDataProvider } from "../interfaces/IEtherFiDataProvider.sol";
+import { ILendGateway } from "../interfaces/ILendGateway.sol";
 import { IWETH } from "../interfaces/IWETH.sol";
 import { UpgradeableProxy } from "../utils/UpgradeableProxy.sol";
 
@@ -83,6 +85,9 @@ contract TopUpDest is UpgradeableProxy {
 
     /// @notice Error thrown when the topup is already processed
     error TopUpAlreadyProcessed();
+
+    /// @notice Error thrown when a self-call-only function is called externally
+    error OnlySelf();
 
     /**
      * @dev Constructor that disables initializers to prevent implementation contract initialization
@@ -207,7 +212,33 @@ contract TopUpDest is UpgradeableProxy {
         $.transactionCompleted[txId] = true;
         _transfer(user, token, amount);
 
+        try this.supplyTopUpToLend(user, token, amount) { } catch { }
+
         emit TopUp(txId, user, token, txHash, chainId, amount);
+    }
+
+    /**
+     * @notice Supplies a topped-up amount into the lend gateway on behalf of the safe
+     * @dev External + self-call only: try/catch needs an external call, so _topUp invokes this via
+     *      this.supplyTopUpToLend(...) to isolate any failure and fall back to a loose topup. The
+     *      msg.sender guard keeps it a private helper. No-op unless the safe is lend-active and the
+     *      token is registered.
+     * @param safe Address of the safe that was topped up
+     * @param token Address of the topped-up token
+     * @param amount Amount of tokens to supply
+     * @custom:throws OnlySelf if called by anyone other than this contract
+     */
+    function supplyTopUpToLend(address safe, address token, uint256 amount) external {
+        if (msg.sender != address(this)) revert OnlySelf();
+
+        ICashModule cashModule = ICashModule(etherFiDataProvider.getCashModule());
+        if (!cashModule.isLendActive(safe)) return;
+
+        ILendGateway lendGateway = cashModule.getLendGateway();
+        if (!lendGateway.isRegistered(token)) return;
+
+        lendGateway.supply(safe, token, amount);
+        lendGateway.setUsingAsCollateral(safe, token, true);
     }
 
     /**

--- a/test/safe/modules/cash/lend/TopUpAutoSupply.t.sol
+++ b/test/safe/modules/cash/lend/TopUpAutoSupply.t.sol
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+
+import { UUPSProxy } from "../../../../../src/UUPSProxy.sol";
+import { CashVerificationLib } from "../../../../../src/libraries/CashVerificationLib.sol";
+import { MockERC20 } from "../../../../../src/mocks/MockERC20.sol";
+import { TopUpDest } from "../../../../../src/top-up/TopUpDest.sol";
+import { CashGatewayTestSetup } from "./CashGatewayTestSetup.t.sol";
+
+/**
+ * @title TopUpAutoSupplyTest
+ * @notice Fork tests for topup auto-supply: TopUpDest, as a gateway driver, supplies a topped-up amount into
+ *         Aave for the safe in the same tx, falling back to a plain loose topup on any failure.
+ * @dev Run with: source .env && FOUNDRY_PROFILE=lend TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test --match-path test/safe/modules/cash/lend/TopUpAutoSupply.t.sol
+ */
+contract TopUpAutoSupplyTest is CashGatewayTestSetup {
+    using MessageHashUtils for bytes32;
+
+    TopUpDest internal topUpDest;
+    address internal topUpKeeper = makeAddr("topUpKeeper");
+
+    bytes32 internal constant SRC_TX_HASH = keccak256("srcTx");
+    uint256 internal constant SRC_CHAIN_ID = 1;
+    uint256 internal constant TOP_UP_USDC = 1000e6;
+
+    function setUp() public override {
+        super.setUp();
+
+        address impl = address(new TopUpDest(address(dataProvider), makeAddr("weth")));
+        topUpDest = TopUpDest(payable(address(new UUPSProxy(impl, abi.encodeWithSelector(TopUpDest.initialize.selector, address(roleRegistry))))));
+
+        vm.startPrank(owner);
+        roleRegistry.grantRole(topUpDest.TOP_UP_ROLE(), topUpKeeper);
+        gw.setDriver(address(topUpDest), true);
+        vm.stopPrank();
+    }
+
+    /// A topup to an Aave safe lands supplied and flagged as collateral, nothing stays loose, and the TopUp
+    /// event carries the raw token so the indexer never sees a different asset.
+    function test_topUp_suppliesForAaveSafe() public {
+        deal(address(usdc), address(topUpDest), TOP_UP_USDC);
+
+        vm.expectEmit(true, true, true, true);
+        emit TopUpDest.TopUp(topUpDest.getTxId(SRC_TX_HASH, address(safe), address(usdc)), address(safe), address(usdc), SRC_TX_HASH, SRC_CHAIN_ID, TOP_UP_USDC);
+        vm.prank(topUpKeeper);
+        topUpDest.topUpUserSafe(SRC_TX_HASH, address(safe), SRC_CHAIN_ID, address(usdc), TOP_UP_USDC);
+
+        assertEq(gw.suppliedOf(address(safe), address(usdc)), TOP_UP_USDC, "topup landed supplied");
+        assertEq(usdc.balanceOf(address(safe)), 0, "nothing left loose");
+        assertGt(gw.getAccountData(address(safe)).availableBorrowsUsd, 0, "supplied topup counts as collateral");
+    }
+
+    /// The supply covers only the topped-up amount: a pre-existing loose balance stays loose.
+    function test_topUp_leavesPriorLooseBalanceUntouched() public {
+        uint256 priorLoose = 250e6;
+        deal(address(usdc), address(safe), priorLoose);
+        deal(address(usdc), address(topUpDest), TOP_UP_USDC);
+
+        vm.prank(topUpKeeper);
+        topUpDest.topUpUserSafe(SRC_TX_HASH, address(safe), SRC_CHAIN_ID, address(usdc), TOP_UP_USDC);
+
+        assertEq(gw.suppliedOf(address(safe), address(usdc)), TOP_UP_USDC, "only the topup amount supplied");
+        assertEq(usdc.balanceOf(address(safe)), priorLoose, "prior loose balance untouched");
+    }
+
+    /// An opted-out safe keeps its topup loose.
+    function test_topUp_leavesLooseWhenOptedOut() public {
+        _optOut();
+        deal(address(usdc), address(topUpDest), TOP_UP_USDC);
+
+        vm.prank(topUpKeeper);
+        topUpDest.topUpUserSafe(SRC_TX_HASH, address(safe), SRC_CHAIN_ID, address(usdc), TOP_UP_USDC);
+
+        assertEq(usdc.balanceOf(address(safe)), TOP_UP_USDC, "topup stayed loose");
+        assertEq(gw.suppliedOf(address(safe), address(usdc)), 0, "nothing supplied");
+    }
+
+    /// A legacy safe keeps its topup loose.
+    function test_topUp_leavesLooseForLegacySafe() public {
+        _forceLegacyEngine(address(safe));
+        deal(address(usdc), address(topUpDest), TOP_UP_USDC);
+
+        vm.prank(topUpKeeper);
+        topUpDest.topUpUserSafe(SRC_TX_HASH, address(safe), SRC_CHAIN_ID, address(usdc), TOP_UP_USDC);
+
+        assertEq(usdc.balanceOf(address(safe)), TOP_UP_USDC, "topup stayed loose");
+        assertEq(gw.suppliedOf(address(safe), address(usdc)), 0, "nothing supplied");
+    }
+
+    /// A token with no Aave reserve keeps its topup loose.
+    function test_topUp_leavesLooseForUnregisteredToken() public {
+        MockERC20 stray = new MockERC20("Stray", "STRAY", 18);
+        uint256 amount = 5 ether;
+        stray.mint(address(topUpDest), amount);
+
+        vm.prank(topUpKeeper);
+        topUpDest.topUpUserSafe(SRC_TX_HASH, address(safe), SRC_CHAIN_ID, address(stray), amount);
+
+        assertEq(stray.balanceOf(address(safe)), amount, "topup stayed loose");
+    }
+
+    /// A failing supply (gateway paused here) never blocks the topup; funds stay loose for the sweep.
+    function test_topUp_succeedsWhenSupplyFails() public {
+        vm.prank(pauser);
+        gw.pause();
+        deal(address(usdc), address(topUpDest), TOP_UP_USDC);
+
+        vm.prank(topUpKeeper);
+        topUpDest.topUpUserSafe(SRC_TX_HASH, address(safe), SRC_CHAIN_ID, address(usdc), TOP_UP_USDC);
+
+        assertEq(usdc.balanceOf(address(safe)), TOP_UP_USDC, "topup stayed loose");
+        assertTrue(topUpDest.isTransactionCompleted(SRC_TX_HASH, address(safe), address(usdc)), "topup marked processed");
+    }
+
+    /// Same when TopUpDest is not (or no longer) an authorized driver.
+    function test_topUp_succeedsWhenNotADriver() public {
+        vm.prank(owner);
+        gw.setDriver(address(topUpDest), false);
+        deal(address(usdc), address(topUpDest), TOP_UP_USDC);
+
+        vm.prank(topUpKeeper);
+        topUpDest.topUpUserSafe(SRC_TX_HASH, address(safe), SRC_CHAIN_ID, address(usdc), TOP_UP_USDC);
+
+        assertEq(usdc.balanceOf(address(safe)), TOP_UP_USDC, "topup stayed loose");
+    }
+
+    /// The supply hook is self-call only.
+    function test_supplyTopUpToLend_revertsWhenNotSelf() public {
+        vm.expectRevert(TopUpDest.OnlySelf.selector);
+        topUpDest.supplyTopUpToLend(address(safe), address(usdc), 1);
+    }
+
+    /// @dev Opts the safe out of the lend market, riding out the mode-change delay.
+    function _optOut() internal {
+        uint256 nonce = cashModule.getNonce(address(safe));
+        bytes32 digest = keccak256(abi.encodePacked(CashVerificationLib.TOGGLE_LEND_METHOD, block.chainid, address(safe), nonce, abi.encode(false))).toEthSignedMessageHash();
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Pk, digest);
+        cashModule.toggleLend(address(safe), false, owner1, abi.encodePacked(r, s, v));
+        (,, uint64 modeDelay) = cashModule.getDelays();
+        if (modeDelay != 0) {
+            vm.warp(block.timestamp + modeDelay + 1);
+            cashModule.processLendOptOut(address(safe));
+        }
+    }
+}

--- a/test/upgrade-bytecode-verification/VerifyOPMainnet.t.sol
+++ b/test/upgrade-bytecode-verification/VerifyOPMainnet.t.sol
@@ -266,6 +266,9 @@ contract VerifyOPMainnetBytecode is ContractCodeChecker, Utils {
     // ---- Top up ----
 
     function test_verifyBytecode_TopUpDest() public {
+        // TopUpDest supplies topups into the lend gateway for Lend, so its bytecode no longer
+        // matches the deployed pre-Lend OP implementation. Re-enable after the Lend deployment.
+        vm.skip(true);
         address local = address(new TopUpDest(dataProviderProxy, cc.weth));
         _verify("TopUpDest", topUpDestImpl, local);
     }


### PR DESCRIPTION
- TopUpDest supplies the topped-up amount into Aave for the safe in the same transaction, right after it sends the tokens.
- It does this as a lend gateway driver, so there is no gateway or CashModule change.
- The supply runs only when the safe uses the lend gateway, has lend enabled, and the token is registered on Aave.
- The supply is best effort. If it fails, the topup still succeeds and the tokens stay loose for the sweep to supply later.
- The TopUp event still records the original token, so the indexer is not affected.
- Shivam first suggested supplying inside TopUpDest and sending the user the aToken. That is not possible on Aave v4, because v4 has no aToken and only the gateway can supply on behalf of a safe. So the order is send first, then supply.
- Before release, upgrade the TopUpDest implementation and set TopUpDest as a driver on the gateway.
- Tests are in test/safe/modules/cash/lend/TopUpAutoSupply.t.sol, against real Aave v4 on an Optimism fork.

Closes COR-1074

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes fund routing on every top-up for lend-active safes and depend on gateway driver authorization and try/catch isolation; failures are handled but misconfiguration could leave more funds loose than before.
> 
> **Overview**
> **TopUpDest** now attempts to **supply topped-up tokens into Aave via the lend gateway** in the same transaction, right after transferring funds to the safe. The flow uses a **best-effort** `try/catch` around a self-only `supplyTopUpToLend` helper so a failed supply never reverts the top-up; tokens stay loose for a later sweep. Supply runs only when the safe has lend active and the token is registered; it also **enables collateral** for that asset. The **TopUp** event is unchanged (original token), so indexers are unaffected.
> 
> Adds **Optimism fork tests** (`TopUpAutoSupply.t.sol`) covering happy path, opt-out/legacy/unregistered token, and supply failures (paused gateway, not a driver). **OP mainnet bytecode verification** for `TopUpDest` is temporarily skipped until the post-Lend implementation is deployed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f9b9870d899b5254ef8f31893952e0ac3c155cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->