### PR TITLE
refactor: pick the lend engine per safe in setup data

### DIFF
--- a/src/modules/cash/CashModuleCore.sol
+++ b/src/modules/cash/CashModuleCore.sol
@@ -70,20 +70,27 @@ contract CashModuleCore is CashModuleStorageContract {
 
     /**
      * @notice Sets up a new Safe's Cash Module with initial configuration
-     * @dev Creates default spending limits and sets initial mode to Debit with 50% cashback split
-     * @param data The encoded initialization data containing daily limit, monthly limit, and timezone offset
+     * @dev Creates default spending limits and sets initial mode to Debit with 50% cashback split. The backend
+     *      picks the engine per safe at deploy time via the useLendGateway flag in the setup data.
+     * @param data ABI-encoded (uint256 dailyLimitInUsd, uint256 monthlyLimitInUsd, int256 timezoneOffset, bool useLendGateway)
      */
     function setupModule(bytes calldata data) external override onlyEtherFiSafe(msg.sender) {
-        (uint256 dailyLimitInUsd, uint256 monthlyLimitInUsd, int256 timezoneOffset) = abi.decode(data, (uint256, uint256, int256));
+        (uint256 dailyLimitInUsd, uint256 monthlyLimitInUsd, int256 timezoneOffset, bool useLendGateway) = abi.decode(data, (uint256, uint256, int256, bool));
 
-        SafeCashConfig storage $ = _getCashModuleStorage().safeCashConfig[msg.sender];
+        CashModuleStorage storage cashStorage = _getCashModuleStorage();
+        SafeCashConfig storage $ = cashStorage.safeCashConfig[msg.sender];
         $.spendingLimit.initialize(dailyLimitInUsd, monthlyLimitInUsd, timezoneOffset);
         $.mode = Mode.Debit;
 
-        // New safes run on the Aave gateway. Guarded because setupModule is re-runnable: a legacy safe with
-        // open DebtManager debt must keep routing to DebtManager until migrateToLendGateway moves its position.
-        (, uint256 legacyDebtUsd) = _getDebtManager().borrowingOf(msg.sender);
-        if (legacyDebtUsd == 0) $.usesLendGateway = true;
+        // The backend decides the engine per safe. When useLendGateway is set the safe onboards onto the Aave
+        // gateway; otherwise it stays on the legacy DebtManager. The legacyDebtUsd guard keeps a safe with open
+        // DebtManager debt on DebtManager until migrateToLendGateway moves its position, since setupModule is
+        // re-runnable.
+        if (useLendGateway) {
+            if (address(cashStorage.gateway) == address(0)) revert LendGatewayNotSet();
+            (, uint256 legacyDebtUsd) = _getDebtManager().borrowingOf(msg.sender);
+            if (legacyDebtUsd == 0) $.usesLendGateway = true;
+        }
     }
 
     /**

--- a/test/safe/SafeTestSetup.t.sol
+++ b/test/safe/SafeTestSetup.t.sol
@@ -224,8 +224,9 @@ contract SafeTestSetup is Utils {
         vm.stopPrank();
     }
 
-    /// @dev Wires the one-time gateway during setup. The gateway is set once and never repointed, so an Aave
-    ///      suite that needs the real gateway overrides this to a no-op and sets it after deploying Aave.
+    /// @dev Wires the one-time gateway during setup, so a safe onboarded with useLendGateway set lands on the
+    ///      gateway. The gateway is set once and never repointed, so an Aave suite that needs the real gateway
+    ///      overrides this to a no-op and sets it after deploying Aave.
     function _wireDefaultGateway() internal virtual {
         cashModule.setLendGateway(address(gateway));
     }

--- a/test/safe/modules/cash/CashLens.t.sol
+++ b/test/safe/modules/cash/CashLens.t.sol
@@ -254,8 +254,8 @@ contract CashLensTest is CashModuleTestSetup {
         shouldWhitelist[0] = true;
         
         bytes[] memory setupData = new bytes[](1);
-        setupData[0] = abi.encode(dailyLimitInUsd, monthlyLimitInUsd, timezoneOffset);
-        
+        setupData[0] = abi.encode(dailyLimitInUsd, monthlyLimitInUsd, timezoneOffset, true);
+
         vm.prank(owner);
         safeFactory.deployEtherFiSafe(keccak256("insufficientSafe"), owners, modules, setupData, 1);
         address insufficientSafe = safeFactory.getDeterministicAddress(keccak256("insufficientSafe"));

--- a/test/safe/modules/cash/CashModuleTestSetup.t.sol
+++ b/test/safe/modules/cash/CashModuleTestSetup.t.sol
@@ -36,7 +36,7 @@ contract CashModuleTestSetup is SafeTestSetup {
         vm.stopPrank();
 
         vm.startPrank(owner);
-        bytes memory safeCashSetupData = abi.encode(dailyLimitInUsd, monthlyLimitInUsd, timezoneOffset);
+        bytes memory safeCashSetupData = abi.encode(dailyLimitInUsd, monthlyLimitInUsd, timezoneOffset, _newSafeUsesLend());
         bytes[] memory setupData = new bytes[](1);
         setupData[0] = safeCashSetupData;
 
@@ -49,6 +49,12 @@ contract CashModuleTestSetup is SafeTestSetup {
         _configureModules(modules, shouldWhitelist, setupData);
 
         vm.stopPrank();
+    }
+
+    /// @dev Engine the default safe onboards onto. True (gateway) by default; a suite whose gateway is not yet
+    ///      configured at setup (real-Aave suites) overrides this to false and flips the engine later.
+    function _newSafeUsesLend() internal pure virtual returns (bool) {
+        return true;
     }
 
     function _requestWithdrawal(address[] memory tokens, uint256[] memory amounts, address recipient) internal {
@@ -158,12 +164,22 @@ contract CashModuleTestSetup is SafeTestSetup {
 
     /**
      * @notice Flips a safe back to the legacy DebtManager engine, modeling a safe that predates the gateway
-     *         (new safes onboard onto the Aave gateway in setupModule).
+     *         (a new safe onboards onto the Aave gateway when its setup data carries the lend flag).
      * @dev Writes the packed usesLendGateway flag via stdstore, then asserts through the public getter so any
      *      storage-layout drift fails loudly here instead of silently testing the wrong engine.
      */
     function _forceLegacyEngine(address _safe) internal {
         stdstore.enable_packed_slots().target(address(cashModule)).sig(ICashModule.usesLendGateway.selector).with_key(_safe).checked_write(false);
         assertFalse(cashModule.usesLendGateway(_safe), "forceLegacyEngine: flag still set");
+    }
+
+    /**
+     * @notice Flips a safe onto the Aave gateway engine, for suites whose default safe was deployed before the
+     *         gateway existed (onboarding with the lend flag reverts until the gateway is set).
+     * @dev Writes the packed usesLendGateway flag via stdstore, then asserts through the public getter.
+     */
+    function _forceGatewayEngine(address _safe) internal {
+        stdstore.enable_packed_slots().target(address(cashModule)).sig(ICashModule.usesLendGateway.selector).with_key(_safe).checked_write(true);
+        assertTrue(cashModule.usesLendGateway(_safe), "forceGatewayEngine: flag not set");
     }
 }

--- a/test/safe/modules/cash/EngineOnboarding.t.sol
+++ b/test/safe/modules/cash/EngineOnboarding.t.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { BinSponsor, ICashModule } from "../../../../src/interfaces/ICashModule.sol";
+import { CashModuleTestSetup } from "./CashModuleTestSetup.t.sol";
+
+/**
+ * @title EngineOnboardingTest
+ * @notice The backend picks a new safe's engine at deploy time through the useLendGateway flag in the cash
+ *         setup data. A safe onboarded with the flag set lands on the Aave gateway; without it, on the legacy
+ *         DebtManager. This suite runs on the default profile with the mock gateway, and starts from an unset
+ *         gateway so it can drive both engines from scratch.
+ * @dev The admin-migrate path that moves a legacy safe onto the gateway is covered by the real-gateway
+ *      DebtManagerMigration test.
+ */
+contract EngineOnboardingTest is CashModuleTestSetup {
+    /// @dev Start with no gateway configured, so the tests wire it themselves.
+    function _wireDefaultGateway() internal override { }
+
+    /// @dev The base default safe deploys before this suite wires a gateway, so it onboards legacy.
+    function _newSafeUsesLend() internal pure override returns (bool) {
+        return false;
+    }
+
+    /// The base default safe onboarded without the flag, so it runs on the legacy engine.
+    function test_defaultSafe_onboardsLegacy() public view {
+        assertFalse(cashModule.usesLendGateway(address(safe)), "default safe is legacy");
+    }
+
+    /// A safe onboarded with the flag set, once a gateway is configured, lands on the gateway.
+    function test_deploy_withFlag_onboardsGateway() public {
+        _wireGateway();
+        assertTrue(cashModule.usesLendGateway(_deploySafe("onboard-gateway", true)), "flagged safe is on the gateway");
+    }
+
+    /// A safe onboarded without the flag lands on the legacy engine, even with a gateway configured.
+    function test_deploy_withoutFlag_onboardsLegacy() public {
+        _wireGateway();
+        assertFalse(cashModule.usesLendGateway(_deploySafe("onboard-legacy", false)), "unflagged safe is legacy");
+    }
+
+    /// Onboarding with the flag set but no gateway configured reverts, so a safe is never flagged for an engine
+    /// that cannot run. Asserted at the setupModule level, since the factory wraps a deploy-time revert.
+    function test_setup_withFlag_revertsWhenGatewayUnset() public {
+        vm.prank(address(safe));
+        vm.expectRevert(ICashModule.LendGatewayNotSet.selector);
+        cashModule.setupModule(abi.encode(dailyLimitInUsd, monthlyLimitInUsd, timezoneOffset, true));
+    }
+
+    /// Re-running setup with the flag set on a safe that carries open DebtManager debt keeps it on the legacy
+    /// engine, so its legacy debt is never stranded behind gateway routing.
+    function test_reSetup_withFlag_keepsLegacyDebtSafeLegacy() public {
+        _wireGateway();
+
+        deal(address(weETH), address(safe), 10 ether);
+        deal(address(usdc), address(debtManager), 1_000_000e6);
+        vm.prank(address(safe));
+        debtManager.borrow(BinSponsor.Reap, address(usdc), 10e6);
+
+        vm.prank(address(safe));
+        cashModule.setupModule(abi.encode(dailyLimitInUsd, monthlyLimitInUsd, timezoneOffset, true));
+        assertFalse(cashModule.usesLendGateway(address(safe)), "safe with legacy debt stays legacy");
+    }
+
+    /// Re-running setup without the flag never un-flips a safe already on the gateway (the per-safe flag is
+    /// one-way).
+    function test_reSetup_withoutFlag_doesNotUnflipGatewaySafe() public {
+        _wireGateway();
+        address gatewaySafe = _deploySafe("onboard-then-resetup", true);
+        assertTrue(cashModule.usesLendGateway(gatewaySafe), "onboarded onto the gateway");
+
+        vm.prank(gatewaySafe);
+        cashModule.setupModule(abi.encode(dailyLimitInUsd, monthlyLimitInUsd, timezoneOffset, false));
+        assertTrue(cashModule.usesLendGateway(gatewaySafe), "still on the gateway after a flagless re-setup");
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    /// @dev Wires the mock gateway (from base setUp) as the CashModule's lend engine, as owner.
+    function _wireGateway() internal {
+        vm.prank(owner);
+        cashModule.setLendGateway(address(gateway));
+    }
+
+    /// @dev Deploys a fresh single-owner safe with the CashModule set up, onboarding it onto the gateway when
+    ///      useLend is set, and returns its address.
+    function _deploySafe(bytes32 salt, bool useLend) internal returns (address) {
+        address[] memory owners = new address[](1);
+        owners[0] = owner1;
+
+        address[] memory modules = new address[](1);
+        modules[0] = address(cashModule);
+
+        bytes[] memory setupData = new bytes[](1);
+        setupData[0] = abi.encode(dailyLimitInUsd, monthlyLimitInUsd, timezoneOffset, useLend);
+
+        vm.prank(owner);
+        safeFactory.deployEtherFiSafe(salt, owners, modules, setupData, 1);
+        return safeFactory.getDeterministicAddress(salt);
+    }
+}

--- a/test/safe/modules/cash/SetLendGateway.t.sol
+++ b/test/safe/modules/cash/SetLendGateway.t.sol
@@ -23,7 +23,7 @@ contract CashModuleSetLendGatewayTest is CashModuleTestSetup {
         _forceLegacyEngine(address(safe));
 
         vm.prank(address(safe));
-        cashModule.setupModule(abi.encode(dailyLimitInUsd, monthlyLimitInUsd, timezoneOffset));
+        cashModule.setupModule(abi.encode(dailyLimitInUsd, monthlyLimitInUsd, timezoneOffset, true));
         assertTrue(cashModule.usesLendGateway(address(safe)), "debt-free re-setup flips to the gateway");
     }
 
@@ -38,7 +38,7 @@ contract CashModuleSetLendGatewayTest is CashModuleTestSetup {
         debtManager.borrow(BinSponsor.Reap, address(usdc), 10e6);
 
         vm.prank(address(safe));
-        cashModule.setupModule(abi.encode(dailyLimitInUsd, monthlyLimitInUsd, timezoneOffset));
+        cashModule.setupModule(abi.encode(dailyLimitInUsd, monthlyLimitInUsd, timezoneOffset, true));
         assertFalse(cashModule.usesLendGateway(address(safe)), "safe with legacy debt stays on the legacy engine");
     }
 
@@ -56,15 +56,11 @@ contract CashModuleSetLendGatewayTest is CashModuleTestSetup {
         assertEq(address(unconfiguredCashModule.getLendGateway()), address(newGateway));
     }
 
-    /// @notice CashLens should read the gateway configured during the one-time Lend bootstrap.
+    /// @notice CashLens should read the gateway configured during the one-time Lend bootstrap. The gateway is
+    ///         set before the safe onboards with the lend flag, so the safe runs on the gateway.
     function test_setLendGateway_bootstrapUpdatesCashLensReads() public {
         (ICashModule unconfiguredCashModule, CashLens unconfiguredCashLens) = _deployUnconfiguredCashModule();
         MockLendGateway newGateway = new MockLendGateway();
-
-        vm.prank(address(safe));
-        unconfiguredCashModule.setupModule(abi.encode(dailyLimitInUsd, monthlyLimitInUsd, timezoneOffset));
-        _setMode(unconfiguredCashModule, Mode.Credit);
-        vm.warp(unconfiguredCashModule.incomingModeStartTime(address(safe)) + 1);
 
         address[] memory tokens = new address[](1);
         tokens[0] = address(usdc);
@@ -78,6 +74,11 @@ contract CashModuleSetLendGatewayTest is CashModuleTestSetup {
         unconfiguredCashModule.setLendGateway(address(newGateway));
 
         assertEq(address(unconfiguredCashLens.gateway()), address(newGateway));
+
+        vm.prank(address(safe));
+        unconfiguredCashModule.setupModule(abi.encode(dailyLimitInUsd, monthlyLimitInUsd, timezoneOffset, true));
+        _setMode(unconfiguredCashModule, Mode.Credit);
+        vm.warp(unconfiguredCashModule.incomingModeStartTime(address(safe)) + 1);
 
         SafeCashData memory data = unconfiguredCashLens.getSafeCashData(address(safe), tokens);
         assertEq(data.totalCollateral, 200e6);

--- a/test/safe/modules/cash/debt-manager/Invariant.t.sol
+++ b/test/safe/modules/cash/debt-manager/Invariant.t.sol
@@ -33,7 +33,7 @@ contract DebtManagerInvariantTest is CashModuleTestSetup {
             modules[0] = address(cashModule);
 
             bytes[] memory modulesSetupData = new bytes[](1);
-            modulesSetupData[0] = abi.encode(dailyLimitInUsd, monthlyLimitInUsd, timezoneOffset);
+            modulesSetupData[0] = abi.encode(dailyLimitInUsd, monthlyLimitInUsd, timezoneOffset, false);
 
             threshold = 1;
             bytes32 salt = keccak256(abi.encodePacked("borrower", i));

--- a/test/safe/modules/cash/lend/CashGatewayTestSetup.t.sol
+++ b/test/safe/modules/cash/lend/CashGatewayTestSetup.t.sol
@@ -63,10 +63,21 @@ abstract contract CashGatewayTestSetup is CashModuleTestSetup, AaveV4Fixture {
 
         _enableModule(address(gw));
         _activateAavePositionManager(address(gw));
+
+        // The default safe was deployed in super.setUp() before the gateway existed, so it onboarded onto the
+        // legacy engine (onboarding with the lend flag reverts until the gateway is set). This suite exercises
+        // gateway operations on that safe, so put it on the gateway engine now.
+        _forceGatewayEngine(address(safe));
     }
 
     /// @dev Empty on purpose: skips the base mock-gateway wiring so this suite's one-time setLendGateway(gw) is the first and only set.
     function _wireDefaultGateway() internal override { }
+
+    /// @dev The default safe deploys in super.setUp() before the real gateway exists, so onboarding it with the
+    ///      lend flag would revert LendGatewayNotSet. It onboards legacy, then _forceGatewayEngine flips it.
+    function _newSafeUsesLend() internal pure override returns (bool) {
+        return false;
+    }
 
     // ----------------------------------------------------------------- overridable reserve policy
 


### PR DESCRIPTION
The backend picks a new safe's engine at deploy time, per Shivam's call that lend is decided per deployment by the backend, not defaulted on for every new safe.

## What changed

- `setupModule` takes a 4th field in its data: `abi.encode(daily, monthly, tzOffset, useLendGateway)`.
- When `useLendGateway` is set, the safe onboards onto the Aave gateway. Otherwise it stays on the legacy DebtManager.
- Onboarding with the flag set but no gateway configured reverts with `LendGatewayNotSet`, so a safe is never flagged for an engine that cannot run.
- The `legacyDebtUsd == 0` guard stays, so a safe with open DebtManager debt keeps routing to DebtManager until `migrateToLendGateway` moves it.

## Why

- The backend deploys every safe (`deployEtherFiSafe` is admin-gated), so it can author the engine choice in the setup data per safe.
- This lets us onboard our own control safes onto the gateway in prod and test there, before onboarding new users.

## Rollout order

- The old 3-field payload against the new decode reverts (too short). A 4-field payload against the old decode is fine, since the old code ignores the trailing bool.
- So ship the 4-field payload from the backend first, then upgrade the contracts.

## Known limit

- Safe owners can remove and re-add the CashModule via `configureModules` with their own setup data, so a debt-free safe could self-flip onto the gateway. It is one-way and lands on the audited path, so we accept it for now. COR-1075 tracks guarding module removal while a safe has open debt.

## Testing

- New `test/safe/modules/cash/EngineOnboarding.t.sol`: flag on gives a gateway safe, off gives a legacy safe, flag on with no gateway reverts, a re-setup does not strand legacy debt, and a flagless re-setup does not un-flip a gateway safe.
- Default cash suite passes (408). Lend suite passes (161); the two failures are a missing OpenOcean API key for live-quote tests, unrelated to this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes per-safe borrow/collateral engine selection at deploy/re-setup time; mis-encoded setup data or rollout order (3-field payload on new contracts) could mis-route safes or fail deploys, though legacy-debt and gateway-unset guards limit the blast radius.
> 
> **Overview**
> **Cash module onboarding** no longer auto-assigns new debt-free safes to the Aave gateway. `setupModule` decodes a fourth field, `useLendGateway`, from `abi.encode(daily, monthly, timezoneOffset, useLendGateway)`.
> 
> When the flag is **true**, the safe sets `usesLendGateway` only if a lend gateway is configured and the safe has **no** open DebtManager debt (`legacyDebtUsd == 0`); otherwise it stays on legacy routing. If the flag is true but the gateway address is zero, setup **reverts** with `LendGatewayNotSet`. When the flag is **false**, the safe does not flip to the gateway. Re-running setup with the flag false does **not** clear an existing gateway assignment (one-way).
> 
> Tests pass the new 4-tuple everywhere, add `_newSafeUsesLend()` / `_forceGatewayEngine()` helpers for suites that deploy before the gateway exists, and add **`EngineOnboarding.t.sol`** for flag on/off, unset-gateway revert, legacy-debt guard, and one-way behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9054e34da92c22c1fbb98303c31a902d063e9cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->