### PR TITLE
feat: decouple the gateway paths from the DebtManager

### DIFF
--- a/src/interfaces/IAaveV4Spoke.sol
+++ b/src/interfaces/IAaveV4Spoke.sol
@@ -39,6 +39,15 @@ interface IAaveV4Spoke {
         uint16 liquidationFee;
     }
 
+    /// @notice Reserve configuration flags. `borrowable` is true if the reserve can be borrowed.
+    struct ReserveConfig {
+        uint24 collateralRisk;
+        bool paused;
+        bool frozen;
+        bool borrowable;
+        bool receiveSharesEnabled;
+    }
+
     /// @notice A user's aggregate position. `healthFactor`/`avgCollateralFactor` are WAD; value fields are Aave Value units.
     struct UserAccountData {
         uint256 riskPremium;
@@ -123,6 +132,9 @@ interface IAaveV4Spoke {
 
     /// @notice The dynamic config (incl. `collateralFactor` in BPS) at `dynamicConfigKey`.
     function getDynamicReserveConfig(uint256 reserveId, uint32 dynamicConfigKey) external view returns (DynamicReserveConfig memory);
+
+    /// @notice The reserve's configuration flags (incl. `borrowable`).
+    function getReserveConfig(uint256 reserveId) external view returns (ReserveConfig memory);
 
     /// @notice The type hash for the SetUserPositionManagers EIP-712 intent.
     function SET_USER_POSITION_MANAGERS_TYPEHASH() external view returns (bytes32);

--- a/src/interfaces/ICashModule.sol
+++ b/src/interfaces/ICashModule.sol
@@ -690,7 +690,7 @@ interface ICashModule {
      * @param amountInUsd Amount to repay in USD
      * @custom:throws OnlyEtherFiWallet if caller doesn't have the wallet role
      * @custom:throws OnlyEtherFiSafe if the safe is not a valid EtherFi Safe
-     * @custom:throws OnlyBorrowToken if token is not a valid borrow token
+     * @custom:throws OnlyBorrowToken if the token cannot carry debt on the safe's engine
      * @custom:throws AmountZero if the converted amount is zero
      * @custom:throws InsufficientBalance if there is not enough balance for the operation
      */
@@ -717,7 +717,7 @@ interface ICashModule {
      * @param signers Addresses of the owners authorizing the borrow
      * @param signatures The signers' signatures over the intent
      * @custom:throws InvalidSignatures if the signatures do not meet the owner quorum
-     * @custom:throws OnlyBorrowToken if token is not a valid borrow token
+     * @custom:throws OnlyBorrowToken if token is not borrowable on the gateway
      * @custom:throws AmountZero if the converted amount is zero
      * @custom:throws OnlyLendGatewaySafe if the safe runs on the legacy DebtManager engine
      */

--- a/src/interfaces/ILendGateway.sol
+++ b/src/interfaces/ILendGateway.sol
@@ -119,4 +119,20 @@ interface ILendGateway {
      * @return The registered asset addresses
      */
     function registeredAssets() external view returns (address[] memory);
+
+    /**
+     * @notice Returns whether `asset` is registered and its Aave reserve allows borrowing
+     * @dev The gateway-native replacement for DebtManager's isBorrowToken: the spend, borrow, and repay
+     *      paths gate their token on this, so retiring the DebtManager does not change what they accept.
+     * @param asset The asset to query
+     * @return True if the asset is registered and the reserve's borrowable flag is set
+     */
+    function isBorrowable(address asset) external view returns (bool);
+
+    /**
+     * @notice Returns the registered assets whose Aave reserves allow borrowing
+     * @dev The gateway-native replacement for DebtManager's getBorrowTokens (see isBorrowable).
+     * @return The borrowable asset addresses
+     */
+    function borrowableAssets() external view returns (address[] memory);
 }

--- a/src/interfaces/ILendGateway.sol
+++ b/src/interfaces/ILendGateway.sol
@@ -121,18 +121,37 @@ interface ILendGateway {
     function registeredAssets() external view returns (address[] memory);
 
     /**
-     * @notice Returns whether `asset` is registered and its Aave reserve allows borrowing
-     * @dev The gateway-native replacement for DebtManager's isBorrowToken: the spend, borrow, and repay
-     *      paths gate their token on this, so retiring the DebtManager does not change what they accept.
+     * @notice Returns whether `asset` is registered and its Aave reserve accepts a borrow
+     * @dev Mirrors Aave's borrow gate (borrowable, not frozen, not paused). The paths that create new
+     *      debt gate on this: the credit auth check, the credit spend, and the signed borrow. Debit
+     *      spends gate on isSpendAsset and repay gates on isRegistered, so existing positions survive a
+     *      freeze or delisting of new debt.
      * @param asset The asset to query
-     * @return True if the asset is registered and the reserve's borrowable flag is set
+     * @return True if the asset is registered and the reserve accepts a borrow
      */
     function isBorrowable(address asset) external view returns (bool);
 
     /**
-     * @notice Returns the registered assets whose Aave reserves allow borrowing
+     * @notice Returns the registered assets whose Aave reserves accept a borrow
      * @dev The gateway-native replacement for DebtManager's getBorrowTokens (see isBorrowable).
      * @return The borrowable asset addresses
      */
     function borrowableAssets() external view returns (address[] memory);
+
+    /**
+     * @notice Returns whether `asset` can fund a debit spend
+     * @dev Registered, marked borrowable (membership: it marks the spendable stables), and not paused.
+     *      Frozen is tolerated: a debit spend only transfers loose balance and withdraws supplied
+     *      balance, both of which Aave allows while frozen.
+     * @param asset The asset to query
+     * @return True if the asset can fund a debit spend
+     */
+    function isSpendAsset(address asset) external view returns (bool);
+
+    /**
+     * @notice Returns the registered assets that can fund a debit spend
+     * @dev See isSpendAsset.
+     * @return The spendable asset addresses
+     */
+    function spendAssets() external view returns (address[] memory);
 }

--- a/src/libraries/DebitSourcingLib.sol
+++ b/src/libraries/DebitSourcingLib.sol
@@ -32,7 +32,7 @@ library DebitSourcingLib {
             if (tokenLtv == 0) {
                 return 0;
             }
-            uint256 headroomCap = _fromUsd(priceProvider, token, (borrowHeadroomUsd * LTV_SCALE) / tokenLtv);
+            uint256 headroomCap = fromUsd(priceProvider, token, (borrowHeadroomUsd * LTV_SCALE) / tokenLtv);
             if (headroomCap < cap) {
                 cap = headroomCap;
             }
@@ -43,7 +43,7 @@ library DebitSourcingLib {
 
     /// @notice Borrowing headroom (USD) consumed by withdrawing `amount` of `token`: its USD value weighted by the LTV
     function headroomConsumed(ILendGateway gateway, IPriceProvider priceProvider, address token, uint256 amount) public view returns (uint256) {
-        return (_toUsd(priceProvider, token, amount) * gateway.ltv(token)) / LTV_SCALE;
+        return (toUsd(priceProvider, token, amount) * gateway.ltv(token)) / LTV_SCALE;
     }
 
     /**
@@ -54,17 +54,17 @@ library DebitSourcingLib {
      *      remaining after the loose leg, so the headroom cap always applies.
      */
     function repayWithdrawable(ILendGateway gateway, IPriceProvider priceProvider, address safe, address token, uint256 fromLoose) public view returns (uint256) {
-        uint256 headroomUsd = gateway.getAccountData(safe).availableBorrowsUsd + _toUsd(priceProvider, token, fromLoose);
+        uint256 headroomUsd = gateway.getAccountData(safe).availableBorrowsUsd + toUsd(priceProvider, token, fromLoose);
         return withdrawableSupplied(gateway, priceProvider, safe, token, headroomUsd, true);
     }
 
-    /// @dev USD value of `amount` of `token` at its current price, on PriceProvider's USD scale
-    function _toUsd(IPriceProvider priceProvider, address token, uint256 amount) private view returns (uint256) {
+    /// @notice USD value of `amount` of `token` at its current price, on PriceProvider's USD scale (matching DebtManager's conversion)
+    function toUsd(IPriceProvider priceProvider, address token, uint256 amount) public view returns (uint256) {
         return (amount * priceProvider.price(token)) / (10 ** IERC20Metadata(token).decimals());
     }
 
-    /// @dev Amount of `token` worth `usd` at its current price, inverting _toUsd
-    function _fromUsd(IPriceProvider priceProvider, address token, uint256 usd) private view returns (uint256) {
+    /// @notice Amount of `token` worth `usd` at its current price, inverting toUsd
+    function fromUsd(IPriceProvider priceProvider, address token, uint256 usd) public view returns (uint256) {
         return (usd * (10 ** IERC20Metadata(token).decimals())) / priceProvider.price(token);
     }
 }

--- a/src/mocks/MockLendGateway.sol
+++ b/src/mocks/MockLendGateway.sol
@@ -30,6 +30,10 @@ contract MockLendGateway is ILendGateway {
     mapping(address asset => uint256) internal _availableCash;
     /// @dev Whether an asset is a registered reserve; defaults to false
     mapping(address asset => bool) internal _registered;
+    /// @dev Whether an asset's reserve allows borrowing; defaults to false
+    mapping(address asset => bool) internal _borrowable;
+    /// @dev Every asset ever registered, in order; registeredAssets/borrowableAssets filter it by the flags
+    address[] internal _assets;
 
     Call public lastSupply;
     Call public lastWithdraw;
@@ -46,7 +50,13 @@ contract MockLendGateway is ILendGateway {
 
     /// @notice Sets whether an asset is a registered reserve (defaults to unregistered)
     function setRegistered(address asset, bool registered) external {
+        if (registered && !_registered[asset]) _assets.push(asset);
         _registered[asset] = registered;
+    }
+
+    /// @notice Sets whether an asset's reserve allows borrowing (defaults to non-borrowable)
+    function setBorrowable(address asset, bool borrowable) external {
+        _borrowable[asset] = borrowable;
     }
 
     /// @notice Sets the amount a subsequent `suppliedOf(safe, asset)` will return
@@ -99,7 +109,34 @@ contract MockLendGateway is ILendGateway {
         return _registered[asset];
     }
 
-    function registeredAssets() external pure returns (address[] memory) {
-        return new address[](0);
+    function registeredAssets() external view returns (address[] memory) {
+        return _filterAssets(false);
+    }
+
+    function isBorrowable(address asset) external view returns (bool) {
+        return _registered[asset] && _borrowable[asset];
+    }
+
+    function borrowableAssets() external view returns (address[] memory) {
+        return _filterAssets(true);
+    }
+
+    /// @dev The registered assets, optionally narrowed to the borrowable ones
+    function _filterAssets(bool onlyBorrowable) internal view returns (address[] memory) {
+        address[] memory out = new address[](_assets.length);
+        uint256 count = 0;
+        for (uint256 i = 0; i < _assets.length; i++) {
+            address asset = _assets[i];
+            if (_registered[asset] && (!onlyBorrowable || _borrowable[asset])) {
+                out[count] = asset;
+                unchecked {
+                    ++count;
+                }
+            }
+        }
+        assembly ("memory-safe") {
+            mstore(out, count)
+        }
+        return out;
     }
 }

--- a/src/mocks/MockLendGateway.sol
+++ b/src/mocks/MockLendGateway.sol
@@ -121,6 +121,15 @@ contract MockLendGateway is ILendGateway {
         return _filterAssets(true);
     }
 
+    /// @dev The mock models no freeze or pause, so the debit-spend gate equals the borrow gate
+    function isSpendAsset(address asset) external view returns (bool) {
+        return _registered[asset] && _borrowable[asset];
+    }
+
+    function spendAssets() external view returns (address[] memory) {
+        return _filterAssets(true);
+    }
+
     /// @dev The registered assets, optionally narrowed to the borrowable ones
     function _filterAssets(bool onlyBorrowable) internal view returns (address[] memory) {
         address[] memory out = new address[](_assets.length);

--- a/src/modules/cash/CashLendLib.sol
+++ b/src/modules/cash/CashLendLib.sol
@@ -117,26 +117,34 @@ library CashLendLib {
 
     /**
      * @notice Executes a repayment on behalf of a safe, routing by engine
-     * @dev A legacy safe repays the DebtManager from its loose balance through the safe's module execution;
-     *      the caller has already validated the amount and cancelled any conflicting withdrawal request.
-     *      A gateway safe repays on Aave via the gateway, sourcing like a debit spend: unreserved loose
-     *      balance first, then the safe's Aave-supplied balance of the same token (Aave v4 has no
-     *      repay-with-aTokens, so the shortfall is withdrawn to the safe and repaid), and only as a last
-     *      resort the withdrawal-reserved loose balance, cancelling the request (the spend paths' rule).
-     *      The loose leg repays before the withdraw so the freed headroom sizes the supplied leg.
+     * @dev Each engine converts the USD quote itself: a legacy safe through the DebtManager, a gateway safe
+     *      through the PriceProvider, so the gateway path never touches the DebtManager. A legacy safe
+     *      repays the DebtManager from its loose balance through the safe's module execution, cancelling a
+     *      conflicting withdrawal request first. A gateway safe repays on Aave via the gateway, sourcing
+     *      like a debit spend: unreserved loose balance first, then the safe's Aave-supplied balance of the
+     *      same token (Aave v4 has no repay-with-aTokens, so the shortfall is withdrawn to the safe and
+     *      repaid), and only as a last resort the withdrawal-reserved loose balance, cancelling the request
+     *      (the spend paths' rule). The loose leg repays before the withdraw so the freed headroom sizes
+     *      the supplied leg.
      * @param $ The CashModule storage (passed by the delegatecalling module)
      * @param dataProvider The module's data provider (for the price provider and withdrawal cancels)
      * @param safe The safe whose debt is repaid
      * @param token The token to repay
-     * @param amount The token amount to repay, capped at the open debt
-     * @param amountInUsd The USD value of the repayment (for the emitted DebtManager event)
+     * @param amountInUsd The USD value to repay, capped at the open debt
+     * @custom:throws OnlyBorrowToken if the token cannot carry debt on the safe's engine
      * @custom:throws LendGatewayNotSet if the safe uses the gateway but none is configured
-     * @custom:throws AmountZero if the safe has no debt in the token
+     * @custom:throws AmountZero if the quote converts to zero or the safe has no debt in the token
      * @custom:throws InsufficientBalance if the safe cannot source the capped amount (the supplied leg is
      *                bounded by borrowing headroom; a max-leveraged position unloops over multiple repays)
      */
-    function repay(CashModuleStorageContract.CashModuleStorage storage $, IEtherFiDataProvider dataProvider, address safe, address token, uint256 amount, uint256 amountInUsd) external {
+    function repay(CashModuleStorageContract.CashModuleStorage storage $, IEtherFiDataProvider dataProvider, address safe, address token, uint256 amountInUsd) external {
+        uint256 amount;
         if (!_usesLendGateway($, safe)) {
+            if (!$.debtManager.isBorrowToken(token)) revert OnlyBorrowToken();
+            amount = $.debtManager.convertUsdToCollateralToken(token, amountInUsd);
+            if (amount == 0) revert AmountZero();
+            _cancelCompetingWithdrawal($, dataProvider, safe, token, amount);
+
             address[] memory to = new address[](3);
             bytes[] memory data = new bytes[](3);
             uint256[] memory values = new uint256[](3);
@@ -156,11 +164,14 @@ library CashLendLib {
 
         ILendGateway gateway = $.gateway;
         if (address(gateway) == address(0)) revert LendGatewayNotSet();
+        if (!gateway.isBorrowable(token)) revert OnlyBorrowToken();
+        IPriceProvider priceProvider = IPriceProvider(dataProvider.getPriceProvider());
+        amount = DebitSourcingLib.fromUsd(priceProvider, token, amountInUsd);
         uint256 debt = gateway.debtOf(safe, token);
         if (amount > debt) {
             // Re-derive the USD value so the capped repay does not report the requested amount
             amount = debt;
-            amountInUsd = $.debtManager.convertCollateralTokenToUsd(token, amount);
+            amountInUsd = DebitSourcingLib.toUsd(priceProvider, token, amount);
         }
         if (amount == 0) revert AmountZero();
 
@@ -181,8 +192,21 @@ library CashLendLib {
 
         // The gateway may repay less than requested (dust refund, or the live Aave debt being smaller than
         // the quote), so report the USD value of what was actually repaid, not the requested amount.
-        uint256 repaidInUsd = repaid == amount ? amountInUsd : $.debtManager.convertCollateralTokenToUsd(token, repaid);
+        uint256 repaidInUsd = repaid == amount ? amountInUsd : DebitSourcingLib.toUsd(priceProvider, token, repaid);
         $.cashEventEmitter.emitRepay(safe, token, repaid, repaidInUsd);
+    }
+
+    /**
+     * @dev Cancels the safe's pending withdrawal request when it competes with a legacy repay of `token`:
+     *      if the quoted amount plus the token's reserved leg exceeds the loose balance, the repay outranks
+     *      the reservation. Conservative on purpose: the quote may exceed the live debt, so a repay quoted
+     *      above the debt can cancel a request the real, smaller pull would have left intact.
+     * @custom:throws InsufficientBalance if `amount` exceeds the safe's loose balance of `token`
+     */
+    function _cancelCompetingWithdrawal(CashModuleStorageContract.CashModuleStorage storage $, IEtherFiDataProvider dataProvider, address safe, address token, uint256 amount) private {
+        uint256 balance = IERC20(token).balanceOf(safe);
+        if (amount > balance) revert InsufficientBalance();
+        if (amount + _pendingWithdrawalAmount($, safe, token) > balance) cancelOldWithdrawal($, dataProvider, safe);
     }
 
     /**
@@ -288,6 +312,7 @@ library CashLendLib {
      *      gateway rejects a borrow for an opted-out safe; the lendOptedOut check here is defense-in-depth,
      *      mirroring spendCredit.
      * @param $ The CashModule storage (passed by the delegatecalling module)
+     * @param dataProvider The module's data provider (for the price provider)
      * @param safe Address of the EtherFi Safe
      * @param token The token to borrow
      * @param amountInUsd The USD value of the borrow (bound by the signatures and emitted in the event)
@@ -295,20 +320,20 @@ library CashLendLib {
      * @param signers The owners who authorized the borrow
      * @param signatures The signers' signatures over the intent
      * @custom:throws InvalidSignatures if the signatures do not meet the owner quorum
-     * @custom:throws OnlyBorrowToken if token is not a valid borrow token
-     * @custom:throws AmountZero if the converted amount is zero
      * @custom:throws OnlyLendGatewaySafe if the safe runs on the legacy DebtManager engine
      * @custom:throws LendGatewayNotSet if no gateway is configured
      * @custom:throws LendOptedOut if the safe has opted out of the lend market
+     * @custom:throws OnlyBorrowToken if token is not borrowable on the gateway
+     * @custom:throws AmountZero if the converted amount is zero
      */
-    function borrow(CashModuleStorageContract.CashModuleStorage storage $, address safe, address token, uint256 amountInUsd, uint256 nonce, address[] calldata signers, bytes[] calldata signatures) external {
+    function borrow(CashModuleStorageContract.CashModuleStorage storage $, IEtherFiDataProvider dataProvider, address safe, address token, uint256 amountInUsd, uint256 nonce, address[] calldata signers, bytes[] calldata signatures) external {
         CashVerificationLib.verifyBorrowSig(safe, nonce, token, amountInUsd, signers, signatures);
-        if (!$.debtManager.isBorrowToken(token)) revert OnlyBorrowToken();
-        uint256 amount = $.debtManager.convertUsdToCollateralToken(token, amountInUsd);
-        if (amount == 0) revert AmountZero();
-
         ILendGateway gateway = _requireGateway($, safe);
         if ($.safeCashConfig[safe].lendOptedOut) revert LendOptedOut();
+
+        if (!gateway.isBorrowable(token)) revert OnlyBorrowToken();
+        uint256 amount = DebitSourcingLib.fromUsd(IPriceProvider(dataProvider.getPriceProvider()), token, amountInUsd);
+        if (amount == 0) revert AmountZero();
 
         gateway.borrow(safe, token, amount, safe);
         _supplyAsCollateral($, gateway, safe, token, amount);
@@ -453,14 +478,15 @@ library CashLendLib {
         // Defense-in-depth: a safe that opted out of lend is forced to Debit and blocked from re-entering
         // Credit, so credit spending must never reach an opted-out safe.
         if ($.safeCashConfig[safe].lendOptedOut) revert LendOptedOut();
-        if (!$.debtManager.isBorrowToken(tokens[0])) revert UnsupportedToken();
-        uint256 amount = $.debtManager.convertUsdToCollateralToken(tokens[0], amountsInUsd[0]);
-        if (amount == 0) revert AmountZero();
 
+        uint256 amount;
         if (!_usesLendGateway($, safe)) {
+            if (!$.debtManager.isBorrowToken(tokens[0])) revert UnsupportedToken();
+            amount = $.debtManager.convertUsdToCollateralToken(tokens[0], amountsInUsd[0]);
+            if (amount == 0) revert AmountZero();
             _spendLegacyCredit($, dataProvider, safe, binSponsor, tokens[0], amount);
         } else {
-            _borrowOnGateway($, dataProvider, safe, binSponsor, tokens[0], amount, amountsInUsd[0]);
+            amount = _spendGatewayCredit($, dataProvider, safe, binSponsor, tokens[0], amountsInUsd[0]);
         }
 
         uint256[] memory amounts = new uint256[](1);
@@ -470,16 +496,20 @@ library CashLendLib {
 
     /// @dev LendGateway credit spend: the safe's position lives on Aave, so borrow there via the gateway (the
     ///      CashModule is always a gateway driver) and send the borrowed token straight to the settlement
-    ///      dispatcher. The legacy DebtManager.borrow path reverts for a migrated safe, and CashLens sizes
-    ///      credit against the same engine flag, so routing here keeps the on-chain spend consistent with
-    ///      the precheck. Aave enforces the borrowing-power/health check on the borrow itself; when the
-    ///      borrow no longer fits (an instant collateral withdrawal can land between the auth-time canSpend
-    ///      and the spend tx), loose collateral is first resupplied to cover the shortfall.
-    function _borrowOnGateway(CashModuleStorageContract.CashModuleStorage storage $, IEtherFiDataProvider dataProvider, address safe, BinSponsor binSponsor, address token, uint256 amount, uint256 amountInUsd) private {
+    ///      dispatcher. The token check and USD conversion are gateway-native (isBorrowable plus the
+    ///      PriceProvider), so this path never touches the DebtManager. Aave enforces the
+    ///      borrowing-power/health check on the borrow itself; when the borrow no longer fits (an instant
+    ///      collateral withdrawal can land between the auth-time canSpend and the spend tx), loose collateral
+    ///      is first resupplied to cover the shortfall. Returns the borrowed token amount.
+    function _spendGatewayCredit(CashModuleStorageContract.CashModuleStorage storage $, IEtherFiDataProvider dataProvider, address safe, BinSponsor binSponsor, address token, uint256 amountInUsd) private returns (uint256) {
         ILendGateway gateway = $.gateway;
         if (address(gateway) == address(0)) revert LendGatewayNotSet();
+        if (!gateway.isBorrowable(token)) revert UnsupportedToken();
+        uint256 amount = DebitSourcingLib.fromUsd(IPriceProvider(dataProvider.getPriceProvider()), token, amountInUsd);
+        if (amount == 0) revert AmountZero();
         _resupplyCollateral($, dataProvider, gateway, safe, amountInUsd);
         gateway.borrow(safe, token, amount, settlementDispatcher($, binSponsor));
+        return amount;
     }
 
     /**
@@ -750,8 +780,8 @@ library CashLendLib {
      *      reservation as void, matching the request having been cancelled at that point.
      */
     function _sourceDebitToken(CashModuleStorageContract.CashModuleStorage storage $, DebitSpendState memory s, IPriceProvider priceProvider, address safe, address token, uint256 amountInUsd, uint256 i) internal view {
-        if (!$.debtManager.isBorrowToken(token)) revert UnsupportedToken();
-        uint256 amount = $.debtManager.convertUsdToCollateralToken(token, amountInUsd);
+        if (!$.gateway.isBorrowable(token)) revert UnsupportedToken();
+        uint256 amount = DebitSourcingLib.fromUsd(priceProvider, token, amountInUsd);
 
         uint256 loose = IERC20(token).balanceOf(safe);
         uint256 withdrawable = DebitSourcingLib.withdrawableSupplied($.gateway, priceProvider, safe, token, s.borrowHeadroom, s.hasDebt);

--- a/src/modules/cash/CashLendLib.sol
+++ b/src/modules/cash/CashLendLib.sol
@@ -782,7 +782,8 @@ library CashLendLib {
      *      reservation as void, matching the request having been cancelled at that point.
      */
     function _sourceDebitToken(CashModuleStorageContract.CashModuleStorage storage $, DebitSpendState memory s, IPriceProvider priceProvider, address safe, address token, uint256 amountInUsd, uint256 i) internal view {
-        if (!$.gateway.isBorrowable(token)) revert UnsupportedToken();
+        // The debit-spend gate, not the borrow gate: a debit only transfers and withdraws, so frozen is fine
+        if (!$.gateway.isSpendAsset(token)) revert UnsupportedToken();
         uint256 amount = DebitSourcingLib.fromUsd(priceProvider, token, amountInUsd);
 
         uint256 loose = IERC20(token).balanceOf(safe);

--- a/src/modules/cash/CashLendLib.sol
+++ b/src/modules/cash/CashLendLib.sol
@@ -164,7 +164,9 @@ library CashLendLib {
 
         ILendGateway gateway = $.gateway;
         if (address(gateway) == address(0)) revert LendGatewayNotSet();
-        if (!gateway.isBorrowable(token)) revert OnlyBorrowToken();
+        // Registered, not borrowable: debt can sit on a reserve that stopped being borrowable (flag off,
+        // or frozen), and Aave allows repaying it. Only new debt takes the borrowable gate.
+        if (!gateway.isRegistered(token)) revert OnlyBorrowToken();
         IPriceProvider priceProvider = IPriceProvider(dataProvider.getPriceProvider());
         amount = DebitSourcingLib.fromUsd(priceProvider, token, amountInUsd);
         uint256 debt = gateway.debtOf(safe, token);

--- a/src/modules/cash/CashLens.sol
+++ b/src/modules/cash/CashLens.sol
@@ -27,7 +27,8 @@ import { CashLensLegacyLib } from "./CashLensLegacyLib.sol";
  *      lines inline), deleted wholesale when the legacy engine is retired; the gateway path is the unguarded
  *      fall-through.
  *
- *      LendGateway safes: the position is read from the Aave gateway; the supported-token list from DebtManager.
+ *      LendGateway safes: the position and the supported-token lists (registered/borrowable assets) are read
+ *      from the Aave gateway; nothing on the gateway path touches the DebtManager.
  *      Credit capacity comes straight from Aave. Debit spendable is the raw Safe balance plus the
  *      withdrawable supplied amount; when the Safe has debt, the withdrawable part is capped by the
  *      borrowing headroom (collateral weighted by LTV, minus debt) so the leftover position keeps
@@ -192,11 +193,11 @@ contract CashLens is UpgradeableProxy, Constants {
 
     /// @notice Credit mode check: the spend must fit the Aave borrowing capacity and the reserve's liquidity
     function _creditCheck(address safe, address token, uint256 totalSpendingInUsd) internal view returns (bool, string memory) {
-        if (!cashModule.getDebtManager().isBorrowToken(token)) {
+        ILendGateway lendGateway = cashModule.getLendGateway();
+        if (!lendGateway.isBorrowable(token)) {
             return (false, "Not a supported borrow token");
         }
 
-        ILendGateway lendGateway = cashModule.getLendGateway();
         if (lendGateway.availableCash(token) < _fromUsd(token, totalSpendingInUsd)) {
             return (false, "Insufficient liquidity to cover the loan");
         }
@@ -214,18 +215,18 @@ contract CashLens is UpgradeableProxy, Constants {
 
     /// @notice Debit mode check: each token's spendable amount must cover its share of the spend, threading the borrowing headroom across tokens
     function _debitCheck(address safe, address[] memory tokens, uint256[] memory amountsInUsd, SafeData memory safeData) internal view returns (bool, string memory) {
-        IDebtManager debtManager = cashModule.getDebtManager();
+        ILendGateway lendGateway = gateway();
         bool hasDebt;
         uint256 borrowHeadroom;
         {
-            ILendGateway.AccountData memory account = gateway().getAccountData(safe);
+            ILendGateway.AccountData memory account = lendGateway.getAccountData(safe);
             hasDebt = account.debtUsd != 0;
             borrowHeadroom = hasDebt ? account.availableBorrowsUsd : 0;
         }
 
         for (uint256 i = 0; i < tokens.length; i++) {
             address token = tokens[i];
-            if (!debtManager.isBorrowToken(token)) {
+            if (!lendGateway.isBorrowable(token)) {
                 return (false, "Not a supported borrow token");
             }
 
@@ -276,20 +277,27 @@ contract CashLens is UpgradeableProxy, Constants {
      *   - incomingModeStartTime: Timestamp when Credit mode takes effect
      */
     function getSafeCashData(address safe, address[] memory debtServiceTokenPreference) external view returns (SafeCashData memory) {
-        IDebtManager debtManager = cashModule.getDebtManager();
         IPriceProvider priceProvider = IPriceProvider(dataProvider.getPriceProvider());
         SafeData memory safeData = cashModule.getData(safe);
 
         SafeCashData memory data;
 
-        address[] memory collateralTokens = debtManager.getCollateralTokens();
-        address[] memory borrowTokens = debtManager.getBorrowTokens();
+        // Each engine names its own token universe: DebtManager's lists for a legacy safe, the gateway's
+        // registered/borrowable assets for an Aave safe.
+        address[] memory collateralTokens;
+        address[] memory borrowTokens;
 
         if (!cashModule.usesLendGateway(safe)) {
+            IDebtManager debtManager = cashModule.getDebtManager();
+            collateralTokens = debtManager.getCollateralTokens();
+            borrowTokens = debtManager.getBorrowTokens();
             (data.collateralBalances, data.totalCollateral, data.borrows, data.totalBorrow) = debtManager.getUserCurrentState(safe);
             data.maxBorrow = debtManager.getMaxBorrowAmount(safe, true);
         } else {
-            ILendGateway.AccountData memory account = gateway().getAccountData(safe);
+            ILendGateway lendGateway = gateway();
+            collateralTokens = lendGateway.registeredAssets();
+            borrowTokens = lendGateway.borrowableAssets();
+            ILendGateway.AccountData memory account = lendGateway.getAccountData(safe);
             data.collateralBalances = _suppliedBalances(safe, collateralTokens);
             data.borrows = _debtBalances(safe, borrowTokens);
             data.totalCollateral = account.collateralUsd;
@@ -355,13 +363,13 @@ contract CashLens is UpgradeableProxy, Constants {
             return CashLensLegacyLib.maxSpendDebit(cashModule, safe, debtServiceTokenPreference);
         }
 
-        IDebtManager debtManager = cashModule.getDebtManager();
+        ILendGateway lendGateway = gateway();
         SafeData memory safeData = cashModule.getData(safe);
 
         bool hasDebt;
         uint256 borrowHeadroom;
         {
-            ILendGateway.AccountData memory account = gateway().getAccountData(safe);
+            ILendGateway.AccountData memory account = lendGateway.getAccountData(safe);
             hasDebt = account.debtUsd != 0;
             if (hasDebt) {
                 borrowHeadroom = account.availableBorrowsUsd;
@@ -374,7 +382,7 @@ contract CashLens is UpgradeableProxy, Constants {
 
         for (uint256 i = 0; i < len;) {
             address token = debtServiceTokenPreference[i];
-            if (!debtManager.isBorrowToken(token)) revert NotABorrowToken();
+            if (!lendGateway.isBorrowable(token)) revert NotABorrowToken();
 
             (uint256 spendable, uint256 used) = _debitSpendable(safe, token, safeData, borrowHeadroom, hasDebt);
             borrowHeadroom = borrowHeadroom > used ? borrowHeadroom - used : 0;
@@ -409,7 +417,7 @@ contract CashLens is UpgradeableProxy, Constants {
         ILendGateway lendGateway = cashModule.getLendGateway();
         uint256 borrowPower = lendGateway.getAccountData(safe).availableBorrowsUsd;
 
-        address[] memory borrowTokens = cashModule.getDebtManager().getBorrowTokens();
+        address[] memory borrowTokens = lendGateway.borrowableAssets();
         uint256 maxLiquidityUsd = 0;
         for (uint256 i = 0; i < borrowTokens.length;) {
             uint256 liquidityUsd = _toUsd(borrowTokens[i], lendGateway.availableCash(borrowTokens[i]));
@@ -498,21 +506,20 @@ contract CashLens is UpgradeableProxy, Constants {
      * @param safe Address of the safe
      * @param token Address of the collateral token to check
      * @return Effective collateral amount
-     * @custom:throws NotACollateralToken if token is not a valid collateral token
+     * @custom:throws NotACollateralToken if token is not a collateral token on the safe's engine
      */
     function getUserCollateralForToken(address safe, address token) public view returns (uint256) {
-        IDebtManager debtManager = cashModule.getDebtManager();
-
-        if (!debtManager.isCollateralToken(token)) revert NotACollateralToken();
-
         if (!cashModule.usesLendGateway(safe)) {
+            if (!cashModule.getDebtManager().isCollateralToken(token)) revert NotACollateralToken();
             uint256 balance = IERC20(token).balanceOf(safe);
             uint256 pendingWithdrawalAmount = getPendingWithdrawalAmount(safe, token);
 
             return balance > pendingWithdrawalAmount ? balance - pendingWithdrawalAmount : 0;
         }
 
-        return gateway().suppliedOf(safe, token);
+        ILendGateway lendGateway = gateway();
+        if (!lendGateway.isRegistered(token)) revert NotACollateralToken();
+        return lendGateway.suppliedOf(safe, token);
     }
 
     /**
@@ -524,14 +531,11 @@ contract CashLens is UpgradeableProxy, Constants {
      * @return Array of token data with token addresses and effective amounts
      */
     function getUserTotalCollateral(address safe) public view returns (IDebtManager.TokenData[] memory) {
-        IDebtManager debtManager = cashModule.getDebtManager();
-        address[] memory collateralTokens = debtManager.getCollateralTokens();
-
         if (!cashModule.usesLendGateway(safe)) {
-            return CashLensLegacyLib.userTotalCollateral(cashModule, safe, collateralTokens);
+            return CashLensLegacyLib.userTotalCollateral(cashModule, safe, cashModule.getDebtManager().getCollateralTokens());
         }
 
-        return _suppliedBalances(safe, collateralTokens);
+        return _suppliedBalances(safe, gateway().registeredAssets());
     }
 
     /**

--- a/src/modules/cash/CashLens.sol
+++ b/src/modules/cash/CashLens.sol
@@ -299,7 +299,10 @@ contract CashLens is UpgradeableProxy, Constants {
             borrowTokens = lendGateway.borrowableAssets();
             ILendGateway.AccountData memory account = lendGateway.getAccountData(safe);
             data.collateralBalances = _suppliedBalances(safe, collateralTokens);
-            data.borrows = _debtBalances(safe, borrowTokens);
+            // Debt can sit on any registered reserve, including one that stopped being borrowable after
+            // the borrow (borrowable flag turned off, or the reserve frozen/paused), so walk all
+            // registered assets here to match totalBorrow and hasOpenBorrows.
+            data.borrows = _debtBalances(safe, collateralTokens);
             data.totalCollateral = account.collateralUsd;
             data.totalBorrow = account.debtUsd;
             // Gross borrowing power (collateral weighted by LTV): the gateway headroom plus current debt

--- a/src/modules/cash/CashLens.sol
+++ b/src/modules/cash/CashLens.sol
@@ -226,8 +226,8 @@ contract CashLens is UpgradeableProxy, Constants {
 
         for (uint256 i = 0; i < tokens.length; i++) {
             address token = tokens[i];
-            if (!lendGateway.isBorrowable(token)) {
-                return (false, "Not a supported borrow token");
+            if (!lendGateway.isSpendAsset(token)) {
+                return (false, "Not a supported spend token");
             }
 
             uint256 needed = _fromUsd(token, amountsInUsd[i]);
@@ -283,20 +283,21 @@ contract CashLens is UpgradeableProxy, Constants {
         SafeCashData memory data;
 
         // Each engine names its own token universe: DebtManager's lists for a legacy safe, the gateway's
-        // registered/borrowable assets for an Aave safe.
+        // registered/spendable assets for an Aave safe. The spend list is the debitMaxSpend default; on
+        // the legacy engine the borrow-token list is that same list.
         address[] memory collateralTokens;
-        address[] memory borrowTokens;
+        address[] memory debitSpendTokens;
 
         if (!cashModule.usesLendGateway(safe)) {
             IDebtManager debtManager = cashModule.getDebtManager();
             collateralTokens = debtManager.getCollateralTokens();
-            borrowTokens = debtManager.getBorrowTokens();
+            debitSpendTokens = debtManager.getBorrowTokens();
             (data.collateralBalances, data.totalCollateral, data.borrows, data.totalBorrow) = debtManager.getUserCurrentState(safe);
             data.maxBorrow = debtManager.getMaxBorrowAmount(safe, true);
         } else {
             ILendGateway lendGateway = gateway();
             collateralTokens = lendGateway.registeredAssets();
-            borrowTokens = lendGateway.borrowableAssets();
+            debitSpendTokens = lendGateway.spendAssets();
             ILendGateway.AccountData memory account = lendGateway.getAccountData(safe);
             data.collateralBalances = _suppliedBalances(safe, collateralTokens);
             // Debt can sit on any registered reserve, including one that stopped being borrowable after
@@ -324,7 +325,7 @@ contract CashLens is UpgradeableProxy, Constants {
         data.creditMaxSpend = getMaxSpendCredit(safe);
 
         if (debtServiceTokenPreference.length == 0) {
-            data.debitMaxSpend = getMaxSpendDebit(safe, borrowTokens);
+            data.debitMaxSpend = getMaxSpendDebit(safe, debitSpendTokens);
         } else {
             data.debitMaxSpend = getMaxSpendDebit(safe, debtServiceTokenPreference);
         }
@@ -385,7 +386,7 @@ contract CashLens is UpgradeableProxy, Constants {
 
         for (uint256 i = 0; i < len;) {
             address token = debtServiceTokenPreference[i];
-            if (!lendGateway.isBorrowable(token)) revert NotABorrowToken();
+            if (!lendGateway.isSpendAsset(token)) revert NotABorrowToken();
 
             (uint256 spendable, uint256 used) = _debitSpendable(safe, token, safeData, borrowHeadroom, hasDebt);
             borrowHeadroom = borrowHeadroom > used ? borrowHeadroom - used : 0;

--- a/src/modules/cash/CashModuleCore.sol
+++ b/src/modules/cash/CashModuleCore.sol
@@ -528,16 +528,15 @@ contract CashModuleCore is CashModuleStorageContract {
 
     /**
      * @notice Repays borrowed tokens
-     * @dev Only callable by EtherFi wallet for valid EtherFi Safe addresses
+     * @dev Only callable by EtherFi wallet for valid EtherFi Safe addresses. CashLendLib routes by engine
+     *      and owns the token check, USD conversion, and withdrawal-reservation handling for both.
      * @param safe Address of the EtherFi Safe
      * @param token Address of the token to repay
      * @param amountInUsd Amount to repay in USD
-     * @custom:throws OnlyBorrowToken if token is not a valid borrow token
+     * @custom:throws OnlyBorrowToken if the token cannot carry debt on the safe's engine
      */
     function repay(address safe, address token, uint256 amountInUsd) public whenNotPaused nonReentrant onlyEtherFiWallet onlyEtherFiSafe(safe) {
-        IDebtManager debtManager = getDebtManager();
-        if (!_isBorrowToken(debtManager, token)) revert OnlyBorrowToken();
-        _repay(safe, debtManager, token, amountInUsd);
+        CashLendLib.repay(_getCashModuleStorage(), etherFiDataProvider, safe, token, amountInUsd);
     }
 
     /**
@@ -565,33 +564,12 @@ contract CashModuleCore is CashModuleStorageContract {
      * @param signers Addresses of the owners authorizing the borrow
      * @param signatures The signers' signatures over the intent
      * @custom:throws InvalidSignatures if the signatures do not meet the owner quorum
-     * @custom:throws OnlyBorrowToken if token is not a valid borrow token
+     * @custom:throws OnlyBorrowToken if token is not borrowable on the gateway
      * @custom:throws AmountZero if the converted amount is zero
      * @custom:throws OnlyLendGatewaySafe if the safe runs on the legacy DebtManager engine
      */
     function borrow(address safe, address token, uint256 amountInUsd, address[] calldata signers, bytes[] calldata signatures) external whenNotPaused nonReentrant onlyEtherFiSafe(safe) {
-        CashLendLib.borrow(_getCashModuleStorage(), safe, token, amountInUsd, IEtherFiSafe(safe).useNonce(), signers, signatures);
-    }
-
-    /**
-     * @dev Internal function to execute the repayment transaction
-     * @param safe Address of the EtherFi Safe
-     * @param debtManager Reference to the debt manager contract
-     * @param token Address of the token to repay
-     * @param amountInUsd Amount to repay in USD
-     * @custom:throws AmountZero if the converted amount is zero
-     */
-    function _repay(address safe, IDebtManager debtManager, address token, uint256 amountInUsd) internal {
-        uint256 amount = IDebtManager(debtManager).convertUsdToCollateralToken(token, amountInUsd);
-        if (amount == 0) revert AmountZero();
-        // A legacy safe repays from its loose balance only, so a repay that needs withdrawal-reserved funds
-        // is resolved here. A gateway safe sources loose plus Aave-supplied balance in CashLendLib.repay,
-        // which owns the reservation handling for that engine.
-        if (!_usesLendGateway(safe)) _cancelCompetingWithdrawal(safe, token, amount);
-
-        // A migrated safe repays on Aave via the gateway; a legacy safe repays the DebtManager. Both paths run
-        // in CashLendLib (extracted to keep this contract within the code-size limit).
-        CashLendLib.repay(_getCashModuleStorage(), etherFiDataProvider, safe, token, amount, amountInUsd);
+        CashLendLib.borrow(_getCashModuleStorage(), etherFiDataProvider, safe, token, amountInUsd, IEtherFiSafe(safe).useNonce(), signers, signatures);
     }
 
     /**

--- a/src/modules/cash/CashModuleStorageContract.sol
+++ b/src/modules/cash/CashModuleStorageContract.sol
@@ -222,56 +222,6 @@ contract CashModuleStorageContract is UpgradeableProxy, ModuleBase {
     }
 
     /**
-     * @dev Cancels the safe's pending withdrawal request when it competes with a repay/spend of `token`.
-     *      Reverts if `amount` exceeds the safe's loose balance. Otherwise, if `token` has a leg in the
-     *      pending request and `amount` plus that reserved leg exceeds the loose balance, the whole request
-     *      is cancelled: the repay/spend outranks the reservation. Conservative on purpose: the check uses
-     *      the quoted `amount`, but both engines cap the actual pull at the live debt (a full repay resolves
-     *      to the outstanding debt), so a repay quoted above the debt can cancel a request that the real,
-     *      smaller pull would have left intact. Only the repaid token's leg and the current balance are
-     *      considered.
-     * @param safe Address of the EtherFi Safe
-     * @param token Address of the token being repaid/spent
-     * @param amount Quoted token amount for the operation
-     * @custom:throws InsufficientBalance if `amount` exceeds the safe's loose balance of `token`
-     */
-    function _cancelCompetingWithdrawal(address safe, address token, uint256 amount) internal {
-        SafeCashConfig storage safeCashConfig = _getCashModuleStorage().safeCashConfig[safe];
-        uint256 balance = IERC20(token).balanceOf(safe);
-
-        if (amount > balance) revert InsufficientBalance();
-
-        uint256 len = safeCashConfig.pendingWithdrawalRequest.tokens.length;
-        uint256 tokenIndex = len;
-        for (uint256 i = 0; i < len;) {
-            if (safeCashConfig.pendingWithdrawalRequest.tokens[i] == token) {
-                tokenIndex = i;
-                break;
-            }
-            unchecked {
-                ++i;
-            }
-        }
-
-        // If the token does not exist in withdrawal request, return
-        if (tokenIndex == len) return;
-
-        if (amount + safeCashConfig.pendingWithdrawalRequest.amounts[tokenIndex] > balance) {
-            _cancelOldWithdrawal(safe);
-        }
-    }
-
-    /**
-     * @dev Checks if a token is a valid borrow token
-     * @param debtManager Reference to the debt manager contract
-     * @param token Address of the token to check
-     * @return Boolean indicating if the token is a borrow token
-     */
-    function _isBorrowToken(IDebtManager debtManager, address token) internal view returns (bool) {
-        return debtManager.isBorrowToken(token);
-    }
-
-    /**
      * @dev Modifier to ensure caller has the EtherFi wallet role
      * @custom:throws OnlyEtherFiWallet if caller does not have the role
      */

--- a/src/modules/lend-gateway/LendGateway.sol
+++ b/src/modules/lend-gateway/LendGateway.sol
@@ -473,6 +473,32 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
         return _getLendGatewayStorage().assets.values();
     }
 
+    /// @notice Whether `asset` is registered and its reserve's borrowable flag is set on the Spoke
+    function isBorrowable(address asset) external view returns (bool) {
+        LendGatewayStorage storage $ = _getLendGatewayStorage();
+        if (!$.assets.contains(asset)) return false;
+        return spoke.getReserveConfig($.reserveId[asset]).borrowable;
+    }
+
+    /// @notice The registered assets whose reserves allow borrowing on the Spoke
+    function borrowableAssets() external view returns (address[] memory) {
+        LendGatewayStorage storage $ = _getLendGatewayStorage();
+        address[] memory assets = $.assets.values();
+        uint256 count = 0;
+        for (uint256 i = 0; i < assets.length; i++) {
+            if (spoke.getReserveConfig($.reserveId[assets[i]]).borrowable) {
+                assets[count] = assets[i];
+                unchecked {
+                    ++count;
+                }
+            }
+        }
+        assembly ("memory-safe") {
+            mstore(assets, count)
+        }
+        return assets;
+    }
+
     /// @notice Whether `account` may drive the gateway (CashModule or an authorized driver)
     function isDriver(address account) external view returns (bool) {
         return account == etherFiDataProvider.getCashModule() || _getLendGatewayStorage().isDriver[account];

--- a/src/modules/lend-gateway/LendGateway.sol
+++ b/src/modules/lend-gateway/LendGateway.sol
@@ -493,21 +493,26 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
 
     /// @notice The registered assets whose reserves accept a borrow on the Spoke
     function borrowableAssets() external view returns (address[] memory) {
+        return _filterAssets(true);
+    }
+
+    /**
+     * @notice Whether `asset` can fund a debit spend: registered, marked borrowable, and not paused
+     * @dev A debit spend transfers loose balance and withdraws supplied balance, and Aave allows both
+     *      while frozen, so frozen is tolerated here. The borrowable flag does membership duty (it marks
+     *      the spendable stables); paused blocks the withdraw leg. Only new debt takes the full
+     *      isBorrowable gate.
+     * @param asset The asset to query
+     */
+    function isSpendAsset(address asset) external view returns (bool) {
         LendGatewayStorage storage $ = _getLendGatewayStorage();
-        address[] memory assets = $.assets.values();
-        uint256 count = 0;
-        for (uint256 i = 0; i < assets.length; i++) {
-            if (_isBorrowable($.reserveId[assets[i]])) {
-                assets[count] = assets[i];
-                unchecked {
-                    ++count;
-                }
-            }
-        }
-        assembly ("memory-safe") {
-            mstore(assets, count)
-        }
-        return assets;
+        if (!$.assets.contains(asset)) return false;
+        return _isSpendAsset($.reserveId[asset]);
+    }
+
+    /// @notice The registered assets that can fund a debit spend (see isSpendAsset)
+    function spendAssets() external view returns (address[] memory) {
+        return _filterAssets(false);
     }
 
     /// @notice Whether `account` may drive the gateway (CashModule or an authorized driver)
@@ -542,6 +547,32 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
     function _isBorrowable(uint256 reserveId) internal view returns (bool) {
         IAaveV4Spoke.ReserveConfig memory config = spoke.getReserveConfig(reserveId);
         return config.borrowable && !config.frozen && !config.paused;
+    }
+
+    /// @dev Whether the reserve can fund a debit spend: borrowable (membership), not paused; frozen tolerated
+    function _isSpendAsset(uint256 reserveId) internal view returns (bool) {
+        IAaveV4Spoke.ReserveConfig memory config = spoke.getReserveConfig(reserveId);
+        return config.borrowable && !config.paused;
+    }
+
+    /// @dev The registered assets passing the borrow gate (`borrowGate`) or the debit-spend gate
+    function _filterAssets(bool borrowGate) internal view returns (address[] memory) {
+        LendGatewayStorage storage $ = _getLendGatewayStorage();
+        address[] memory assets = $.assets.values();
+        uint256 count = 0;
+        for (uint256 i = 0; i < assets.length; i++) {
+            uint256 reserveId = $.reserveId[assets[i]];
+            if (borrowGate ? _isBorrowable(reserveId) : _isSpendAsset(reserveId)) {
+                assets[count] = assets[i];
+                unchecked {
+                    ++count;
+                }
+            }
+        }
+        assembly ("memory-safe") {
+            mstore(assets, count)
+        }
+        return assets;
     }
 
     /// @dev The registered reserveId for `asset`, reverting if unregistered

--- a/src/modules/lend-gateway/LendGateway.sol
+++ b/src/modules/lend-gateway/LendGateway.sol
@@ -104,6 +104,8 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
     error ZeroAmount();
     /// @notice Thrown when a lend op is attempted for a safe that has opted out of lend
     error LendOptedOut();
+    /// @notice Thrown when de-registering a reserve that still has outstanding debt or supplied balance
+    error ReserveStillInUse();
 
     /**
      * @param _etherFiDataProvider Address of the EtherFiDataProvider
@@ -170,13 +172,20 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
 
     /**
      * @notice De-registers an asset
+     * @dev Reverts while the reserve still has outstanding debt or supplied balance. Removing a
+     * held asset would drop it from the USD views (debt reads 0, understating debt and inflating
+     * borrow headroom) and strand supplied funds behind AssetNotRegistered on the withdraw paths.
+     * Our whitelabel Spoke serves only our safes, so the reserve aggregates gate on our positions.
      * @param asset The asset to remove from the registry
-     * @dev Warning: do not remove an asset any safe still holds a position in; 
-     * it drops from the USD views (debt reads 0), understating debt and inflating borrow headroom.
      */
     function removeReserve(address asset) external onlyRole(LEND_GATEWAY_ADMIN_ROLE) {
         LendGatewayStorage storage $ = _getLendGatewayStorage();
         if (!$.assets.contains(asset)) revert AssetNotRegistered(asset);
+
+        uint256 reserveId = $.reserveId[asset];
+        if (spoke.getReserveTotalDebt(reserveId) != 0 || spoke.getReserveSuppliedAssets(reserveId) != 0) {
+            revert ReserveStillInUse();
+        }
 
         $.assets.remove(asset);
         delete $.reserveId[asset];
@@ -473,20 +482,22 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
         return _getLendGatewayStorage().assets.values();
     }
 
-    /// @notice Whether `asset` is registered and its reserve's borrowable flag is set on the Spoke
+    /// @notice Whether `asset` is registered and its reserve accepts a borrow on the Spoke
+    /// @dev Mirrors Aave's borrow gate (borrowable, not frozen, not paused) so an asset that passes
+    ///      here at auth cannot then fail the Spoke's borrow at spend.
     function isBorrowable(address asset) external view returns (bool) {
         LendGatewayStorage storage $ = _getLendGatewayStorage();
         if (!$.assets.contains(asset)) return false;
-        return spoke.getReserveConfig($.reserveId[asset]).borrowable;
+        return _isBorrowable($.reserveId[asset]);
     }
 
-    /// @notice The registered assets whose reserves allow borrowing on the Spoke
+    /// @notice The registered assets whose reserves accept a borrow on the Spoke
     function borrowableAssets() external view returns (address[] memory) {
         LendGatewayStorage storage $ = _getLendGatewayStorage();
         address[] memory assets = $.assets.values();
         uint256 count = 0;
         for (uint256 i = 0; i < assets.length; i++) {
-            if (spoke.getReserveConfig($.reserveId[assets[i]]).borrowable) {
+            if (_isBorrowable($.reserveId[assets[i]])) {
                 assets[count] = assets[i];
                 unchecked {
                     ++count;
@@ -525,6 +536,12 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
     /// @dev Whether `safe` has opted out of lend, per the CashModule (the source of truth for the opt-out)
     function _isLendOptedOut(address safe) internal view returns (bool) {
         return ICashModule(etherFiDataProvider.getCashModule()).isLendOptedOut(safe);
+    }
+
+    /// @dev Whether the reserve accepts a borrow on the Spoke: borrowable, not frozen, not paused
+    function _isBorrowable(uint256 reserveId) internal view returns (bool) {
+        IAaveV4Spoke.ReserveConfig memory config = spoke.getReserveConfig(reserveId);
+        return config.borrowable && !config.frozen && !config.paused;
     }
 
     /// @dev The registered reserveId for `asset`, reverting if unregistered

--- a/test/safe/SafeTestSetup.t.sol
+++ b/test/safe/SafeTestSetup.t.sol
@@ -180,6 +180,11 @@ contract SafeTestSetup is Utils {
         hook = EtherFiHook(address(new UUPSProxy(hookImpl, abi.encodeWithSelector(EtherFiHook.initialize.selector, address(roleRegistry)))));
 
         gateway = new MockLendGateway();
+        // Mirror the DebtManager's token universe on the mock: the gateway paths read their token checks
+        // from the gateway (isBorrowable/isRegistered), not the DebtManager
+        gateway.setRegistered(address(weETH), true);
+        gateway.setRegistered(address(usdc), true);
+        gateway.setBorrowable(address(usdc), true);
         address cashLensImpl = address(new CashLens(address(cashModule), address(dataProvider)));
         cashLens = CashLens(address(new UUPSProxy(cashLensImpl, abi.encodeWithSelector(CashLens.initialize.selector, address(roleRegistry)))));
 

--- a/test/safe/modules/cash/CanSpend.t.sol
+++ b/test/safe/modules/cash/CanSpend.t.sol
@@ -51,6 +51,8 @@ contract CashLensCanSpendTest is CashModuleTestSetup {
 
         minShares = uint128(10 * 10 ** IERC20Metadata(address(liquidUsd)).decimals());
         debtManager.supportBorrowToken(address(liquidUsd), borrowApyPerSecond, minShares);
+        gateway.setRegistered(address(liquidUsd), true);
+        gateway.setBorrowable(address(liquidUsd), true);
         
         CashbackTokens[] memory cashbackTokens = new CashbackTokens[](1);
         CashbackTokens memory scr = CashbackTokens({
@@ -441,7 +443,8 @@ contract CashLensCanSpendTest is CashModuleTestSetup {
     /// Debit mode allows spending multiple tokens when each has enough balance.
     function test_canSpend_debitMode() public {
         vm.prank(owner);
-        debtManager.supportBorrowToken(address(weETH), borrowApyPerSecond, minShares);        
+        debtManager.supportBorrowToken(address(weETH), borrowApyPerSecond, minShares);
+        gateway.setBorrowable(address(weETH), true);
 
         // Setup test state with multiple tokens
         deal(address(weETH), address(safe), 5 ether);

--- a/test/safe/modules/cash/CanSpend.t.sol
+++ b/test/safe/modules/cash/CanSpend.t.sol
@@ -553,7 +553,7 @@ contract CashLensCanSpendTest is CashModuleTestSetup {
         (bool canSpend, string memory message) = cashLens.canSpend(address(safe), txId, tokens, amountsInUsd);
         
         assertFalse(canSpend, "Should not allow spending a non-borrow token");
-        assertEq(message, "Not a supported borrow token", "Error message should match");
+        assertEq(message, "Not a supported spend token", "Error message should match");
     }
 
     /// canSpend is declined when reusing a txId that was already spent.

--- a/test/safe/modules/cash/CashLens.t.sol
+++ b/test/safe/modules/cash/CashLens.t.sol
@@ -58,6 +58,8 @@ contract CashLensTest is CashModuleTestSetup {
 
         minShares = uint128(10 * 10 ** IERC20Metadata(address(liquidUsd)).decimals());
         debtManager.supportBorrowToken(address(liquidUsd), borrowApyPerSecond, minShares);
+        gateway.setRegistered(address(liquidUsd), true);
+        gateway.setBorrowable(address(liquidUsd), true);
 
         // Add some collateral to safe for tests
         deal(address(weETH), address(safe), 10 ether);

--- a/test/safe/modules/cash/MultiSpend.t.sol
+++ b/test/safe/modules/cash/MultiSpend.t.sol
@@ -23,6 +23,7 @@ contract CashModuleMultiSpendTest is CashModuleTestSetup {
         // Support weETH as another borrow token
         vm.prank(owner);
         debtManager.supportBorrowToken(address(weETH), borrowApyPerSecond, minShares);
+        gateway.setBorrowable(address(weETH), true);
     }
 
     function test_spend_variousTokenProportions_inDebitMode() public {
@@ -562,6 +563,8 @@ contract CashModuleMultiSpendTest is CashModuleTestSetup {
         IDebtManager.CollateralTokenConfig memory collateralTokenConfig = IDebtManager.CollateralTokenConfig({ltv: ltv, liquidationThreshold: liquidationThreshold, liquidationBonus: liquidationBonus});
         debtManager.supportCollateralToken(address(cashbackToken), collateralTokenConfig);
         debtManager.supportBorrowToken(address(cashbackToken), borrowApyPerSecond, minShares);
+        gateway.setRegistered(address(cashbackToken), true);
+        gateway.setBorrowable(address(cashbackToken), true);
         vm.stopPrank();
         
         // Setup three tokens with sample amounts

--- a/test/safe/modules/cash/SetLendGateway.t.sol
+++ b/test/safe/modules/cash/SetLendGateway.t.sol
@@ -68,6 +68,8 @@ contract CashModuleSetLendGatewayTest is CashModuleTestSetup {
         amountsInUsd[0] = 100e6;
 
         newGateway.setAvailableCash(address(usdc), type(uint128).max);
+        newGateway.setRegistered(address(usdc), true);
+        newGateway.setBorrowable(address(usdc), true);
         newGateway.setAccountData(address(safe), ILendGateway.AccountData({ collateralUsd: 200e6, debtUsd: 0, availableBorrowsUsd: amountsInUsd[0], healthFactor: type(uint256).max }));
 
         vm.prank(owner);

--- a/test/safe/modules/cash/Spend.t.sol
+++ b/test/safe/modules/cash/Spend.t.sol
@@ -48,6 +48,7 @@ contract CashModuleSpendTest is CashModuleTestSetup {
     function test_spend_worksWithMultipleToken_inDebitMode() public {
         vm.prank(owner);
         debtManager.supportBorrowToken(address(weETH), borrowApyPerSecond, minShares);
+        gateway.setBorrowable(address(weETH), true);
 
         uint256 amountInUsd = 100e6;
         uint256 totalAmountInUsd = amountInUsd * 2; // Pre-calculate total

--- a/test/safe/modules/cash/lend/AutoSupply.t.sol
+++ b/test/safe/modules/cash/lend/AutoSupply.t.sol
@@ -112,6 +112,15 @@ contract AutoSupplyTest is CashGatewayTestSetup {
         cashModule.borrow(address(safe), address(usdc), 100e6, signers, signatures);
     }
 
+    /// A registered but collateral-only asset (weETH's reserve has borrowable off) is rejected with the
+    /// module's own error, not deep inside Aave. The check reads the gateway, not the DebtManager.
+    function test_borrow_revertsForNonBorrowableToken() public {
+        _supplyToGateway(address(safe), address(usdc), 1000e6);
+        (address[] memory signers, bytes[] memory signatures) = _borrowSig(address(weETH), 100e6);
+        vm.expectRevert(ICashModule.OnlyBorrowToken.selector);
+        cashModule.borrow(address(safe), address(weETH), 100e6, signers, signatures);
+    }
+
     /// A legacy safe has no gateway borrow flow.
     function test_borrow_revertsForLegacySafe() public {
         _forceLegacyEngine(address(safe));

--- a/test/safe/modules/cash/lend/CanSpend.t.sol
+++ b/test/safe/modules/cash/lend/CanSpend.t.sol
@@ -29,6 +29,22 @@ contract CashLensCanSpendAaveTest is CashGatewayTestSetup {
         assertEq(reason, "");
     }
 
+    /// A freeze does not stop debit: the spend only transfers loose and withdraws supplied balance, both
+    /// allowed on a frozen reserve, so the auth keeps approving.
+    function test_canSpend_succeeds_inDebitMode_whileReserveFrozen() public {
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 100e6;
+
+        _supplyToGateway(address(safe), address(usdc), 1000e6);
+        _setAaveReserveFrozen(usdcReserveId, true);
+
+        (bool canSpend, string memory reason) = cashLens.canSpend(address(safe), txId, tokens, amounts);
+        assertEq(canSpend, true);
+        assertEq(reason, "");
+    }
+
     /// Credit spend succeeds when the supplied collateral gives enough borrowing power to cover the amount.
     function test_canSpend_succeeds_inCreditMode_whenCollateralAvailable() public {
         _setMode(Mode.Credit);

--- a/test/safe/modules/cash/lend/CanSpend.t.sol
+++ b/test/safe/modules/cash/lend/CanSpend.t.sol
@@ -45,6 +45,27 @@ contract CashLensCanSpendAaveTest is CashGatewayTestSetup {
         assertEq(reason, "");
     }
 
+    /// An otherwise-fine credit spend is declined once the borrow reserve is frozen: canSpend gates on the same
+    /// borrow gate Aave enforces at spend, so auth and the on-chain borrow cannot disagree.
+    function test_canSpend_fails_inCreditMode_whenBorrowReserveFrozen() public {
+        _setMode(Mode.Credit);
+        vm.warp(cashModule.incomingModeStartTime(address(safe)) + 1);
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 100e6;
+
+        _supplyToGateway(address(safe), address(weETH), 1 ether);
+
+        // Ample borrowing power, but freezing the USDC reserve makes it non-borrowable
+        _setAaveReserveFrozen(usdcReserveId, true);
+
+        (bool canSpend, string memory reason) = cashLens.canSpend(address(safe), txId, tokens, amounts);
+        assertEq(canSpend, false);
+        assertEq(reason, "Not a supported borrow token");
+    }
+
     /// Credit spend is declined when borrowing power is ample but the Aave reserve holds too little cash for the loan.
     function test_canSpend_fails_inCreditMode_whenReserveLiquidityUnavailable() public {
         _setMode(Mode.Credit);

--- a/test/safe/modules/cash/lend/CashGatewayTestSetup.t.sol
+++ b/test/safe/modules/cash/lend/CashGatewayTestSetup.t.sol
@@ -45,7 +45,7 @@ abstract contract CashGatewayTestSetup is CashModuleTestSetup, AaveV4Fixture {
         // Real Aave v4 instance on the fork, weETH + USDC reserves priced by live Chainlink feeds
         _deployAaveV4();
         address weethSource = address(new ChainlinkCompositePriceFeed(IAggregatorV3(weEthWethOracle), IAggregatorV3(ethUsdcOracle), 8, 30 days, 30 days, "weETH / USD"));
-        weethReserveId = _addAaveReserve(address(weETH), weethSource, _weethCollateralFactorBps(), false);
+        weethReserveId = _addAaveReserve(address(weETH), weethSource, _weethCollateralFactorBps(), _weethBorrowable());
         usdcReserveId = _addAaveReserve(address(usdc), usdcUsdOracle, _usdcCollateralFactorBps(), true);
         _seedInitialLiquidity();
 
@@ -84,6 +84,12 @@ abstract contract CashGatewayTestSetup is CashModuleTestSetup, AaveV4Fixture {
     /// @dev weETH reserve collateral factor in BPS; override to model a different Aave LTV.
     function _weethCollateralFactorBps() internal pure virtual returns (uint16) {
         return 8000;
+    }
+
+    /// @dev Whether the weETH reserve allows borrowing (collateral-only by default, matching the planned
+    ///      instance config); override to model weETH as a spendable (borrowable) token.
+    function _weethBorrowable() internal pure virtual returns (bool) {
+        return false;
     }
 
     /// @dev USDC reserve collateral factor in BPS; override to model a different Aave LTV.

--- a/test/safe/modules/cash/lend/CashLens.t.sol
+++ b/test/safe/modules/cash/lend/CashLens.t.sol
@@ -75,8 +75,9 @@ contract CashLensAaveTest is CashGatewayTestSetup {
         assertApproxEqAbs(data.totalBorrow, borrowAmount, 2, "Total borrow should match the Aave debt");
     }
 
-    /// Turning a reserve's borrowable flag off after a borrow must not drop that debt from the breakdown:
-    /// the per-token borrows walk registered assets, so they stay consistent with totalBorrow.
+    /// A reserve that stops being borrowable after a borrow (flag off, or frozen/paused) must not drop its
+    /// debt from the breakdown: the per-token borrows walk registered assets, so they stay consistent with
+    /// totalBorrow.
     function test_getSafeCashData_borrowsSurviveReserveMadeNonBorrowable() public {
         uint256 borrowAmount = 1000e6;
         _buildGatewayPosition(address(safe), address(weETH), 5 ether, address(usdc), borrowAmount);

--- a/test/safe/modules/cash/lend/CashLens.t.sol
+++ b/test/safe/modules/cash/lend/CashLens.t.sol
@@ -75,6 +75,24 @@ contract CashLensAaveTest is CashGatewayTestSetup {
         assertApproxEqAbs(data.totalBorrow, borrowAmount, 2, "Total borrow should match the Aave debt");
     }
 
+    /// Turning a reserve's borrowable flag off after a borrow must not drop that debt from the breakdown:
+    /// the per-token borrows walk registered assets, so they stay consistent with totalBorrow.
+    function test_getSafeCashData_borrowsSurviveReserveMadeNonBorrowable() public {
+        uint256 borrowAmount = 1000e6;
+        _buildGatewayPosition(address(safe), address(weETH), 5 ether, address(usdc), borrowAmount);
+
+        // Governance blocks new USDC borrows; the existing debt stays open.
+        _setAaveReserveBorrowable(usdcReserveId, false);
+        assertFalse(gw.isBorrowable(address(usdc)), "USDC no longer borrowable");
+
+        SafeCashData memory data = cashLens.getSafeCashData(address(safe), new address[](0));
+
+        assertEq(data.borrows.length, 1, "Debt breakdown still lists the USDC borrow");
+        assertEq(data.borrows[0].token, address(usdc), "Borrow token should be USDC");
+        assertApproxEqAbs(data.borrows[0].amount, borrowAmount, 2, "Breakdown matches the Aave debt");
+        assertApproxEqAbs(data.totalBorrow, borrowAmount, 2, "Total still matches, so breakdown and total agree");
+    }
+
     /// With no debt, the max is the loose balance (net of a pending withdrawal) plus the full supplied balance.
     function test_getMaxSourceable_noDebt_looseNetOfPendingPlusSupplied() public {
         _supplyToGateway(address(safe), address(weETH), 3 ether);

--- a/test/safe/modules/cash/lend/LendGatewayAaveV4.t.sol
+++ b/test/safe/modules/cash/lend/LendGatewayAaveV4.t.sol
@@ -49,6 +49,22 @@ contract LendGatewayAaveV4Test is CashGatewayTestSetup {
         assertEq(borrowable[0], address(usdc));
     }
 
+    /// isBorrowable mirrors Aave's borrow gate: freezing or pausing a reserve makes it non-borrowable (and drops
+    /// it from borrowableAssets), even though its borrowable flag is still set — so auth cannot pass a token the
+    /// Spoke would then reject at the borrow.
+    function test_reads_borrowable_frozenOrPausedIsNotBorrowable() public {
+        _setAaveReserveFrozen(usdcReserveId, true);
+        assertFalse(gw.isBorrowable(address(usdc)), "frozen reserve not borrowable");
+        assertEq(gw.borrowableAssets().length, 0, "frozen reserve dropped from list");
+        _setAaveReserveFrozen(usdcReserveId, false);
+        assertTrue(gw.isBorrowable(address(usdc)), "borrowable again after unfreeze");
+
+        _setAaveReservePaused(usdcReserveId, true);
+        assertFalse(gw.isBorrowable(address(usdc)), "paused reserve not borrowable");
+        _setAaveReservePaused(usdcReserveId, false);
+        assertTrue(gw.isBorrowable(address(usdc)), "borrowable again after unpause");
+    }
+
     function test_getAccountData_freshSafeIsEmptyAndHealthy() public view {
         ILendGateway.AccountData memory data = gw.getAccountData(address(safe));
         assertEq(data.collateralUsd, 0);
@@ -157,18 +173,22 @@ contract LendGatewayAaveV4Test is CashGatewayTestSetup {
         gw.setReserveId(address(0), 0);
     }
 
+    /// An empty reserve (no supply, no debt) removes cleanly and its reads zero out. weETH is used because the
+    /// USDC reserve carries seeded liquidity, which the in-use guard (below) blocks.
     function test_removeReserve_unregistersAndZeroesReads() public {
+        assertEq(spoke.getReserveSuppliedAssets(weethReserveId), 0, "weETH reserve empty at setup");
+
         vm.prank(owner);
-        gw.removeReserve(address(usdc));
+        gw.removeReserve(address(weETH));
 
-        assertFalse(gw.isRegistered(address(usdc)));
-        assertEq(gw.ltv(address(usdc)), 0);
-        assertEq(gw.availableCash(address(usdc)), 0);
-        assertEq(gw.suppliedOf(address(safe), address(usdc)), 0);
-        assertEq(gw.debtOf(address(safe), address(usdc)), 0);
+        assertFalse(gw.isRegistered(address(weETH)));
+        assertEq(gw.ltv(address(weETH)), 0);
+        assertEq(gw.availableCash(address(weETH)), 0);
+        assertEq(gw.suppliedOf(address(safe), address(weETH)), 0);
+        assertEq(gw.debtOf(address(safe), address(weETH)), 0);
 
-        vm.expectRevert(abi.encodeWithSelector(LendGateway.AssetNotRegistered.selector, address(usdc)));
-        gw.reserveIdOf(address(usdc));
+        vm.expectRevert(abi.encodeWithSelector(LendGateway.AssetNotRegistered.selector, address(weETH)));
+        gw.reserveIdOf(address(weETH));
     }
 
     function test_removeReserve_guards() public {
@@ -179,7 +199,31 @@ contract LendGatewayAaveV4Test is CashGatewayTestSetup {
 
         vm.prank(makeAddr("notAdmin"));
         vm.expectRevert(UpgradeableProxy.Unauthorized.selector);
+        gw.removeReserve(address(weETH));
+    }
+
+    /// removeReserve refuses while the reserve still has supply or debt, so a delisting cannot strand positions
+    /// or corrupt the USD views (mirrors the legacy DebtManager unsupportBorrowToken guard).
+    function test_removeReserve_revertsWhileReserveInUse() public {
+        // USDC carries seeded LP liquidity (supplied != 0), so it cannot be pulled
+        vm.prank(owner);
+        vm.expectRevert(LendGateway.ReserveStillInUse.selector);
         gw.removeReserve(address(usdc));
+
+        // Supplying weETH puts its reserve in use too; a safe borrow then adds USDC debt on top
+        deal(address(weETH), address(safe), 5 ether);
+        vm.startPrank(driver);
+        gw.supply(address(safe), address(weETH), 5 ether);
+        gw.setUsingAsCollateral(address(safe), address(weETH), true);
+        gw.borrow(address(safe), address(usdc), 1000e6, recipient);
+        vm.stopPrank();
+
+        vm.startPrank(owner);
+        vm.expectRevert(LendGateway.ReserveStillInUse.selector);
+        gw.removeReserve(address(weETH));
+        vm.expectRevert(LendGateway.ReserveStillInUse.selector);
+        gw.removeReserve(address(usdc));
+        vm.stopPrank();
     }
 
     // ----------------------------------------------------------------- driver management

--- a/test/safe/modules/cash/lend/LendGatewayAaveV4.t.sol
+++ b/test/safe/modules/cash/lend/LendGatewayAaveV4.t.sol
@@ -65,6 +65,23 @@ contract LendGatewayAaveV4Test is CashGatewayTestSetup {
         assertTrue(gw.isBorrowable(address(usdc)), "borrowable again after unpause");
     }
 
+    /// isSpendAsset (the debit gate) keeps the borrowable flag as membership (weETH stays non-spendable)
+    /// and tolerates a freeze, since a debit only transfers and withdraws; only a pause blocks it.
+    function test_reads_spendAsset_toleratesFreezeNotPause() public {
+        assertTrue(gw.isSpendAsset(address(usdc)));
+        assertFalse(gw.isSpendAsset(address(weETH)), "collateral-only asset is not spendable");
+        assertFalse(gw.isSpendAsset(address(0xdead)));
+
+        _setAaveReserveFrozen(usdcReserveId, true);
+        assertTrue(gw.isSpendAsset(address(usdc)), "frozen reserve still spendable");
+        assertEq(gw.spendAssets().length, 1, "stays in spendAssets while frozen");
+        _setAaveReserveFrozen(usdcReserveId, false);
+
+        _setAaveReservePaused(usdcReserveId, true);
+        assertFalse(gw.isSpendAsset(address(usdc)), "paused reserve not spendable");
+        assertEq(gw.spendAssets().length, 0, "dropped from spendAssets while paused");
+    }
+
     function test_getAccountData_freshSafeIsEmptyAndHealthy() public view {
         ILendGateway.AccountData memory data = gw.getAccountData(address(safe));
         assertEq(data.collateralUsd, 0);

--- a/test/safe/modules/cash/lend/LendGatewayAaveV4.t.sol
+++ b/test/safe/modules/cash/lend/LendGatewayAaveV4.t.sol
@@ -37,6 +37,18 @@ contract LendGatewayAaveV4Test is CashGatewayTestSetup {
         assertGe(gw.availableCash(address(usdc)), 1_000_000e6);
     }
 
+    /// isBorrowable/borrowableAssets read the reserve's borrowable flag on the Spoke: USDC's reserve allows
+    /// borrowing, weETH's is collateral-only, and unregistered assets are never borrowable.
+    function test_reads_borrowable() public view {
+        assertTrue(gw.isBorrowable(address(usdc)));
+        assertFalse(gw.isBorrowable(address(weETH)));
+        assertFalse(gw.isBorrowable(address(0xdead)));
+
+        address[] memory borrowable = gw.borrowableAssets();
+        assertEq(borrowable.length, 1);
+        assertEq(borrowable[0], address(usdc));
+    }
+
     function test_getAccountData_freshSafeIsEmptyAndHealthy() public view {
         ILendGateway.AccountData memory data = gw.getAccountData(address(safe));
         assertEq(data.collateralUsd, 0);

--- a/test/safe/modules/cash/lend/MultiSpend.t.sol
+++ b/test/safe/modules/cash/lend/MultiSpend.t.sol
@@ -13,11 +13,9 @@ import { CashGatewayTestSetup } from "./CashGatewayTestSetup.t.sol";
  * @dev Run with: source .env && FOUNDRY_PROFILE=lend TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test --match-path "test/safe/modules/cash/lend/MultiSpend.t.sol"
  */
 contract CashModuleMultiSpendAaveTest is CashGatewayTestSetup {
-    function setUp() public override {
-        super.setUp();
-        // weETH is a spendable (borrow) token in these multi-token tests.
-        vm.prank(owner);
-        debtManager.supportBorrowToken(address(weETH), borrowApyPerSecond, uint128(1));
+    /// @dev weETH is a spendable (borrowable) token in these multi-token tests.
+    function _weethBorrowable() internal pure override returns (bool) {
+        return true;
     }
 
     /// A two-token debit under debt: USDC fully from the loose balance, weETH from a loose + Aave-supplied mix.

--- a/test/safe/modules/cash/lend/RepaySourcing.t.sol
+++ b/test/safe/modules/cash/lend/RepaySourcing.t.sol
@@ -139,6 +139,26 @@ contract RepaySourcingTest is CashGatewayTestSetup {
         assertEq(cashModule.getPendingWithdrawalAmount(address(safe), address(usdc)), 0, "withdrawal request cancelled");
     }
 
+    /// Freezing the reserve blocks new borrows but never repayment: the repay gates on registration, not
+    /// borrowability, and Aave allows both the repay and its supplied-leg withdraw while frozen.
+    function test_repay_worksWhileReserveFrozen() public {
+        uint256 borrowedUsdc = 1000e6;
+        _buildGatewayPosition(address(safe), address(weETH), 5 ether, address(usdc), borrowedUsdc);
+        // Part loose, part supplied, so both repay legs run against the frozen reserve
+        _supplyToGateway(address(safe), address(usdc), 600e6);
+        deal(address(usdc), address(safe), 500e6);
+
+        _setAaveReserveFrozen(usdcReserveId, true);
+        assertFalse(gw.isBorrowable(address(usdc)), "frozen reserve no longer borrowable");
+
+        uint256 debt = gw.debtOf(address(safe), address(usdc));
+        uint256 debtUsd = debtManager.convertCollateralTokenToUsd(address(usdc), debt);
+        vm.prank(etherFiWallet);
+        cashModule.repay(address(safe), address(usdc), debtUsd);
+
+        assertApproxEqAbs(gw.debtOf(address(safe), address(usdc)), 0, 2, "debt repaid from loose plus supplied while frozen");
+    }
+
     function _uint1(uint256 a) internal pure returns (uint256[] memory) {
         uint256[] memory arr = new uint256[](1);
         arr[0] = a;

--- a/test/safe/modules/cash/lend/Spend.t.sol
+++ b/test/safe/modules/cash/lend/Spend.t.sol
@@ -119,6 +119,20 @@ contract CashModuleSpendAaveTest is CashGatewayTestSetup {
         assertApproxEqAbs(gw.suppliedOf(address(safe), address(usdc)), 200e6 - 20e6, 2, "20 shortfall withdrawn from Aave");
     }
 
+    /// The auth-vs-freeze race: an auth approved while the reserve was borrowable cannot settle once the
+    /// reserve is frozen. The spend reverts on the module's gate — the same predicate the auth now declines
+    /// on — instead of deep inside Aave.
+    function test_spend_credit_reverts_whenReserveFrozenAfterAuth() public {
+        _supplyToGateway(address(safe), address(usdc), 100e6);
+        _enterCreditMode();
+
+        _setAaveReserveFrozen(usdcReserveId, true);
+
+        vm.prank(etherFiWallet);
+        vm.expectRevert(ICashModule.UnsupportedToken.selector);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, _tokens(address(usdc)), _amounts(10e6), _noCashback());
+    }
+
     // ================ credit resupply: supply loose collateral when the borrow doesn't fit ================
 
     /// Borrowing power already covers the spend, so nothing is resupplied and the borrow just goes through.

--- a/test/safe/modules/cash/lend/Spend.t.sol
+++ b/test/safe/modules/cash/lend/Spend.t.sol
@@ -119,6 +119,22 @@ contract CashModuleSpendAaveTest is CashGatewayTestSetup {
         assertApproxEqAbs(gw.suppliedOf(address(safe), address(usdc)), 200e6 - 20e6, 2, "20 shortfall withdrawn from Aave");
     }
 
+    /// A freeze does not stop debit: the loose leg is a plain transfer and the supplied leg is an Aave
+    /// withdraw, both allowed on a frozen reserve, so the spend lands.
+    function test_spend_debit_succeeds_whileReserveFrozen() public {
+        _supplyToGateway(address(safe), address(usdc), 100e6);
+        deal(address(usdc), address(safe), 40e6);
+        _setAaveReserveFrozen(usdcReserveId, true);
+
+        uint256 dispatcherBefore = usdc.balanceOf(address(settlementDispatcherReap));
+
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, _tokens(address(usdc)), _amounts(100e6), _noCashback());
+
+        assertEq(usdc.balanceOf(address(settlementDispatcherReap)), dispatcherBefore + 100e6, "loose plus supplied funded the spend while frozen");
+        assertApproxEqAbs(gw.suppliedOf(address(safe), address(usdc)), 100e6 - 60e6, 2, "shortfall withdrawn from the frozen reserve");
+    }
+
     /// The auth-vs-freeze race: an auth approved while the reserve was borrowable cannot settle once the
     /// reserve is frozen. The spend reverts on the module's gate — the same predicate the auth now declines
     /// on — instead of deep inside Aave.

--- a/test/safe/modules/cash/lend/WithdrawalSourcing.t.sol
+++ b/test/safe/modules/cash/lend/WithdrawalSourcing.t.sol
@@ -38,6 +38,18 @@ contract WithdrawalSourcingTest is CashGatewayTestSetup {
         assertEq(weETH.balanceOf(withdrawRecipient), 3 ether, "recipient paid the full amount");
     }
 
+    /// A frozen reserve still honors withdrawals: the request pulls from the supplied pot as usual, since
+    /// Aave's freeze blocks supply and borrow but not withdraw.
+    function test_requestWithdrawal_pullsFromSuppliedWhileReserveFrozen() public {
+        _supplyToGateway(address(safe), address(weETH), 3 ether);
+        _setAaveReserveFrozen(weethReserveId, true);
+
+        _requestWithdrawal(_addr1(address(weETH)), _uint1(2 ether), withdrawRecipient);
+
+        assertEq(weETH.balanceOf(address(safe)), 2 ether, "shortfall pulled from Aave while frozen");
+        assertEq(cashModule.getPendingWithdrawalAmount(address(safe), address(weETH)), 2 ether, "request queued");
+    }
+
     /// A fully swept safe (zero loose) can withdraw: the whole amount is pulled from the supplied pot.
     function test_requestWithdrawal_fullySweptSafe() public {
         _supplyToGateway(address(safe), address(usdc), 5000e6);

--- a/test/safe/modules/cash/lend/helpers/AaveV4Fixture.sol
+++ b/test/safe/modules/cash/lend/helpers/AaveV4Fixture.sol
@@ -155,6 +155,24 @@ abstract contract AaveV4Fixture is Test {
         spoke.updateReserveConfig(reserveId, cfg);
     }
 
+    /// @notice Flips a listed reserve's frozen flag, preserving its other config (Aave blocks new supply and
+    ///         borrows on a frozen reserve while leaving existing positions withdrawable/repayable)
+    function _setAaveReserveFrozen(uint256 reserveId, bool frozen) internal {
+        ISpoke.ReserveConfig memory cfg = spoke.getReserveConfig(reserveId);
+        cfg.frozen = frozen;
+        vm.prank(aaveAdmin);
+        spoke.updateReserveConfig(reserveId, cfg);
+    }
+
+    /// @notice Flips a listed reserve's paused flag, preserving its other config (Aave blocks every op on a
+    ///         paused reserve)
+    function _setAaveReservePaused(uint256 reserveId, bool paused) internal {
+        ISpoke.ReserveConfig memory cfg = spoke.getReserveConfig(reserveId);
+        cfg.paused = paused;
+        vm.prank(aaveAdmin);
+        spoke.updateReserveConfig(reserveId, cfg);
+    }
+
     /// @notice Updates a listed reserve's collateral factor (BPS), preserving its other dynamic config
     function _setAaveReserveCollateralFactor(uint256 reserveId, uint16 collateralFactorBps) internal {
         uint32 key = spoke.getReserve(reserveId).dynamicConfigKey;

--- a/test/safe/modules/cash/lend/helpers/AaveV4Fixture.sol
+++ b/test/safe/modules/cash/lend/helpers/AaveV4Fixture.sol
@@ -88,11 +88,12 @@ abstract contract AaveV4Fixture is Test {
         accessManager.grantRole(Roles.HUB_ADMIN_ROLE, aaveAdmin, 0);
         accessManager.grantRole(Roles.SPOKE_ADMIN_ROLE, aaveAdmin, 0);
 
-        bytes4[] memory spokeSelectors = new bytes4[](4);
+        bytes4[] memory spokeSelectors = new bytes4[](5);
         spokeSelectors[0] = ISpoke.addReserve.selector;
         spokeSelectors[1] = ISpoke.updatePositionManager.selector;
         spokeSelectors[2] = ISpoke.updateLiquidationConfig.selector;
         spokeSelectors[3] = ISpoke.updateDynamicReserveConfig.selector;
+        spokeSelectors[4] = ISpoke.updateReserveConfig.selector;
         accessManager.setTargetFunctionRole(address(spoke), spokeSelectors, Roles.SPOKE_ADMIN_ROLE);
 
         bytes4[] memory hubSelectors = new bytes4[](3);
@@ -143,6 +144,15 @@ abstract contract AaveV4Fixture is Test {
     function _activateAavePositionManager(address positionManager) internal {
         vm.prank(aaveAdmin);
         spoke.updatePositionManager(positionManager, true);
+    }
+
+    /// @notice Flips a listed reserve's borrowable flag, preserving its other config (models a governance
+    ///         change or freeze that blocks new borrows without clearing existing debt)
+    function _setAaveReserveBorrowable(uint256 reserveId, bool borrowable) internal {
+        ISpoke.ReserveConfig memory cfg = spoke.getReserveConfig(reserveId);
+        cfg.borrowable = borrowable;
+        vm.prank(aaveAdmin);
+        spoke.updateReserveConfig(reserveId, cfg);
     }
 
     /// @notice Updates a listed reserve's collateral factor (BPS), preserving its other dynamic config


### PR DESCRIPTION
## What

- Gateway safes no longer read the DebtManager on any path. The gateway is the token authority.
- New `ILendGateway.isBorrowable` and `borrowableAssets` mirror Aave's full borrow gate, so a frozen or paused reserve is not borrowable.
- Paths that create new debt (credit auth, credit spend, signed borrow) gate on `isBorrowable`.
- Debit spends gate on the new `isSpendAsset`, which tolerates a frozen reserve. A debit only transfers loose balance and withdraws supplied balance, and Aave allows both while frozen. Paused still blocks it.
- Paths that touch existing positions (repay, debt breakdown, `hasOpenBorrows`, withdrawal sizing) key on registered assets, so a freeze never hides or locks open debt.
- `removeReserve` reverts while the reserve still holds supply or debt, like the legacy `unsupportBorrowToken` guard.
- Gateway USD conversions go through the PriceProvider (`DebitSourcingLib`), not the DebtManager.
- `CashModuleCore.repay` is a one-line forward to `CashLendLib.repay`, which owns the engine routing.
- `IAaveV4Spoke` gains the MIT `ReserveConfig` struct and `getReserveConfig`.

## Why

- The DebtManager should be removable after migration, and the gateway paths still leaned on it for token membership and pricing.
- Freezing or delisting an asset must not let an auth approve a spend that Aave will then reject, and must not strand or hide existing positions.

## How tested

- Full cash and lend fork suites are green on both profiles. The only failures are the pre-existing OpenOcean tests that need `OPENOCEAN_API_KEY`.
- New tests pin the freeze and delist behavior. Credit auth declines and the credit spend reverts on the module gate, debit auth and debit spend still land, repay and withdrawals still land, `removeReserve` refuses while in use, and the debt breakdown keeps showing debt on a non-borrowable reserve.

## Decisions to flag

- "Borrowable" still doubles as the debit-spendable gate. That coupling is pre-existing. A dedicated spendable set can come later.
- Stopping new auths for an asset before an on-chain delist needs a backend lever. That is a cash-be ticket, not this PR.

Closes COR-1078

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes spend/borrow/repay authorization and pricing for all gateway safes; behavior is intentionally stricter on new debt and more permissive on debit/repay when reserves are frozen, with broad test coverage on fork suites.
> 
> **Overview**
> Gateway safes stop using **DebtManager** for token lists and USD math on lend paths. **`ILendGateway`** adds **`isBorrowable` / `borrowableAssets`** (Aave borrowable, not frozen, not paused) and **`isSpendAsset` / `spendAssets`** (debit gate: tolerates frozen reserves). **Credit auth, credit spend, and signed borrow** gate on borrowability; **debit spend** gates on spend assets; **repay** and debt views gate on **registration** so existing debt stays visible and repayable after freeze or delist.
> 
> **`LendGateway`** reads **`getReserveConfig`** from **`IAaveV4Spoke`** and **`removeReserve`** now reverts with **`ReserveStillInUse`** while supply or debt remains. **`CashLendLib`** / **`CashLens`** route gateway USD through **`DebitSourcingLib`** + **PriceProvider**; **`CashModuleCore.repay`** delegates fully to **`CashLendLib.repay`** (engine routing and withdrawal competition live there). Legacy safes still use DebtManager inside the same library branches.
> 
> Tests cover frozen/paused reserves, non-borrowable debt in lens data, and reserve removal guards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a288c1c76dfa7ee736fd9ac6a53186d69c2b8518. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

