### PR TITLE
feat: handle frozen, paused, and capped Aave reserves in the sweep and auth views

### DIFF
--- a/src/debt-manager/DebtManagerCore.sol
+++ b/src/debt-manager/DebtManagerCore.sol
@@ -702,7 +702,7 @@ contract DebtManagerCore is DebtManagerStorageContract {
         if (lendOptedOut && totalDebtUsd != 0) revert LendOptedOutSafeHasDebt();
 
         // 2. Clear the legacy DebtManager debt FIRST (if any), capturing the token amount to re-borrow, and
-        //    check Aave has the cash to fund it. Clearing first is load-bearing: supplying collateral (step 3)
+        //    check Aave can fund it (pool liquidity within the reserve's borrow cap). Clearing first is load-bearing: supplying collateral (step 3)
         //    moves it out of the Safe via execTransactionFromModule, which runs the EtherFiHook's DebtManager
         //    health check — that would revert while the debt is still open. The Aave borrow (step 5) re-funds
         //    the pool; the whole tx reverts on any failure, so the Safe is never left half-migrated nor the pool short.
@@ -710,7 +710,7 @@ contract DebtManagerCore is DebtManagerStorageContract {
         for (uint256 i = 0; i < bLen;) {
             if (borrowings[i].amount != 0) {
                 uint256 debtTokenAmt = _clearLegacyDebt(safe, borrowings[i].token);
-                if (_gateway.availableCash(borrowings[i].token) < debtTokenAmt) revert InsufficientLendGatewayLiquidity(borrowings[i].token);
+                if (_gateway.availableToBorrow(borrowings[i].token) < debtTokenAmt) revert InsufficientLendGatewayLiquidity(borrowings[i].token);
                 debtTokenAmts[i] = debtTokenAmt;
             }
             unchecked {

--- a/src/interfaces/IAaveV4Hub.sol
+++ b/src/interfaces/IAaveV4Hub.sol
@@ -3,7 +3,12 @@ pragma solidity ^0.8.28;
 
 /**
  * @title IAaveV4Hub
- * @notice The slice of the Aave v4 Hub that the AaveV4Lens reads.
+ * @notice The slice of the Aave v4 Hub that ether.fi reads: asset rate/config for the AaveV4Lens, and a
+ *         spoke's borrow cap and usage for the LendGateway.
+ * @dev Caps are per-spoke and enforced only in the Hub (the Spoke's own checks do not know about them), so a
+ *      borrow can pass every Spoke check and still revert here with DrawCapExceeded. Cap values are whole
+ *      tokens (not scaled by decimals); the Hub multiplies by 10**decimals at check time. A cap equal to
+ *      MAX_ALLOWED_SPOKE_CAP means uncapped. The Hub address and assetId come from IAaveV4Spoke.getReserve.
  * @author ether.fi
  */
 interface IAaveV4Hub {
@@ -15,9 +20,27 @@ interface IAaveV4Hub {
         address reinvestmentController;
     }
 
+    /// @notice Per-spoke config for one asset. `addCap`/`drawCap` are whole-token supply/borrow caps.
+    struct SpokeConfig {
+        uint40 addCap;
+        uint40 drawCap;
+        uint24 riskPremiumThreshold;
+        bool active;
+        bool halted;
+    }
+
     /// @notice Returns the current annual drawn (borrow) rate of the asset, in RAY.
     function getAssetDrawnRate(uint256 assetId) external view returns (uint256);
 
     /// @notice Returns the asset configuration.
     function getAssetConfig(uint256 assetId) external view returns (AssetConfig memory);
+
+    /// @notice The spoke's config for `assetId` (incl. `addCap`, `drawCap`, `active`, `halted`).
+    function getSpokeConfig(uint256 assetId, address spoke) external view returns (SpokeConfig memory);
+
+    /// @notice The spoke's current borrow usage for `assetId` (drawn + premium), in asset units.
+    function getSpokeTotalOwed(uint256 assetId, address spoke) external view returns (uint256);
+
+    /// @notice The cap sentinel meaning "uncapped": a cap equal to this imposes no limit.
+    function MAX_ALLOWED_SPOKE_CAP() external view returns (uint40);
 }

--- a/src/interfaces/ILendGateway.sol
+++ b/src/interfaces/ILendGateway.sol
@@ -152,16 +152,18 @@ interface ILendGateway {
 
     /**
      * @notice Returns whether `asset` can fund a debit spend
-     * @dev Registered, marked borrowable (membership: it marks the spendable stables), and not paused.
-     *      Frozen is tolerated: a debit spend only transfers loose balance and withdraws supplied
-     *      balance, both of which Aave allows while frozen.
+     * @dev An admin-declared spend asset (via setSpendAsset, always a registered reserve) whose reserve is
+     *      not paused. Membership is declared, not read from Aave's borrowable flag, so a supply-only
+     *      reserve can be spendable. Frozen is tolerated: a debit spend only transfers loose balance and
+     *      withdraws supplied balance, both of which Aave allows while frozen. Paused blocks the withdraw
+     *      leg, so a paused reserve is not spendable.
      * @param asset The asset to query
      * @return True if the asset can fund a debit spend
      */
     function isSpendAsset(address asset) external view returns (bool);
 
     /**
-     * @notice Returns the registered assets that can fund a debit spend
+     * @notice Returns the spend-set assets that can currently fund a debit spend
      * @dev See isSpendAsset.
      * @return The spendable asset addresses
      */

--- a/src/interfaces/ILendGateway.sol
+++ b/src/interfaces/ILendGateway.sol
@@ -90,11 +90,23 @@ interface ILendGateway {
     function debtOf(address safe, address asset) external view returns (uint256);
 
     /**
-     * @notice Returns the withdrawable and borrowable liquidity of `asset`'s reserve
+     * @notice Returns the reserve's withdrawable liquidity: supplied minus borrowed
+     * @dev Answers "how much can a withdraw pull". Not the borrow limit: a borrow is also bounded by the
+     *      Hub's drawCap, so use availableToBorrow for the credit side.
      * @param asset The reserve asset
      * @return The available liquidity, in asset units
      */
     function availableCash(address asset) external view returns (uint256);
+
+    /**
+     * @notice Returns how much of `asset` a borrow can actually draw right now
+     * @dev The lesser of the reserve's withdrawable liquidity and the Hub's remaining drawCap for this
+     *      spoke. Zero if the Hub spoke is inactive or halted. This is the credit-side liquidity gate;
+     *      availableCash is the withdraw-side one.
+     * @param asset The reserve asset
+     * @return The borrowable amount, in asset units
+     */
+    function availableToBorrow(address asset) external view returns (uint256);
 
     /**
      * @notice Returns the loan-to-value of `asset`'s reserve, in the 100e18 = 100% scale (matching DebtManager's CollateralTokenConfig.ltv)

--- a/src/mocks/MockLendGateway.sol
+++ b/src/mocks/MockLendGateway.sol
@@ -32,6 +32,8 @@ contract MockLendGateway is ILendGateway {
     mapping(address asset => bool) internal _registered;
     /// @dev Whether an asset's reserve allows borrowing; defaults to false
     mapping(address asset => bool) internal _borrowable;
+    /// @dev Whether an asset is an admin-declared debit-spend token; defaults to false
+    mapping(address asset => bool) internal _spendAsset;
     /// @dev Every asset ever registered, in order; registeredAssets/borrowableAssets filter it by the flags
     address[] internal _assets;
 
@@ -57,6 +59,11 @@ contract MockLendGateway is ILendGateway {
     /// @notice Sets whether an asset's reserve allows borrowing (defaults to non-borrowable)
     function setBorrowable(address asset, bool borrowable) external {
         _borrowable[asset] = borrowable;
+    }
+
+    /// @notice Sets whether an asset is a debit-spend token (defaults to non-spendable)
+    function setSpendAsset(address asset, bool spendable) external {
+        _spendAsset[asset] = spendable;
     }
 
     /// @notice Sets the amount a subsequent `suppliedOf(safe, asset)` will return
@@ -126,13 +133,26 @@ contract MockLendGateway is ILendGateway {
         return _filterAssets(true);
     }
 
-    /// @dev The mock models no freeze or pause, so the debit-spend gate equals the borrow gate
+    /// @dev The mock models no pause, so the debit-spend gate is just the admin spend flag
     function isSpendAsset(address asset) external view returns (bool) {
-        return _registered[asset] && _borrowable[asset];
+        return _spendAsset[asset];
     }
 
     function spendAssets() external view returns (address[] memory) {
-        return _filterAssets(true);
+        address[] memory out = new address[](_assets.length);
+        uint256 count = 0;
+        for (uint256 i = 0; i < _assets.length; i++) {
+            if (_spendAsset[_assets[i]]) {
+                out[count] = _assets[i];
+                unchecked {
+                    ++count;
+                }
+            }
+        }
+        assembly ("memory-safe") {
+            mstore(out, count)
+        }
+        return out;
     }
 
     /// @dev The registered assets, optionally narrowed to the borrowable ones

--- a/src/mocks/MockLendGateway.sol
+++ b/src/mocks/MockLendGateway.sol
@@ -101,6 +101,11 @@ contract MockLendGateway is ILendGateway {
         return _availableCash[asset];
     }
 
+    /// @dev The mock models no borrow cap, so the borrowable liquidity equals availableCash
+    function availableToBorrow(address asset) external view returns (uint256) {
+        return _availableCash[asset];
+    }
+
     function ltv(address) external pure returns (uint256) {
         return 0;
     }

--- a/src/modules/ModuleLendGatewaySandwich.sol
+++ b/src/modules/ModuleLendGatewaySandwich.sol
@@ -65,9 +65,12 @@ abstract contract ModuleLendGatewaySandwich {
     }
 
     /**
-     * @notice Supplies an asset from the safe back into Aave and marks it as collateral
+     * @notice Supplies an asset from the safe back into Aave and marks it as collateral, best-effort
      * @dev No-op for a safe whose assets do not live in Aave, and for an asset the gateway does not list as a
-     *      reserve (the gateway would reject the supply); in both cases the output stays loose in the safe.
+     *      reserve. The supply itself is best-effort: a reserve that rejects it (frozen, paused, at its supply
+     *      cap, or the Hub spoke halted) is swallowed rather than reverting the whole operation after the swap
+     *      or bridge already ran. In every case the output stays loose in the safe and the next sweep restores
+     *      it as collateral.
      * @param safe The safe whose position is credited
      * @param asset The asset to supply
      * @param amount The amount to supply
@@ -76,7 +79,8 @@ abstract contract ModuleLendGatewaySandwich {
         if (!_lendActive(safe)) return;
         ILendGateway lendGateway = gateway();
         if (!lendGateway.isRegistered(asset)) return;
-        lendGateway.supply(safe, asset, amount);
-        lendGateway.setUsingAsCollateral(safe, asset, true);
+        try lendGateway.supply(safe, asset, amount) {
+            lendGateway.setUsingAsCollateral(safe, asset, true);
+        } catch { }
     }
 }

--- a/src/modules/cash/CashLendLib.sol
+++ b/src/modules/cash/CashLendLib.sol
@@ -281,9 +281,11 @@ library CashLendLib {
      * @notice Supplies a safe's loose balances into the lend market and flags them as collateral (the
      *         auto-supply sweep)
      * @dev Per token: supplies the loose balance net of the pending-withdrawal reservation, so a queued
-     *      withdrawal is never swept back into Aave. Zero and unregistered tokens are skipped, not
-     *      reverted, so a keeper batch never bricks. An opted-out safe is a no-op, since the keeper
-     *      legitimately races an opt-out; a legacy safe reverts, since routing one here is a keeper bug.
+     *      withdrawal is never swept back into Aave. Zero and unregistered tokens are skipped, and the
+     *      supply is best-effort (a reserve that rejects it, e.g. frozen/paused/at cap, leaves the funds
+     *      loose for the next sweep), so a keeper batch never bricks. An opted-out safe is a no-op, since
+     *      the keeper legitimately races an opt-out; a legacy safe reverts, since routing one here is a
+     *      keeper bug.
      * @param $ The CashModule storage (passed by the delegatecalling module)
      * @param safe Address of the EtherFi Safe
      * @param tokens Tokens to sweep
@@ -306,12 +308,13 @@ library CashLendLib {
 
     /**
      * @notice Borrows `token` against the safe's lend-market position; the proceeds land in the safe and
-     *         are immediately supplied back as collateral (a borrow-page borrow with instant auto-supply)
+     *         are supplied back as collateral, best-effort (a borrow-page borrow with instant auto-supply)
      * @dev Owner-quorum signed: the signatures bind the token and USD amount, so neither a compromised backend
      *      nor a single compromised admin can lever a safe up; the caller has already resolved and consumed the
-     *      nonce. The portfolio gains the borrowed asset as supplied collateral, so the borrowing power moves by
-     *      its LTV weight net of the new debt. Aave enforces the health check on the borrow itself, and the
-     *      gateway rejects a borrow for an opted-out safe; the lendOptedOut check here is defense-in-depth,
+     *      nonce. The proceeds are supplied back as collateral best-effort: if that reserve rejects the supply
+     *      (e.g. at its supply cap), the proceeds stay loose and the next sweep restores them, rather than
+     *      failing the borrow the owners signed for. Aave enforces the health check on the borrow itself, and
+     *      the gateway rejects a borrow for an opted-out safe; the lendOptedOut check here is defense-in-depth,
      *      mirroring spendCredit.
      * @param $ The CashModule storage (passed by the delegatecalling module)
      * @param dataProvider The module's data provider (for the price provider)
@@ -350,11 +353,15 @@ library CashLendLib {
         return gateway;
     }
 
-    /// @dev Supplies `amount` of `token` from the safe into the lend market and flags it as collateral
+    /// @dev Best-effort supply of `amount` of `token` into the lend market as collateral. A supply the
+    ///      reserve rejects (frozen, paused, at its supply cap, or the Hub spoke halted) is swallowed so the
+    ///      funds stay loose for the next sweep. Used by the sweep and the borrow auto-supply, where leaving
+    ///      the funds loose is fine; callers that must not proceed without the supply do not use this.
     function _supplyAsCollateral(CashModuleStorageContract.CashModuleStorage storage $, ILendGateway gateway, address safe, address token, uint256 amount) private {
-        gateway.supply(safe, token, amount);
-        gateway.setUsingAsCollateral(safe, token, true);
-        $.cashEventEmitter.emitLendSupplied(safe, token, amount);
+        try gateway.supply(safe, token, amount) {
+            gateway.setUsingAsCollateral(safe, token, true);
+            $.cashEventEmitter.emitLendSupplied(safe, token, amount);
+        } catch { }
     }
 
     /**

--- a/src/modules/cash/CashLens.sol
+++ b/src/modules/cash/CashLens.sol
@@ -198,7 +198,7 @@ contract CashLens is UpgradeableProxy, Constants {
             return (false, "Not a supported borrow token");
         }
 
-        if (lendGateway.availableCash(token) < _fromUsd(token, totalSpendingInUsd)) {
+        if (lendGateway.availableToBorrow(token) < _fromUsd(token, totalSpendingInUsd)) {
             return (false, "Insufficient liquidity to cover the loan");
         }
 
@@ -424,7 +424,7 @@ contract CashLens is UpgradeableProxy, Constants {
         address[] memory borrowTokens = lendGateway.borrowableAssets();
         uint256 maxLiquidityUsd = 0;
         for (uint256 i = 0; i < borrowTokens.length;) {
-            uint256 liquidityUsd = _toUsd(borrowTokens[i], lendGateway.availableCash(borrowTokens[i]));
+            uint256 liquidityUsd = _toUsd(borrowTokens[i], lendGateway.availableToBorrow(borrowTokens[i]));
             if (liquidityUsd > maxLiquidityUsd) {
                 maxLiquidityUsd = liquidityUsd;
             }

--- a/src/modules/lend-gateway/LendGateway.sol
+++ b/src/modules/lend-gateway/LendGateway.sol
@@ -6,6 +6,7 @@ import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/I
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { EnumerableSetLib } from "solady/utils/EnumerableSetLib.sol";
 
+import { IAaveV4Hub } from "../../interfaces/IAaveV4Hub.sol";
 import { IAaveV4Spoke } from "../../interfaces/IAaveV4Spoke.sol";
 import { ICashModule } from "../../interfaces/ICashModule.sol";
 import { IEtherFiSafe } from "../../interfaces/IEtherFiSafe.sol";
@@ -438,17 +439,45 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
     }
 
     /**
-     * @notice Returns the withdrawable/borrowable liquidity of `asset`'s reserve (supplied minus borrowed)
+     * @notice Returns the reserve's withdrawable liquidity (supplied minus borrowed)
+     * @dev The withdraw-side liquidity gate. A borrow is additionally bounded by the Hub's drawCap, so the
+     *      credit side reads availableToBorrow.
      * @param asset The reserve asset
      * @return The available liquidity in asset units, or 0 if the asset is not registered
      */
     function availableCash(address asset) external view returns (uint256) {
         LendGatewayStorage storage $ = _getLendGatewayStorage();
         if (!$.assets.contains(asset)) return 0;
+        return _availableCash($.reserveId[asset]);
+    }
+
+    /**
+     * @notice Returns how much of `asset` a borrow can draw right now: min(withdrawable liquidity, remaining
+     *         Hub drawCap), or 0 if the asset is unregistered or the Hub spoke is inactive or halted
+     * @dev The credit-side liquidity gate. drawCap is enforced only in the Hub, so a borrow within
+     *      availableCash can still revert DrawCapExceeded; folding the cap in here keeps the auth decision
+     *      honest. The Hub also counts a reported deficit toward the cap, which this omits, so a nonzero
+     *      deficit makes this a slight overestimate.
+     * @param asset The reserve asset
+     * @return The borrowable amount in asset units
+     */
+    function availableToBorrow(address asset) external view returns (uint256) {
+        LendGatewayStorage storage $ = _getLendGatewayStorage();
+        if (!$.assets.contains(asset)) return 0;
+
         uint256 reserveId = $.reserveId[asset];
-        uint256 supplied = spoke.getReserveSuppliedAssets(reserveId);
-        uint256 debt = spoke.getReserveTotalDebt(reserveId);
-        return supplied > debt ? supplied - debt : 0;
+        IAaveV4Spoke.Reserve memory reserve = spoke.getReserve(reserveId);
+        IAaveV4Hub hub = IAaveV4Hub(reserve.hub);
+        IAaveV4Hub.SpokeConfig memory config = hub.getSpokeConfig(reserve.assetId, address(spoke));
+        if (!config.active || config.halted) return 0;
+
+        uint256 cash = _availableCash(reserveId);
+        if (config.drawCap == hub.MAX_ALLOWED_SPOKE_CAP()) return cash;
+
+        uint256 capLimit = uint256(config.drawCap) * (10 ** reserve.decimals);
+        uint256 owed = hub.getSpokeTotalOwed(reserve.assetId, address(spoke));
+        uint256 remainingCap = capLimit > owed ? capLimit - owed : 0;
+        return cash < remainingCap ? cash : remainingCap;
     }
 
     /**
@@ -580,6 +609,13 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
         LendGatewayStorage storage $ = _getLendGatewayStorage();
         if (!$.assets.contains(asset)) revert AssetNotRegistered(asset);
         return $.reserveId[asset];
+    }
+
+    /// @dev The reserve's withdrawable liquidity (supplied minus borrowed), in asset units
+    function _availableCash(uint256 reserveId) internal view returns (uint256) {
+        uint256 supplied = spoke.getReserveSuppliedAssets(reserveId);
+        uint256 debt = spoke.getReserveTotalDebt(reserveId);
+        return supplied > debt ? supplied - debt : 0;
     }
 
     /// @dev The reserve's LTV in the 100e18 scale, from its current dynamic collateralFactor (BPS)

--- a/src/modules/lend-gateway/LendGateway.sol
+++ b/src/modules/lend-gateway/LendGateway.sol
@@ -69,6 +69,8 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
         EnumerableSetLib.AddressSet assets;
         /// @notice Extra authorized drivers beyond the CashModule (auto-supply / migration paths)
         mapping(address driver => bool authorized) isDriver;
+        /// @notice The tokens the card can settle a debit spend in; admin-declared, a subset of `assets`
+        EnumerableSetLib.AddressSet spendAssets;
     }
 
     // keccak256(abi.encode(uint256(keccak256("etherfi.storage.LendGateway")) - 1)) & ~bytes32(uint256(0xff))
@@ -80,6 +82,8 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
     event ReserveDeregistered(address indexed asset);
     /// @notice Emitted when a driver is authorized or de-authorized
     event DriverSet(address indexed driver, bool authorized);
+    /// @notice Emitted when an asset is added to or removed from the debit-spend set
+    event SpendAssetSet(address indexed asset, bool spendable);
     /// @notice Emitted when the gateway (re-)approves itself as `safe`'s position manager (folded into an op)
     event PositionManagerApproved(address indexed safe);
     /// @notice Emitted on a supply on a safe's behalf
@@ -189,6 +193,7 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
         }
 
         $.assets.remove(asset);
+        $.spendAssets.remove(asset);
         delete $.reserveId[asset];
 
         emit ReserveDeregistered(asset);
@@ -203,6 +208,25 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
         if (driver == address(0)) revert ZeroAddress();
         _getLendGatewayStorage().isDriver[driver] = authorized;
         emit DriverSet(driver, authorized);
+    }
+
+    /**
+     * @notice Adds or removes an asset from the debit-spend set (the tokens the card can settle in)
+     * @dev A spend asset must be a registered reserve, so this reverts with AssetNotRegistered when adding
+     *      an unregistered asset. Membership is declared here, not read from Aave's borrowable flag, so a
+     *      supply-only reserve can still be a debit-spend token.
+     * @param asset The registered asset
+     * @param spendable True to add to the set, false to remove
+     */
+    function setSpendAsset(address asset, bool spendable) external onlyRole(LEND_GATEWAY_ADMIN_ROLE) {
+        LendGatewayStorage storage $ = _getLendGatewayStorage();
+        if (spendable) {
+            if (!$.assets.contains(asset)) revert AssetNotRegistered(asset);
+            $.spendAssets.add(asset);
+        } else {
+            $.spendAssets.remove(asset);
+        }
+        emit SpendAssetSet(asset, spendable);
     }
 
     // ---------------------------------------------------------------------
@@ -513,7 +537,8 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
 
     /// @notice Whether `asset` is registered and its reserve accepts a borrow on the Spoke
     /// @dev Mirrors Aave's borrow gate (borrowable, not frozen, not paused) so an asset that passes
-    ///      here at auth cannot then fail the Spoke's borrow at spend.
+    ///      here at auth cannot then fail the Spoke's borrow at spend. Credit membership is Aave's
+    ///      borrowable flag by design; only the debit gate (isSpendAsset) reads the admin spend set.
     function isBorrowable(address asset) external view returns (bool) {
         LendGatewayStorage storage $ = _getLendGatewayStorage();
         if (!$.assets.contains(asset)) return false;
@@ -522,26 +547,41 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
 
     /// @notice The registered assets whose reserves accept a borrow on the Spoke
     function borrowableAssets() external view returns (address[] memory) {
-        return _filterAssets(true);
+        return _borrowableAssets();
     }
 
     /**
-     * @notice Whether `asset` can fund a debit spend: registered, marked borrowable, and not paused
-     * @dev A debit spend transfers loose balance and withdraws supplied balance, and Aave allows both
-     *      while frozen, so frozen is tolerated here. The borrowable flag does membership duty (it marks
-     *      the spendable stables); paused blocks the withdraw leg. Only new debt takes the full
-     *      isBorrowable gate.
+     * @notice Whether `asset` can fund a debit spend: an admin-declared spend asset whose reserve is not paused
+     * @dev Membership is declared via setSpendAsset (always a subset of registered reserves), so "is this a
+     *      card settlement token" no longer keys on Aave's borrowable flag and a supply-only reserve can be
+     *      spendable. A debit spend transfers loose balance and withdraws supplied balance, which Aave allows
+     *      while frozen, so frozen is tolerated; paused blocks the withdraw leg, so a paused reserve is not
+     *      spendable. New debt takes the full isBorrowable gate instead.
      * @param asset The asset to query
      */
     function isSpendAsset(address asset) external view returns (bool) {
         LendGatewayStorage storage $ = _getLendGatewayStorage();
-        if (!$.assets.contains(asset)) return false;
-        return _isSpendAsset($.reserveId[asset]);
+        if (!$.spendAssets.contains(asset)) return false;
+        return !spoke.getReserveConfig($.reserveId[asset]).paused;
     }
 
-    /// @notice The registered assets that can fund a debit spend (see isSpendAsset)
+    /// @notice The spend-set assets that can currently fund a debit spend (see isSpendAsset)
     function spendAssets() external view returns (address[] memory) {
-        return _filterAssets(false);
+        LendGatewayStorage storage $ = _getLendGatewayStorage();
+        address[] memory assets = $.spendAssets.values();
+        uint256 count = 0;
+        for (uint256 i = 0; i < assets.length; i++) {
+            if (!spoke.getReserveConfig($.reserveId[assets[i]]).paused) {
+                assets[count] = assets[i];
+                unchecked {
+                    ++count;
+                }
+            }
+        }
+        assembly ("memory-safe") {
+            mstore(assets, count)
+        }
+        return assets;
     }
 
     /// @notice Whether `account` may drive the gateway (CashModule or an authorized driver)
@@ -578,20 +618,13 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
         return config.borrowable && !config.frozen && !config.paused;
     }
 
-    /// @dev Whether the reserve can fund a debit spend: borrowable (membership), not paused; frozen tolerated
-    function _isSpendAsset(uint256 reserveId) internal view returns (bool) {
-        IAaveV4Spoke.ReserveConfig memory config = spoke.getReserveConfig(reserveId);
-        return config.borrowable && !config.paused;
-    }
-
-    /// @dev The registered assets passing the borrow gate (`borrowGate`) or the debit-spend gate
-    function _filterAssets(bool borrowGate) internal view returns (address[] memory) {
+    /// @dev The registered assets whose reserves pass the borrow gate (see _isBorrowable)
+    function _borrowableAssets() internal view returns (address[] memory) {
         LendGatewayStorage storage $ = _getLendGatewayStorage();
         address[] memory assets = $.assets.values();
         uint256 count = 0;
         for (uint256 i = 0; i < assets.length; i++) {
-            uint256 reserveId = $.reserveId[assets[i]];
-            if (borrowGate ? _isBorrowable(reserveId) : _isSpendAsset(reserveId)) {
+            if (_isBorrowable($.reserveId[assets[i]])) {
                 assets[count] = assets[i];
                 unchecked {
                     ++count;

--- a/test/safe/SafeTestSetup.t.sol
+++ b/test/safe/SafeTestSetup.t.sol
@@ -185,6 +185,7 @@ contract SafeTestSetup is Utils {
         gateway.setRegistered(address(weETH), true);
         gateway.setRegistered(address(usdc), true);
         gateway.setBorrowable(address(usdc), true);
+        gateway.setSpendAsset(address(usdc), true);
         address cashLensImpl = address(new CashLens(address(cashModule), address(dataProvider)));
         cashLens = CashLens(address(new UUPSProxy(cashLensImpl, abi.encodeWithSelector(CashLens.initialize.selector, address(roleRegistry)))));
 

--- a/test/safe/modules/cash/CanSpend.t.sol
+++ b/test/safe/modules/cash/CanSpend.t.sol
@@ -53,7 +53,8 @@ contract CashLensCanSpendTest is CashModuleTestSetup {
         debtManager.supportBorrowToken(address(liquidUsd), borrowApyPerSecond, minShares);
         gateway.setRegistered(address(liquidUsd), true);
         gateway.setBorrowable(address(liquidUsd), true);
-        
+        gateway.setSpendAsset(address(liquidUsd), true);
+
         CashbackTokens[] memory cashbackTokens = new CashbackTokens[](1);
         CashbackTokens memory scr = CashbackTokens({
             token: address(cashbackToken),
@@ -445,6 +446,7 @@ contract CashLensCanSpendTest is CashModuleTestSetup {
         vm.prank(owner);
         debtManager.supportBorrowToken(address(weETH), borrowApyPerSecond, minShares);
         gateway.setBorrowable(address(weETH), true);
+        gateway.setSpendAsset(address(weETH), true);
 
         // Setup test state with multiple tokens
         deal(address(weETH), address(safe), 5 ether);

--- a/test/safe/modules/cash/CashLens.t.sol
+++ b/test/safe/modules/cash/CashLens.t.sol
@@ -60,6 +60,7 @@ contract CashLensTest is CashModuleTestSetup {
         debtManager.supportBorrowToken(address(liquidUsd), borrowApyPerSecond, minShares);
         gateway.setRegistered(address(liquidUsd), true);
         gateway.setBorrowable(address(liquidUsd), true);
+        gateway.setSpendAsset(address(liquidUsd), true);
 
         // Add some collateral to safe for tests
         deal(address(weETH), address(safe), 10 ether);

--- a/test/safe/modules/cash/MultiSpend.t.sol
+++ b/test/safe/modules/cash/MultiSpend.t.sol
@@ -24,6 +24,7 @@ contract CashModuleMultiSpendTest is CashModuleTestSetup {
         vm.prank(owner);
         debtManager.supportBorrowToken(address(weETH), borrowApyPerSecond, minShares);
         gateway.setBorrowable(address(weETH), true);
+        gateway.setSpendAsset(address(weETH), true);
     }
 
     function test_spend_variousTokenProportions_inDebitMode() public {
@@ -565,6 +566,7 @@ contract CashModuleMultiSpendTest is CashModuleTestSetup {
         debtManager.supportBorrowToken(address(cashbackToken), borrowApyPerSecond, minShares);
         gateway.setRegistered(address(cashbackToken), true);
         gateway.setBorrowable(address(cashbackToken), true);
+        gateway.setSpendAsset(address(cashbackToken), true);
         vm.stopPrank();
         
         // Setup three tokens with sample amounts

--- a/test/safe/modules/cash/SetLendGateway.t.sol
+++ b/test/safe/modules/cash/SetLendGateway.t.sol
@@ -70,6 +70,7 @@ contract CashModuleSetLendGatewayTest is CashModuleTestSetup {
         newGateway.setAvailableCash(address(usdc), type(uint128).max);
         newGateway.setRegistered(address(usdc), true);
         newGateway.setBorrowable(address(usdc), true);
+        newGateway.setSpendAsset(address(usdc), true);
         newGateway.setAccountData(address(safe), ILendGateway.AccountData({ collateralUsd: 200e6, debtUsd: 0, availableBorrowsUsd: amountsInUsd[0], healthFactor: type(uint256).max }));
 
         vm.prank(owner);

--- a/test/safe/modules/cash/Spend.t.sol
+++ b/test/safe/modules/cash/Spend.t.sol
@@ -49,6 +49,7 @@ contract CashModuleSpendTest is CashModuleTestSetup {
         vm.prank(owner);
         debtManager.supportBorrowToken(address(weETH), borrowApyPerSecond, minShares);
         gateway.setBorrowable(address(weETH), true);
+        gateway.setSpendAsset(address(weETH), true);
 
         uint256 amountInUsd = 100e6;
         uint256 totalAmountInUsd = amountInUsd * 2; // Pre-calculate total

--- a/test/safe/modules/cash/lend/AutoSupply.t.sol
+++ b/test/safe/modules/cash/lend/AutoSupply.t.sol
@@ -57,6 +57,28 @@ contract AutoSupplyTest is CashGatewayTestSetup {
         assertEq(gw.suppliedOf(address(safe), address(weETH)), 0, "nothing supplied");
     }
 
+    /// A reserve that rejects the supply (here, frozen) is skipped best-effort: the sweep supplies the
+    /// healthy token, leaves the blocked token's balance loose for the next sweep, and never bricks the batch.
+    function test_supplyToLend_skipsReserveThatRejectsSupply() public {
+        uint256 looseUsdc = 1000e6;
+        uint256 looseWeeth = 2 ether;
+        deal(address(usdc), address(safe), looseUsdc);
+        deal(address(weETH), address(safe), looseWeeth);
+
+        _setAaveReserveFrozen(usdcReserveId, true); // supply into the USDC reserve now reverts inside Aave
+
+        address[] memory tokens = new address[](2);
+        tokens[0] = address(usdc);
+        tokens[1] = address(weETH);
+
+        vm.prank(etherFiWallet);
+        cashModule.supplyToLend(address(safe), tokens);
+
+        assertEq(gw.suppliedOf(address(safe), address(usdc)), 0, "frozen reserve skipped, nothing supplied");
+        assertEq(usdc.balanceOf(address(safe)), looseUsdc, "blocked token stays loose for the next sweep");
+        assertEq(gw.suppliedOf(address(safe), address(weETH)), looseWeeth, "healthy token still swept");
+    }
+
     /// An opted-out safe is a no-op sweep (the keeper legitimately races an opt-out); its funds stay loose.
     function test_supplyToLend_noopWhenOptedOut() public {
         uint256 looseUsdc = 500e6;
@@ -101,6 +123,28 @@ contract AutoSupplyTest is CashGatewayTestSetup {
         // weight, so the net borrowing-power cost is the remaining (100 - CF)%
         uint256 powerConsumedUsd = borrowUsd - (borrowUsd * _usdcCollateralFactorBps()) / 10_000;
         assertApproxEqAbs(availableBefore - gw.getAccountData(address(safe)).availableBorrowsUsd, powerConsumedUsd, 2e6, "borrow power moved by debt minus LTV-weighted supply");
+    }
+
+    /// The borrow proceeds are supplied back best-effort: with the borrow reserve at its supply cap, the
+    /// borrow the owners signed for still lands and the proceeds stay loose (the next sweep restores them),
+    /// rather than reverting the whole borrow.
+    function test_borrow_proceedsStayLooseWhenSupplyCapped() public {
+        uint256 collateralWeeth = 5 ether;
+        uint256 borrowUsd = 500e6;
+        _supplyToGateway(address(safe), address(weETH), collateralWeeth);
+
+        // USDC reserve at a zero supply cap (any add reverts AddCapExceeded); borrow draw stays uncapped
+        _setAaveSpokeCaps(usdcReserveId, 0, type(uint40).max);
+
+        uint256 borrowAmt = debtManager.convertUsdToCollateralToken(address(usdc), borrowUsd);
+        (address[] memory signers, bytes[] memory signatures) = _borrowSig(address(usdc), borrowUsd);
+        vm.expectEmit(true, true, true, true);
+        emit CashEventEmitter.LendBorrowed(address(safe), address(usdc), borrowAmt, borrowUsd);
+        cashModule.borrow(address(safe), address(usdc), borrowUsd, signers, signatures);
+
+        assertApproxEqAbs(gw.debtOf(address(safe), address(usdc)), borrowAmt, 2, "debt opened");
+        assertEq(gw.suppliedOf(address(safe), address(usdc)), 0, "capped reserve rejected the supply-back");
+        assertApproxEqAbs(usdc.balanceOf(address(safe)), borrowAmt, 2, "proceeds stay loose for the next sweep");
     }
 
     /// An opted-out safe cannot borrow.

--- a/test/safe/modules/cash/lend/CanSpend.t.sol
+++ b/test/safe/modules/cash/lend/CanSpend.t.sol
@@ -93,10 +93,32 @@ contract CashLensCanSpendAaveTest is CashGatewayTestSetup {
         amounts[0] = 100e6;
 
         // Ample borrowing power, but the reserve holds less cash than the loan needs. Reaching a genuinely
-        // drained reserve on real Aave takes an unrelated whale borrow, so the reserve read is mocked here to
-        // isolate CashLens's liquidity gate (the branch under test).
+        // drained reserve on real Aave takes an unrelated whale borrow, so the borrowable read is mocked here
+        // to isolate CashLens's liquidity gate (the branch under test).
         _supplyToGateway(address(safe), address(weETH), 1 ether);
-        vm.mockCall(address(gw), abi.encodeWithSelector(ILendGateway.availableCash.selector, address(usdc)), abi.encode(amounts[0] - 1));
+        vm.mockCall(address(gw), abi.encodeWithSelector(ILendGateway.availableToBorrow.selector, address(usdc)), abi.encode(amounts[0] - 1));
+
+        (bool canSpend, string memory reason) = cashLens.canSpend(address(safe), txId, tokens, amounts);
+        assertEq(canSpend, false);
+        assertEq(reason, "Insufficient liquidity to cover the loan");
+    }
+
+    /// Credit spend is declined when borrowing power is ample and the pool holds cash, but the loan exceeds
+    /// the Hub's remaining drawCap: availableToBorrow folds the cap in, so the auth cannot approve a borrow
+    /// the Hub would revert with DrawCapExceeded.
+    function test_canSpend_fails_inCreditMode_whenBorrowExceedsDrawCap() public {
+        _setMode(Mode.Credit);
+        vm.warp(cashModule.incomingModeStartTime(address(safe)) + 1);
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 100e6;
+
+        _supplyToGateway(address(safe), address(weETH), 1 ether); // ample borrowing power
+
+        // drawCap of 50 whole USDC ($50), well under the $100 spend, though the pool holds ~1M cash
+        _setAaveSpokeCaps(usdcReserveId, type(uint40).max, 50);
 
         (bool canSpend, string memory reason) = cashLens.canSpend(address(safe), txId, tokens, amounts);
         assertEq(canSpend, false);

--- a/test/safe/modules/cash/lend/CashGatewayTestSetup.t.sol
+++ b/test/safe/modules/cash/lend/CashGatewayTestSetup.t.sol
@@ -57,6 +57,8 @@ abstract contract CashGatewayTestSetup is CashModuleTestSetup, AaveV4Fixture {
         roleRegistry.grantRole(gw.LEND_GATEWAY_ADMIN_ROLE(), owner);
         gw.setReserveId(address(weETH), weethReserveId);
         gw.setReserveId(address(usdc), usdcReserveId);
+        // USDC is the card settlement token; weETH is collateral-only and never a debit-spend asset
+        gw.setSpendAsset(address(usdc), true);
         gw.setDriver(driver, true);
         cashModule.setLendGateway(address(gw));
         vm.stopPrank();

--- a/test/safe/modules/cash/lend/CashLensMaxSpend.t.sol
+++ b/test/safe/modules/cash/lend/CashLensMaxSpend.t.sol
@@ -365,15 +365,16 @@ contract CashLensMaxSpendAaveTest is CashGatewayTestSetup {
         assertEq(creditMaxSpend, borrowPower, "credit max spend is the gateway borrowing power");
     }
 
-    /// Credit max spend is capped by the borrow token's pool liquidity, not just the borrowing power.
+    /// Credit max spend is capped by the borrow token's borrowable liquidity (pool cash under the drawCap),
+    /// not just the borrowing power.
     function test_credit_cappedByPoolLiquidity() public {
         _supplyToGateway(address(safe), address(usdc), 2000e6); // ~$1000 borrowing power at 50%
 
-        // Every borrow reserve holds less cash than the borrowing power, so liquidity binds.
-        vm.mockCall(address(gw), abi.encodeWithSelector(ILendGateway.availableCash.selector, address(usdc)), abi.encode(uint256(400e6)));
-        vm.mockCall(address(gw), abi.encodeWithSelector(ILendGateway.availableCash.selector, address(liquidUsd)), abi.encode(uint256(0)));
+        // Every borrow reserve can lend less than the borrowing power, so borrowable liquidity binds.
+        vm.mockCall(address(gw), abi.encodeWithSelector(ILendGateway.availableToBorrow.selector, address(usdc)), abi.encode(uint256(400e6)));
+        vm.mockCall(address(gw), abi.encodeWithSelector(ILendGateway.availableToBorrow.selector, address(liquidUsd)), abi.encode(uint256(0)));
 
-        assertEq(cashLens.getMaxSpendCredit(address(safe)), 400e6, "credit max spend capped by reserve liquidity, not borrowing power");
+        assertEq(cashLens.getMaxSpendCredit(address(safe)), 400e6, "credit max spend capped by borrowable liquidity, not borrowing power");
     }
 
     // ================ getSafeCashData ================

--- a/test/safe/modules/cash/lend/CashLensMaxSpend.t.sol
+++ b/test/safe/modules/cash/lend/CashLensMaxSpend.t.sol
@@ -60,8 +60,10 @@ contract CashLensMaxSpendAaveTest is CashGatewayTestSetup {
 
         // liquidUSD Aave reserve at 50% collateral factor, priced by the USDC/USD feed; seed borrowable liquidity.
         liquidUsdReserveId = _addAaveReserve(address(liquidUsd), usdcUsdOracle, 5000, true);
-        vm.prank(owner);
+        vm.startPrank(owner);
         gw.setReserveId(address(liquidUsd), liquidUsdReserveId);
+        gw.setSpendAsset(address(liquidUsd), true);
+        vm.stopPrank();
         _seedAaveLiquidity(liquidUsdReserveId, address(liquidUsd), 1_000_000e6);
     }
 

--- a/test/safe/modules/cash/lend/EtherFiLiquidGateway.t.sol
+++ b/test/safe/modules/cash/lend/EtherFiLiquidGateway.t.sol
@@ -129,6 +129,22 @@ contract EtherFiLiquidGatewayTest is CashGatewayTestSetup {
         assertEq(gw.suppliedOf(address(safe), address(liquidVault)), 0, "receipt must not be supplied to Aave");
     }
 
+    // The receipt re-supply is best-effort: if the receipt's reserve is frozen, the deposit still completes
+    // and the receipt stays loose in the safe for the next sweep, rather than reverting after the vault
+    // deposit already ran.
+    function test_deposit_receiptStaysLooseWhenReserveFrozen() public {
+        uint256 amount = 1000e6;
+        deal(address(usdc), address(safe), amount);
+
+        // Freeze the receipt's reserve so Aave rejects the sandwich's re-supply of the minted receipt
+        _setAaveReserveFrozen(gw.reserveIdOf(address(liquidVault)), true);
+
+        liquidModule.deposit(address(safe), address(usdc), address(liquidVault), amount, amount, owner1, _depositSig(address(usdc), amount, amount));
+
+        assertEq(liquidVault.balanceOf(address(safe)), amount, "receipt stays loose when the re-supply is rejected");
+        assertEq(gw.suppliedOf(address(safe), address(liquidVault)), 0, "nothing supplied to the frozen reserve");
+    }
+
     function _depositSig(address assetToDeposit, uint256 amount, uint256 minReturn) internal view returns (bytes memory) {
         bytes32 digestHash = keccak256(
             abi.encodePacked(liquidModule.DEPOSIT_SIG(), block.chainid, address(liquidModule), liquidModule.getNonce(address(safe)), address(safe), abi.encode(assetToDeposit, address(liquidVault), amount, minReturn))

--- a/test/safe/modules/cash/lend/LendGatewayAaveV4.t.sol
+++ b/test/safe/modules/cash/lend/LendGatewayAaveV4.t.sol
@@ -81,11 +81,12 @@ contract LendGatewayAaveV4Test is CashGatewayTestSetup {
         assertTrue(gw.isBorrowable(address(usdc)), "borrowable again after unpause");
     }
 
-    /// isSpendAsset (the debit gate) keeps the borrowable flag as membership (weETH stays non-spendable)
-    /// and tolerates a freeze, since a debit only transfers and withdraws; only a pause blocks it.
-    function test_reads_spendAsset_toleratesFreezeNotPause() public {
+    /// isSpendAsset (the debit gate) reads the admin spend set, not Aave's borrowable flag: USDC is a declared
+    /// spend asset, weETH is a registered reserve that was never declared spendable, and the set tolerates a
+    /// freeze (a debit only transfers and withdraws) while a pause blocks it.
+    function test_reads_spendAsset_readsAdminSetToleratesFreezeNotPause() public {
         assertTrue(gw.isSpendAsset(address(usdc)));
-        assertFalse(gw.isSpendAsset(address(weETH)), "collateral-only asset is not spendable");
+        assertFalse(gw.isSpendAsset(address(weETH)), "registered but not a declared spend asset");
         assertFalse(gw.isSpendAsset(address(0xdead)));
 
         _setAaveReserveFrozen(usdcReserveId, true);
@@ -96,6 +97,35 @@ contract LendGatewayAaveV4Test is CashGatewayTestSetup {
         _setAaveReservePaused(usdcReserveId, true);
         assertFalse(gw.isSpendAsset(address(usdc)), "paused reserve not spendable");
         assertEq(gw.spendAssets().length, 0, "dropped from spendAssets while paused");
+    }
+
+    /// Membership is decoupled from Aave's borrowable flag: turning USDC's borrowable flag off (so it is no
+    /// longer credit-borrowable) leaves it a debit-spend asset, which is the whole point of the admin set.
+    function test_reads_spendAsset_survivesBorrowableFlagOff() public {
+        _setAaveReserveBorrowable(usdcReserveId, false);
+        assertFalse(gw.isBorrowable(address(usdc)), "no longer borrowable for credit");
+        assertTrue(gw.isSpendAsset(address(usdc)), "still a debit-spend asset");
+    }
+
+    /// setSpendAsset is admin-gated, requires a registered reserve, and removeReserve drops spend membership.
+    function test_setSpendAsset_guardsAndRemovalDropsMembership() public {
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(LendGateway.AssetNotRegistered.selector, address(0xdead)));
+        gw.setSpendAsset(address(0xdead), true);
+
+        vm.expectRevert(); // caller lacks LEND_GATEWAY_ADMIN_ROLE
+        gw.setSpendAsset(address(usdc), false);
+
+        // _addAaveReserve manages its own aaveAdmin prank, so list the idle USDT reserve before pranking owner
+        uint256 usdtReserveId = _addAaveReserve(address(usdt), usdcUsdOracle, _usdcCollateralFactorBps(), true);
+
+        vm.startPrank(owner);
+        gw.setReserveId(address(usdt), usdtReserveId);
+        gw.setSpendAsset(address(usdt), true);
+        assertTrue(gw.isSpendAsset(address(usdt)));
+        gw.removeReserve(address(usdt)); // idle reserve: no debt, no supplied balance
+        vm.stopPrank();
+        assertFalse(gw.isSpendAsset(address(usdt)), "removeReserve drops spend membership");
     }
 
     function test_getAccountData_freshSafeIsEmptyAndHealthy() public view {

--- a/test/safe/modules/cash/lend/LendGatewayAaveV4.t.sol
+++ b/test/safe/modules/cash/lend/LendGatewayAaveV4.t.sol
@@ -37,6 +37,22 @@ contract LendGatewayAaveV4Test is CashGatewayTestSetup {
         assertGe(gw.availableCash(address(usdc)), 1_000_000e6);
     }
 
+    /// availableToBorrow is the credit-side liquidity gate: uncapped it equals availableCash, a finite drawCap
+    /// caps it at the spoke's remaining borrow headroom, and a halted Hub spoke drives it to zero.
+    function test_reads_availableToBorrow_boundedByDrawCap() public {
+        // Uncapped (fixture default): equals the withdrawable liquidity
+        assertEq(gw.availableToBorrow(address(usdc)), gw.availableCash(address(usdc)));
+
+        // With no borrows yet, a 400k-token drawCap is the whole borrowable amount (< the 1M seeded cash)
+        _setAaveSpokeCaps(usdcReserveId, type(uint40).max, 400_000);
+        assertEq(gw.availableToBorrow(address(usdc)), 400_000e6, "capped at remaining drawCap");
+        assertGe(gw.availableCash(address(usdc)), 1_000_000e6, "withdraw side is unchanged by the borrow cap");
+
+        // Halting the spoke stops new borrows entirely
+        _setAaveSpokeHalted(usdcReserveId, true);
+        assertEq(gw.availableToBorrow(address(usdc)), 0, "halted spoke cannot borrow");
+    }
+
     /// isBorrowable/borrowableAssets read the reserve's borrowable flag on the Spoke: USDC's reserve allows
     /// borrowing, weETH's is collateral-only, and unregistered assets are never borrowable.
     function test_reads_borrowable() public view {

--- a/test/safe/modules/cash/lend/MultiSpend.t.sol
+++ b/test/safe/modules/cash/lend/MultiSpend.t.sol
@@ -18,6 +18,13 @@ contract CashModuleMultiSpendAaveTest is CashGatewayTestSetup {
         return true;
     }
 
+    function setUp() public override {
+        super.setUp();
+        // These tests debit-spend weETH, so declare it a spend asset (membership is no longer the borrowable flag)
+        vm.prank(owner);
+        gw.setSpendAsset(address(weETH), true);
+    }
+
     /// A two-token debit under debt: USDC fully from the loose balance, weETH from a loose + Aave-supplied mix.
     function test_spend_multiToken_mixedLooseAndSupplied_withDebt() public {
         uint256 usdcAmount = debtManager.convertUsdToCollateralToken(address(usdc), 50e6); // fully from the loose balance

--- a/test/safe/modules/cash/lend/Spend.t.sol
+++ b/test/safe/modules/cash/lend/Spend.t.sol
@@ -135,6 +135,25 @@ contract CashModuleSpendAaveTest is CashGatewayTestSetup {
         assertApproxEqAbs(gw.suppliedOf(address(safe), address(usdc)), 100e6 - 60e6, 2, "shortfall withdrawn from the frozen reserve");
     }
 
+    /// A debit spend does not need the reserve to be borrowable: membership is the admin spend set, so a
+    /// supply-only reserve (borrowable flag off, e.g. a stable listed only to hold and spend) still funds a
+    /// debit spend from loose balance plus an Aave withdraw.
+    function test_spend_debit_succeeds_whenReserveNotBorrowable() public {
+        _supplyToGateway(address(safe), address(usdc), 100e6);
+        deal(address(usdc), address(safe), 40e6);
+        _setAaveReserveBorrowable(usdcReserveId, false);
+        assertFalse(gw.isBorrowable(address(usdc)), "reserve is supply-only");
+        assertTrue(gw.isSpendAsset(address(usdc)), "still a declared spend asset");
+
+        uint256 dispatcherBefore = usdc.balanceOf(address(settlementDispatcherReap));
+
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, _tokens(address(usdc)), _amounts(100e6), _noCashback());
+
+        assertEq(usdc.balanceOf(address(settlementDispatcherReap)), dispatcherBefore + 100e6, "loose plus supplied funded the spend on a supply-only reserve");
+        assertApproxEqAbs(gw.suppliedOf(address(safe), address(usdc)), 100e6 - 60e6, 2, "shortfall withdrawn from the supply-only reserve");
+    }
+
     /// The auth-vs-freeze race: an auth approved while the reserve was borrowable cannot settle once the
     /// reserve is frozen. The spend reverts on the module's gate — the same predicate the auth now declines
     /// on — instead of deep inside Aave.

--- a/test/safe/modules/cash/lend/helpers/AaveV4Fixture.sol
+++ b/test/safe/modules/cash/lend/helpers/AaveV4Fixture.sol
@@ -96,10 +96,11 @@ abstract contract AaveV4Fixture is Test {
         spokeSelectors[4] = ISpoke.updateReserveConfig.selector;
         accessManager.setTargetFunctionRole(address(spoke), spokeSelectors, Roles.SPOKE_ADMIN_ROLE);
 
-        bytes4[] memory hubSelectors = new bytes4[](3);
+        bytes4[] memory hubSelectors = new bytes4[](4);
         hubSelectors[0] = IHub.addAsset.selector;
         hubSelectors[1] = IHub.updateAssetConfig.selector;
         hubSelectors[2] = IHub.addSpoke.selector;
+        hubSelectors[3] = IHub.updateSpokeConfig.selector;
         accessManager.setTargetFunctionRole(address(hub), hubSelectors, Roles.HUB_ADMIN_ROLE);
 
         // A permissive liquidation config, so borrows/withdrawals are governed by collateral factors alone
@@ -171,6 +172,27 @@ abstract contract AaveV4Fixture is Test {
         cfg.paused = paused;
         vm.prank(aaveAdmin);
         spoke.updateReserveConfig(reserveId, cfg);
+    }
+
+    /// @notice Sets a listed reserve's per-spoke supply/borrow caps, in whole tokens (type(uint40).max is the
+    ///         uncapped sentinel), preserving the spoke's other config (active, halted, riskPremiumThreshold)
+    function _setAaveSpokeCaps(uint256 reserveId, uint40 addCap, uint40 drawCap) internal {
+        uint256 assetId = spoke.getReserve(reserveId).assetId;
+        IHub.SpokeConfig memory cfg = hub.getSpokeConfig(assetId, address(spoke));
+        cfg.addCap = addCap;
+        cfg.drawCap = drawCap;
+        vm.prank(aaveAdmin);
+        hub.updateSpokeConfig(assetId, address(spoke), cfg);
+    }
+
+    /// @notice Halts (or resumes) a listed reserve's spoke on the Hub, preserving its other config. A halted
+    ///         spoke rejects new supplies and borrows.
+    function _setAaveSpokeHalted(uint256 reserveId, bool halted) internal {
+        uint256 assetId = spoke.getReserve(reserveId).assetId;
+        IHub.SpokeConfig memory cfg = hub.getSpokeConfig(assetId, address(spoke));
+        cfg.halted = halted;
+        vm.prank(aaveAdmin);
+        hub.updateSpokeConfig(assetId, address(spoke), cfg);
     }
 
     /// @notice Updates a listed reserve's collateral factor (BPS), preserving its other dynamic config


### PR DESCRIPTION
Closes COR-1077.

## What this does

Two changes so an Aave reserve that is frozen, paused, or over a Hub cap can no longer brick a sweep or slip past the auth check and revert at spend.

1. Adds `availableToBorrow(asset)` on the gateway: the lesser of the reserve's withdrawable liquidity and the Hub's remaining `drawCap` for this spoke, and 0 when the Hub spoke is halted or inactive. The credit auth checks and `getMaxSpendCredit` now read it instead of `availableCash`, so a credit spend that fits pool liquidity but exceeds the remaining `drawCap` is declined at auth rather than reverting at spend. `availableCash` stays the withdraw-side view. The DebtManager migration re-borrow pre-check also reads `availableToBorrow`.

2. Makes the supply legs best-effort. The per-safe sweep, the borrow's supply-back, and the module sandwich re-supply now skip a reserve that rejects the supply (frozen, paused, at `addCap`, or halted) instead of reverting the whole batch. The funds stay loose in the safe for the next sweep. The credit-spend resupply and the migration keep their hard reverts on purpose.

## Why

An Aave reserve can be frozen or paused, or hit a Hub `addCap` / `drawCap`, between when we list it and when we use it. Before this, one reserve that rejects a supply reverted the entire per-safe sweep, and a borrow blocked only by the Hub's `drawCap` was approved at auth and then reverted deep in Aave at spend.

## Notes for review

- New MIT interface `IAaveV4Hub` (hand-written; we do not vendor the BUSL Aave v4 source). It declares only the Hub reads we call: `getSpokeConfig`, `getSpokeTotalOwed`, and `MAX_ALLOWED_SPOKE_CAP`.
- Known approximation to flag: `availableToBorrow` bounds the `drawCap` headroom with `getSpokeTotalOwed` (drawn plus premium) and omits the spoke's reported deficit, so it can slightly overestimate the borrowable amount. We accept that rather than mirroring the Hub's full `SpokeData` accounting.
- The migration re-borrow pre-check now fails with our `InsufficientLendGatewayLiquidity` when a cap blocks it, instead of a raw Aave `DrawCapExceeded`. The migration still hard-reverts.

## How it was tested

Full lend profile suite against a real Aave v4 instance deployed in-test on an Optimism fork, plus the default-profile cash suite, both green. New tests cover the drawCap-bounded `availableToBorrow` reads, a two-token sweep where one reserve is frozen or capped and the batch still supplies the healthy token, a credit auth declined over the drawCap, and the best-effort borrow and sandwich legs leaving output loose. `forge lint` clean on the changed files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches credit auth, migration liquidity gates, and debit spend eligibility—important for card settlement and borrows—but changes are mostly defensive (honest caps, non-bricking sweeps) with broad test coverage; `availableToBorrow` may slightly overestimate when Hub deficits apply.
> 
> **Overview**
> Hardens lend flows when Aave reserves are frozen, paused, capped, or Hub spokes are halted.
> 
> **Credit liquidity:** New `availableToBorrow` on `LendGateway` is `min(availableCash, remaining Hub drawCap)` (zero if spoke inactive/halted), backed by extended `IAaveV4Hub`. `CashLens` credit checks, `getMaxSpendCredit`, and DebtManager migration re-borrow preflight use it instead of `availableCash`, so auth declines borrows that would hit `DrawCapExceeded` at execution.
> 
> **Best-effort supply:** Auto-supply (`CashLendLib`), borrow supply-back, and sandwich re-supply (`ModuleLendGatewaySandwich`) wrap `supply` in `try/catch` so one bad reserve does not revert the whole batch; funds stay loose for the next sweep. Credit-spend resupply and migration supplies remain hard-revert paths.
> 
> **Debit spend membership:** `isSpendAsset` / `spendAssets` now use an admin `spendAssets` set (`setSpendAsset`) rather than Aave’s borrowable flag, so supply-only reserves can still settle card debits; `removeReserve` clears spend membership. `MockLendGateway` and tests updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69490c8fa63d93b1a52c45946ba4a8241dfcf5fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->