### PR TITLE
feat: gate debit spends on an admin spend-asset set, not Aave borrowable

### DIFF
--- a/src/interfaces/ILendGateway.sol
+++ b/src/interfaces/ILendGateway.sol
@@ -152,16 +152,18 @@ interface ILendGateway {
 
     /**
      * @notice Returns whether `asset` can fund a debit spend
-     * @dev Registered, marked borrowable (membership: it marks the spendable stables), and not paused.
-     *      Frozen is tolerated: a debit spend only transfers loose balance and withdraws supplied
-     *      balance, both of which Aave allows while frozen.
+     * @dev An admin-declared spend asset (via setSpendAsset, always a registered reserve) whose reserve is
+     *      not paused. Membership is declared, not read from Aave's borrowable flag, so a supply-only
+     *      reserve can be spendable. Frozen is tolerated: a debit spend only transfers loose balance and
+     *      withdraws supplied balance, both of which Aave allows while frozen. Paused blocks the withdraw
+     *      leg, so a paused reserve is not spendable.
      * @param asset The asset to query
      * @return True if the asset can fund a debit spend
      */
     function isSpendAsset(address asset) external view returns (bool);
 
     /**
-     * @notice Returns the registered assets that can fund a debit spend
+     * @notice Returns the spend-set assets that can currently fund a debit spend
      * @dev See isSpendAsset.
      * @return The spendable asset addresses
      */

--- a/src/mocks/MockLendGateway.sol
+++ b/src/mocks/MockLendGateway.sol
@@ -32,6 +32,8 @@ contract MockLendGateway is ILendGateway {
     mapping(address asset => bool) internal _registered;
     /// @dev Whether an asset's reserve allows borrowing; defaults to false
     mapping(address asset => bool) internal _borrowable;
+    /// @dev Whether an asset is an admin-declared debit-spend token; defaults to false
+    mapping(address asset => bool) internal _spendAsset;
     /// @dev Every asset ever registered, in order; registeredAssets/borrowableAssets filter it by the flags
     address[] internal _assets;
 
@@ -57,6 +59,11 @@ contract MockLendGateway is ILendGateway {
     /// @notice Sets whether an asset's reserve allows borrowing (defaults to non-borrowable)
     function setBorrowable(address asset, bool borrowable) external {
         _borrowable[asset] = borrowable;
+    }
+
+    /// @notice Sets whether an asset is a debit-spend token (defaults to non-spendable)
+    function setSpendAsset(address asset, bool spendable) external {
+        _spendAsset[asset] = spendable;
     }
 
     /// @notice Sets the amount a subsequent `suppliedOf(safe, asset)` will return
@@ -126,13 +133,26 @@ contract MockLendGateway is ILendGateway {
         return _filterAssets(true);
     }
 
-    /// @dev The mock models no freeze or pause, so the debit-spend gate equals the borrow gate
+    /// @dev The mock models no pause, so the debit-spend gate is just the admin spend flag
     function isSpendAsset(address asset) external view returns (bool) {
-        return _registered[asset] && _borrowable[asset];
+        return _spendAsset[asset];
     }
 
     function spendAssets() external view returns (address[] memory) {
-        return _filterAssets(true);
+        address[] memory out = new address[](_assets.length);
+        uint256 count = 0;
+        for (uint256 i = 0; i < _assets.length; i++) {
+            if (_spendAsset[_assets[i]]) {
+                out[count] = _assets[i];
+                unchecked {
+                    ++count;
+                }
+            }
+        }
+        assembly ("memory-safe") {
+            mstore(out, count)
+        }
+        return out;
     }
 
     /// @dev The registered assets, optionally narrowed to the borrowable ones

--- a/src/modules/lend-gateway/LendGateway.sol
+++ b/src/modules/lend-gateway/LendGateway.sol
@@ -69,6 +69,8 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
         EnumerableSetLib.AddressSet assets;
         /// @notice Extra authorized drivers beyond the CashModule (auto-supply / migration paths)
         mapping(address driver => bool authorized) isDriver;
+        /// @notice The tokens the card can settle a debit spend in; admin-declared, a subset of `assets`
+        EnumerableSetLib.AddressSet spendAssets;
     }
 
     // keccak256(abi.encode(uint256(keccak256("etherfi.storage.LendGateway")) - 1)) & ~bytes32(uint256(0xff))
@@ -80,6 +82,8 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
     event ReserveDeregistered(address indexed asset);
     /// @notice Emitted when a driver is authorized or de-authorized
     event DriverSet(address indexed driver, bool authorized);
+    /// @notice Emitted when an asset is added to or removed from the debit-spend set
+    event SpendAssetSet(address indexed asset, bool spendable);
     /// @notice Emitted when the gateway (re-)approves itself as `safe`'s position manager (folded into an op)
     event PositionManagerApproved(address indexed safe);
     /// @notice Emitted on a supply on a safe's behalf
@@ -189,6 +193,7 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
         }
 
         $.assets.remove(asset);
+        $.spendAssets.remove(asset);
         delete $.reserveId[asset];
 
         emit ReserveDeregistered(asset);
@@ -203,6 +208,25 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
         if (driver == address(0)) revert ZeroAddress();
         _getLendGatewayStorage().isDriver[driver] = authorized;
         emit DriverSet(driver, authorized);
+    }
+
+    /**
+     * @notice Adds or removes an asset from the debit-spend set (the tokens the card can settle in)
+     * @dev A spend asset must be a registered reserve, so this reverts with AssetNotRegistered when adding
+     *      an unregistered asset. Membership is declared here, not read from Aave's borrowable flag, so a
+     *      supply-only reserve can still be a debit-spend token.
+     * @param asset The registered asset
+     * @param spendable True to add to the set, false to remove
+     */
+    function setSpendAsset(address asset, bool spendable) external onlyRole(LEND_GATEWAY_ADMIN_ROLE) {
+        LendGatewayStorage storage $ = _getLendGatewayStorage();
+        if (spendable) {
+            if (!$.assets.contains(asset)) revert AssetNotRegistered(asset);
+            $.spendAssets.add(asset);
+        } else {
+            $.spendAssets.remove(asset);
+        }
+        emit SpendAssetSet(asset, spendable);
     }
 
     // ---------------------------------------------------------------------
@@ -513,7 +537,8 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
 
     /// @notice Whether `asset` is registered and its reserve accepts a borrow on the Spoke
     /// @dev Mirrors Aave's borrow gate (borrowable, not frozen, not paused) so an asset that passes
-    ///      here at auth cannot then fail the Spoke's borrow at spend.
+    ///      here at auth cannot then fail the Spoke's borrow at spend. Credit membership is Aave's
+    ///      borrowable flag by design; only the debit gate (isSpendAsset) reads the admin spend set.
     function isBorrowable(address asset) external view returns (bool) {
         LendGatewayStorage storage $ = _getLendGatewayStorage();
         if (!$.assets.contains(asset)) return false;
@@ -522,26 +547,41 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
 
     /// @notice The registered assets whose reserves accept a borrow on the Spoke
     function borrowableAssets() external view returns (address[] memory) {
-        return _filterAssets(true);
+        return _borrowableAssets();
     }
 
     /**
-     * @notice Whether `asset` can fund a debit spend: registered, marked borrowable, and not paused
-     * @dev A debit spend transfers loose balance and withdraws supplied balance, and Aave allows both
-     *      while frozen, so frozen is tolerated here. The borrowable flag does membership duty (it marks
-     *      the spendable stables); paused blocks the withdraw leg. Only new debt takes the full
-     *      isBorrowable gate.
+     * @notice Whether `asset` can fund a debit spend: an admin-declared spend asset whose reserve is not paused
+     * @dev Membership is declared via setSpendAsset (always a subset of registered reserves), so "is this a
+     *      card settlement token" no longer keys on Aave's borrowable flag and a supply-only reserve can be
+     *      spendable. A debit spend transfers loose balance and withdraws supplied balance, which Aave allows
+     *      while frozen, so frozen is tolerated; paused blocks the withdraw leg, so a paused reserve is not
+     *      spendable. New debt takes the full isBorrowable gate instead.
      * @param asset The asset to query
      */
     function isSpendAsset(address asset) external view returns (bool) {
         LendGatewayStorage storage $ = _getLendGatewayStorage();
-        if (!$.assets.contains(asset)) return false;
-        return _isSpendAsset($.reserveId[asset]);
+        if (!$.spendAssets.contains(asset)) return false;
+        return !spoke.getReserveConfig($.reserveId[asset]).paused;
     }
 
-    /// @notice The registered assets that can fund a debit spend (see isSpendAsset)
+    /// @notice The spend-set assets that can currently fund a debit spend (see isSpendAsset)
     function spendAssets() external view returns (address[] memory) {
-        return _filterAssets(false);
+        LendGatewayStorage storage $ = _getLendGatewayStorage();
+        address[] memory assets = $.spendAssets.values();
+        uint256 count = 0;
+        for (uint256 i = 0; i < assets.length; i++) {
+            if (!spoke.getReserveConfig($.reserveId[assets[i]]).paused) {
+                assets[count] = assets[i];
+                unchecked {
+                    ++count;
+                }
+            }
+        }
+        assembly ("memory-safe") {
+            mstore(assets, count)
+        }
+        return assets;
     }
 
     /// @notice Whether `account` may drive the gateway (CashModule or an authorized driver)
@@ -578,20 +618,13 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
         return config.borrowable && !config.frozen && !config.paused;
     }
 
-    /// @dev Whether the reserve can fund a debit spend: borrowable (membership), not paused; frozen tolerated
-    function _isSpendAsset(uint256 reserveId) internal view returns (bool) {
-        IAaveV4Spoke.ReserveConfig memory config = spoke.getReserveConfig(reserveId);
-        return config.borrowable && !config.paused;
-    }
-
-    /// @dev The registered assets passing the borrow gate (`borrowGate`) or the debit-spend gate
-    function _filterAssets(bool borrowGate) internal view returns (address[] memory) {
+    /// @dev The registered assets whose reserves pass the borrow gate (see _isBorrowable)
+    function _borrowableAssets() internal view returns (address[] memory) {
         LendGatewayStorage storage $ = _getLendGatewayStorage();
         address[] memory assets = $.assets.values();
         uint256 count = 0;
         for (uint256 i = 0; i < assets.length; i++) {
-            uint256 reserveId = $.reserveId[assets[i]];
-            if (borrowGate ? _isBorrowable(reserveId) : _isSpendAsset(reserveId)) {
+            if (_isBorrowable($.reserveId[assets[i]])) {
                 assets[count] = assets[i];
                 unchecked {
                     ++count;

--- a/test/safe/SafeTestSetup.t.sol
+++ b/test/safe/SafeTestSetup.t.sol
@@ -185,6 +185,7 @@ contract SafeTestSetup is Utils {
         gateway.setRegistered(address(weETH), true);
         gateway.setRegistered(address(usdc), true);
         gateway.setBorrowable(address(usdc), true);
+        gateway.setSpendAsset(address(usdc), true);
         address cashLensImpl = address(new CashLens(address(cashModule), address(dataProvider)));
         cashLens = CashLens(address(new UUPSProxy(cashLensImpl, abi.encodeWithSelector(CashLens.initialize.selector, address(roleRegistry)))));
 

--- a/test/safe/modules/cash/CanSpend.t.sol
+++ b/test/safe/modules/cash/CanSpend.t.sol
@@ -53,7 +53,8 @@ contract CashLensCanSpendTest is CashModuleTestSetup {
         debtManager.supportBorrowToken(address(liquidUsd), borrowApyPerSecond, minShares);
         gateway.setRegistered(address(liquidUsd), true);
         gateway.setBorrowable(address(liquidUsd), true);
-        
+        gateway.setSpendAsset(address(liquidUsd), true);
+
         CashbackTokens[] memory cashbackTokens = new CashbackTokens[](1);
         CashbackTokens memory scr = CashbackTokens({
             token: address(cashbackToken),
@@ -445,6 +446,7 @@ contract CashLensCanSpendTest is CashModuleTestSetup {
         vm.prank(owner);
         debtManager.supportBorrowToken(address(weETH), borrowApyPerSecond, minShares);
         gateway.setBorrowable(address(weETH), true);
+        gateway.setSpendAsset(address(weETH), true);
 
         // Setup test state with multiple tokens
         deal(address(weETH), address(safe), 5 ether);

--- a/test/safe/modules/cash/CashLens.t.sol
+++ b/test/safe/modules/cash/CashLens.t.sol
@@ -60,6 +60,7 @@ contract CashLensTest is CashModuleTestSetup {
         debtManager.supportBorrowToken(address(liquidUsd), borrowApyPerSecond, minShares);
         gateway.setRegistered(address(liquidUsd), true);
         gateway.setBorrowable(address(liquidUsd), true);
+        gateway.setSpendAsset(address(liquidUsd), true);
 
         // Add some collateral to safe for tests
         deal(address(weETH), address(safe), 10 ether);

--- a/test/safe/modules/cash/MultiSpend.t.sol
+++ b/test/safe/modules/cash/MultiSpend.t.sol
@@ -24,6 +24,7 @@ contract CashModuleMultiSpendTest is CashModuleTestSetup {
         vm.prank(owner);
         debtManager.supportBorrowToken(address(weETH), borrowApyPerSecond, minShares);
         gateway.setBorrowable(address(weETH), true);
+        gateway.setSpendAsset(address(weETH), true);
     }
 
     function test_spend_variousTokenProportions_inDebitMode() public {
@@ -565,6 +566,7 @@ contract CashModuleMultiSpendTest is CashModuleTestSetup {
         debtManager.supportBorrowToken(address(cashbackToken), borrowApyPerSecond, minShares);
         gateway.setRegistered(address(cashbackToken), true);
         gateway.setBorrowable(address(cashbackToken), true);
+        gateway.setSpendAsset(address(cashbackToken), true);
         vm.stopPrank();
         
         // Setup three tokens with sample amounts

--- a/test/safe/modules/cash/SetLendGateway.t.sol
+++ b/test/safe/modules/cash/SetLendGateway.t.sol
@@ -70,6 +70,7 @@ contract CashModuleSetLendGatewayTest is CashModuleTestSetup {
         newGateway.setAvailableCash(address(usdc), type(uint128).max);
         newGateway.setRegistered(address(usdc), true);
         newGateway.setBorrowable(address(usdc), true);
+        newGateway.setSpendAsset(address(usdc), true);
         newGateway.setAccountData(address(safe), ILendGateway.AccountData({ collateralUsd: 200e6, debtUsd: 0, availableBorrowsUsd: amountsInUsd[0], healthFactor: type(uint256).max }));
 
         vm.prank(owner);

--- a/test/safe/modules/cash/Spend.t.sol
+++ b/test/safe/modules/cash/Spend.t.sol
@@ -49,6 +49,7 @@ contract CashModuleSpendTest is CashModuleTestSetup {
         vm.prank(owner);
         debtManager.supportBorrowToken(address(weETH), borrowApyPerSecond, minShares);
         gateway.setBorrowable(address(weETH), true);
+        gateway.setSpendAsset(address(weETH), true);
 
         uint256 amountInUsd = 100e6;
         uint256 totalAmountInUsd = amountInUsd * 2; // Pre-calculate total

--- a/test/safe/modules/cash/lend/CashGatewayTestSetup.t.sol
+++ b/test/safe/modules/cash/lend/CashGatewayTestSetup.t.sol
@@ -57,6 +57,8 @@ abstract contract CashGatewayTestSetup is CashModuleTestSetup, AaveV4Fixture {
         roleRegistry.grantRole(gw.LEND_GATEWAY_ADMIN_ROLE(), owner);
         gw.setReserveId(address(weETH), weethReserveId);
         gw.setReserveId(address(usdc), usdcReserveId);
+        // USDC is the card settlement token; weETH is collateral-only and never a debit-spend asset
+        gw.setSpendAsset(address(usdc), true);
         gw.setDriver(driver, true);
         cashModule.setLendGateway(address(gw));
         vm.stopPrank();

--- a/test/safe/modules/cash/lend/CashLensMaxSpend.t.sol
+++ b/test/safe/modules/cash/lend/CashLensMaxSpend.t.sol
@@ -60,8 +60,10 @@ contract CashLensMaxSpendAaveTest is CashGatewayTestSetup {
 
         // liquidUSD Aave reserve at 50% collateral factor, priced by the USDC/USD feed; seed borrowable liquidity.
         liquidUsdReserveId = _addAaveReserve(address(liquidUsd), usdcUsdOracle, 5000, true);
-        vm.prank(owner);
+        vm.startPrank(owner);
         gw.setReserveId(address(liquidUsd), liquidUsdReserveId);
+        gw.setSpendAsset(address(liquidUsd), true);
+        vm.stopPrank();
         _seedAaveLiquidity(liquidUsdReserveId, address(liquidUsd), 1_000_000e6);
     }
 

--- a/test/safe/modules/cash/lend/LendGatewayAaveV4.t.sol
+++ b/test/safe/modules/cash/lend/LendGatewayAaveV4.t.sol
@@ -81,11 +81,12 @@ contract LendGatewayAaveV4Test is CashGatewayTestSetup {
         assertTrue(gw.isBorrowable(address(usdc)), "borrowable again after unpause");
     }
 
-    /// isSpendAsset (the debit gate) keeps the borrowable flag as membership (weETH stays non-spendable)
-    /// and tolerates a freeze, since a debit only transfers and withdraws; only a pause blocks it.
-    function test_reads_spendAsset_toleratesFreezeNotPause() public {
+    /// isSpendAsset (the debit gate) reads the admin spend set, not Aave's borrowable flag: USDC is a declared
+    /// spend asset, weETH is a registered reserve that was never declared spendable, and the set tolerates a
+    /// freeze (a debit only transfers and withdraws) while a pause blocks it.
+    function test_reads_spendAsset_readsAdminSetToleratesFreezeNotPause() public {
         assertTrue(gw.isSpendAsset(address(usdc)));
-        assertFalse(gw.isSpendAsset(address(weETH)), "collateral-only asset is not spendable");
+        assertFalse(gw.isSpendAsset(address(weETH)), "registered but not a declared spend asset");
         assertFalse(gw.isSpendAsset(address(0xdead)));
 
         _setAaveReserveFrozen(usdcReserveId, true);
@@ -96,6 +97,35 @@ contract LendGatewayAaveV4Test is CashGatewayTestSetup {
         _setAaveReservePaused(usdcReserveId, true);
         assertFalse(gw.isSpendAsset(address(usdc)), "paused reserve not spendable");
         assertEq(gw.spendAssets().length, 0, "dropped from spendAssets while paused");
+    }
+
+    /// Membership is decoupled from Aave's borrowable flag: turning USDC's borrowable flag off (so it is no
+    /// longer credit-borrowable) leaves it a debit-spend asset, which is the whole point of the admin set.
+    function test_reads_spendAsset_survivesBorrowableFlagOff() public {
+        _setAaveReserveBorrowable(usdcReserveId, false);
+        assertFalse(gw.isBorrowable(address(usdc)), "no longer borrowable for credit");
+        assertTrue(gw.isSpendAsset(address(usdc)), "still a debit-spend asset");
+    }
+
+    /// setSpendAsset is admin-gated, requires a registered reserve, and removeReserve drops spend membership.
+    function test_setSpendAsset_guardsAndRemovalDropsMembership() public {
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(LendGateway.AssetNotRegistered.selector, address(0xdead)));
+        gw.setSpendAsset(address(0xdead), true);
+
+        vm.expectRevert(); // caller lacks LEND_GATEWAY_ADMIN_ROLE
+        gw.setSpendAsset(address(usdc), false);
+
+        // _addAaveReserve manages its own aaveAdmin prank, so list the idle USDT reserve before pranking owner
+        uint256 usdtReserveId = _addAaveReserve(address(usdt), usdcUsdOracle, _usdcCollateralFactorBps(), true);
+
+        vm.startPrank(owner);
+        gw.setReserveId(address(usdt), usdtReserveId);
+        gw.setSpendAsset(address(usdt), true);
+        assertTrue(gw.isSpendAsset(address(usdt)));
+        gw.removeReserve(address(usdt)); // idle reserve: no debt, no supplied balance
+        vm.stopPrank();
+        assertFalse(gw.isSpendAsset(address(usdt)), "removeReserve drops spend membership");
     }
 
     function test_getAccountData_freshSafeIsEmptyAndHealthy() public view {

--- a/test/safe/modules/cash/lend/MultiSpend.t.sol
+++ b/test/safe/modules/cash/lend/MultiSpend.t.sol
@@ -18,6 +18,13 @@ contract CashModuleMultiSpendAaveTest is CashGatewayTestSetup {
         return true;
     }
 
+    function setUp() public override {
+        super.setUp();
+        // These tests debit-spend weETH, so declare it a spend asset (membership is no longer the borrowable flag)
+        vm.prank(owner);
+        gw.setSpendAsset(address(weETH), true);
+    }
+
     /// A two-token debit under debt: USDC fully from the loose balance, weETH from a loose + Aave-supplied mix.
     function test_spend_multiToken_mixedLooseAndSupplied_withDebt() public {
         uint256 usdcAmount = debtManager.convertUsdToCollateralToken(address(usdc), 50e6); // fully from the loose balance

--- a/test/safe/modules/cash/lend/Spend.t.sol
+++ b/test/safe/modules/cash/lend/Spend.t.sol
@@ -135,6 +135,25 @@ contract CashModuleSpendAaveTest is CashGatewayTestSetup {
         assertApproxEqAbs(gw.suppliedOf(address(safe), address(usdc)), 100e6 - 60e6, 2, "shortfall withdrawn from the frozen reserve");
     }
 
+    /// A debit spend does not need the reserve to be borrowable: membership is the admin spend set, so a
+    /// supply-only reserve (borrowable flag off, e.g. a stable listed only to hold and spend) still funds a
+    /// debit spend from loose balance plus an Aave withdraw.
+    function test_spend_debit_succeeds_whenReserveNotBorrowable() public {
+        _supplyToGateway(address(safe), address(usdc), 100e6);
+        deal(address(usdc), address(safe), 40e6);
+        _setAaveReserveBorrowable(usdcReserveId, false);
+        assertFalse(gw.isBorrowable(address(usdc)), "reserve is supply-only");
+        assertTrue(gw.isSpendAsset(address(usdc)), "still a declared spend asset");
+
+        uint256 dispatcherBefore = usdc.balanceOf(address(settlementDispatcherReap));
+
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, _tokens(address(usdc)), _amounts(100e6), _noCashback());
+
+        assertEq(usdc.balanceOf(address(settlementDispatcherReap)), dispatcherBefore + 100e6, "loose plus supplied funded the spend on a supply-only reserve");
+        assertApproxEqAbs(gw.suppliedOf(address(safe), address(usdc)), 100e6 - 60e6, 2, "shortfall withdrawn from the supply-only reserve");
+    }
+
     /// The auth-vs-freeze race: an auth approved while the reserve was borrowable cannot settle once the
     /// reserve is frozen. The spend reverts on the module's gate — the same predicate the auth now declines
     /// on — instead of deep inside Aave.


### PR DESCRIPTION
Stacked on #185 (base branch `cor-1077`). Review and merge that one first. The diff here is just the spend-asset commit on top.

Answers Shivam's review comment on #183: the debit gate should not decide "the card can settle this token" from Aave's `borrowable` flag.

## What this does

Adds an admin-declared spend set on the gateway (`setSpendAsset`, a subset of registered reserves). `isSpendAsset` / `spendAssets` now read that set plus the not-paused runtime check, instead of the reserve's `borrowable` flag. `removeReserve` drops spend membership. Frozen stays tolerated, since a debit only transfers loose balance and withdraws supplied balance, both of which Aave allows on a frozen reserve.

## Why

The debit gate used `borrowable` as membership, which tied "the card can settle this token" to "Aave lets you borrow it". A supply-only stable listed only to hold and spend (Shivam's EURC example) would then be wrongly declined as a debit spend, even though a debit never borrows. On the gateway side the `borrowable` flag is set by Aave governance, not us, so it also meant Aave's config was implicitly deciding our card's spend set. The admin set puts that decision back on our side, matching how the legacy engine already works (its spend set is the DebtManager borrow tokens).

## Decisions I made, worth a second look

- Debit gate only. Credit still keys on Aave's `borrowable` flag by design (`isBorrowable` is unchanged), so the same asset can be a debit-spend token without being credit-borrowable. Flag if you want credit gated on the set too.
- A spend asset must be a registered reserve (`setSpendAsset` reverts otherwise), so debit sourcing keeps its single shape (loose transfer plus withdraw supplied).
- `setSpendAsset` is not declared in `ILendGateway`, matching the other admin setters (`setReserveId`, `setDriver`, `removeReserve`), which are also concrete-only.

## Deploy note

Any already-deployed gateway needs `setSpendAsset(<settlement token>, true)` after this upgrade, or every debit spend declines. There is no reserve-wiring deploy script in the repo, so this is a manual op alongside the existing `setReserveId`.

## How it was tested

Full lend profile suite against a real Aave v4 instance on an Optimism fork, plus the default-profile cash suite, both green. New tests cover the spend gate reading the admin set (not `borrowable`), a supply-only reserve (borrowable flag off) still funding a debit spend end-to-end, the `setSpendAsset` guards, and `removeReserve` dropping membership. `forge lint` clean on the changed files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which tokens can settle debit card spends and requires a manual post-upgrade `setSpendAsset` configuration; credit/borrow gating is untouched but misconfiguration would block all debits.
> 
> **Overview**
> **Debit card settlement** no longer treats Aave’s `borrowable` flag as “this token can fund a debit spend.” Instead, `LendGateway` keeps an **admin-declared spend set** (`setSpendAsset` / `spendAssets` storage, `SpendAssetSet` event). `isSpendAsset` and `spendAssets()` read that set and still require the reserve **not paused**; **frozen** reserves remain allowed for debits. **`isBorrowable` / credit paths are unchanged** and still mirror Aave’s borrow gate.
> 
> `removeReserve` now also drops spend membership. The mock gateway mirrors the separate spend flag. Tests and gateway setup call `setSpendAsset` where debit spends need tokens (e.g. USDC only in Aave setup, weETH when multi-token debit tests apply).
> 
> **Deploy:** existing gateways must run `setSpendAsset` for settlement tokens after upgrade, or debit spends will decline until configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d1e1709a6bb9a6fbcfd71632e4f9960338c48a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->