### PR TITLE
feat: sandwich the stake, Frax, and Midas modules onto Aave

### DIFF
--- a/src/modules/ModuleCheckBalance.sol
+++ b/src/modules/ModuleCheckBalance.sol
@@ -3,9 +3,9 @@ pragma solidity ^0.8.28;
 
 import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
 
+import { ICashModule } from "../interfaces/ICashModule.sol";
 import { IEtherFiDataProvider } from "../interfaces/IEtherFiDataProvider.sol";
 import { IEtherFiSafe } from "../interfaces/IEtherFiSafe.sol";
-import { ICashModule } from "../interfaces/ICashModule.sol";
 import { SignatureUtils } from "../libraries/SignatureUtils.sol";
 import { Constants } from "../utils/Constants.sol";
 
@@ -37,9 +37,9 @@ abstract contract ModuleCheckBalance is Constants {
         uint256 balance;
         if (asset == ETH) balance = safe.balance;
         else balance = IERC20(asset).balanceOf(safe);
-        
+
         if (pendingWithdrawalAmount > balance) return 0;
-        
+
         return balance - pendingWithdrawalAmount;
     }
 

--- a/src/modules/ModuleLendGatewaySandwich.sol
+++ b/src/modules/ModuleLendGatewaySandwich.sol
@@ -2,57 +2,50 @@
 pragma solidity ^0.8.28;
 
 import { ILendGateway } from "../interfaces/ILendGateway.sol";
+import { ModuleCheckBalance } from "./ModuleCheckBalance.sol";
 
 /**
  * @title ModuleLendGatewaySandwich
- * @notice Shared helper for modules that move a safe's assets once those assets live in Aave.
- *         Auto-supply leaves the asset in the safe's Aave position, not the safe, so a module
- *         withdraws it back to the safe, runs its action, then re-supplies the output as collateral.
- * @dev Provides the two bookends; the module brackets its own action between them. Health is enforced
- *      by Aave itself: the Spoke rejects any collateral withdraw that would leave the position's health
- *      factor below 1, and with Aave v4's single collateralFactor (LTV and liquidation threshold are the
- *      same) that is exactly the under-LTV bound. The back bookend only ever adds collateral, so the
- *      post-op position can never be worse than what Aave validated at withdraw time; no extra check here.
+ * @notice Bookends for modules that move a safe's assets once auto-supply has parked them in Aave:
+ *         withdraw the input back to the safe, run the action, re-supply the output as collateral.
+ * @dev No health check of its own: Aave rejects any withdraw that would push the health factor below 1
+ *      (its collateralFactor is both LTV and liquidation threshold), and the back bookend only adds
+ *      collateral. Both bookends no-op unless _lendActive, so a legacy or opted-out safe is untouched.
  *
- *      The helper holds no state: the consumer supplies the gateway (resolved live from the CashModule,
- *      its single source of truth) and the _lendActive predicate (CashModule.isLendActive). Every bookend
- *      sits behind _lendActive, which is false for a legacy safe or one that opted out, so the gateway is
- *      only dereferenced for a safe whose assets actually live in Aave.
+ *      Inherits ModuleCheckBalance because the bookends extend its balance model (the front bookend
+ *      sources what _getAvailableAmount found missing) and it holds the cashModule reference every
+ *      consumer already has. Abstract, compiled into each consumer, never deployed on its own; changes
+ *      ship by redeploying the consumers.
  * @author ether.fi
  */
-abstract contract ModuleLendGatewaySandwich {
+abstract contract ModuleLendGatewaySandwich is ModuleCheckBalance {
     /**
-     * @notice The lend gateway the bookends drive
-     * @dev A consumer resolves it live from the CashModule (`cashModule.getLendGateway()`), the gateway
-     *      address's single source of truth, rather than capturing it at deploy.
+     * @notice The lend gateway the bookends drive, resolved live from the CashModule
+     * @dev Virtual only for the test harness, which pins a mock
      * @return The lend gateway
      */
-    function gateway() public view virtual returns (ILendGateway);
+    function gateway() public view virtual returns (ILendGateway) {
+        return cashModule.getLendGateway();
+    }
 
     /**
-     * @notice Whether the sandwich should touch Aave for `safe`
-     * @dev A consumer must return true only when the safe's assets actually live in Aave: the safe is on the
-     *      gateway engine and has not opted out. That is exactly CashModule.isLendActive, which a legacy safe
-     *      reports false (its assets stay loose under DebtManager, so re-supplying its output into Aave would
-     *      hide it from DebtManager). Left abstract so every consumer states the predicate.
+     * @notice Whether the safe's assets live in Aave: on the gateway engine and not opted out
+     * @dev Virtual only for the test harness
      * @param safe The safe to test
      * @return True if the Aave bookends should run for the safe
      */
-    function _lendActive(address safe) internal view virtual returns (bool);
+    function _lendActive(address safe) internal view virtual returns (bool) {
+        return cashModule.isLendActive(safe);
+    }
 
     /**
      * @notice Pulls the part of `amount` not already loose in the safe out of its Aave position
-     * @dev Sizes the withdraw at min(amount - looseAvailable, supplied) so it never asks Aave for more than
-     *      the safe supplied and never touches an unsupplied or unregistered asset (suppliedOf is zero for
-     *      both, so ETH and non-reserve inputs stay untouched). The caller passes `looseAvailable` (the loose
-     *      balance net of reservations) since the reservation view lives on the module, not the helper.
-     *      A safe whose assets do not live in Aave has nothing to pull back, so this is a no-op for it.
-     *      Aave reverts if the withdraw would drop the position's health factor below 1 (its collateralFactor
-     *      doubles as LTV and liquidation threshold), so the operation cannot leave the safe over-LTV.
+     * @dev Withdraws min(amount - looseAvailable, supplied), so an unsupplied or unregistered asset (ETH
+     *      included) is untouched. Aave rejects a withdraw that would push the health factor below 1.
      * @param safe The safe whose position is debited
      * @param asset The asset to make available
      * @param amount The total amount the operation needs loose in the safe
-     * @param looseAvailable The loose balance already usable in the safe (balance net of pending-withdrawal reservations)
+     * @param looseAvailable The loose balance already usable in the safe (net of pending-withdrawal reservations)
      */
     function _withdrawShortfall(address safe, address asset, uint256 amount, uint256 looseAvailable) internal {
         if (amount <= looseAvailable) return;
@@ -66,11 +59,8 @@ abstract contract ModuleLendGatewaySandwich {
 
     /**
      * @notice Supplies an asset from the safe back into Aave and marks it as collateral, best-effort
-     * @dev No-op for a safe whose assets do not live in Aave, and for an asset the gateway does not list as a
-     *      reserve. The supply itself is best-effort: a reserve that rejects it (frozen, paused, at its supply
-     *      cap, or the Hub spoke halted) is swallowed rather than reverting the whole operation after the swap
-     *      or bridge already ran. In every case the output stays loose in the safe and the next sweep restores
-     *      it as collateral.
+     * @dev No-op for an unregistered asset. A rejected supply (frozen, paused, capped) is swallowed rather
+     *      than reverting the action that already ran; the output stays loose and the next sweep restores it.
      * @param safe The safe whose position is credited
      * @param asset The asset to supply
      * @param amount The amount to supply

--- a/src/modules/etherfi/EtherFiLiquidModule.sol
+++ b/src/modules/etherfi/EtherFiLiquidModule.sol
@@ -11,7 +11,6 @@ import { IEtherFiSafe } from "../../interfaces/IEtherFiSafe.sol";
 import { WithdrawalRequest, SafeData } from "../../interfaces/ICashModule.sol";
 import { IWETH } from "../../interfaces/IWETH.sol";
 import { ILayerZeroTeller } from "../../interfaces/ILayerZeroTeller.sol";
-import { ILendGateway } from "../../interfaces/ILendGateway.sol";
 import { IRoleRegistry } from "../../interfaces/IRoleRegistry.sol";
 import { ModuleBase } from "../ModuleBase.sol";
 import { ModuleCheckBalance } from "../ModuleCheckBalance.sol";
@@ -166,15 +165,6 @@ contract EtherFiLiquidModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardT
         }
     }
 
-    /// @dev Resolved live from the CashModule, the gateway address's single source of truth.
-    function gateway() public view override returns (ILendGateway) {
-        return cashModule.getLendGateway();
-    }
-
-    /// @dev The sandwich acts only for a safe whose assets live in Aave: on the gateway engine and not opted out.
-    function _lendActive(address safe) internal view override returns (bool) {
-        return cashModule.isLendActive(safe);
-    }
 
     /**
      * @notice Deposits tokens to a Liquid vault using signature verification

--- a/src/modules/etherfi/EtherFiStakeModule.sol
+++ b/src/modules/etherfi/EtherFiStakeModule.sol
@@ -6,7 +6,9 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import { ModuleBase } from "../ModuleBase.sol";
 import { ModuleCheckBalance } from "../ModuleCheckBalance.sol";
+import { ModuleLendGatewaySandwich } from "../ModuleLendGatewaySandwich.sol";
 import { IL2SyncPool } from "../../../src/interfaces/IL2SyncPool.sol";
+import { ILendGateway } from "../../interfaces/ILendGateway.sol";
 import { IWETH } from "../../interfaces/IWETH.sol";
 import { IEtherFiSafe } from "../../interfaces/IEtherFiSafe.sol";
 
@@ -14,9 +16,11 @@ import { IEtherFiSafe } from "../../interfaces/IEtherFiSafe.sol";
  * @title EtherFiStakeModule
  * @author ether.fi
  * @notice Module for staking ETH and WETH through the EtherFi protocol
- * @dev Extends ModuleBase to provide staking functionality for Safes
+ * @dev Extends ModuleBase to provide staking functionality for Safes. A gateway safe's WETH may be supplied
+ *      to Aave, so the deposit withdraws any shortfall of the input from the safe's Aave position first and
+ *      re-supplies the weETH output when the gateway lists it as a reserve.
  */
-contract EtherFiStakeModule is ModuleBase, ModuleCheckBalance {
+contract EtherFiStakeModule is ModuleBase, ModuleCheckBalance, ModuleLendGatewaySandwich {
     using MessageHashUtils for bytes32;
 
     /// @notice Reference to the L2SyncPool contract for staking operations
@@ -52,6 +56,16 @@ contract EtherFiStakeModule is ModuleBase, ModuleCheckBalance {
         syncPool = IL2SyncPool(_syncPool);
         weth = _weth;
         weETH = _weETH;
+    }
+
+    /// @dev Resolved live from the CashModule, the gateway address's single source of truth.
+    function gateway() public view override returns (ILendGateway) {
+        return cashModule.getLendGateway();
+    }
+
+    /// @dev The sandwich acts only for a safe whose assets live in Aave: on the gateway engine and not opted out.
+    function _lendActive(address safe) internal view override returns (bool) {
+        return cashModule.isLendActive(safe);
     }
 
     /**
@@ -101,6 +115,10 @@ contract EtherFiStakeModule is ModuleBase, ModuleCheckBalance {
     function _deposit(address safe, address assetToDeposit, uint256 amountToDeposit, uint256 minReturn) internal {
         if (assetToDeposit != weth && assetToDeposit != ETH) revert UnsupportedAsset();
         if (amountToDeposit == 0 || minReturn == 0) revert InvalidInput();
+
+        // Pull any shortfall of the input out of the safe's Aave position (a no-op for ETH, which is not a
+        // reserve), then confirm the safe holds the full amount loose.
+        _withdrawShortfall(safe, assetToDeposit, amountToDeposit, _getAvailableAmount(safe, assetToDeposit));
         _checkAmountAvailable(safe, assetToDeposit, amountToDeposit);
 
         address[] memory to;
@@ -133,6 +151,9 @@ contract EtherFiStakeModule is ModuleBase, ModuleCheckBalance {
         uint256 weETHAmtReceived = IERC20(weETH).balanceOf(safe) - weETHBalBefore;
 
         if (weETHAmtReceived < minReturn) revert InsufficientReturnAmount();
+
+        // Re-supply the weETH output as collateral when the gateway lists it; an unlisted output stays loose.
+        _resupplyToGateway(safe, weETH, weETHAmtReceived);
 
         emit StakeDeposit(safe, assetToDeposit, weETH, amountToDeposit, weETHAmtReceived);
     }

--- a/src/modules/etherfi/EtherFiStakeModule.sol
+++ b/src/modules/etherfi/EtherFiStakeModule.sol
@@ -8,7 +8,6 @@ import { ModuleBase } from "../ModuleBase.sol";
 import { ModuleCheckBalance } from "../ModuleCheckBalance.sol";
 import { ModuleLendGatewaySandwich } from "../ModuleLendGatewaySandwich.sol";
 import { IL2SyncPool } from "../../../src/interfaces/IL2SyncPool.sol";
-import { ILendGateway } from "../../interfaces/ILendGateway.sol";
 import { IWETH } from "../../interfaces/IWETH.sol";
 import { IEtherFiSafe } from "../../interfaces/IEtherFiSafe.sol";
 
@@ -56,16 +55,6 @@ contract EtherFiStakeModule is ModuleBase, ModuleCheckBalance, ModuleLendGateway
         syncPool = IL2SyncPool(_syncPool);
         weth = _weth;
         weETH = _weETH;
-    }
-
-    /// @dev Resolved live from the CashModule, the gateway address's single source of truth.
-    function gateway() public view override returns (ILendGateway) {
-        return cashModule.getLendGateway();
-    }
-
-    /// @dev The sandwich acts only for a safe whose assets live in Aave: on the gateway engine and not opted out.
-    function _lendActive(address safe) internal view override returns (bool) {
-        return cashModule.isLendActive(safe);
     }
 
     /**

--- a/src/modules/etherfi/LiquidUSDLiquifierOP.sol
+++ b/src/modules/etherfi/LiquidUSDLiquifierOP.sol
@@ -6,7 +6,6 @@ import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IER
 
 import { UpgradeableProxy } from "../../utils/UpgradeableProxy.sol";
 import { IDebtManager } from "../../interfaces/IDebtManager.sol";
-import { ILendGateway } from "../../interfaces/ILendGateway.sol";
 import { IPriceProvider } from "../../interfaces/IPriceProvider.sol";
 import { ModuleCheckBalance } from "../ModuleCheckBalance.sol";
 import { ModuleLendGatewaySandwich } from "../ModuleLendGatewaySandwich.sol";
@@ -103,15 +102,6 @@ contract LiquidUSDLiquifierOPModule is Constants, UpgradeableProxy, ModuleCheckB
         _disableInitializers();
     }
 
-    /// @dev Resolved live from the CashModule, the gateway address's single source of truth.
-    function gateway() public view override returns (ILendGateway) {
-        return cashModule.getLendGateway();
-    }
-
-    /// @dev The gateway legs act only for a safe whose assets live in Aave: on the gateway engine and not opted out.
-    function _lendActive(address safe) internal view override returns (bool) {
-        return cashModule.isLendActive(safe);
-    }
 
     /**
      * @notice Initializes the contract

--- a/src/modules/frax/FraxModule.sol
+++ b/src/modules/frax/FraxModule.sol
@@ -11,7 +11,6 @@ import { SafeData, WithdrawalRequest } from "../../interfaces/ICashModule.sol";
 import { IEtherFiSafe } from "../../interfaces/IEtherFiSafe.sol";
 import { IFraxCustodian } from "../../interfaces/IFraxCustodian.sol";
 import { IFraxRemoteHop, MessagingFee } from "../../interfaces/IFraxRemoteHop.sol";
-import { ILendGateway } from "../../interfaces/ILendGateway.sol";
 import { ModuleBase } from "../ModuleBase.sol";
 import { ModuleCheckBalance } from "../ModuleCheckBalance.sol";
 import { ModuleLendGatewaySandwich } from "../ModuleLendGatewaySandwich.sol";
@@ -125,16 +124,6 @@ contract FraxModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardTransient,
         fraxusd = _fraxusd;
         custodian = _custodian;
         remoteHop = _remoteHop;
-    }
-
-    /// @dev Resolved live from the CashModule, the gateway address's single source of truth.
-    function gateway() public view override returns (ILendGateway) {
-        return cashModule.getLendGateway();
-    }
-
-    /// @dev The sandwich acts only for a safe whose assets live in Aave: on the gateway engine and not opted out.
-    function _lendActive(address safe) internal view override returns (bool) {
-        return cashModule.isLendActive(safe);
     }
 
     /**

--- a/src/modules/frax/FraxModule.sol
+++ b/src/modules/frax/FraxModule.sol
@@ -11,16 +11,22 @@ import { SafeData, WithdrawalRequest } from "../../interfaces/ICashModule.sol";
 import { IEtherFiSafe } from "../../interfaces/IEtherFiSafe.sol";
 import { IFraxCustodian } from "../../interfaces/IFraxCustodian.sol";
 import { IFraxRemoteHop, MessagingFee } from "../../interfaces/IFraxRemoteHop.sol";
+import { ILendGateway } from "../../interfaces/ILendGateway.sol";
 import { ModuleBase } from "../ModuleBase.sol";
 import { ModuleCheckBalance } from "../ModuleCheckBalance.sol";
+import { ModuleLendGatewaySandwich } from "../ModuleLendGatewaySandwich.sol";
 
 /**
  * @title FraxModule
  * @author ether.fi
  * @notice Module for interacting with FraxUSD
- * @dev Extends ModuleBase to provide FraxUSD integration for Safes
+ * @dev Extends ModuleBase to provide FraxUSD integration for Safes. A gateway safe's assets may be supplied
+ *      to Aave, so the synchronous deposit and withdraw withdraw any shortfall of the input from the safe's
+ *      Aave position first and re-supply the output when the gateway lists it as a reserve. The async
+ *      withdraw leg goes through the Cash withdrawal flow, which already sources from Aave, so it is not
+ *      sandwiched here.
  */
-contract FraxModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardTransient, IBridgeModule {
+contract FraxModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardTransient, IBridgeModule, ModuleLendGatewaySandwich {
     using MessageHashUtils for bytes32;
     using SafeCast for uint256;
 
@@ -121,6 +127,16 @@ contract FraxModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardTransient,
         remoteHop = _remoteHop;
     }
 
+    /// @dev Resolved live from the CashModule, the gateway address's single source of truth.
+    function gateway() public view override returns (ILendGateway) {
+        return cashModule.getLendGateway();
+    }
+
+    /// @dev The sandwich acts only for a safe whose assets live in Aave: on the gateway engine and not opted out.
+    function _lendActive(address safe) internal view override returns (bool) {
+        return cashModule.isLendActive(safe);
+    }
+
     /**
      * @notice Deposits Asset and mints FraxUSD using signature verification
      * @param safe The Safe address which holds the asset tokens
@@ -163,6 +179,9 @@ contract FraxModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardTransient,
     function _deposit(address safe, address assetToDeposit, uint256 amountToDeposit, uint256 minReturnAmount) internal {
         if (amountToDeposit == 0 || assetToDeposit == address(0)) revert InvalidInput();
 
+        // Pull any shortfall of the input out of the safe's Aave position, then confirm the safe holds the
+        // full amount loose.
+        _withdrawShortfall(safe, assetToDeposit, amountToDeposit, _getAvailableAmount(safe, assetToDeposit));
         _checkAmountAvailable(safe, assetToDeposit, amountToDeposit);
 
         // Validate that custodian has sufficient balance for synchronous deposit
@@ -188,6 +207,9 @@ contract FraxModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardTransient,
         uint256 fraxUSDTokenReceived = ERC20(fraxusd).balanceOf(safe) - fraxUSDTokenBefore;
 
         if (fraxUSDTokenReceived < minReturnAmount) revert InsufficientReturnAmount();
+
+        // Re-supply the fraxUSD output as collateral when the gateway lists it; an unlisted output stays loose.
+        _resupplyToGateway(safe, fraxusd, fraxUSDTokenReceived);
 
         emit Deposit(safe, assetToDeposit, amountToDeposit, fraxUSDTokenReceived);
     }
@@ -235,6 +257,9 @@ contract FraxModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardTransient,
     function _withdraw(address safe, uint128 amountToWithdraw, address outputAsset, uint256 minReceiveAmount) internal {
         if (amountToWithdraw == 0 || outputAsset == address(0)) revert InvalidInput();
 
+        // Pull any shortfall of the fraxUSD input out of the safe's Aave position, then confirm the safe holds
+        // the full amount loose.
+        _withdrawShortfall(safe, fraxusd, amountToWithdraw, _getAvailableAmount(safe, fraxusd));
         _checkAmountAvailable(safe, fraxusd, amountToWithdraw);
 
         address[] memory to = new address[](2);
@@ -254,6 +279,9 @@ contract FraxModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardTransient,
         uint256 assetReceived = ERC20(outputAsset).balanceOf(safe) - assetBefore;
 
         if (assetReceived < minReceiveAmount) revert InsufficientReturnAmount();
+
+        // Re-supply the output as collateral when the gateway lists it; an unlisted output stays loose.
+        _resupplyToGateway(safe, outputAsset, assetReceived);
 
         emit Withdrawal(safe, outputAsset, amountToWithdraw, assetReceived);
     }

--- a/src/modules/hype/BeHYPEStakeModule.sol
+++ b/src/modules/hype/BeHYPEStakeModule.sol
@@ -7,7 +7,9 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import { ModuleBase } from "../ModuleBase.sol";
 import { ModuleCheckBalance } from "../ModuleCheckBalance.sol";
+import { ModuleLendGatewaySandwich } from "../ModuleLendGatewaySandwich.sol";
 import { IL2BeHYPEOAppStaker } from "../../interfaces/IL2BeHYPEOAppStaker.sol";
+import { ILendGateway } from "../../interfaces/ILendGateway.sol";
 import { IEtherFiSafe } from "../../interfaces/IEtherFiSafe.sol";
 import { IRoleRegistry } from "../../interfaces/IRoleRegistry.sol";
 
@@ -16,9 +18,11 @@ import { IRoleRegistry } from "../../interfaces/IRoleRegistry.sol";
  * @author ether.fi
  * @notice Module for staking WHYPE tokens to receive beHYPE through cross-chain messaging
  * @dev Extends ModuleBase to provide async staking functionality for Safes
- *      beHYPE tokens are delivered asynchronously via LayerZero to the safe
+ *      beHYPE tokens are delivered asynchronously via LayerZero to the safe. A gateway safe's WHYPE may be
+ *      supplied to Aave, so the stake withdraws any shortfall of the input from the safe's Aave position
+ *      first. There is no re-supply bookend because the beHYPE output arrives asynchronously, not in this call.
  */
-contract BeHYPEStakeModule is ModuleBase, ModuleCheckBalance {
+contract BeHYPEStakeModule is ModuleBase, ModuleCheckBalance, ModuleLendGatewaySandwich {
     using MessageHashUtils for bytes32;
 
     /// @notice Reference to the L2BeHYPEOAppStaker contract for staking operations
@@ -70,6 +74,16 @@ contract BeHYPEStakeModule is ModuleBase, ModuleCheckBalance {
         whype = _whype;
         beHYPE = _beHYPE;
         _getBeHYPEStakeModuleStorage().refundGasLimit = _refundGasLimit;
+    }
+
+    /// @dev Resolved live from the CashModule, the gateway address's single source of truth.
+    function gateway() public view override returns (ILendGateway) {
+        return cashModule.getLendGateway();
+    }
+
+    /// @dev The sandwich acts only for a safe whose assets live in Aave: on the gateway engine and not opted out.
+    function _lendActive(address safe) internal view override returns (bool) {
+        return cashModule.isLendActive(safe);
     }
 
     /**
@@ -134,6 +148,10 @@ contract BeHYPEStakeModule is ModuleBase, ModuleCheckBalance {
      */
     function _stake(address safe, uint256 amountToStake) internal {
         if (amountToStake == 0) revert InvalidInput();
+
+        // Pull any shortfall of the WHYPE input out of the safe's Aave position, then confirm the safe holds
+        // the full amount loose.
+        _withdrawShortfall(safe, whype, amountToStake, _getAvailableAmount(safe, whype));
         _checkAmountAvailable(safe, whype, amountToStake);
 
         uint256 quotedFee = staker.quoteStake(amountToStake, safe);

--- a/src/modules/hype/BeHYPEStakeModule.sol
+++ b/src/modules/hype/BeHYPEStakeModule.sol
@@ -9,7 +9,6 @@ import { ModuleBase } from "../ModuleBase.sol";
 import { ModuleCheckBalance } from "../ModuleCheckBalance.sol";
 import { ModuleLendGatewaySandwich } from "../ModuleLendGatewaySandwich.sol";
 import { IL2BeHYPEOAppStaker } from "../../interfaces/IL2BeHYPEOAppStaker.sol";
-import { ILendGateway } from "../../interfaces/ILendGateway.sol";
 import { IEtherFiSafe } from "../../interfaces/IEtherFiSafe.sol";
 import { IRoleRegistry } from "../../interfaces/IRoleRegistry.sol";
 
@@ -74,16 +73,6 @@ contract BeHYPEStakeModule is ModuleBase, ModuleCheckBalance, ModuleLendGatewayS
         whype = _whype;
         beHYPE = _beHYPE;
         _getBeHYPEStakeModuleStorage().refundGasLimit = _refundGasLimit;
-    }
-
-    /// @dev Resolved live from the CashModule, the gateway address's single source of truth.
-    function gateway() public view override returns (ILendGateway) {
-        return cashModule.getLendGateway();
-    }
-
-    /// @dev The sandwich acts only for a safe whose assets live in Aave: on the gateway engine and not opted out.
-    function _lendActive(address safe) internal view override returns (bool) {
-        return cashModule.isLendActive(safe);
     }
 
     /**

--- a/src/modules/midas/MidasModule.sol
+++ b/src/modules/midas/MidasModule.sol
@@ -7,17 +7,23 @@ import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/Mes
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
 import { IEtherFiSafe } from "../../interfaces/IEtherFiSafe.sol";
+import { ILendGateway } from "../../interfaces/ILendGateway.sol";
 import { IMidasVault } from "../../interfaces/IMidasVault.sol";
 import { ModuleBase } from "../ModuleBase.sol";
 import { ModuleCheckBalance } from "../ModuleCheckBalance.sol";
+import { ModuleLendGatewaySandwich } from "../ModuleLendGatewaySandwich.sol";
 
 /**
  * @title MidasModule
  * @author ether.fi
  * @notice Module for interacting with Midas Vaults
- * @dev Extends ModuleBase to provide Midas Vault integration for Safes
+ * @dev Extends ModuleBase to provide Midas Vault integration for Safes. A gateway safe's assets may be
+ *      supplied to Aave, so the deposit withdraws any shortfall of the input from the safe's Aave position
+ *      first and re-supplies the Midas-token output when the gateway lists it as a reserve. Withdraw pulls
+ *      any shortfall of the Midas token back from Aave, but has no re-supply bookend because the asset output
+ *      arrives asynchronously through the redemption vault, not in this call.
  */
-contract MidasModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardTransient {
+contract MidasModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardTransient, ModuleLendGatewaySandwich {
     using MessageHashUtils for bytes32;
     using SafeCast for uint256;
 
@@ -90,6 +96,16 @@ contract MidasModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardTransient
                 ++i;
             }
         }
+    }
+
+    /// @dev Resolved live from the CashModule, the gateway address's single source of truth.
+    function gateway() public view override returns (ILendGateway) {
+        return cashModule.getLendGateway();
+    }
+
+    /// @dev The sandwich acts only for a safe whose assets live in Aave: on the gateway engine and not opted out.
+    function _lendActive(address safe) internal view override returns (bool) {
+        return cashModule.isLendActive(safe);
     }
 
     /**
@@ -165,6 +181,10 @@ contract MidasModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardTransient
         if (depositVault == address(0)) revert UnsupportedMidasToken();
 
         uint256 scaledAmount = _scaleAmount(amount, asset, midasToken);
+
+        // Pull any shortfall of the input out of the safe's Aave position, then confirm the safe holds the
+        // full amount loose.
+        _withdrawShortfall(safe, asset, amount, _getAvailableAmount(safe, asset));
         _checkAmountAvailable(safe, asset, amount);
 
         uint256 midasTokenBefore = ERC20(midasToken).balanceOf(safe);
@@ -182,6 +202,9 @@ contract MidasModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardTransient
 
         uint256 midasTokenReceived = ERC20(midasToken).balanceOf(safe) - midasTokenBefore;
         if (midasTokenReceived < minReturnAmount) revert InsufficientReturnAmount();
+
+        // Re-supply the Midas-token output as collateral when the gateway lists it; an unlisted output stays loose.
+        _resupplyToGateway(safe, midasToken, midasTokenReceived);
 
         emit Deposit(safe, asset, amount, midasToken, midasTokenReceived);
     }
@@ -234,6 +257,10 @@ contract MidasModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardTransient
         address redemptionVault = vaultConfig.redemptionVault;
         if (redemptionVault == address(0)) revert UnsupportedMidasToken();
 
+        // Pull any shortfall of the Midas token out of the safe's Aave position, then confirm the safe holds
+        // the full amount loose. No re-supply bookend: the asset output arrives asynchronously via the
+        // redemption vault, not in this call.
+        _withdrawShortfall(safe, midasToken, amount, _getAvailableAmount(safe, midasToken));
         _checkAmountAvailable(safe, midasToken, amount);
 
         address[] memory to = new address[](2);

--- a/src/modules/midas/MidasModule.sol
+++ b/src/modules/midas/MidasModule.sol
@@ -7,7 +7,6 @@ import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/Mes
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
 import { IEtherFiSafe } from "../../interfaces/IEtherFiSafe.sol";
-import { ILendGateway } from "../../interfaces/ILendGateway.sol";
 import { IMidasVault } from "../../interfaces/IMidasVault.sol";
 import { ModuleBase } from "../ModuleBase.sol";
 import { ModuleCheckBalance } from "../ModuleCheckBalance.sol";
@@ -96,16 +95,6 @@ contract MidasModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardTransient
                 ++i;
             }
         }
-    }
-
-    /// @dev Resolved live from the CashModule, the gateway address's single source of truth.
-    function gateway() public view override returns (ILendGateway) {
-        return cashModule.getLendGateway();
-    }
-
-    /// @dev The sandwich acts only for a safe whose assets live in Aave: on the gateway engine and not opted out.
-    function _lendActive(address safe) internal view override returns (bool) {
-        return cashModule.isLendActive(safe);
     }
 
     /**

--- a/src/modules/openocean-swap/OpenOceanSwapModule.sol
+++ b/src/modules/openocean-swap/OpenOceanSwapModule.sol
@@ -6,7 +6,6 @@ import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/Mes
 
 import {OpenOceanSwapDescription, IOpenOceanCaller, IOpenOceanRouter} from "../../interfaces/IOpenOcean.sol";
 import { IEtherFiSafe } from "../../interfaces/IEtherFiSafe.sol";
-import { ILendGateway } from "../../interfaces/ILendGateway.sol";
 import { ModuleBase } from "../ModuleBase.sol";
 import { ModuleCheckBalance } from "../ModuleCheckBalance.sol";
 import { ModuleLendGatewaySandwich } from "../ModuleLendGatewaySandwich.sol";
@@ -55,16 +54,6 @@ contract OpenOceanSwapModule is ModuleBase, ModuleCheckBalance, ModuleLendGatewa
      */
     constructor(address _swapRouter, address _dataProvider) ModuleBase(_dataProvider) ModuleCheckBalance(_dataProvider) {
         swapRouter = _swapRouter;
-    }
-
-    /// @dev Resolved live from the CashModule, the gateway address's single source of truth.
-    function gateway() public view override returns (ILendGateway) {
-        return cashModule.getLendGateway();
-    }
-
-    /// @dev The sandwich acts only for a safe whose assets live in Aave: on the gateway engine and not opted out.
-    function _lendActive(address safe) internal view override returns (bool) {
-        return cashModule.isLendActive(safe);
     }
 
     /**

--- a/test/safe/modules/ModuleLendGatewaySandwich.t.sol
+++ b/test/safe/modules/ModuleLendGatewaySandwich.t.sol
@@ -5,7 +5,15 @@ import { Test } from "forge-std/Test.sol";
 
 import { ILendGateway } from "../../../src/interfaces/ILendGateway.sol";
 import { MockLendGateway } from "../../../src/mocks/MockLendGateway.sol";
+import { ModuleCheckBalance } from "../../../src/modules/ModuleCheckBalance.sol";
 import { ModuleLendGatewaySandwich } from "../../../src/modules/ModuleLendGatewaySandwich.sol";
+
+/// @dev Satisfies the ModuleCheckBalance constructor; the harness overrides everything that touches cashModule.
+contract MockDataProvider {
+    function getCashModule() external pure returns (address) {
+        return address(1);
+    }
+}
 
 /// @notice Exposes the base's internal bookends so they can be called directly in tests
 contract SandwichHarness is ModuleLendGatewaySandwich {
@@ -15,7 +23,7 @@ contract SandwichHarness is ModuleLendGatewaySandwich {
     /// @dev A real consumer computes this from cashModule.isLendActive; the harness sets it directly (defaults on).
     bool public lendActive = true;
 
-    constructor(address _gateway) {
+    constructor(address _gateway, address _dataProvider) ModuleCheckBalance(_dataProvider) {
         mockGateway = ILendGateway(_gateway);
     }
 
@@ -50,7 +58,7 @@ contract ModuleLendGatewaySandwichTest is Test {
 
     function setUp() public {
         gateway = new MockLendGateway();
-        harness = new SandwichHarness(address(gateway));
+        harness = new SandwichHarness(address(gateway), address(new MockDataProvider()));
     }
 
     // The withdraw bookend routes to the safe and does not guard health; Aave guards the withdraw itself.

--- a/test/safe/modules/cash/lend/BeHYPEStakeGateway.t.sol
+++ b/test/safe/modules/cash/lend/BeHYPEStakeGateway.t.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+
+import { IL2BeHYPEOAppStaker } from "../../../../../src/interfaces/IL2BeHYPEOAppStaker.sol";
+import { MockERC20 } from "../../../../../src/mocks/MockERC20.sol";
+import { BeHYPEStakeModule } from "../../../../../src/modules/hype/BeHYPEStakeModule.sol";
+import { CashGatewayTestSetup } from "./CashGatewayTestSetup.t.sol";
+
+/// @dev Staker stub: pulls the WHYPE it is approved for and escrows it. beHYPE is delivered asynchronously on
+///      the real staker, so the stub mints nothing back — matching the module having no re-supply bookend.
+contract MockBeHYPEStaker is IL2BeHYPEOAppStaker {
+    IERC20 internal immutable whype;
+
+    constructor(address _whype) {
+        whype = IERC20(_whype);
+    }
+
+    function quoteStake(uint256, address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function stake(uint256 hypeAmountIn, address) external payable {
+        whype.transferFrom(msg.sender, address(this), hypeAmountIn);
+    }
+}
+
+/**
+ * @title BeHYPEStakeGatewayTest
+ * @notice Exercises the beHYPE stake module's Aave sandwich against the real LendGateway: the WHYPE input is
+ *         supplied to Aave, so the module withdraws it back before staking. There is no re-supply bookend
+ *         because beHYPE arrives asynchronously via LayerZero, not in the call. The staker is a stub; the
+ *         gateway and Aave are real.
+ */
+contract BeHYPEStakeGatewayTest is CashGatewayTestSetup {
+    using MessageHashUtils for bytes32;
+
+    BeHYPEStakeModule internal stakeModule;
+    MockBeHYPEStaker internal staker;
+    MockERC20 internal whype;
+    MockERC20 internal beHYPE;
+
+    function setUp() public override {
+        super.setUp();
+
+        whype = new MockERC20("Wrapped HYPE", "WHYPE", 18);
+        beHYPE = new MockERC20("ether.fi HYPE", "beHYPE", 18);
+
+        // WHYPE is a listed reserve so the sandwich can pull a supplied WHYPE input back out of Aave ($1-priced).
+        uint256 whypeReserveId = _addAaveReserve(address(whype), usdcUsdOracle, 8000, false);
+
+        staker = new MockBeHYPEStaker(address(whype));
+
+        stakeModule = new BeHYPEStakeModule(address(dataProvider), address(staker), address(whype), address(beHYPE), 100_000);
+        _enableModule(address(stakeModule));
+
+        vm.startPrank(owner);
+        gw.setReserveId(address(whype), whypeReserveId);
+        // The sandwich drives gateway withdraw / supply on the safe's behalf, so it must be an authorized driver.
+        gw.setDriver(address(stakeModule), true);
+        vm.stopPrank();
+    }
+
+    // A stake sources its WHYPE input entirely from Aave: the module withdraws the supplied WHYPE and stakes it.
+    // beHYPE is async, so nothing is re-supplied; the safe simply holds no loose WHYPE after.
+    function test_stake_sourcesWhypeFromAave() public {
+        uint256 amount = 100e18;
+        _supplyToGateway(address(safe), address(whype), amount);
+        uint256 whypeSuppliedBefore = gw.suppliedOf(address(safe), address(whype));
+
+        stakeModule.stake(address(safe), amount, owner1, _stakeSig(amount));
+
+        assertEq(gw.suppliedOf(address(safe), address(whype)), whypeSuppliedBefore - amount, "WHYPE not withdrawn from Aave");
+        assertEq(whype.balanceOf(address(safe)), 0, "WHYPE left loose in safe");
+        assertEq(whype.balanceOf(address(staker)), amount, "WHYPE not staked");
+    }
+
+    // A legacy safe has not opted out yet must not touch Aave: its loose WHYPE is staked directly.
+    function test_stake_legacySafe_doesNotTouchAave() public {
+        _forceLegacyEngine(address(safe));
+        assertFalse(cashModule.isLendActive(address(safe)), "fixture: a legacy safe is not lend-active");
+
+        uint256 amount = 100e18;
+        deal(address(whype), address(safe), amount);
+
+        stakeModule.stake(address(safe), amount, owner1, _stakeSig(amount));
+
+        assertEq(gw.suppliedOf(address(safe), address(whype)), 0, "must not touch Aave for a legacy safe");
+        assertEq(whype.balanceOf(address(staker)), amount, "WHYPE not staked");
+    }
+
+    function _stakeSig(uint256 amount) internal view returns (bytes memory) {
+        bytes32 digestHash = keccak256(abi.encodePacked(stakeModule.STAKE_SIG(), block.chainid, address(stakeModule), stakeModule.getNonce(address(safe)), address(safe), abi.encode(amount))).toEthSignedMessageHash();
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Pk, digestHash);
+        return abi.encodePacked(r, s, v);
+    }
+}

--- a/test/safe/modules/cash/lend/EtherFiStakeGateway.t.sol
+++ b/test/safe/modules/cash/lend/EtherFiStakeGateway.t.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+
+import { IL2SyncPool } from "../../../../../src/interfaces/IL2SyncPool.sol";
+import { EtherFiStakeModule } from "../../../../../src/modules/etherfi/EtherFiStakeModule.sol";
+import { CashGatewayTestSetup } from "./CashGatewayTestSetup.t.sol";
+
+/// @dev Sync pool stub: returns weETH 1:1 to the staking safe (pre-funded with weETH in setUp), keeping the
+///      ETH sent by the module. Enough to drive the sandwich without the real L2 staking mechanics.
+contract MockSyncPool is IL2SyncPool {
+    IERC20 internal immutable weETH;
+
+    constructor(address _weETH) {
+        weETH = IERC20(_weETH);
+    }
+
+    function deposit(address, uint256 amountIn, uint256) external payable returns (uint256) {
+        weETH.transfer(msg.sender, amountIn);
+        return amountIn;
+    }
+
+    receive() external payable { }
+}
+
+/**
+ * @title EtherFiStakeGatewayTest
+ * @notice Exercises the stake module's Aave sandwich against the real LendGateway: the WETH input is supplied
+ *         to Aave, so the module withdraws it back, stakes through the (stubbed) sync pool, and re-supplies the
+ *         weETH output as collateral. The sync pool is a stub; the gateway and Aave are real.
+ */
+contract EtherFiStakeGatewayTest is CashGatewayTestSetup {
+    using MessageHashUtils for bytes32;
+
+    EtherFiStakeModule internal stakeModule;
+    MockSyncPool internal syncPool;
+    address internal weth;
+
+    function setUp() public override {
+        super.setUp();
+
+        weth = chainConfig.weth;
+
+        // WETH is a listed reserve so the sandwich can pull a supplied WETH input back out of Aave.
+        uint256 wethReserveId = _addAaveReserve(weth, ethUsdcOracle, 8000, false);
+
+        syncPool = new MockSyncPool(address(weETH));
+        deal(address(weETH), address(syncPool), 100 ether);
+
+        stakeModule = new EtherFiStakeModule(address(dataProvider), address(syncPool), weth, address(weETH));
+        _enableModule(address(stakeModule));
+
+        vm.startPrank(owner);
+        gw.setReserveId(weth, wethReserveId);
+        // The sandwich drives gateway withdraw / supply on the safe's behalf, so it must be an authorized driver.
+        gw.setDriver(address(stakeModule), true);
+        vm.stopPrank();
+    }
+
+    // A stake sources its WETH input entirely from Aave: the module withdraws the supplied WETH, stakes it, and
+    // re-supplies the weETH output as collateral. Nothing is left loose in the safe.
+    function test_deposit_sourcesWethFromAaveAndResuppliesWeETH() public {
+        uint256 amount = 1 ether;
+        _supplyToGateway(address(safe), weth, amount);
+
+        uint256 wethSuppliedBefore = gw.suppliedOf(address(safe), weth);
+        uint256 weethSuppliedBefore = gw.suppliedOf(address(safe), address(weETH));
+
+        stakeModule.deposit(address(safe), weth, amount, amount, owner1, _depositSig(weth, amount, amount));
+
+        assertEq(gw.suppliedOf(address(safe), weth), wethSuppliedBefore - amount, "WETH not withdrawn from Aave");
+        assertEq(gw.suppliedOf(address(safe), address(weETH)), weethSuppliedBefore + amount, "weETH output not re-supplied");
+        assertEq(IERC20(weth).balanceOf(address(safe)), 0, "WETH left loose in safe");
+        assertEq(weETH.balanceOf(address(safe)), 0, "weETH output left loose in safe");
+    }
+
+    // The sandwich is engine-gated, not opt-out-gated: a legacy safe has not opted out, yet its stake must not
+    // touch Aave — the weETH output stays loose where the DebtManager can see it.
+    function test_deposit_legacySafe_outputStaysLoose() public {
+        _forceLegacyEngine(address(safe));
+        assertFalse(cashModule.isLendActive(address(safe)), "fixture: a legacy safe is not lend-active");
+
+        uint256 amount = 1 ether;
+        deal(weth, address(safe), amount);
+
+        stakeModule.deposit(address(safe), weth, amount, amount, owner1, _depositSig(weth, amount, amount));
+
+        assertEq(weETH.balanceOf(address(safe)), amount, "weETH output must stay loose in the safe");
+        assertEq(gw.suppliedOf(address(safe), address(weETH)), 0, "weETH output must not be supplied to Aave");
+    }
+
+    function _depositSig(address assetToDeposit, uint256 amount, uint256 minReturn) internal view returns (bytes memory) {
+        bytes32 digestHash = keccak256(abi.encodePacked(stakeModule.DEPOSIT_SIG(), block.chainid, address(stakeModule), stakeModule.getNonce(address(safe)), address(safe), abi.encode(assetToDeposit, amount, minReturn))).toEthSignedMessageHash();
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Pk, digestHash);
+        return abi.encodePacked(r, s, v);
+    }
+}

--- a/test/safe/modules/cash/lend/FraxGateway.t.sol
+++ b/test/safe/modules/cash/lend/FraxGateway.t.sol
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+
+import { IFraxCustodian } from "../../../../../src/interfaces/IFraxCustodian.sol";
+import { MockERC20 } from "../../../../../src/mocks/MockERC20.sol";
+import { FraxModule } from "../../../../../src/modules/frax/FraxModule.sol";
+import { CashGatewayTestSetup } from "./CashGatewayTestSetup.t.sol";
+
+/// @dev Custodian stub: deposit pulls the 6-decimal asset and mints 18-decimal fraxUSD 1:1e12; redeem burns
+///      fraxUSD and returns the asset (pre-funded in setUp). Enough to drive the sandwich without the real
+///      Frax custodian's mint-cap / cross-chain mechanics.
+contract MockFraxCustodian is IFraxCustodian {
+    MockERC20 internal immutable fraxusd;
+    IERC20 internal immutable asset;
+
+    constructor(address _fraxusd, address _asset) {
+        fraxusd = MockERC20(_fraxusd);
+        asset = IERC20(_asset);
+    }
+
+    function deposit(uint256 amountIn, address receiver) external payable returns (uint256) {
+        asset.transferFrom(receiver, address(this), amountIn);
+        uint256 shares = amountIn * 1e12;
+        fraxusd.mint(receiver, shares);
+        return shares;
+    }
+
+    function redeem(uint256 sharesIn, address receiver, address owner) external returns (uint256) {
+        fraxusd.transferFrom(owner, address(this), sharesIn);
+        uint256 amountOut = sharesIn / 1e12;
+        asset.transfer(receiver, amountOut);
+        return amountOut;
+    }
+}
+
+/**
+ * @title FraxGatewayTest
+ * @notice Exercises the Frax module's Aave sandwich against the real LendGateway: the synchronous deposit and
+ *         withdraw source their input from Aave and re-supply the output as collateral. The custodian is a
+ *         stub; the gateway and Aave are real. The async withdraw leg rides the Cash withdrawal flow (sourced
+ *         elsewhere) and is not covered here.
+ */
+contract FraxGatewayTest is CashGatewayTestSetup {
+    using MessageHashUtils for bytes32;
+
+    FraxModule internal fraxModule;
+    MockFraxCustodian internal custodian;
+    MockERC20 internal fraxusd;
+
+    function setUp() public override {
+        super.setUp();
+
+        fraxusd = new MockERC20("Frax USD", "frxUSD", 18);
+
+        // fraxUSD is a listed reserve so the deposit can re-supply it and the withdraw can pull it back ($1-priced).
+        uint256 fraxReserveId = _addAaveReserve(address(fraxusd), usdcUsdOracle, 8000, false);
+
+        custodian = new MockFraxCustodian(address(fraxusd), address(usdc));
+        // Seed the custodian: fraxUSD to clear the module's synchronous-deposit balance check, USDC to pay redeems.
+        fraxusd.mint(address(custodian), 1_000_000e18);
+        deal(address(usdc), address(custodian), 1_000_000e6);
+
+        fraxModule = new FraxModule(address(dataProvider), address(fraxusd), address(custodian), makeAddr("remoteHop"));
+        _enableModule(address(fraxModule));
+
+        vm.startPrank(owner);
+        gw.setReserveId(address(fraxusd), fraxReserveId);
+        // The sandwich drives gateway withdraw / supply on the safe's behalf, so it must be an authorized driver.
+        gw.setDriver(address(fraxModule), true);
+        vm.stopPrank();
+    }
+
+    // A deposit sources its USDC input from Aave and re-supplies the fraxUSD output as collateral.
+    function test_deposit_sourcesUsdcFromAaveAndResuppliesFraxUsd() public {
+        uint256 amount = 1000e6;
+        _supplyToGateway(address(safe), address(usdc), amount);
+        uint256 usdcSuppliedBefore = gw.suppliedOf(address(safe), address(usdc));
+
+        uint256 minReturn = amount * 1e12;
+        fraxModule.deposit(address(safe), address(usdc), amount, minReturn, owner1, _depositSig(address(usdc), amount, minReturn));
+
+        assertEq(gw.suppliedOf(address(safe), address(usdc)), usdcSuppliedBefore - amount, "USDC not withdrawn from Aave");
+        assertEq(gw.suppliedOf(address(safe), address(fraxusd)), minReturn, "fraxUSD output not re-supplied");
+        assertEq(usdc.balanceOf(address(safe)), 0, "USDC left loose in safe");
+        assertEq(fraxusd.balanceOf(address(safe)), 0, "fraxUSD output left loose in safe");
+    }
+
+    // A withdraw sources its fraxUSD input from Aave and re-supplies the USDC output as collateral.
+    function test_withdraw_sourcesFraxUsdFromAaveAndResuppliesUsdc() public {
+        uint128 shares = 1000e18;
+        _supplyToGateway(address(safe), address(fraxusd), shares);
+        uint256 usdcSuppliedBefore = gw.suppliedOf(address(safe), address(usdc));
+
+        uint256 minReceive = uint256(shares) / 1e12;
+        fraxModule.withdraw(address(safe), shares, address(usdc), minReceive, owner1, _withdrawSig(shares, address(usdc), minReceive));
+
+        assertEq(gw.suppliedOf(address(safe), address(fraxusd)), 0, "fraxUSD not withdrawn from Aave");
+        assertEq(gw.suppliedOf(address(safe), address(usdc)), usdcSuppliedBefore + minReceive, "USDC output not re-supplied");
+        assertEq(fraxusd.balanceOf(address(safe)), 0, "fraxUSD left loose in safe");
+        assertEq(usdc.balanceOf(address(safe)), 0, "USDC output left loose in safe");
+    }
+
+    // A legacy safe has not opted out yet must not touch Aave: the fraxUSD output stays loose.
+    function test_deposit_legacySafe_outputStaysLoose() public {
+        _forceLegacyEngine(address(safe));
+        assertFalse(cashModule.isLendActive(address(safe)), "fixture: a legacy safe is not lend-active");
+
+        uint256 amount = 1000e6;
+        deal(address(usdc), address(safe), amount);
+
+        uint256 minReturn = amount * 1e12;
+        fraxModule.deposit(address(safe), address(usdc), amount, minReturn, owner1, _depositSig(address(usdc), amount, minReturn));
+
+        assertEq(fraxusd.balanceOf(address(safe)), minReturn, "fraxUSD output must stay loose in the safe");
+        assertEq(gw.suppliedOf(address(safe), address(fraxusd)), 0, "fraxUSD output must not be supplied to Aave");
+    }
+
+    function _depositSig(address asset, uint256 amount, uint256 minReturn) internal view returns (bytes memory) {
+        bytes32 digestHash = keccak256(abi.encodePacked(fraxModule.DEPOSIT_SIG(), block.chainid, address(fraxModule), fraxModule.getNonce(address(safe)), address(safe), abi.encode(asset, amount, minReturn))).toEthSignedMessageHash();
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Pk, digestHash);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function _withdrawSig(uint128 amount, address outputAsset, uint256 minReceive) internal view returns (bytes memory) {
+        bytes32 digestHash = keccak256(abi.encodePacked(fraxModule.WITHDRAW_SIG(), block.chainid, address(fraxModule), fraxModule.getNonce(address(safe)), address(safe), abi.encode(amount, outputAsset, minReceive))).toEthSignedMessageHash();
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Pk, digestHash);
+        return abi.encodePacked(r, s, v);
+    }
+}

--- a/test/safe/modules/cash/lend/MidasGateway.t.sol
+++ b/test/safe/modules/cash/lend/MidasGateway.t.sol
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+
+import { IMidasVault } from "../../../../../src/interfaces/IMidasVault.sol";
+import { MockERC20 } from "../../../../../src/mocks/MockERC20.sol";
+import { MidasModule } from "../../../../../src/modules/midas/MidasModule.sol";
+import { CashGatewayTestSetup } from "./CashGatewayTestSetup.t.sol";
+
+/// @dev Midas vault stub (deposit + redemption in one): depositInstant pulls the approved asset and mints the
+///      18-decimal midas token; redeemRequest escrows the midas token and returns nothing (async redemption on
+///      the real vault). Enough to drive the sandwich without the real Midas mechanics.
+contract MockMidasVault is IMidasVault {
+    MockERC20 internal immutable midasToken;
+
+    constructor(address _midasToken) {
+        midasToken = MockERC20(_midasToken);
+    }
+
+    function depositInstant(address tokenIn, uint256 amountToken, uint256, bytes32) external {
+        uint256 pull = IERC20(tokenIn).allowance(msg.sender, address(this));
+        IERC20(tokenIn).transferFrom(msg.sender, address(this), pull);
+        midasToken.mint(msg.sender, amountToken);
+    }
+
+    function redeemInstant(address, uint256, uint256) external { }
+
+    function redeemRequest(address, uint256 amountMTokenIn, address) external returns (uint256) {
+        midasToken.transferFrom(msg.sender, address(this), amountMTokenIn);
+        return 0;
+    }
+}
+
+/**
+ * @title MidasGatewayTest
+ * @notice Exercises the Midas module's Aave sandwich against the real LendGateway: the deposit sources its
+ *         asset from Aave and re-supplies the midas-token output as collateral; the withdraw pulls the supplied
+ *         midas token back for the async redemption request (no re-supply, since the asset arrives later). The
+ *         vault is a stub; the gateway and Aave are real.
+ */
+contract MidasGatewayTest is CashGatewayTestSetup {
+    using MessageHashUtils for bytes32;
+
+    MidasModule internal midasModule;
+    MockMidasVault internal vault;
+    MockERC20 internal midasToken;
+
+    function setUp() public override {
+        super.setUp();
+
+        midasToken = new MockERC20("Midas mToken", "mTKN", 18);
+
+        // The midas token is a listed reserve so the deposit can re-supply it and the withdraw can pull it back.
+        uint256 midasReserveId = _addAaveReserve(address(midasToken), usdcUsdOracle, 8000, false);
+
+        vault = new MockMidasVault(address(midasToken));
+
+        address[] memory midasTokens = _addr1(address(midasToken));
+        address[] memory depositVaults = _addr1(address(vault));
+        address[] memory redemptionVaults = _addr1(address(vault));
+        midasModule = new MidasModule(address(dataProvider), midasTokens, depositVaults, redemptionVaults);
+        _enableModule(address(midasModule));
+
+        vm.startPrank(owner);
+        gw.setReserveId(address(midasToken), midasReserveId);
+        // The sandwich drives gateway withdraw / supply on the safe's behalf, so it must be an authorized driver.
+        gw.setDriver(address(midasModule), true);
+        vm.stopPrank();
+    }
+
+    // A deposit sources its USDC input from Aave and re-supplies the midas-token output as collateral.
+    function test_deposit_sourcesUsdcFromAaveAndResuppliesMidasToken() public {
+        uint256 amount = 1000e6;
+        _supplyToGateway(address(safe), address(usdc), amount);
+        uint256 usdcSuppliedBefore = gw.suppliedOf(address(safe), address(usdc));
+
+        uint256 minReturn = amount * 1e12; // 6-decimal USDC -> 18-decimal midas token
+        midasModule.deposit(address(safe), address(usdc), address(midasToken), amount, minReturn, owner1, _depositSig(address(usdc), amount, minReturn));
+
+        assertEq(gw.suppliedOf(address(safe), address(usdc)), usdcSuppliedBefore - amount, "USDC not withdrawn from Aave");
+        assertEq(gw.suppliedOf(address(safe), address(midasToken)), minReturn, "midas token output not re-supplied");
+        assertEq(usdc.balanceOf(address(safe)), 0, "USDC left loose in safe");
+        assertEq(midasToken.balanceOf(address(safe)), 0, "midas token output left loose in safe");
+    }
+
+    // A withdraw pulls the supplied midas token back out of Aave for the async redemption request. The asset
+    // output arrives later through the vault, so nothing is re-supplied here.
+    function test_withdraw_pullsSuppliedMidasTokenForRequest() public {
+        uint128 amount = 500e18;
+        _supplyToGateway(address(safe), address(midasToken), amount);
+
+        midasModule.withdraw(address(safe), address(midasToken), amount, address(usdc), owner1, _withdrawSig(address(midasToken), amount, address(usdc)));
+
+        assertEq(gw.suppliedOf(address(safe), address(midasToken)), 0, "midas token not withdrawn from Aave");
+        assertEq(midasToken.balanceOf(address(vault)), amount, "midas token not escrowed for the redemption request");
+        assertEq(midasToken.balanceOf(address(safe)), 0, "midas token left loose in safe");
+    }
+
+    // A legacy safe has not opted out yet must not touch Aave: the midas-token output stays loose.
+    function test_deposit_legacySafe_outputStaysLoose() public {
+        _forceLegacyEngine(address(safe));
+        assertFalse(cashModule.isLendActive(address(safe)), "fixture: a legacy safe is not lend-active");
+
+        uint256 amount = 1000e6;
+        deal(address(usdc), address(safe), amount);
+
+        uint256 minReturn = amount * 1e12;
+        midasModule.deposit(address(safe), address(usdc), address(midasToken), amount, minReturn, owner1, _depositSig(address(usdc), amount, minReturn));
+
+        assertEq(midasToken.balanceOf(address(safe)), minReturn, "midas token output must stay loose in the safe");
+        assertEq(gw.suppliedOf(address(safe), address(midasToken)), 0, "midas token output must not be supplied to Aave");
+    }
+
+    function _depositSig(address asset, uint256 amount, uint256 minReturn) internal view returns (bytes memory) {
+        bytes32 digestHash = keccak256(abi.encodePacked(midasModule.DEPOSIT_SIG(), block.chainid, address(midasModule), midasModule.getNonce(address(safe)), address(safe), abi.encode(asset, address(midasToken), amount, minReturn))).toEthSignedMessageHash();
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Pk, digestHash);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function _withdrawSig(address midasToken_, uint128 amount, address asset) internal view returns (bytes memory) {
+        bytes32 digestHash = keccak256(abi.encodePacked(midasModule.WITHDRAW_SIG(), block.chainid, address(midasModule), midasModule.getNonce(address(safe)), address(safe), abi.encode(midasToken_, amount, asset))).toEthSignedMessageHash();
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Pk, digestHash);
+        return abi.encodePacked(r, s, v);
+    }
+}

--- a/test/safe/modules/cash/lend/StargateGateway.t.sol
+++ b/test/safe/modules/cash/lend/StargateGateway.t.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+
+import { WithdrawalRequest } from "../../../../../src/interfaces/ICashModule.sol";
+import { StargateModule } from "../../../../../src/modules/stargate/StargateModule.sol";
+import { CashGatewayTestSetup } from "./CashGatewayTestSetup.t.sol";
+
+/**
+ * @title StargateGatewayTest
+ * @notice Coverage-only: the Stargate module needs no Aave sandwich. requestBridge routes through
+ *         cashModule.requestWithdrawalByModule, and the Cash withdrawal flow already sources a supplied
+ *         balance out of Aave (CashLendLib.sourceWithdrawal) before the pending withdrawal is recorded. This
+ *         proves a bridge request on a lend-active safe pulls the supplied asset back into the safe with no
+ *         module-side change. Wormhole shares the same withdrawal-flow path and is covered by the same
+ *         argument. No bridge is executed here (that needs the real Stargate endpoint); only the sourcing at
+ *         request time is asserted.
+ */
+contract StargateGatewayTest is CashGatewayTestSetup {
+    using MessageHashUtils for bytes32;
+
+    StargateModule internal stargateModule;
+    uint32 internal mainnetDestEid = 30_101;
+    uint256 internal maxSlippage = 50;
+    address internal destRecipientAddr = makeAddr("destRecipient");
+
+    function setUp() public override {
+        vm.skip(getChainConfig().stargateUsdcPool == address(0));
+        super.setUp();
+
+        address[] memory assets = _addr1(address(usdc));
+        StargateModule.AssetConfig[] memory assetConfigs = new StargateModule.AssetConfig[](1);
+        assetConfigs[0] = StargateModule.AssetConfig({ isOFT: false, pool: chainConfig.stargateUsdcPool });
+
+        stargateModule = new StargateModule(assets, assetConfigs, address(dataProvider));
+        _enableModule(address(stargateModule));
+
+        // The bridge request creates a Cash withdrawal on the module's behalf, so it must be allowed to do so.
+        vm.prank(owner);
+        cashModule.configureModulesCanRequestWithdraw(_addr1(address(stargateModule)), _bool1(true));
+    }
+
+    // A bridge request on a lend-active safe whose USDC is supplied to Aave: the withdrawal flow sources the
+    // supplied balance back into the safe, so the pending bridge withdrawal is covered without any sandwich.
+    function test_requestBridge_sourcesSuppliedBalanceFromAave() public {
+        uint256 amount = 100e6;
+        _supplyToGateway(address(safe), address(usdc), amount);
+
+        uint256 usdcSuppliedBefore = gw.suppliedOf(address(safe), address(usdc));
+        assertEq(usdc.balanceOf(address(safe)), 0, "fixture: USDC supplied, none loose");
+
+        (address[] memory signers, bytes[] memory signatures) = _getSignatures(mainnetDestEid, address(usdc), amount, destRecipientAddr, maxSlippage);
+        stargateModule.requestBridge(address(safe), mainnetDestEid, address(usdc), amount, destRecipientAddr, maxSlippage, signers, signatures);
+
+        // Sourced out of Aave into the safe, held loose to back the pending bridge withdrawal.
+        assertEq(gw.suppliedOf(address(safe), address(usdc)), usdcSuppliedBefore - amount, "supplied USDC not sourced from Aave");
+        assertEq(usdc.balanceOf(address(safe)), amount, "sourced USDC not held loose for the withdrawal");
+
+        WithdrawalRequest memory request = cashModule.getData(address(safe)).pendingWithdrawalRequest;
+        assertEq(request.tokens[0], address(usdc), "withdrawal asset mismatch");
+        assertEq(request.amounts[0], amount, "withdrawal amount mismatch");
+        assertEq(request.recipient, address(stargateModule), "withdrawal recipient must be the module");
+    }
+
+    function _getSignatures(uint32 destEid, address asset, uint256 amount, address destRecipient, uint256 maxSlippageInBps) internal view returns (address[] memory, bytes[] memory) {
+        bytes32 digestHash = keccak256(abi.encodePacked(stargateModule.REQUEST_BRIDGE_SIG(), block.chainid, address(stargateModule), safe.nonce(), address(safe), abi.encode(destEid, asset, amount, destRecipient, maxSlippageInBps))).toEthSignedMessageHash();
+
+        address[] memory signers = new address[](2);
+        signers[0] = owner1;
+        signers[1] = owner2;
+
+        bytes[] memory signatures = new bytes[](2);
+        (uint8 v1, bytes32 r1, bytes32 s1) = vm.sign(owner1Pk, digestHash);
+        signatures[0] = abi.encodePacked(r1, s1, v1);
+        (uint8 v2, bytes32 r2, bytes32 s2) = vm.sign(owner2Pk, digestHash);
+        signatures[1] = abi.encodePacked(r2, s2, v2);
+
+        return (signers, signatures);
+    }
+}

--- a/test/safe/modules/frax/FraxVerifyBytecode.t.sol
+++ b/test/safe/modules/frax/FraxVerifyBytecode.t.sol
@@ -20,6 +20,9 @@ contract FraxVerifyBytecode is ContractCodeChecker, Test {
     }
 
     function test_fraxModule_verifyBytecode() public {
+        // FraxModule gains the Aave sandwich for Lend, so its bytecode no longer matches the deployed
+        // pre-Lend implementation. Re-enable after the Lend deployment.
+        vm.skip(true);
         FraxModule fraxModule = new FraxModule(dataProvider, fraxusd, custodian, remoteHop);
 
         console.log("-------------- FraxModule ----------------");

--- a/test/safe/modules/midas/MidasVerifyBytecode.t.sol
+++ b/test/safe/modules/midas/MidasVerifyBytecode.t.sol
@@ -20,6 +20,9 @@ contract MidasVerifyBytecode is ContractCodeChecker, Test {
     }
 
     function test_midasModule_verifyBytecode() public {
+        // MidasModule gains the Aave sandwich for Lend, so its bytecode no longer matches the deployed
+        // pre-Lend implementation. Re-enable after the Lend deployment.
+        vm.skip(true);
         address[] memory midasTokens = new address[](1);
         midasTokens[0] = midasToken;
 

--- a/test/upgrade-bytecode-verification/VerifyOPMainnet.t.sol
+++ b/test/upgrade-bytecode-verification/VerifyOPMainnet.t.sol
@@ -330,11 +330,17 @@ contract VerifyOPMainnetBytecode is ContractCodeChecker, Utils {
     }
 
     function test_verifyBytecode_FraxModule() public {
+        // FraxModule gains the Aave sandwich for Lend, so its bytecode no longer matches the deployed
+        // pre-Lend OP implementation. Re-enable after the Lend deployment.
+        vm.skip(true);
         address local = address(new FraxModule(dataProviderProxy, cc.fraxusd, cc.fraxCustodian, cc.fraxRemoteHop));
         _verify("FraxModule", fraxModule, local);
     }
 
     function test_verifyBytecode_EtherFiStakeModule() public {
+        // EtherFiStakeModule gains the Aave sandwich for Lend, so its bytecode no longer matches the deployed
+        // pre-Lend OP implementation. Re-enable after the Lend deployment.
+        vm.skip(true);
         address local = address(new EtherFiStakeModule(dataProviderProxy, cc.syncPool, cc.weth, cc.weETH));
         _verify("EtherFiStakeModule", etherFiStakeModule, local);
     }


### PR DESCRIPTION
## What

Wire the shared `ModuleLendGatewaySandwich` helper into the remaining asset-moving modules, so they keep working when a lend-active safe's assets live in Aave. Same pattern as the swap module (#177) and the Liquid modules.

- **EtherFiStakeModule.deposit** — withdraw the WETH input from Aave, stake, re-supply weETH. ETH input is a no-op (not a reserve).
- **BeHYPEStakeModule.stake** — withdraw the WHYPE input. No re-supply: beHYPE is delivered asynchronously via LayerZero.
- **FraxModule.deposit / withdraw** — sandwich both synchronous legs. The async withdraw leg rides the Cash withdrawal flow (already sourced) and is untouched.
- **MidasModule.deposit / withdraw** — deposit re-supplies the midas-token output; withdraw pulls the supplied midas token back for the async redemption request, no re-supply (the asset arrives later).

## Why

Auto-supply leaves a supplied asset in the safe's Aave position, not loose in the safe, so a module that pulls loose funds finds nothing. The sandwich withdraws the input from Aave, runs the action, and re-supplies any synchronous output as collateral.

## Decisions worth a look

- **Stargate and Wormhole get no code change.** `requestBridge` routes through `cashModule.requestWithdrawalByModule`, and the Cash withdrawal flow already sources supplied funds out of Aave via `CashLendLib.sourceWithdrawal`. Added a coverage test proving it; Wormhole is covered by the same argument.
- **AaveV3Module left out of scope.** Pulling Aave v4 collateral to supply Aave v3 is a product call, not something to wire silently.
- **Async output legs get a front bookend only** (BeHYPE stake, Midas withdraw), since there is no synchronous output to re-supply.

## Testing

- 5 fork test files under `test/safe/modules/cash/lend/` mirroring `EtherFiLiquidGateway` / `OpenOceanSwapGateway`, against the real LendGateway + Aave. Each mocks its external protocol (Midas and BeHYPE have no Optimism deployment, so mocks run uniformly): input sourced from Aave, output re-supplied (or not, for async), and a legacy-safe no-touch guard.
- The four modules' existing unit tests still pass (Midas skips on Optimism, as before).

## Note

Modules are immutable (constructor-wired), so this implies redeploying them, same as #177.

Closes COR-1084

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how multiple immutable modules move user collateral through the LendGateway/Aave path; mistakes could strand assets or break legacy-safe isolation, and deployment requires new module bytecode.
> 
> **Overview**
> Extends the shared **`ModuleLendGatewaySandwich`** pattern so lend-active safes can still run asset moves when auto-supply keeps balances in Aave instead of loose in the safe.
> 
> **`ModuleLendGatewaySandwich`** now inherits **`ModuleCheckBalance`** and ships default **`gateway()`** / **`_lendActive()`** from `cashModule`, so consumers like Liquid, OpenOcean, and Liquifier drop duplicated overrides.
> 
> **EtherFiStake**, **Frax**, and **Midas** wrap synchronous legs with **`_withdrawShortfall`** before balance checks and **`_resupplyToGateway`** on synchronous outputs. **BeHYPE** only withdraws WHYPE (async beHYPE, no re-supply). **Midas** withdraw and **Frax** async withdraw stay front-bookend-only or unchanged where Cash already sources Aave.
> 
> Adds fork tests under `test/safe/modules/cash/lend/` and skips bytecode match tests until post-Lend redeploys. **Stargate/Wormhole** unchanged—bridge requests already source via Cash withdrawal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae55ac1369f74f475a36e222f2e8d00fda4d2a52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->