### PR TITLE
fix: lend opt out automatically comes into action

### DIFF
--- a/src/interfaces/ICashModule.sol
+++ b/src/interfaces/ICashModule.sol
@@ -358,11 +358,13 @@ interface ICashModule {
     function isLendActive(address safe) external view returns (bool);
 
     /**
-     * @notice The user's raw lend opt-out preference, independent of which engine the safe runs on
+     * @notice The user's effective lend opt-out state, independent of which engine the safe runs on
      * @dev The gateway's supply/collateral gates read this (not isLendActive), since a safe is supplied into
-     *      Aave during migration before its engine flag flips.
+     *      Aave during migration before its engine flag flips. Effective: a pending opt-out whose finalize
+     *      time has passed reports true even before it is processed, mirroring how getMode honors a matured
+     *      incoming mode.
      * @param safe The safe to query
-     * @return True if the safe has opted out via toggleLend(false) + processLendOptOut
+     * @return True if the safe opted out via toggleLend(false), processed or matured-pending
      */
     function isLendOptedOut(address safe) external view returns (bool);
 

--- a/src/modules/cash/CashLendLib.sol
+++ b/src/modules/cash/CashLendLib.sol
@@ -405,7 +405,7 @@ library CashLendLib {
      */
     function isLendOptedOut(CashModuleStorageContract.CashModuleStorage storage $, address safe) public view returns (bool) {
         SafeCashConfig storage $$ = $.safeCashConfig[safe];
-        return $$.lendOptedOut || ($$.lendOptOutFinalizeTime != 0 && block.timestamp >= $$.lendOptOutFinalizeTime);
+        return $$.lendOptedOut || ($$.lendOptOutFinalizeTime != 0 && block.timestamp > $$.lendOptOutFinalizeTime);
     }
 
     /**

--- a/src/modules/cash/CashLendLib.sol
+++ b/src/modules/cash/CashLendLib.sol
@@ -440,6 +440,16 @@ library CashLendLib {
 
         uint96 finalizeTime = uint96(block.timestamp) + $.modeDelay;
         $$.lendOptOutFinalizeTime = finalizeTime;
+
+        if ($$.incomingModeStartTime != 0 && block.timestamp > $$.incomingModeStartTime) $$.mode = $$.incomingMode;
+        delete $$.incomingMode;
+        delete $$.incomingModeStartTime;
+        if ($$.mode == Mode.Credit) {
+            $$.incomingMode = Mode.Debit;
+            $$.incomingModeStartTime = finalizeTime;
+            $.cashEventEmitter.emitSetMode(safe, Mode.Credit, Mode.Debit, finalizeTime);
+        }
+
         $.cashEventEmitter.emitLendOptOutRequested(safe, finalizeTime);
 
         if ($.modeDelay == 0) executeLendOptOut($, safe);
@@ -492,6 +502,12 @@ library CashLendLib {
     function optInToLend(CashModuleStorageContract.CashModuleStorage storage $, address safe) public {
         SafeCashConfig storage $$ = $.safeCashConfig[safe];
         if (!$$.lendOptedOut && $$.lendOptOutFinalizeTime == 0) revert LendNotOptedOut();
+
+        if ($$.lendOptOutFinalizeTime != 0) {
+            if ($$.incomingModeStartTime != 0 && block.timestamp > $$.incomingModeStartTime) $$.mode = $$.incomingMode;
+            delete $$.incomingMode;
+            delete $$.incomingModeStartTime;
+        }
 
         $$.lendOptedOut = false;
         $$.lendOptOutFinalizeTime = 0;

--- a/src/modules/cash/CashLendLib.sol
+++ b/src/modules/cash/CashLendLib.sol
@@ -294,7 +294,8 @@ library CashLendLib {
      */
     function supplyToLend(CashModuleStorageContract.CashModuleStorage storage $, address safe, address[] calldata tokens) external {
         ILendGateway gateway = _requireGateway($, safe);
-        if ($.safeCashConfig[safe].lendOptedOut) return;
+        processLendOptOutIfReady($, safe);
+        if (isLendOptedOut($, safe)) return;
 
         for (uint256 i = 0; i < tokens.length; i++) {
             if (!gateway.isRegistered(tokens[i])) continue;
@@ -334,7 +335,7 @@ library CashLendLib {
     function borrow(CashModuleStorageContract.CashModuleStorage storage $, IEtherFiDataProvider dataProvider, address safe, address token, uint256 amountInUsd, uint256 nonce, address[] calldata signers, bytes[] calldata signatures) external {
         CashVerificationLib.verifyBorrowSig(safe, nonce, token, amountInUsd, signers, signatures);
         ILendGateway gateway = _requireGateway($, safe);
-        if ($.safeCashConfig[safe].lendOptedOut) revert LendOptedOut();
+        if (isLendOptedOut($, safe)) revert LendOptedOut();
 
         if (!gateway.isBorrowable(token)) revert OnlyBorrowToken();
         uint256 amount = DebitSourcingLib.fromUsd(IPriceProvider(dataProvider.getPriceProvider()), token, amountInUsd);
@@ -392,6 +393,36 @@ library CashLendLib {
         }
         (, uint256 debtManagerDebt) = $.debtManager.borrowingOf(safe);
         return debtManagerDebt != 0;
+    }
+
+    /**
+     * @notice Whether the safe is effectively opted out of lend: either the opt-out has been processed,
+     *         or a pending request's finalize time has passed (mirroring how getMode honors a matured
+     *         incoming mode before _setCurrentMode has applied it)
+     * @param $ The CashModule storage (passed by the delegatecalling module)
+     * @param safe Address of the EtherFi Safe
+     * @return True if the safe is opted out or a matured opt-out request awaits processing
+     */
+    function isLendOptedOut(CashModuleStorageContract.CashModuleStorage storage $, address safe) public view returns (bool) {
+        SafeCashConfig storage $$ = $.safeCashConfig[safe];
+        return $$.lendOptedOut || ($$.lendOptOutFinalizeTime != 0 && block.timestamp >= $$.lendOptOutFinalizeTime);
+    }
+
+    /**
+     * @notice Lazily executes a matured lend opt-out on the mutating paths, so a user never has to wait
+     *         for the permissionless processLendOptOut call (the opt-out twin of _setCurrentMode)
+     * @dev No-op when nothing is pending or the delay hasn't elapsed. Also a no-op — never a revert — when
+     *      open borrows block the unwind (all collateral cannot be withdrawn under debt): the effective
+     *      views already report the safe as opted out meanwhile, and the next touch after the debt clears
+     *      (e.g. repay) completes the opt-out.
+     * @param $ The CashModule storage (passed by the delegatecalling module)
+     * @param safe Address of the EtherFi Safe
+     */
+    function processLendOptOutIfReady(CashModuleStorageContract.CashModuleStorage storage $, address safe) public {
+        SafeCashConfig storage $$ = $.safeCashConfig[safe];
+        if ($$.lendOptOutFinalizeTime == 0 || block.timestamp < $$.lendOptOutFinalizeTime) return;
+        if (hasOpenBorrows($, safe)) return;
+        executeLendOptOut($, safe);
     }
 
     /**
@@ -485,8 +516,9 @@ library CashLendLib {
      */
     function spendCredit(CashModuleStorageContract.CashModuleStorage storage $, IEtherFiDataProvider dataProvider, address safe, bytes32 txId, BinSponsor binSponsor, address[] calldata tokens, uint256[] calldata amountsInUsd, uint256 totalSpendingInUsd) external {
         // Defense-in-depth: a safe that opted out of lend is forced to Debit and blocked from re-entering
-        // Credit, so credit spending must never reach an opted-out safe.
-        if ($.safeCashConfig[safe].lendOptedOut) revert LendOptedOut();
+        // Credit, so credit spending must never reach an opted-out safe. Effective check: a matured
+        // opt-out blocked from lazy processing by open borrows must still stop borrowing more.
+        if (isLendOptedOut($, safe)) revert LendOptedOut();
 
         uint256 amount;
         if (!_usesLendGateway($, safe)) {

--- a/src/modules/cash/CashLendLib.sol
+++ b/src/modules/cash/CashLendLib.sol
@@ -420,9 +420,16 @@ library CashLendLib {
      */
     function processLendOptOutIfReady(CashModuleStorageContract.CashModuleStorage storage $, address safe) public {
         SafeCashConfig storage $$ = $.safeCashConfig[safe];
-        if ($$.lendOptOutFinalizeTime == 0 || block.timestamp < $$.lendOptOutFinalizeTime) return;
+        // Strictly after the finalize time, matching isLendOptedOut and the incoming-mode rail, so reads
+        // and lazy processing flip in the same second
+        if ($$.lendOptOutFinalizeTime == 0 || block.timestamp <= $$.lendOptOutFinalizeTime) return;
         if (hasOpenBorrows($, safe)) return;
-        executeLendOptOut($, safe);
+        // Best-effort unwind: a temporarily failing withdraw (paused gateway or reserve) must not revert
+        // the unrelated action that triggered the lazy processing — the opt-out stays pending (the
+        // effective views already report it) and the next touch retries. The opt-out is only marked
+        // processed once everything is actually withdrawn.
+        if (!_unwindLendCollateral($, safe, true)) return;
+        _finalizeLendOptOut($, safe);
     }
 
     /**
@@ -466,21 +473,58 @@ library CashLendLib {
      * @param safe Address of the EtherFi Safe
      */
     function executeLendOptOut(CashModuleStorageContract.CashModuleStorage storage $, address safe) public {
-        if (_usesLendGateway($, safe)) {
-            ILendGateway gateway = $.gateway;
-            if (address(gateway) == address(0)) revert LendGatewayNotSet();
+        _unwindLendCollateral($, safe, false);
+        _finalizeLendOptOut($, safe);
+    }
 
-            address[] memory collateralTokens = gateway.registeredAssets();
-            uint256 len = collateralTokens.length;
-            for (uint256 i = 0; i < len;) {
-                uint256 supplied = gateway.suppliedOf(safe, collateralTokens[i]);
-                if (supplied != 0) gateway.withdraw(safe, collateralTokens[i], supplied, safe);
-                unchecked {
-                    ++i;
+    /**
+     * @notice Withdraws ALL of the safe's Aave collateral back to the safe
+     * @dev For a gateway safe, iterates the gateway's registered assets, not DebtManager's collateral list,
+     *      so a token delisted from DebtManager while still supplied on Aave stays withdrawable. A legacy
+     *      safe has nothing on Aave to unwind. In best-effort mode a failing withdraw (paused gateway or
+     *      reserve) is swallowed and reported instead of reverting, and the other tokens still unwind, so
+     *      the lazy paths never block an unrelated action; the strict mode (explicit processLendOptOut,
+     *      zero-delay requests) lets the error surface to the caller.
+     * @param $ The CashModule storage (passed by the delegatecalling module)
+     * @param safe Address of the EtherFi Safe
+     * @param bestEffort True to swallow individual withdraw failures instead of reverting
+     * @return fullyUnwound True when nothing is left supplied on Aave
+     */
+    function _unwindLendCollateral(CashModuleStorageContract.CashModuleStorage storage $, address safe, bool bestEffort) private returns (bool fullyUnwound) {
+        fullyUnwound = true;
+        if (!_usesLendGateway($, safe)) return fullyUnwound;
+
+        ILendGateway gateway = $.gateway;
+        if (address(gateway) == address(0)) revert LendGatewayNotSet();
+
+        address[] memory collateralTokens = gateway.registeredAssets();
+        uint256 len = collateralTokens.length;
+        for (uint256 i = 0; i < len;) {
+            uint256 supplied = gateway.suppliedOf(safe, collateralTokens[i]);
+            if (supplied != 0) {
+                if (bestEffort) {
+                    try gateway.withdraw(safe, collateralTokens[i], supplied, safe) { }
+                    catch {
+                        fullyUnwound = false;
+                    }
+                } else {
+                    gateway.withdraw(safe, collateralTokens[i], supplied, safe);
                 }
             }
+            unchecked {
+                ++i;
+            }
         }
+    }
 
+    /**
+     * @notice Marks the opt-out processed: sets the flag, clears the pending request, and forces Debit
+     * @dev Only called once the collateral is fully unwound (or there was none). Credit needs lend
+     *      collateral, so the mode is forced to Debit and any pending mode change is dropped.
+     * @param $ The CashModule storage (passed by the delegatecalling module)
+     * @param safe Address of the EtherFi Safe
+     */
+    function _finalizeLendOptOut(CashModuleStorageContract.CashModuleStorage storage $, address safe) private {
         SafeCashConfig storage $$ = $.safeCashConfig[safe];
         $$.lendOptedOut = true;
         $$.lendOptOutFinalizeTime = 0;

--- a/src/modules/cash/CashLens.sol
+++ b/src/modules/cash/CashLens.sol
@@ -127,6 +127,7 @@ contract CashLens is UpgradeableProxy, Constants {
         SafeData memory safeData = cashModule.getData(safe);
         if (safeData.incomingModeStartTime != 0) mode = safeData.incomingMode;
         else mode = safeData.mode;
+        if (mode == Mode.Credit && _lendOptOutForcesDebit(safe)) mode = Mode.Debit;
 
         address[] memory tokenPreferences = mode == Mode.Debit ? debitModeTokenPreferences : creditModeTokenPreferences;
 
@@ -137,6 +138,17 @@ contract CashLens is UpgradeableProxy, Constants {
         (token, canSpendResult, declineReason) = _checkTokenPreferences(safe, txId, tokenPreferences, amountInUsd);
 
         return (mode, token, canSpendResult, declineReason);
+    }
+
+    /**
+     * @dev Mirrors the spend path's lazy opt-out processing: a pending lend opt-out forces the safe into
+     *      Debit mode when it matures (executeLendOptOut), so credit-mode simulations must route as Debit.
+     *      A not-yet-matured request is treated the same way — like the incoming-mode handling above — since
+     *      a spend authorized now can settle on-chain after the request matures. isLendOptedOut is the
+     *      effective view (true once the finalize time passes), lendOptOutFinalizeTime covers the pending window.
+     */
+    function _lendOptOutForcesDebit(address safe) internal view returns (bool) {
+        return cashModule.isLendOptedOut(safe) || cashModule.lendOptOutFinalizeTime(safe) != 0;
     }
 
     function _checkTokenPreferences(address safe, bytes32 txId, address[] memory tokenPreferences, uint256 amountInUsd) internal view returns (address token, bool canSpendResult, string memory declineReason) {
@@ -169,6 +181,7 @@ contract CashLens is UpgradeableProxy, Constants {
         Mode mode = safeData.mode;
         // Update mode if necessary
         if (safeData.incomingModeStartTime != 0) mode = safeData.incomingMode;
+        if (mode == Mode.Credit && _lendOptOutForcesDebit(safe)) mode = Mode.Debit;
 
         // In Credit mode, only one token is allowed
         if (mode == Mode.Credit && tokens.length > 1) return (false, "Only one token allowed in Credit mode");

--- a/src/modules/cash/CashLens.sol
+++ b/src/modules/cash/CashLens.sol
@@ -127,7 +127,6 @@ contract CashLens is UpgradeableProxy, Constants {
         SafeData memory safeData = cashModule.getData(safe);
         if (safeData.incomingModeStartTime != 0) mode = safeData.incomingMode;
         else mode = safeData.mode;
-        if (mode == Mode.Credit && _lendOptOutForcesDebit(safe)) mode = Mode.Debit;
 
         address[] memory tokenPreferences = mode == Mode.Debit ? debitModeTokenPreferences : creditModeTokenPreferences;
 
@@ -138,17 +137,6 @@ contract CashLens is UpgradeableProxy, Constants {
         (token, canSpendResult, declineReason) = _checkTokenPreferences(safe, txId, tokenPreferences, amountInUsd);
 
         return (mode, token, canSpendResult, declineReason);
-    }
-
-    /**
-     * @dev Mirrors the spend path's lazy opt-out processing: a pending lend opt-out forces the safe into
-     *      Debit mode when it matures (executeLendOptOut), so credit-mode simulations must route as Debit.
-     *      A not-yet-matured request is treated the same way — like the incoming-mode handling above — since
-     *      a spend authorized now can settle on-chain after the request matures. isLendOptedOut is the
-     *      effective view (true once the finalize time passes), lendOptOutFinalizeTime covers the pending window.
-     */
-    function _lendOptOutForcesDebit(address safe) internal view returns (bool) {
-        return cashModule.isLendOptedOut(safe) || cashModule.lendOptOutFinalizeTime(safe) != 0;
     }
 
     function _checkTokenPreferences(address safe, bytes32 txId, address[] memory tokenPreferences, uint256 amountInUsd) internal view returns (address token, bool canSpendResult, string memory declineReason) {
@@ -179,9 +167,7 @@ contract CashLens is UpgradeableProxy, Constants {
         SafeData memory safeData = cashModule.getData(safe);
 
         Mode mode = safeData.mode;
-        // Update mode if necessary
         if (safeData.incomingModeStartTime != 0) mode = safeData.incomingMode;
-        if (mode == Mode.Credit && _lendOptOutForcesDebit(safe)) mode = Mode.Debit;
 
         // In Credit mode, only one token is allowed
         if (mode == Mode.Credit && tokens.length > 1) return (false, "Only one token allowed in Credit mode");

--- a/src/modules/cash/CashModuleCore.sol
+++ b/src/modules/cash/CashModuleCore.sol
@@ -325,7 +325,7 @@ contract CashModuleCore is CashModuleStorageContract {
         CashModuleStorage storage $ = _getCashModuleStorage();
         SafeCashConfig storage safeConfig = $.safeCashConfig[safe];
         if (safeConfig.lendOptOutFinalizeTime == 0) revert NoPendingLendOptOut();
-        if (block.timestamp < safeConfig.lendOptOutFinalizeTime) revert LendOptOutNotReady();
+        if (block.timestamp <= safeConfig.lendOptOutFinalizeTime) revert LendOptOutNotReady();
         if (CashLendLib.hasOpenBorrows($, safe)) revert HasOpenBorrows();
         CashLendLib.executeLendOptOut($, safe);
     }

--- a/src/modules/cash/CashModuleCore.sol
+++ b/src/modules/cash/CashModuleCore.sol
@@ -256,18 +256,20 @@ contract CashModuleCore is CashModuleStorageContract {
      * @return True if the safe uses the gateway engine and has not opted out
      */
     function isLendActive(address safe) external view returns (bool) {
-        return _usesLendGateway(safe) && !_getCashModuleStorage().safeCashConfig[safe].lendOptedOut;
+        return _usesLendGateway(safe) && !CashLendLib.isLendOptedOut(_getCashModuleStorage(), safe);
     }
 
     /**
-     * @notice The user's raw lend opt-out preference, independent of the safe's engine
+     * @notice The user's effective lend opt-out state, independent of the safe's engine
      * @dev The gateway's supply/collateral gates read this (not isLendActive), since a safe is supplied into
-     *      Aave during migration before its engine flag flips.
+     *      Aave during migration before its engine flag flips. Effective: a pending opt-out whose finalize
+     *      time has passed reports true even before processLendOptOut runs, mirroring how getMode honors a
+     *      matured incoming mode.
      * @param safe Address of the EtherFi Safe
-     * @return True if the safe has opted out via toggleLend(false) + processLendOptOut
+     * @return True if the safe opted out via toggleLend(false), processed or matured-pending
      */
     function isLendOptedOut(address safe) external view returns (bool) {
-        return _getCashModuleStorage().safeCashConfig[safe].lendOptedOut;
+        return CashLendLib.isLendOptedOut(_getCashModuleStorage(), safe);
     }
 
     /**
@@ -388,6 +390,10 @@ contract CashModuleCore is CashModuleStorageContract {
      */
     function spend(address safe, bytes32 txId, BinSponsor binSponsor, address[] calldata tokens, uint256[] calldata amountsInUsd, Cashback[] calldata cashbacks) external whenNotPaused nonReentrant onlyEtherFiWallet onlyEtherFiSafe(safe) {
         CashModuleStorage storage $ = _getCashModuleStorage();
+
+        // A matured opt-out takes effect before the spend routes: it forces Debit mode (and unwinds the
+        // Aave position), so this must run before _validateSpend reads the mode.
+        CashLendLib.processLendOptOutIfReady($, safe);
 
         uint256 totalSpendingInUsd = _validateSpend($.safeCashConfig[safe], txId, tokens, amountsInUsd);
 
@@ -536,7 +542,10 @@ contract CashModuleCore is CashModuleStorageContract {
      * @custom:throws OnlyBorrowToken if the token cannot carry debt on the safe's engine
      */
     function repay(address safe, address token, uint256 amountInUsd) public whenNotPaused nonReentrant onlyEtherFiWallet onlyEtherFiSafe(safe) {
-        CashLendLib.repay(_getCashModuleStorage(), etherFiDataProvider, safe, token, amountInUsd);
+        CashModuleStorage storage $ = _getCashModuleStorage();
+        CashLendLib.repay($, etherFiDataProvider, safe, token, amountInUsd);
+        // A repay can clear the open borrows that were blocking a matured opt-out from processing
+        CashLendLib.processLendOptOutIfReady($, safe);
     }
 
     /**

--- a/src/modules/cash/CashModuleSetters.sol
+++ b/src/modules/cash/CashModuleSetters.sol
@@ -269,6 +269,8 @@ contract CashModuleSetters is CashModuleStorageContract {
         if (!etherFiDataProvider.isWhitelistedModule(msg.sender)) revert ModuleNotWhitelistedOnDataProvider();
         if (!$.whitelistedModulesCanRequestWithdraw.contains(msg.sender)) revert OnlyWhitelistedModuleCanRequestWithdraw();
 
+        CashLendLib.processLendOptOutIfReady($, safe);
+
         address[] memory tokens = new address[](1);
         uint256[] memory amounts = new uint256[](1);
         tokens[0] = token;

--- a/src/modules/cash/CashModuleSetters.sol
+++ b/src/modules/cash/CashModuleSetters.sol
@@ -204,12 +204,19 @@ contract CashModuleSetters is CashModuleStorageContract {
     function setMode(address safe, Mode mode, address signer, bytes calldata signature) external onlyEtherFiSafe(safe) onlySafeAdmin(safe, signer) {
         CashModuleStorage storage $ = _getCashModuleStorage();
 
-        // A matured opt-out forces Debit and must land before the mode logic reads or changes state
-        CashLendLib.processLendOptOutIfReady($, safe);
+        // While an opt-out request is pending, the mode trajectory belongs to the opt-out: a Credit
+        // request would overwrite the Debit switch the request scheduled on the pending-mode rail, and a
+        // Debit request could only DEFER it (both use modeDelay, so a re-request always lands after the
+        // opt-out's finalize time), reopening the window where a matured-but-blocked opt-out sits in
+        // stored Credit. Opting back in (toggleLend(true)) re-opens setMode. No lazy opt-out processing
+        // here: with the request pending this reverts anyway, so processing could never be persisted.
+        if ($.safeCashConfig[safe].lendOptOutFinalizeTime != 0) revert LendOptedOut();
+
         _setCurrentMode($.safeCashConfig[safe]);
 
         if (mode == $.safeCashConfig[safe].mode) revert ModeAlreadySet();
-        if (mode == Mode.Credit && ($.safeCashConfig[safe].lendOptedOut || $.safeCashConfig[safe].lendOptOutFinalizeTime != 0)) revert LendOptedOut();
+        // Credit mode requires collateral on Lend: a safe that opted out of lend cannot re-enter Credit
+        if (mode == Mode.Credit && $.safeCashConfig[safe].lendOptedOut) revert LendOptedOut();
 
         CashVerificationLib.verifySetModeSig(safe, signer, _useNonce(safe), mode, signature);
 

--- a/src/modules/cash/CashModuleSetters.sol
+++ b/src/modules/cash/CashModuleSetters.sol
@@ -204,11 +204,14 @@ contract CashModuleSetters is CashModuleStorageContract {
     function setMode(address safe, Mode mode, address signer, bytes calldata signature) external onlyEtherFiSafe(safe) onlySafeAdmin(safe, signer) {
         CashModuleStorage storage $ = _getCashModuleStorage();
 
+        // A matured opt-out forces Debit and must land before the mode logic reads or changes state
+        CashLendLib.processLendOptOutIfReady($, safe);
         _setCurrentMode($.safeCashConfig[safe]);
 
         if (mode == $.safeCashConfig[safe].mode) revert ModeAlreadySet();
-        // Credit mode requires lend collateral on Aave; a safe that opted out of lend cannot enter Credit
-        if (mode == Mode.Credit && $.safeCashConfig[safe].lendOptedOut) revert LendOptedOut();
+        // Credit mode requires lend collateral on Aave; a safe that opted out of lend cannot enter Credit.
+        // Effective check: also blocks a matured opt-out that open borrows kept from processing above.
+        if (mode == Mode.Credit && CashLendLib.isLendOptedOut($, safe)) revert LendOptedOut();
 
         CashVerificationLib.verifySetModeSig(safe, signer, _useNonce(safe), mode, signature);
 
@@ -245,6 +248,10 @@ contract CashModuleSetters is CashModuleStorageContract {
         if (_getCashModuleStorage().whitelistedModulesCanRequestWithdraw.contains(msg.sender) || _getCashModuleStorage().whitelistedModulesCanRequestWithdraw.contains(recipient)) {
             revert InvalidWithdrawRequest();
         }
+
+        // A matured opt-out returns all Aave collateral to the safe first, so the withdrawal sources
+        // from loose balances instead of pulling from the lend market
+        CashLendLib.processLendOptOutIfReady(_getCashModuleStorage(), safe);
 
         _requestWithdrawal(safe, tokens, amounts, recipient);
     }

--- a/src/modules/cash/CashModuleSetters.sol
+++ b/src/modules/cash/CashModuleSetters.sol
@@ -209,9 +209,7 @@ contract CashModuleSetters is CashModuleStorageContract {
         _setCurrentMode($.safeCashConfig[safe]);
 
         if (mode == $.safeCashConfig[safe].mode) revert ModeAlreadySet();
-        // Credit mode requires lend collateral on Aave; a safe that opted out of lend cannot enter Credit.
-        // Effective check: also blocks a matured opt-out that open borrows kept from processing above.
-        if (mode == Mode.Credit && CashLendLib.isLendOptedOut($, safe)) revert LendOptedOut();
+        if (mode == Mode.Credit && ($.safeCashConfig[safe].lendOptedOut || $.safeCashConfig[safe].lendOptOutFinalizeTime != 0)) revert LendOptedOut();
 
         CashVerificationLib.verifySetModeSig(safe, signer, _useNonce(safe), mode, signature);
 

--- a/test/safe/modules/cash/lend/CashLendOptOut.t.sol
+++ b/test/safe/modules/cash/lend/CashLendOptOut.t.sol
@@ -345,16 +345,21 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
 
     // ----------------------------------------------------------------- effective state & lazy processing
 
-    /// isLendOptedOut / isLendActive report the opt-out as soon as the finalize time passes — before
-    /// processLendOptOut runs — mirroring how getMode honors a matured incoming mode.
+    /// isLendOptedOut / isLendActive report the opt-out as soon as the finalize time PASSES — before
+    /// processLendOptOut runs — with the same strictly-after comparison as the mode rail (getMode /
+    /// _setCurrentMode), so the effective flag and the scheduled Debit switch always flip in the same second.
     function test_isLendOptedOut_effectiveOnceDelayElapses() public {
         _requestOptOut();
         assertFalse(cashModule.isLendOptedOut(address(safe)), "not opted out during the delay");
         assertTrue(cashModule.isLendActive(address(safe)), "still active during the delay");
 
+        // At exactly the finalize time the window is still open, matching the mode rail's strict >
         vm.warp(block.timestamp + MODE_DELAY);
-        assertTrue(cashModule.isLendOptedOut(address(safe)), "effectively opted out at the finalize time");
-        assertFalse(cashModule.isLendActive(address(safe)), "lend inactive at the finalize time");
+        assertFalse(cashModule.isLendOptedOut(address(safe)), "boundary second still inside the window");
+
+        vm.warp(block.timestamp + 1);
+        assertTrue(cashModule.isLendOptedOut(address(safe)), "effectively opted out once the finalize time passes");
+        assertFalse(cashModule.isLendActive(address(safe)), "lend inactive once the finalize time passes");
         assertTrue(cashModule.lendOptOutFinalizeTime(address(safe)) != 0, "not yet processed");
     }
 
@@ -420,7 +425,8 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
         // Borrow during the delay window (allowed: the opt-out has not matured yet)
         _buildGatewayPosition(address(safe), address(weETH), 5 ether, address(usdc), 1000e6);
 
-        vm.warp(block.timestamp + MODE_DELAY);
+        // The effective flag flips strictly after the finalize time, like the mode rail
+        vm.warp(block.timestamp + MODE_DELAY + 1);
         assertTrue(cashModule.isLendOptedOut(address(safe)), "effectively opted out while debt blocks processing");
 
         // The explicit processor still reverts on open borrows
@@ -443,7 +449,8 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
     function test_borrow_revertsOnMaturedUnprocessedOptOut() public {
         _supplyToGateway(address(safe), address(weETH), 5 ether);
         _requestOptOut();
-        vm.warp(block.timestamp + MODE_DELAY);
+        // The effective flag flips strictly after the finalize time, like the mode rail
+        vm.warp(block.timestamp + MODE_DELAY + 1);
 
         (address[] memory signers, bytes[] memory sigs) = _borrowSig(address(usdc), 100e6);
         vm.expectRevert(ICashModule.LendOptedOut.selector);
@@ -629,7 +636,8 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
     function test_optInToLend_cancelsMaturedUnprocessedRequest() public {
         _supplyToGateway(address(safe), address(weETH), 5 ether);
         _requestOptOut();
-        vm.warp(block.timestamp + MODE_DELAY);
+        // The effective flag flips strictly after the finalize time, like the mode rail
+        vm.warp(block.timestamp + MODE_DELAY + 1);
         assertTrue(cashModule.isLendOptedOut(address(safe)), "effectively opted out");
 
         _optIn();

--- a/test/safe/modules/cash/lend/CashLendOptOut.t.sol
+++ b/test/safe/modules/cash/lend/CashLendOptOut.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.28;
 
 import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
-import { BinSponsor, Cashback, ICashModule, Mode } from "../../../../../src/interfaces/ICashModule.sol";
+import { BinSponsor, Cashback, ICashModule, Mode, SafeData } from "../../../../../src/interfaces/ICashModule.sol";
 import { ILendGateway } from "../../../../../src/interfaces/ILendGateway.sol";
 import { CashVerificationLib } from "../../../../../src/libraries/CashVerificationLib.sol";
 import { SignatureUtils } from "../../../../../src/libraries/SignatureUtils.sol";
@@ -474,6 +474,125 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
         deal(address(usdc), address(safe), 100e6);
         (Mode mode,,,) = cashLens.canSpendSingleToken(address(safe), txId, _tokens(address(usdc)), _tokens(address(usdc)), 50e6);
         assertEq(uint8(mode), uint8(Mode.Debit), "pending opt-out routes as Debit");
+    }
+
+    /// Execution stays on the CURRENT mode during the delay window: a credit-mode safe with a pending
+    /// (unmatured) opt-out still spends in credit — a card tapped before the request settles as the user
+    /// expects, even if they hold no debit-spendable assets. (The lens simulates new auths defensively as
+    /// Debit meanwhile; execution demotes only at maturity.)
+    function test_spend_creditMode_pendingOptOut_executesCredit() public {
+        _supplyToGateway(address(safe), address(weETH), 5 ether);
+        _setModeCredit();
+        _requestOptOut();
+        // Still inside the delay window
+        assertFalse(cashModule.isLendOptedOut(address(safe)), "not yet effective");
+
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, _tokens(address(usdc)), _amounts(50e6), _noCashback());
+
+        assertTrue(cashModule.transactionCleared(address(safe), txId), "credit spend settled");
+        assertApproxEqAbs(gw.debtOf(address(safe), address(usdc)), 50e6, 1e5, "spent on credit (Aave debt taken)");
+    }
+
+    /// A credit-mode safe whose matured opt-out is BLOCKED from processing by open borrows must still
+    /// spend as Debit from its loose balance — matching the lens, which routes it as Debit — instead of
+    /// reaching spendCredit's LendOptedOut revert (an approved auth would otherwise fail at settlement).
+    /// The forced Debit arrives through the pending-mode rail requestLendOptOut scheduled, so the stored
+    /// mode flips at maturity even though the collateral unwind stays blocked.
+    function test_spend_creditMode_maturedOptOutBlockedByBorrows_spendsDebitFromLooseBalance() public {
+        _setModeCredit();
+        _requestOptOut();
+        // Borrow during the delay window so the unwind is blocked at maturity
+        _buildGatewayPosition(address(safe), address(weETH), 5 ether, address(usdc), 1000e6);
+        // The mode rail applies strictly after the start time, so step past the finalize time
+        vm.warp(block.timestamp + MODE_DELAY + 1);
+        assertTrue(cashModule.isLendOptedOut(address(safe)), "effectively opted out, unwind blocked");
+        assertEq(uint8(cashModule.getMode(address(safe))), uint8(Mode.Debit), "scheduled Debit switch matured");
+
+        // The lens routes this safe as Debit; the spend must agree and use the loose balance
+        deal(address(usdc), address(safe), 100e6);
+        (Mode lensMode,, bool lensCanSpend,) = cashLens.canSpendSingleToken(address(safe), txId, _tokens(address(usdc)), _tokens(address(usdc)), 50e6);
+        assertEq(uint8(lensMode), uint8(Mode.Debit), "lens routes as Debit");
+        assertTrue(lensCanSpend, "lens approves the debit spend");
+
+        uint256 debtBefore = gw.debtOf(address(safe), address(usdc));
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, _tokens(address(usdc)), _amounts(50e6), _noCashback());
+
+        assertTrue(cashModule.transactionCleared(address(safe), txId), "spend went through as debit");
+        assertEq(gw.debtOf(address(safe), address(usdc)), debtBefore, "no new Aave debt taken");
+        assertTrue(cashModule.lendOptOutFinalizeTime(address(safe)) != 0, "opt-out still pending (debt blocks unwind)");
+        assertApproxEqAbs(gw.suppliedOf(address(safe), address(weETH)), 5 ether, 2, "collateral still on Aave");
+    }
+
+    /// A multi-token credit spend attempt reverts on the one-token rule without burning the txId: the
+    /// same txId spends fine afterward.
+    function test_spend_creditMode_multiTokenRevertDoesNotBurnTxId() public {
+        _supplyToGateway(address(safe), address(weETH), 5 ether);
+        _setModeCredit();
+
+        address[] memory twoTokens = new address[](2);
+        twoTokens[0] = address(usdc);
+        twoTokens[1] = address(weETH);
+        uint256[] memory twoAmounts = new uint256[](2);
+        twoAmounts[0] = 30e6;
+        twoAmounts[1] = 20e6;
+
+        vm.prank(etherFiWallet);
+        vm.expectRevert(ICashModule.OnlyOneTokenAllowedInCreditMode.selector);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, twoTokens, twoAmounts, _noCashback());
+
+        assertFalse(cashModule.transactionCleared(address(safe), txId), "txId not burned by the failed attempt");
+
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, _tokens(address(usdc)), _amounts(50e6), _noCashback());
+        assertTrue(cashModule.transactionCleared(address(safe), txId), "txId spendable after the failed attempt");
+    }
+
+    /// requestLendOptOut schedules the forced Debit switch on the standard pending-mode rail: the lens and
+    /// getMode see it through the ordinary incoming-mode convention, and the stored mode flips at maturity
+    /// with no processing call at all.
+    function test_requestLendOptOut_schedulesIncomingDebit() public {
+        _setModeCredit();
+        uint256 expectedFinalize = block.timestamp + MODE_DELAY;
+        _requestOptOut();
+
+        SafeData memory data = cashModule.getData(address(safe));
+        assertEq(uint8(data.incomingMode), uint8(Mode.Debit), "incoming Debit scheduled");
+        assertEq(data.incomingModeStartTime, expectedFinalize, "scheduled for the finalize time");
+        assertEq(uint8(cashModule.getMode(address(safe))), uint8(Mode.Credit), "still Credit during the window");
+
+        vm.warp(expectedFinalize + 1);
+        assertEq(uint8(cashModule.getMode(address(safe))), uint8(Mode.Debit), "Debit at maturity, no processing needed");
+    }
+
+    /// setMode(Credit) is rejected while an opt-out request is pending — it would also overwrite the
+    /// scheduled Debit switch. Opting back in re-opens Credit.
+    function test_setMode_pendingOptOut_blocksCredit() public {
+        _requestOptOut();
+
+        uint256 nonce = cashModule.getNonce(address(safe));
+        bytes32 digest = keccak256(abi.encodePacked(CashVerificationLib.SET_MODE_METHOD, block.chainid, address(safe), nonce, abi.encode(Mode.Credit))).toEthSignedMessageHash();
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Pk, digest);
+        vm.expectRevert(ICashModule.LendOptedOut.selector);
+        cashModule.setMode(address(safe), Mode.Credit, owner1, abi.encodePacked(r, s, v));
+    }
+
+    /// Opting back in during the window voids the scheduled Debit switch: the safe stays in Credit.
+    function test_optInToLend_cancelsScheduledDebitSwitch() public {
+        _setModeCredit();
+        _requestOptOut();
+        assertEq(uint8(cashModule.getData(address(safe)).incomingMode), uint8(Mode.Debit), "Debit scheduled");
+
+        _optIn();
+
+        SafeData memory data = cashModule.getData(address(safe));
+        assertEq(data.incomingModeStartTime, 0, "scheduled switch voided");
+        assertEq(uint8(cashModule.getMode(address(safe))), uint8(Mode.Credit), "still Credit");
+
+        // And the voided switch never fires
+        vm.warp(block.timestamp + MODE_DELAY + 1);
+        assertEq(uint8(cashModule.getMode(address(safe))), uint8(Mode.Credit), "Credit after the would-be finalize time");
     }
 
     /// Opting back in after the request matured (but before processing) cancels it — the collateral

--- a/test/safe/modules/cash/lend/CashLendOptOut.t.sol
+++ b/test/safe/modules/cash/lend/CashLendOptOut.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.28;
 
 import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
-import { BinSponsor, ICashModule, Mode } from "../../../../../src/interfaces/ICashModule.sol";
+import { BinSponsor, Cashback, ICashModule, Mode } from "../../../../../src/interfaces/ICashModule.sol";
 import { ILendGateway } from "../../../../../src/interfaces/ILendGateway.sol";
 import { CashVerificationLib } from "../../../../../src/libraries/CashVerificationLib.sol";
 import { SignatureUtils } from "../../../../../src/libraries/SignatureUtils.sol";
@@ -343,6 +343,153 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
         cashModule.processLendOptOut(address(safe));
     }
 
+    // ----------------------------------------------------------------- effective state & lazy processing
+
+    /// isLendOptedOut / isLendActive report the opt-out as soon as the finalize time passes — before
+    /// processLendOptOut runs — mirroring how getMode honors a matured incoming mode.
+    function test_isLendOptedOut_effectiveOnceDelayElapses() public {
+        _requestOptOut();
+        assertFalse(cashModule.isLendOptedOut(address(safe)), "not opted out during the delay");
+        assertTrue(cashModule.isLendActive(address(safe)), "still active during the delay");
+
+        vm.warp(block.timestamp + MODE_DELAY);
+        assertTrue(cashModule.isLendOptedOut(address(safe)), "effectively opted out at the finalize time");
+        assertFalse(cashModule.isLendActive(address(safe)), "lend inactive at the finalize time");
+        assertTrue(cashModule.lendOptOutFinalizeTime(address(safe)) != 0, "not yet processed");
+    }
+
+    /// A spend lazily executes a matured opt-out before routing: the collateral comes home, the flag is
+    /// set, and the spend runs as a debit from the loose balance.
+    function test_spend_processesMaturedOptOut() public {
+        _supplyToGateway(address(safe), address(weETH), 5 ether);
+        _requestOptOut();
+        vm.warp(block.timestamp + MODE_DELAY);
+
+        deal(address(usdc), address(safe), 100e6);
+
+        vm.expectEmit(true, false, false, false, address(cashEventEmitter));
+        emit CashEventEmitter.LendOptOutExecuted(address(safe));
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, _tokens(address(usdc)), _amounts(50e6), _noCashback());
+
+        assertTrue(cashModule.isLendOptedOut(address(safe)), "opted out");
+        assertEq(cashModule.lendOptOutFinalizeTime(address(safe)), 0, "processed, not just matured");
+        assertApproxEqAbs(weETH.balanceOf(address(safe)), 5 ether, 2, "collateral back in the safe");
+        assertTrue(cashModule.transactionCleared(address(safe), txId), "spend went through");
+    }
+
+    /// A credit-mode safe with a matured opt-out spends as Debit: the lazy processing forces the mode
+    /// before spend reads it, so no new Aave debt is ever taken.
+    function test_spend_creditMode_maturedOptOut_routesDebit() public {
+        _setModeCredit();
+        _requestOptOut();
+        vm.warp(block.timestamp + MODE_DELAY);
+
+        deal(address(usdc), address(safe), 100e6);
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, _tokens(address(usdc)), _amounts(50e6), _noCashback());
+
+        assertEq(uint8(cashModule.getMode(address(safe))), uint8(Mode.Debit), "forced to Debit");
+        assertEq(gw.debtOf(address(safe), address(usdc)), 0, "no Aave debt taken");
+        assertApproxEqAbs(usdc.balanceOf(address(safe)), 50e6, 1e5, "spent from the loose balance");
+    }
+
+    /// The auto-supply sweep lazily executes a matured opt-out and then skips supplying.
+    function test_supplyToLend_processesMaturedOptOutAndSkips() public {
+        _supplyToGateway(address(safe), address(weETH), 5 ether);
+        _requestOptOut();
+        vm.warp(block.timestamp + MODE_DELAY);
+
+        deal(address(weETH), address(safe), 1 ether); // loose funds the sweep would otherwise supply
+
+        vm.expectEmit(true, false, false, false, address(cashEventEmitter));
+        emit CashEventEmitter.LendOptOutExecuted(address(safe));
+        vm.prank(etherFiWallet);
+        cashModule.supplyToLend(address(safe), _tokens(address(weETH)));
+
+        assertLe(gw.suppliedOf(address(safe), address(weETH)), 2, "nothing supplied");
+        assertApproxEqAbs(weETH.balanceOf(address(safe)), 6 ether, 2, "loose + returned collateral stay in the safe");
+        assertTrue(cashModule.isLendOptedOut(address(safe)), "opted out");
+        assertEq(cashModule.lendOptOutFinalizeTime(address(safe)), 0, "processed");
+    }
+
+    /// A borrow taken during the delay window blocks processing but not the effective state: the views
+    /// report opted out, credit is blocked, and the repay that clears the debt completes the opt-out.
+    function test_repay_completesOptOutBlockedByOpenBorrows() public {
+        _requestOptOut();
+        // Borrow during the delay window (allowed: the opt-out has not matured yet)
+        _buildGatewayPosition(address(safe), address(weETH), 5 ether, address(usdc), 1000e6);
+
+        vm.warp(block.timestamp + MODE_DELAY);
+        assertTrue(cashModule.isLendOptedOut(address(safe)), "effectively opted out while debt blocks processing");
+
+        // The explicit processor still reverts on open borrows
+        vm.expectRevert(ICashModule.HasOpenBorrows.selector);
+        cashModule.processLendOptOut(address(safe));
+
+        // Repaying the debt completes the opt-out in the same call
+        deal(address(usdc), address(safe), 2000e6);
+        vm.expectEmit(true, false, false, false, address(cashEventEmitter));
+        emit CashEventEmitter.LendOptOutExecuted(address(safe));
+        vm.prank(etherFiWallet);
+        cashModule.repay(address(safe), address(usdc), 1100e6); // over-quote; capped at the live debt
+
+        assertEq(gw.debtOf(address(safe), address(usdc)), 0, "debt cleared");
+        assertEq(cashModule.lendOptOutFinalizeTime(address(safe)), 0, "opt-out completed by the repay");
+        assertApproxEqAbs(weETH.balanceOf(address(safe)), 5 ether, 2, "collateral unwound to the safe");
+    }
+
+    /// CashModule.borrow rejects a matured-but-unprocessed opt-out (the effective check).
+    function test_borrow_revertsOnMaturedUnprocessedOptOut() public {
+        _supplyToGateway(address(safe), address(weETH), 5 ether);
+        _requestOptOut();
+        vm.warp(block.timestamp + MODE_DELAY);
+
+        (address[] memory signers, bytes[] memory sigs) = _borrowSig(address(usdc), 100e6);
+        vm.expectRevert(ICashModule.LendOptedOut.selector);
+        cashModule.borrow(address(safe), address(usdc), 100e6, signers, sigs);
+    }
+
+    /// setMode(Credit) is blocked while a matured opt-out awaits processing (the effective check).
+    function test_setMode_maturedOptOut_blocksCredit() public {
+        _requestOptOut();
+        vm.warp(block.timestamp + MODE_DELAY);
+
+        uint256 nonce = cashModule.getNonce(address(safe));
+        bytes32 digest = keccak256(abi.encodePacked(CashVerificationLib.SET_MODE_METHOD, block.chainid, address(safe), nonce, abi.encode(Mode.Credit))).toEthSignedMessageHash();
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Pk, digest);
+
+        vm.expectRevert(ICashModule.LendOptedOut.selector);
+        cashModule.setMode(address(safe), Mode.Credit, owner1, abi.encodePacked(r, s, v));
+    }
+
+    /// The lens routes a credit-mode safe with a pending opt-out as Debit, matching the spend path's
+    /// lazy processing (and the incoming-mode convention: pending counts, since the spend can settle
+    /// after the request matures).
+    function test_canSpendSingleToken_pendingOptOutForcesDebit() public {
+        _supplyToGateway(address(safe), address(weETH), 5 ether);
+        _setModeCredit();
+        _requestOptOut();
+
+        deal(address(usdc), address(safe), 100e6);
+        (Mode mode,,,) = cashLens.canSpendSingleToken(address(safe), txId, _tokens(address(usdc)), _tokens(address(usdc)), 50e6);
+        assertEq(uint8(mode), uint8(Mode.Debit), "pending opt-out routes as Debit");
+    }
+
+    /// Opting back in after the request matured (but before processing) cancels it — the collateral
+    /// never left Aave and lend is immediately active again.
+    function test_optInToLend_cancelsMaturedUnprocessedRequest() public {
+        _supplyToGateway(address(safe), address(weETH), 5 ether);
+        _requestOptOut();
+        vm.warp(block.timestamp + MODE_DELAY);
+        assertTrue(cashModule.isLendOptedOut(address(safe)), "effectively opted out");
+
+        _optIn();
+        assertFalse(cashModule.isLendOptedOut(address(safe)), "opt-out cancelled");
+        assertTrue(cashModule.isLendActive(address(safe)), "lend active again");
+        assertApproxEqAbs(gw.suppliedOf(address(safe), address(weETH)), 5 ether, 2, "collateral never left Aave");
+    }
+
     // ----------------------------------------------------------------- signing helpers
 
     function _requestOptOut() internal {
@@ -369,5 +516,37 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
         cashModule.setMode(address(safe), Mode.Credit, owner1, abi.encodePacked(r, s, v));
         // Credit takes effect after the mode delay
         vm.warp(block.timestamp + MODE_DELAY + 1);
+    }
+
+    /// @dev Builds the owner quorum (owner1 + owner2, the safe's threshold) signing a borrow intent.
+    function _borrowSig(address token, uint256 amountInUsd) internal view returns (address[] memory, bytes[] memory) {
+        bytes32 digest = keccak256(abi.encodePacked(CashVerificationLib.BORROW_METHOD, block.chainid, address(safe), safe.nonce(), abi.encode(token, amountInUsd))).toEthSignedMessageHash();
+        (uint8 v1, bytes32 r1, bytes32 s1) = vm.sign(owner1Pk, digest);
+        (uint8 v2, bytes32 r2, bytes32 s2) = vm.sign(owner2Pk, digest);
+
+        address[] memory signers = new address[](2);
+        signers[0] = owner1;
+        signers[1] = owner2;
+
+        bytes[] memory signatures = new bytes[](2);
+        signatures[0] = abi.encodePacked(r1, s1, v1);
+        signatures[1] = abi.encodePacked(r2, s2, v2);
+        return (signers, signatures);
+    }
+
+    function _tokens(address token) internal pure returns (address[] memory) {
+        address[] memory arr = new address[](1);
+        arr[0] = token;
+        return arr;
+    }
+
+    function _amounts(uint256 amount) internal pure returns (uint256[] memory) {
+        uint256[] memory arr = new uint256[](1);
+        arr[0] = amount;
+        return arr;
+    }
+
+    function _noCashback() internal pure returns (Cashback[] memory) {
+        return new Cashback[](0);
     }
 }

--- a/test/safe/modules/cash/lend/CashLendOptOut.t.sol
+++ b/test/safe/modules/cash/lend/CashLendOptOut.t.sol
@@ -73,7 +73,7 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
         assertTrue(cashModule.isLendActive(address(safe)), "still active until executed");
 
         // Execute after the delay: permissionless
-        vm.warp(block.timestamp + MODE_DELAY);
+        vm.warp(block.timestamp + MODE_DELAY + 1);
         vm.expectEmit(true, false, false, false, address(cashEventEmitter));
         emit CashEventEmitter.LendOptOutExecuted(address(safe));
         cashModule.processLendOptOut(address(safe));
@@ -106,7 +106,7 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
         assertEq(uint8(cashModule.getMode(address(safe))), uint8(Mode.Credit), "in credit mode");
 
         _requestOptOut();
-        vm.warp(block.timestamp + MODE_DELAY);
+        vm.warp(block.timestamp + MODE_DELAY + 1);
         cashModule.processLendOptOut(address(safe));
 
         assertEq(uint8(cashModule.getMode(address(safe))), uint8(Mode.Debit), "credit dropped to debit");
@@ -116,7 +116,7 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
     function test_processLendOptOut_noCollateral_marksOptedOut() public {
         // No Aave position at all: opting out is still valid and just flips the flag
         _requestOptOut();
-        vm.warp(block.timestamp + MODE_DELAY);
+        vm.warp(block.timestamp + MODE_DELAY + 1);
         cashModule.processLendOptOut(address(safe));
 
         assertTrue(cashModule.isLendOptedOut(address(safe)), "opted out with no collateral");
@@ -130,7 +130,7 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
         deal(address(weETH), address(safe), 5 ether);
 
         _requestOptOut();
-        vm.warp(block.timestamp + MODE_DELAY);
+        vm.warp(block.timestamp + MODE_DELAY + 1);
         cashModule.processLendOptOut(address(safe));
 
         assertTrue(cashModule.isLendOptedOut(address(safe)), "legacy safe opted out");
@@ -180,7 +180,7 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
     /// Requesting the opt-out reverts when lend is already disabled.
     function test_requestLendOptOut_revertsWhenAlreadyOptedOut() public {
         _requestOptOut();
-        vm.warp(block.timestamp + MODE_DELAY);
+        vm.warp(block.timestamp + MODE_DELAY + 1);
         cashModule.processLendOptOut(address(safe));
 
         (address signer, bytes memory sig) = _toggleLendSig(false);
@@ -223,10 +223,16 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
         cashModule.processLendOptOut(address(safe));
     }
 
-    /// processLendOptOut reverts while still inside the mode-change delay.
+    /// processLendOptOut reverts while still inside the mode-change delay — including at exactly the
+    /// finalize time: processing is strictly after it, matching isLendOptedOut and the mode rail.
     function test_processLendOptOut_revertsWhenNotReady() public {
         _requestOptOut();
         // Still inside the delay window
+        vm.expectRevert(ICashModule.LendOptOutNotReady.selector);
+        cashModule.processLendOptOut(address(safe));
+
+        // The boundary second is still inside the window
+        vm.warp(block.timestamp + MODE_DELAY);
         vm.expectRevert(ICashModule.LendOptOutNotReady.selector);
         cashModule.processLendOptOut(address(safe));
     }
@@ -243,7 +249,7 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
         gw.borrow(address(safe), address(usdc), 1000e6, driver);
         vm.stopPrank();
 
-        vm.warp(block.timestamp + MODE_DELAY);
+        vm.warp(block.timestamp + MODE_DELAY + 1);
         vm.expectRevert(ICashModule.HasOpenBorrows.selector);
         cashModule.processLendOptOut(address(safe));
     }
@@ -269,7 +275,7 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
     ///      lend-disabled safe; only turning it ON is a lend op that a disabled safe is blocked from.
     function test_setUsingAsCollateralFalse_allowedWhenLendOptedOut() public {
         _requestOptOut();
-        vm.warp(block.timestamp + MODE_DELAY);
+        vm.warp(block.timestamp + MODE_DELAY + 1);
         cashModule.processLendOptOut(address(safe));
         assertTrue(cashModule.isLendOptedOut(address(safe)));
 
@@ -285,7 +291,7 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
     /// A lend-disabled safe cannot switch into Credit mode.
     function test_afterOptOut_cannotEnterCreditMode() public {
         _requestOptOut();
-        vm.warp(block.timestamp + MODE_DELAY);
+        vm.warp(block.timestamp + MODE_DELAY + 1);
         cashModule.processLendOptOut(address(safe));
 
         uint256 nonce = cashModule.getNonce(address(safe));
@@ -302,7 +308,7 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
     /// Re-enabling lend flips the flag back on and resumes auto-supply.
     function test_optInToLend_reenablesAndResumesSupply() public {
         _requestOptOut();
-        vm.warp(block.timestamp + MODE_DELAY);
+        vm.warp(block.timestamp + MODE_DELAY + 1);
         cashModule.processLendOptOut(address(safe));
         assertTrue(cashModule.isLendOptedOut(address(safe)));
 
@@ -338,7 +344,7 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
         assertTrue(cashModule.isLendActive(address(safe)), "still active");
 
         // With the request cancelled, executing must revert
-        vm.warp(block.timestamp + MODE_DELAY);
+        vm.warp(block.timestamp + MODE_DELAY + 1);
         vm.expectRevert(ICashModule.NoPendingLendOptOut.selector);
         cashModule.processLendOptOut(address(safe));
     }
@@ -368,7 +374,7 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
     function test_spend_processesMaturedOptOut() public {
         _supplyToGateway(address(safe), address(weETH), 5 ether);
         _requestOptOut();
-        vm.warp(block.timestamp + MODE_DELAY);
+        vm.warp(block.timestamp + MODE_DELAY + 1);
 
         deal(address(usdc), address(safe), 100e6);
 
@@ -388,7 +394,7 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
     function test_spend_creditMode_maturedOptOut_routesDebit() public {
         _setModeCredit();
         _requestOptOut();
-        vm.warp(block.timestamp + MODE_DELAY);
+        vm.warp(block.timestamp + MODE_DELAY + 1);
 
         deal(address(usdc), address(safe), 100e6);
         vm.prank(etherFiWallet);
@@ -403,7 +409,7 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
     function test_supplyToLend_processesMaturedOptOutAndSkips() public {
         _supplyToGateway(address(safe), address(weETH), 5 ether);
         _requestOptOut();
-        vm.warp(block.timestamp + MODE_DELAY);
+        vm.warp(block.timestamp + MODE_DELAY + 1);
 
         deal(address(weETH), address(safe), 1 ether); // loose funds the sweep would otherwise supply
 
@@ -460,7 +466,7 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
     /// setMode(Credit) is blocked while a matured opt-out awaits processing (the effective check).
     function test_setMode_maturedOptOut_blocksCredit() public {
         _requestOptOut();
-        vm.warp(block.timestamp + MODE_DELAY);
+        vm.warp(block.timestamp + MODE_DELAY + 1);
 
         uint256 nonce = cashModule.getNonce(address(safe));
         bytes32 digest = keccak256(abi.encodePacked(CashVerificationLib.SET_MODE_METHOD, block.chainid, address(safe), nonce, abi.encode(Mode.Credit))).toEthSignedMessageHash();
@@ -585,6 +591,57 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
         cashModule.setMode(address(safe), Mode.Credit, owner1, abi.encodePacked(r, s, v));
     }
 
+    /// setMode(Debit) is also rejected while an opt-out request is pending: a re-request restarts the
+    /// mode delay, so it could only DEFER the Debit switch past the opt-out's finalize time — reopening
+    /// the window where a matured-but-blocked opt-out sits in stored Credit.
+    function test_setMode_pendingOptOut_blocksDebitToo() public {
+        _setModeCredit();
+        _requestOptOut();
+
+        uint256 nonce = cashModule.getNonce(address(safe));
+        bytes32 digest = keccak256(abi.encodePacked(CashVerificationLib.SET_MODE_METHOD, block.chainid, address(safe), nonce, abi.encode(Mode.Debit))).toEthSignedMessageHash();
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Pk, digest);
+        vm.expectRevert(ICashModule.LendOptedOut.selector);
+        cashModule.setMode(address(safe), Mode.Debit, owner1, abi.encodePacked(r, s, v));
+
+        // The scheduled switch is untouched and fires at the original finalize time
+        vm.warp(block.timestamp + MODE_DELAY + 1);
+        assertEq(uint8(cashModule.getMode(address(safe))), uint8(Mode.Debit), "original deadline preserved");
+    }
+
+    /// The lazy unwind is best-effort: a paused reserve must not revert the unrelated action that
+    /// triggered it. The opt-out stays pending (nothing is marked processed until everything is actually
+    /// withdrawn), the explicit processor still surfaces the error, and the next touch after unpausing
+    /// completes the opt-out.
+    function test_processLendOptOutIfReady_bestEffort_pausedReserveDoesNotBlock() public {
+        _supplyToGateway(address(safe), address(weETH), 5 ether);
+        _requestOptOut();
+        vm.warp(block.timestamp + MODE_DELAY + 1);
+        _setAaveReservePaused(weethReserveId, true);
+
+        // An unrelated debit spend from loose funds settles; the blocked unwind stays pending
+        deal(address(usdc), address(safe), 100e6);
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, _tokens(address(usdc)), _amounts(50e6), _noCashback());
+        assertTrue(cashModule.transactionCleared(address(safe), txId), "unrelated spend went through");
+        assertTrue(cashModule.lendOptOutFinalizeTime(address(safe)) != 0, "opt-out still pending, not marked processed");
+        assertApproxEqAbs(gw.suppliedOf(address(safe), address(weETH)), 5 ether, 2, "collateral still on Aave");
+        assertTrue(cashModule.isLendOptedOut(address(safe)), "effective view unaffected");
+
+        // The explicit processor stays strict and surfaces the paused reserve
+        vm.expectRevert();
+        cashModule.processLendOptOut(address(safe));
+
+        // Unpaused: the next touch completes the opt-out
+        _setAaveReservePaused(weethReserveId, false);
+        vm.expectEmit(true, false, false, false, address(cashEventEmitter));
+        emit CashEventEmitter.LendOptOutExecuted(address(safe));
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), keccak256("second-spend"), BinSponsor.Reap, _tokens(address(usdc)), _amounts(25e6), _noCashback());
+        assertEq(cashModule.lendOptOutFinalizeTime(address(safe)), 0, "opt-out processed");
+        assertApproxEqAbs(weETH.balanceOf(address(safe)), 5 ether, 2, "collateral unwound to the safe");
+    }
+
     /// Opting back in during the window voids the scheduled Debit switch: the safe stays in Credit.
     function test_optInToLend_cancelsScheduledDebitSwitch() public {
         _setModeCredit();
@@ -618,7 +675,7 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
 
         _supplyToGateway(address(safe), address(weETH), 5 ether);
         _requestOptOut();
-        vm.warp(block.timestamp + MODE_DELAY);
+        vm.warp(block.timestamp + MODE_DELAY + 1);
 
         vm.expectEmit(true, false, false, false, address(cashEventEmitter));
         emit CashEventEmitter.LendOptOutExecuted(address(safe));

--- a/test/safe/modules/cash/lend/CashLendOptOut.t.sol
+++ b/test/safe/modules/cash/lend/CashLendOptOut.t.sol
@@ -595,6 +595,35 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
         assertEq(uint8(cashModule.getMode(address(safe))), uint8(Mode.Credit), "Credit after the would-be finalize time");
     }
 
+    /// A module withdrawal request lazily executes a matured opt-out just like the owner path: all the
+    /// collateral comes home first, so the request sources loose funds instead of pulling only the
+    /// shortfall and leaving the rest supplied on a safe the views already report as opted out.
+    function test_requestWithdrawalByModule_processesMaturedOptOut() public {
+        address module = makeAddr("withdrawModule");
+        address[] memory modules = new address[](1);
+        modules[0] = module;
+        bool[] memory shouldWhitelist = new bool[](1);
+        shouldWhitelist[0] = true;
+        vm.startPrank(owner);
+        dataProvider.configureModules(modules, shouldWhitelist);
+        cashModule.configureModulesCanRequestWithdraw(modules, shouldWhitelist);
+        vm.stopPrank();
+
+        _supplyToGateway(address(safe), address(weETH), 5 ether);
+        _requestOptOut();
+        vm.warp(block.timestamp + MODE_DELAY);
+
+        vm.expectEmit(true, false, false, false, address(cashEventEmitter));
+        emit CashEventEmitter.LendOptOutExecuted(address(safe));
+        vm.prank(module);
+        cashModule.requestWithdrawalByModule(address(safe), address(weETH), 1 ether);
+
+        assertTrue(cashModule.isLendOptedOut(address(safe)), "opted out");
+        assertEq(cashModule.lendOptOutFinalizeTime(address(safe)), 0, "fully processed, not left half-honored");
+        assertLe(gw.suppliedOf(address(safe), address(weETH)), 2, "nothing left supplied on Aave");
+        assertApproxEqAbs(weETH.balanceOf(address(safe)), 5 ether, 2, "all collateral loose in the safe");
+    }
+
     /// Opting back in after the request matured (but before processing) cancels it — the collateral
     /// never left Aave and lend is immediately active again.
     function test_optInToLend_cancelsMaturedUnprocessedRequest() public {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes spend/repay/withdraw routing, mode scheduling, and collateral unwind semantics for lend opt-out—core cash and borrowing behavior with many edge cases (debt-blocked unwind, best-effort vs strict processing).
> 
> **Overview**
> Matured lend opt-outs now take effect automatically, aligned with how **incoming mode** is honored before storage is updated.
> 
> **Effective opt-out state:** `isLendOptedOut` / `isLendActive` treat a pending request as opted out once `block.timestamp` is **strictly after** the finalize time (same boundary as `processLendOptOut` and mode rails). Borrow, credit spend, and supply gates use this effective check instead of the raw `lendOptedOut` flag.
> 
> **Lazy processing:** `processLendOptOutIfReady` unwinds Aave collateral (best-effort on user paths so paused reserves do not block spends/withdrawals) and finalizes only when fully unwound; open debt still blocks unwind but views already block new credit/borrow. Hooks run on **spend**, **repay**, **supplyToLend**, and **withdrawal** requests so users need not call `processLendOptOut` first.
> 
> **Opt-out request side effects:** Requesting opt-out from Credit schedules a forced **Debit** on the pending-mode rail at finalize time; `setMode` is rejected while any opt-out is pending; opt-in clears that scheduled switch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7d4c2828b6cf843a49af6d47fb73d2f456b0e50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->