### PR TITLE
feat: add min health factor to gateway ops

### DIFF
--- a/src/interfaces/ICashModule.sol
+++ b/src/interfaces/ICashModule.sol
@@ -358,11 +358,13 @@ interface ICashModule {
     function isLendActive(address safe) external view returns (bool);
 
     /**
-     * @notice The user's raw lend opt-out preference, independent of which engine the safe runs on
+     * @notice The user's effective lend opt-out state, independent of which engine the safe runs on
      * @dev The gateway's supply/collateral gates read this (not isLendActive), since a safe is supplied into
-     *      Aave during migration before its engine flag flips.
+     *      Aave during migration before its engine flag flips. Effective: a pending opt-out whose finalize
+     *      time has passed reports true even before it is processed, mirroring how getMode honors a matured
+     *      incoming mode.
      * @param safe The safe to query
-     * @return True if the safe has opted out via toggleLend(false) + processLendOptOut
+     * @return True if the safe opted out via toggleLend(false), processed or matured-pending
      */
     function isLendOptedOut(address safe) external view returns (bool);
 

--- a/src/interfaces/ILendGateway.sol
+++ b/src/interfaces/ILendGateway.sol
@@ -73,15 +73,32 @@ interface ILendGateway {
      */
     function getAccountData(address safe) external view returns (AccountData memory);
 
-    /// @notice The post-op health-factor floor (WAD) for user-extraction ops; 0 = disabled
+    /**
+     * @notice Whether the safe carries any raw debt on Aave (raw per-asset reads, immune to the
+     *         6-decimal flooring of getAccountData's debtUsd)
+     * @param safe The safe to check
+     * @return True when any registered asset carries debt for the safe
+     */
+    function hasDebt(address safe) external view returns (bool);
+
+    /**
+     * @notice The post-op health-factor floor (WAD) for user-extraction ops; 0 = disabled
+     * @return The floor in WAD
+     */
     function minHealthFactor() external view returns (uint256);
 
-    /// @notice Reverts HealthFactorBelowMinimum when the floor is set and `safe`'s health factor is below it.
-    ///         Extraction paths (borrow page, withdrawal sourcing, collateral flag off) call this post-op;
-    ///         spends and repays are deliberately exempt.
+    /**
+     * @notice Reverts HealthFactorBelowMinimum when the floor is set and `safe`'s health factor is below it
+     * @dev Extraction paths (borrow page, withdrawal sourcing, collateral flag off, risk-increasing module
+     *      flows) call this post-op; spends and repays are deliberately exempt.
+     * @param safe The safe to check
+     */
     function ensureMinHealthFactor(address safe) external view;
 
-    /// @notice Sets the post-op health-factor floor (WAD; 0 disables, otherwise bounded to [1e18, 2e18])
+    /**
+     * @notice Sets the post-op health-factor floor
+     * @param value The floor in WAD; 0 disables, otherwise bounded to [1e18, 2e18]
+     */
     function setMinHealthFactor(uint256 value) external;
 
     /**

--- a/src/interfaces/ILendGateway.sol
+++ b/src/interfaces/ILendGateway.sol
@@ -73,6 +73,17 @@ interface ILendGateway {
      */
     function getAccountData(address safe) external view returns (AccountData memory);
 
+    /// @notice The post-op health-factor floor (WAD) for user-extraction ops; 0 = disabled
+    function minHealthFactor() external view returns (uint256);
+
+    /// @notice Reverts HealthFactorBelowMinimum when the floor is set and `safe`'s health factor is below it.
+    ///         Extraction paths (borrow page, withdrawal sourcing, collateral flag off) call this post-op;
+    ///         spends and repays are deliberately exempt.
+    function ensureMinHealthFactor(address safe) external view;
+
+    /// @notice Sets the post-op health-factor floor (WAD; 0 disables, otherwise bounded to [1e18, 2e18])
+    function setMinHealthFactor(uint256 value) external;
+
     /**
      * @notice Returns the amount of `asset` that `safe` has supplied to Aave
      * @param safe The safe to query

--- a/src/libraries/DebitSourcingLib.sol
+++ b/src/libraries/DebitSourcingLib.sol
@@ -43,18 +43,24 @@ library DebitSourcingLib {
 
     /**
      * @notice Max credit-mode spend (USD, 6 decimals): the floor-buffered borrowing power bounded by the
-     *         single most liquid borrow reserve (a credit spend draws one borrow token), matching
-     *         creditCheck's liquidity and borrowing-power declines
+     *         most liquid card-settleable borrow reserve (a credit spend draws one settlement token),
+     *         matching creditCheck's liquidity and borrowing-power declines
      */
     function maxSpendCredit(ILendGateway gateway, IPriceProvider priceProvider, address safe) public view returns (uint256) {
         uint256 borrowPower = bufferedCreditHeadroom(gateway, gateway.getAccountData(safe));
 
-        address[] memory borrowTokens = gateway.borrowableAssets();
+        // A credit spend draws ONE token and sends it to the settlement dispatcher, so the achievable
+        // ceiling is set by the card-settleable tokens (spendAssets), not every borrowable reserve: a
+        // reserve the card cannot settle in must not advertise its liquidity as spendable. A spend asset
+        // whose reserve does not allow new borrows cannot fund a credit spend either, so it is skipped.
+        address[] memory spendTokens = gateway.spendAssets();
         uint256 maxLiquidityUsd = 0;
-        for (uint256 i = 0; i < borrowTokens.length;) {
-            uint256 liquidityUsd = toUsd(priceProvider, borrowTokens[i], gateway.availableToBorrow(borrowTokens[i]));
-            if (liquidityUsd > maxLiquidityUsd) {
-                maxLiquidityUsd = liquidityUsd;
+        for (uint256 i = 0; i < spendTokens.length;) {
+            if (gateway.isBorrowable(spendTokens[i])) {
+                uint256 liquidityUsd = toUsd(priceProvider, spendTokens[i], gateway.availableToBorrow(spendTokens[i]));
+                if (liquidityUsd > maxLiquidityUsd) {
+                    maxLiquidityUsd = liquidityUsd;
+                }
             }
             unchecked {
                 ++i;
@@ -76,7 +82,9 @@ library DebitSourcingLib {
      *      the safe's pending withdrawal; canSpend must not advertise it as headroom.
      */
     function creditCheck(ILendGateway gateway, IPriceProvider priceProvider, address safe, address token, uint256 totalSpendingInUsd) public view returns (bool, string memory) {
-        if (!gateway.isBorrowable(token)) {
+        // Matching spendCredit's execution gate: the drawn token settles the card, so it must be a
+        // card-settleable spend asset AND borrowable on Aave
+        if (!gateway.isBorrowable(token) || !gateway.isSpendAsset(token)) {
             return (false, "Not a supported borrow token");
         }
 
@@ -117,7 +125,9 @@ library DebitSourcingLib {
     function bufferedDebitHeadroom(ILendGateway gateway, ILendGateway.AccountData memory account) public view returns (uint256) {
         uint256 floor = gateway.minHealthFactor();
         if (floor == 0) return account.availableBorrowsUsd;
-        uint256 required = (account.debtUsd * floor) / 1e18;
+        // required is a MINIMUM, so it rounds up: rounding down would let the exact max quote sit one
+        // micro-dollar past the floor and fail the post-op health check
+        uint256 required = (account.debtUsd * floor + 1e18 - 1) / 1e18;
         uint256 maxBorrow = account.availableBorrowsUsd + account.debtUsd;
         return maxBorrow > required ? maxBorrow - required : 0;
     }

--- a/src/libraries/DebitSourcingLib.sol
+++ b/src/libraries/DebitSourcingLib.sol
@@ -41,6 +41,87 @@ library DebitSourcingLib {
         return cap;
     }
 
+    /**
+     * @notice Max credit-mode spend (USD, 6 decimals): the floor-buffered borrowing power bounded by the
+     *         single most liquid borrow reserve (a credit spend draws one borrow token), matching
+     *         creditCheck's liquidity and borrowing-power declines
+     */
+    function maxSpendCredit(ILendGateway gateway, IPriceProvider priceProvider, address safe) public view returns (uint256) {
+        uint256 borrowPower = bufferedCreditHeadroom(gateway, gateway.getAccountData(safe));
+
+        address[] memory borrowTokens = gateway.borrowableAssets();
+        uint256 maxLiquidityUsd = 0;
+        for (uint256 i = 0; i < borrowTokens.length;) {
+            uint256 liquidityUsd = toUsd(priceProvider, borrowTokens[i], gateway.availableToBorrow(borrowTokens[i]));
+            if (liquidityUsd > maxLiquidityUsd) {
+                maxLiquidityUsd = liquidityUsd;
+            }
+            unchecked {
+                ++i;
+            }
+        }
+
+        return borrowPower < maxLiquidityUsd ? borrowPower : maxLiquidityUsd;
+    }
+
+    /**
+     * @notice The lens's credit-mode spend gate: token borrowability, reserve liquidity, and the
+     *         floor-buffered borrowing power, returning canSpend-style (ok, declineReason)
+     * @dev The quoted headroom is the already-supplied position's capacity, buffered by the gateway's
+     *      health-factor floor (bufferedCreditHeadroom): new auths are approved only up to the amount that
+     *      keeps the post-borrow health factor above the floor, while spend execution keeps Aave's raw
+     *      bound — so a spend authorized here always settles, and a previously-authorized spend can still
+     *      settle past the floor. It also deliberately excludes loose collateral the spend-time resupply
+     *      can pull in (CashLendLib._resupplyCollateral), since that capacity exists only by cancelling
+     *      the safe's pending withdrawal; canSpend must not advertise it as headroom.
+     */
+    function creditCheck(ILendGateway gateway, IPriceProvider priceProvider, address safe, address token, uint256 totalSpendingInUsd) public view returns (bool, string memory) {
+        if (!gateway.isBorrowable(token)) {
+            return (false, "Not a supported borrow token");
+        }
+
+        if (gateway.availableToBorrow(token) < fromUsd(priceProvider, token, totalSpendingInUsd)) {
+            return (false, "Insufficient liquidity to cover the loan");
+        }
+
+        if (totalSpendingInUsd > bufferedCreditHeadroom(gateway, gateway.getAccountData(safe))) {
+            return (false, "Insufficient borrowing power");
+        }
+
+        return (true, "");
+    }
+
+    /**
+     * @notice Credit headroom (USD) the lens may quote: the new-debt capacity that keeps the post-borrow
+     *         health factor at or above the gateway's floor; raw availableBorrowsUsd while no floor is set
+     * @dev v4's collateralFactor doubles as LTV and liquidation threshold, so healthFactor ==
+     *      maxBorrowUsd / debtUsd and debt' <= maxBorrowUsd / floor keeps HF' >= floor. Quote-side only:
+     *      execution keeps Aave's raw bound (spends are exempt from the floor), so every quoted amount
+     *      still executes — with margin — and a previously-authorized spend can settle past the floor.
+     */
+    function bufferedCreditHeadroom(ILendGateway gateway, ILendGateway.AccountData memory account) public view returns (uint256) {
+        uint256 floor = gateway.minHealthFactor();
+        if (floor == 0) return account.availableBorrowsUsd;
+        uint256 maxDebt = ((account.availableBorrowsUsd + account.debtUsd) * 1e18) / floor;
+        return maxDebt > account.debtUsd ? maxDebt - account.debtUsd : 0;
+    }
+
+    /**
+     * @notice Borrow headroom (USD) the lens may size collateral withdrawals against: consuming it keeps
+     *         the post-withdraw health factor at or above the gateway's floor; raw availableBorrowsUsd
+     *         while no floor is set
+     * @dev HF' = (maxBorrowUsd - consumed) / debtUsd >= floor <=> consumed <= maxBorrowUsd - debtUsd * floor.
+     *      Quote-side only, like bufferedCreditHeadroom — except withdrawal requests, which also enforce
+     *      the floor at execution, so this quote is exactly what a request can pull.
+     */
+    function bufferedDebitHeadroom(ILendGateway gateway, ILendGateway.AccountData memory account) public view returns (uint256) {
+        uint256 floor = gateway.minHealthFactor();
+        if (floor == 0) return account.availableBorrowsUsd;
+        uint256 required = (account.debtUsd * floor) / 1e18;
+        uint256 maxBorrow = account.availableBorrowsUsd + account.debtUsd;
+        return maxBorrow > required ? maxBorrow - required : 0;
+    }
+
     /// @notice Borrowing headroom (USD) consumed by withdrawing `amount` of `token`: its USD value weighted by the LTV
     function headroomConsumed(ILendGateway gateway, IPriceProvider priceProvider, address token, uint256 amount) public view returns (uint256) {
         return (toUsd(priceProvider, token, amount) * gateway.ltv(token)) / LTV_SCALE;

--- a/src/mocks/MockLendGateway.sol
+++ b/src/mocks/MockLendGateway.sol
@@ -83,6 +83,13 @@ contract MockLendGateway is ILendGateway {
 
     uint256 public minHealthFactor;
 
+    function hasDebt(address safe) external view returns (bool) {
+        for (uint256 i = 0; i < _assets.length; i++) {
+            if (_debtOf[safe][_assets[i]] != 0) return true;
+        }
+        return false;
+    }
+
     function setMinHealthFactor(uint256 value) external {
         minHealthFactor = value;
     }

--- a/src/mocks/MockLendGateway.sol
+++ b/src/mocks/MockLendGateway.sol
@@ -81,6 +81,14 @@ contract MockLendGateway is ILendGateway {
 
     function borrow(address safe, address asset, uint256 amount, address to) external { }
 
+    uint256 public minHealthFactor;
+
+    function setMinHealthFactor(uint256 value) external {
+        minHealthFactor = value;
+    }
+
+    function ensureMinHealthFactor(address safe) external view { }
+
     function repay(address safe, address asset, uint256 amount) external returns (uint256) {
         uint256 debt = _debtOf[safe][asset];
         uint256 repaid = amount < debt ? amount : debt;

--- a/src/modules/ModuleLendGatewaySandwich.sol
+++ b/src/modules/ModuleLendGatewaySandwich.sol
@@ -8,9 +8,13 @@ import { ModuleCheckBalance } from "./ModuleCheckBalance.sol";
  * @title ModuleLendGatewaySandwich
  * @notice Bookends for modules that move a safe's assets once auto-supply has parked them in Aave:
  *         withdraw the input back to the safe, run the action, re-supply the output as collateral.
- * @dev No health check of its own: Aave rejects any withdraw that would push the health factor below 1
- *      (its collateralFactor is both LTV and liquidation threshold), and the back bookend only adds
- *      collateral. Both bookends no-op unless _lendActive, so a legacy or opted-out safe is untouched.
+ * @dev Aave rejects any withdraw that would push the health factor below 1 (its collateralFactor is both
+ *      LTV and liquidation threshold), and the back bookend only adds collateral. On top of that,
+ *      risk-increasing consumer flows end with _ensureGatewayFloor: whatever the resupply put back, the
+ *      end state must sit at or above the gateway's configured health-factor floor (a failed or
+ *      unregistered resupply otherwise leaves the health factor between Aave's 1.0 limit and the floor).
+ *      Repayment flows (the LiquidUSD liquifier) are deliberately exempt: de-risking must never be
+ *      blocked. Both bookends no-op unless _lendActive, so a legacy or opted-out safe is untouched.
  *
  *      Inherits ModuleCheckBalance because the bookends extend its balance model (the front bookend
  *      sources what _getAvailableAmount found missing) and it holds the cashModule reference every
@@ -72,5 +76,20 @@ abstract contract ModuleLendGatewaySandwich is ModuleCheckBalance {
         try lendGateway.supply(safe, asset, amount) {
             lendGateway.setUsingAsCollateral(safe, asset, true);
         } catch { }
+    }
+
+    /**
+     * @notice Post-op health-factor floor check for risk-increasing consumer flows
+     * @dev Called at the very end of an operation that may have pulled collateral out of Aave: the
+     *      module's signed amount is not bound to the lens quote, and a failed or unregistered resupply
+     *      can leave the health factor between Aave's 1.0 limit and the configured floor — this makes the
+     *      end state take the floor. Repayment flows are deliberately exempt (de-risking must never be
+     *      blocked). No-op for legacy or opted-out safes (their ops only touch loose, non-collateral
+     *      funds) and while the floor is disabled.
+     * @param safe The safe to check
+     */
+    function _ensureGatewayFloor(address safe) internal view {
+        if (!_lendActive(safe)) return;
+        gateway().ensureMinHealthFactor(safe);
     }
 }

--- a/src/modules/ModuleLendGatewaySandwich.sol
+++ b/src/modules/ModuleLendGatewaySandwich.sol
@@ -14,7 +14,11 @@ import { ModuleCheckBalance } from "./ModuleCheckBalance.sol";
  *      end state must sit at or above the gateway's configured health-factor floor (a failed or
  *      unregistered resupply otherwise leaves the health factor between Aave's 1.0 limit and the floor).
  *      Repayment flows (the LiquidUSD liquifier) are deliberately exempt: de-risking must never be
- *      blocked. Both bookends no-op unless _lendActive, so a legacy or opted-out safe is untouched.
+ *      blocked. Gating is asymmetric by design: the WITHDRAW bookend runs for any gateway-engine safe —
+ *      an opted-out safe (including a matured opt-out whose unwind open borrows still block) can hold
+ *      funds supplied on Aave, and pulling them loose is an exit op the repayment/exit paths depend on
+ *      (repayUsingLiquidUSD sourcing supplied LiquidUSD). The RESUPPLY bookend and the floor check stay
+ *      on _lendActive, so no new supply reaches Aave for a legacy or opted-out safe.
  *
  *      Inherits ModuleCheckBalance because the bookends extend its balance model (the front bookend
  *      sources what _getAvailableAmount found missing) and it holds the cashModule reference every
@@ -34,12 +38,24 @@ abstract contract ModuleLendGatewaySandwich is ModuleCheckBalance {
 
     /**
      * @notice Whether the safe's assets live in Aave: on the gateway engine and not opted out
-     * @dev Virtual only for the test harness
+     * @dev Virtual only for the test harness. Gates the resupply bookend and the floor check.
      * @param safe The safe to test
-     * @return True if the Aave bookends should run for the safe
+     * @return True if new supply may reach Aave for the safe
      */
     function _lendActive(address safe) internal view virtual returns (bool) {
         return cashModule.isLendActive(safe);
+    }
+
+    /**
+     * @notice Whether the safe runs on the gateway engine, regardless of its opt-out state
+     * @dev Virtual only for the test harness. Gates the withdraw bookend: an opted-out safe can still
+     *      hold funds supplied on Aave (a matured opt-out blocked by open borrows, or a residual after
+     *      processing), and reclaiming them is an exit op that must stay open.
+     * @param safe The safe to test
+     * @return True if the safe's supplied funds may sit in the gateway
+     */
+    function _onGatewayEngine(address safe) internal view virtual returns (bool) {
+        return cashModule.usesLendGateway(safe);
     }
 
     /**
@@ -53,8 +69,10 @@ abstract contract ModuleLendGatewaySandwich is ModuleCheckBalance {
      */
     function _withdrawShortfall(address safe, address asset, uint256 amount, uint256 looseAvailable) internal {
         if (amount <= looseAvailable) return;
-        if (!_lendActive(safe)) return;
+        // Engine-gated, NOT _lendActive: an opted-out safe's supplied funds must stay reclaimable
+        if (!_onGatewayEngine(safe)) return;
         ILendGateway lendGateway = gateway();
+        if (address(lendGateway) == address(0)) return;
         uint256 supplied = lendGateway.suppliedOf(safe, asset);
         uint256 shortfall = amount - looseAvailable;
         if (shortfall > supplied) shortfall = supplied;

--- a/src/modules/cash/CashLendLib.sol
+++ b/src/modules/cash/CashLendLib.sol
@@ -405,7 +405,7 @@ library CashLendLib {
      */
     function isLendOptedOut(CashModuleStorageContract.CashModuleStorage storage $, address safe) public view returns (bool) {
         SafeCashConfig storage $$ = $.safeCashConfig[safe];
-        return $$.lendOptedOut || ($$.lendOptOutFinalizeTime != 0 && block.timestamp >= $$.lendOptOutFinalizeTime);
+        return $$.lendOptedOut || ($$.lendOptOutFinalizeTime != 0 && block.timestamp > $$.lendOptOutFinalizeTime);
     }
 
     /**

--- a/src/modules/cash/CashLendLib.sol
+++ b/src/modules/cash/CashLendLib.sol
@@ -440,6 +440,16 @@ library CashLendLib {
 
         uint96 finalizeTime = uint96(block.timestamp) + $.modeDelay;
         $$.lendOptOutFinalizeTime = finalizeTime;
+
+        if ($$.incomingModeStartTime != 0 && block.timestamp > $$.incomingModeStartTime) $$.mode = $$.incomingMode;
+        delete $$.incomingMode;
+        delete $$.incomingModeStartTime;
+        if ($$.mode == Mode.Credit) {
+            $$.incomingMode = Mode.Debit;
+            $$.incomingModeStartTime = finalizeTime;
+            $.cashEventEmitter.emitSetMode(safe, Mode.Credit, Mode.Debit, finalizeTime);
+        }
+
         $.cashEventEmitter.emitLendOptOutRequested(safe, finalizeTime);
 
         if ($.modeDelay == 0) executeLendOptOut($, safe);
@@ -492,6 +502,12 @@ library CashLendLib {
     function optInToLend(CashModuleStorageContract.CashModuleStorage storage $, address safe) public {
         SafeCashConfig storage $$ = $.safeCashConfig[safe];
         if (!$$.lendOptedOut && $$.lendOptOutFinalizeTime == 0) revert LendNotOptedOut();
+
+        if ($$.lendOptOutFinalizeTime != 0) {
+            if ($$.incomingModeStartTime != 0 && block.timestamp > $$.incomingModeStartTime) $$.mode = $$.incomingMode;
+            delete $$.incomingMode;
+            delete $$.incomingModeStartTime;
+        }
 
         $$.lendOptedOut = false;
         $$.lendOptOutFinalizeTime = 0;

--- a/src/modules/cash/CashLendLib.sol
+++ b/src/modules/cash/CashLendLib.sol
@@ -266,6 +266,7 @@ library CashLendLib {
         ILendGateway gateway = $.gateway;
         if (address(gateway) == address(0)) revert LendGatewayNotSet();
 
+        bool pulled;
         for (uint256 i = 0; i < tokens.length; i++) {
             if (!gateway.isRegistered(tokens[i])) continue;
             uint256 loose = IERC20(tokens[i]).balanceOf(safe);
@@ -274,7 +275,11 @@ library CashLendLib {
             uint256 supplied = gateway.suppliedOf(safe, tokens[i]);
             if (supplied == 0) continue;
             gateway.withdraw(safe, tokens[i], shortfall > supplied ? supplied : shortfall, safe);
+            pulled = true;
         }
+        // A withdrawal is a user extraction, so pulling from Aave takes the health-factor floor; a
+        // loose-balance-only withdrawal never touches the position and is exempt (as are card spends)
+        if (pulled) gateway.ensureMinHealthFactor(safe);
     }
 
     /**
@@ -343,6 +348,8 @@ library CashLendLib {
 
         gateway.borrow(safe, token, amount, safe);
         _supplyAsCollateral($, gateway, safe, token, amount);
+        // The borrow page takes the health-factor floor (post-resupply end state); card spends are exempt
+        gateway.ensureMinHealthFactor(safe);
         $.cashEventEmitter.emitLendBorrowed(safe, token, amount, amountInUsd);
     }
 

--- a/src/modules/cash/CashLendLib.sol
+++ b/src/modules/cash/CashLendLib.sol
@@ -294,7 +294,8 @@ library CashLendLib {
      */
     function supplyToLend(CashModuleStorageContract.CashModuleStorage storage $, address safe, address[] calldata tokens) external {
         ILendGateway gateway = _requireGateway($, safe);
-        if ($.safeCashConfig[safe].lendOptedOut) return;
+        processLendOptOutIfReady($, safe);
+        if (isLendOptedOut($, safe)) return;
 
         for (uint256 i = 0; i < tokens.length; i++) {
             if (!gateway.isRegistered(tokens[i])) continue;
@@ -334,7 +335,7 @@ library CashLendLib {
     function borrow(CashModuleStorageContract.CashModuleStorage storage $, IEtherFiDataProvider dataProvider, address safe, address token, uint256 amountInUsd, uint256 nonce, address[] calldata signers, bytes[] calldata signatures) external {
         CashVerificationLib.verifyBorrowSig(safe, nonce, token, amountInUsd, signers, signatures);
         ILendGateway gateway = _requireGateway($, safe);
-        if ($.safeCashConfig[safe].lendOptedOut) revert LendOptedOut();
+        if (isLendOptedOut($, safe)) revert LendOptedOut();
 
         if (!gateway.isBorrowable(token)) revert OnlyBorrowToken();
         uint256 amount = DebitSourcingLib.fromUsd(IPriceProvider(dataProvider.getPriceProvider()), token, amountInUsd);
@@ -392,6 +393,36 @@ library CashLendLib {
         }
         (, uint256 debtManagerDebt) = $.debtManager.borrowingOf(safe);
         return debtManagerDebt != 0;
+    }
+
+    /**
+     * @notice Whether the safe is effectively opted out of lend: either the opt-out has been processed,
+     *         or a pending request's finalize time has passed (mirroring how getMode honors a matured
+     *         incoming mode before _setCurrentMode has applied it)
+     * @param $ The CashModule storage (passed by the delegatecalling module)
+     * @param safe Address of the EtherFi Safe
+     * @return True if the safe is opted out or a matured opt-out request awaits processing
+     */
+    function isLendOptedOut(CashModuleStorageContract.CashModuleStorage storage $, address safe) public view returns (bool) {
+        SafeCashConfig storage $$ = $.safeCashConfig[safe];
+        return $$.lendOptedOut || ($$.lendOptOutFinalizeTime != 0 && block.timestamp >= $$.lendOptOutFinalizeTime);
+    }
+
+    /**
+     * @notice Lazily executes a matured lend opt-out on the mutating paths, so a user never has to wait
+     *         for the permissionless processLendOptOut call (the opt-out twin of _setCurrentMode)
+     * @dev No-op when nothing is pending or the delay hasn't elapsed. Also a no-op — never a revert — when
+     *      open borrows block the unwind (all collateral cannot be withdrawn under debt): the effective
+     *      views already report the safe as opted out meanwhile, and the next touch after the debt clears
+     *      (e.g. repay) completes the opt-out.
+     * @param $ The CashModule storage (passed by the delegatecalling module)
+     * @param safe Address of the EtherFi Safe
+     */
+    function processLendOptOutIfReady(CashModuleStorageContract.CashModuleStorage storage $, address safe) public {
+        SafeCashConfig storage $$ = $.safeCashConfig[safe];
+        if ($$.lendOptOutFinalizeTime == 0 || block.timestamp < $$.lendOptOutFinalizeTime) return;
+        if (hasOpenBorrows($, safe)) return;
+        executeLendOptOut($, safe);
     }
 
     /**
@@ -485,8 +516,9 @@ library CashLendLib {
      */
     function spendCredit(CashModuleStorageContract.CashModuleStorage storage $, IEtherFiDataProvider dataProvider, address safe, bytes32 txId, BinSponsor binSponsor, address[] calldata tokens, uint256[] calldata amountsInUsd, uint256 totalSpendingInUsd) external {
         // Defense-in-depth: a safe that opted out of lend is forced to Debit and blocked from re-entering
-        // Credit, so credit spending must never reach an opted-out safe.
-        if ($.safeCashConfig[safe].lendOptedOut) revert LendOptedOut();
+        // Credit, so credit spending must never reach an opted-out safe. Effective check: a matured
+        // opt-out blocked from lazy processing by open borrows must still stop borrowing more.
+        if (isLendOptedOut($, safe)) revert LendOptedOut();
 
         uint256 amount;
         if (!_usesLendGateway($, safe)) {

--- a/src/modules/cash/CashLendLib.sol
+++ b/src/modules/cash/CashLendLib.sol
@@ -420,9 +420,16 @@ library CashLendLib {
      */
     function processLendOptOutIfReady(CashModuleStorageContract.CashModuleStorage storage $, address safe) public {
         SafeCashConfig storage $$ = $.safeCashConfig[safe];
-        if ($$.lendOptOutFinalizeTime == 0 || block.timestamp < $$.lendOptOutFinalizeTime) return;
+        // Strictly after the finalize time, matching isLendOptedOut and the incoming-mode rail, so reads
+        // and lazy processing flip in the same second
+        if ($$.lendOptOutFinalizeTime == 0 || block.timestamp <= $$.lendOptOutFinalizeTime) return;
         if (hasOpenBorrows($, safe)) return;
-        executeLendOptOut($, safe);
+        // Best-effort unwind: a temporarily failing withdraw (paused gateway or reserve) must not revert
+        // the unrelated action that triggered the lazy processing — the opt-out stays pending (the
+        // effective views already report it) and the next touch retries. The opt-out is only marked
+        // processed once everything is actually withdrawn.
+        if (!_unwindLendCollateral($, safe, true)) return;
+        _finalizeLendOptOut($, safe);
     }
 
     /**
@@ -466,21 +473,58 @@ library CashLendLib {
      * @param safe Address of the EtherFi Safe
      */
     function executeLendOptOut(CashModuleStorageContract.CashModuleStorage storage $, address safe) public {
-        if (_usesLendGateway($, safe)) {
-            ILendGateway gateway = $.gateway;
-            if (address(gateway) == address(0)) revert LendGatewayNotSet();
+        _unwindLendCollateral($, safe, false);
+        _finalizeLendOptOut($, safe);
+    }
 
-            address[] memory collateralTokens = gateway.registeredAssets();
-            uint256 len = collateralTokens.length;
-            for (uint256 i = 0; i < len;) {
-                uint256 supplied = gateway.suppliedOf(safe, collateralTokens[i]);
-                if (supplied != 0) gateway.withdraw(safe, collateralTokens[i], supplied, safe);
-                unchecked {
-                    ++i;
+    /**
+     * @notice Withdraws ALL of the safe's Aave collateral back to the safe
+     * @dev For a gateway safe, iterates the gateway's registered assets, not DebtManager's collateral list,
+     *      so a token delisted from DebtManager while still supplied on Aave stays withdrawable. A legacy
+     *      safe has nothing on Aave to unwind. In best-effort mode a failing withdraw (paused gateway or
+     *      reserve) is swallowed and reported instead of reverting, and the other tokens still unwind, so
+     *      the lazy paths never block an unrelated action; the strict mode (explicit processLendOptOut,
+     *      zero-delay requests) lets the error surface to the caller.
+     * @param $ The CashModule storage (passed by the delegatecalling module)
+     * @param safe Address of the EtherFi Safe
+     * @param bestEffort True to swallow individual withdraw failures instead of reverting
+     * @return fullyUnwound True when nothing is left supplied on Aave
+     */
+    function _unwindLendCollateral(CashModuleStorageContract.CashModuleStorage storage $, address safe, bool bestEffort) private returns (bool fullyUnwound) {
+        fullyUnwound = true;
+        if (!_usesLendGateway($, safe)) return fullyUnwound;
+
+        ILendGateway gateway = $.gateway;
+        if (address(gateway) == address(0)) revert LendGatewayNotSet();
+
+        address[] memory collateralTokens = gateway.registeredAssets();
+        uint256 len = collateralTokens.length;
+        for (uint256 i = 0; i < len;) {
+            uint256 supplied = gateway.suppliedOf(safe, collateralTokens[i]);
+            if (supplied != 0) {
+                if (bestEffort) {
+                    try gateway.withdraw(safe, collateralTokens[i], supplied, safe) { }
+                    catch {
+                        fullyUnwound = false;
+                    }
+                } else {
+                    gateway.withdraw(safe, collateralTokens[i], supplied, safe);
                 }
             }
+            unchecked {
+                ++i;
+            }
         }
+    }
 
+    /**
+     * @notice Marks the opt-out processed: sets the flag, clears the pending request, and forces Debit
+     * @dev Only called once the collateral is fully unwound (or there was none). Credit needs lend
+     *      collateral, so the mode is forced to Debit and any pending mode change is dropped.
+     * @param $ The CashModule storage (passed by the delegatecalling module)
+     * @param safe Address of the EtherFi Safe
+     */
+    function _finalizeLendOptOut(CashModuleStorageContract.CashModuleStorage storage $, address safe) private {
         SafeCashConfig storage $$ = $.safeCashConfig[safe];
         $$.lendOptedOut = true;
         $$.lendOptOutFinalizeTime = 0;

--- a/src/modules/cash/CashLendLib.sol
+++ b/src/modules/cash/CashLendLib.sol
@@ -612,7 +612,9 @@ library CashLendLib {
     function _spendGatewayCredit(CashModuleStorageContract.CashModuleStorage storage $, IEtherFiDataProvider dataProvider, address safe, BinSponsor binSponsor, address token, uint256 amountInUsd) private returns (uint256) {
         ILendGateway gateway = $.gateway;
         if (address(gateway) == address(0)) revert LendGatewayNotSet();
-        if (!gateway.isBorrowable(token)) revert UnsupportedToken();
+        // The drawn token settles the card, so it must be a card-settleable spend asset AND borrowable on
+        // Aave — a borrowable reserve the card cannot settle in must not fund a credit spend
+        if (!gateway.isBorrowable(token) || !gateway.isSpendAsset(token)) revert UnsupportedToken();
         uint256 amount = DebitSourcingLib.fromUsd(IPriceProvider(dataProvider.getPriceProvider()), token, amountInUsd);
         if (amount == 0) revert AmountZero();
         _resupplyCollateral($, dataProvider, gateway, safe, amountInUsd);
@@ -784,7 +786,9 @@ library CashLendLib {
         s.fromLoose = new uint256[](tokens.length);
         {
             ILendGateway.AccountData memory account = $.gateway.getAccountData(safe);
-            s.hasDebt = account.debtUsd != 0;
+            // Raw per-asset debt, not the 6-decimal-floored debtUsd: dust debt must still cap the
+            // supplied-withdraw legs, or Aave reverts the spend on a position the sizing called debt-free
+            s.hasDebt = $.gateway.hasDebt(safe);
             s.borrowHeadroom = s.hasDebt ? account.availableBorrowsUsd : 0;
         }
         IPriceProvider priceProvider = IPriceProvider(dataProvider.getPriceProvider());

--- a/src/modules/cash/CashLens.sol
+++ b/src/modules/cash/CashLens.sol
@@ -127,6 +127,7 @@ contract CashLens is UpgradeableProxy, Constants {
         SafeData memory safeData = cashModule.getData(safe);
         if (safeData.incomingModeStartTime != 0) mode = safeData.incomingMode;
         else mode = safeData.mode;
+        if (mode == Mode.Credit && _lendOptOutForcesDebit(safe)) mode = Mode.Debit;
 
         address[] memory tokenPreferences = mode == Mode.Debit ? debitModeTokenPreferences : creditModeTokenPreferences;
 
@@ -137,6 +138,17 @@ contract CashLens is UpgradeableProxy, Constants {
         (token, canSpendResult, declineReason) = _checkTokenPreferences(safe, txId, tokenPreferences, amountInUsd);
 
         return (mode, token, canSpendResult, declineReason);
+    }
+
+    /**
+     * @dev Mirrors the spend path's lazy opt-out processing: a pending lend opt-out forces the safe into
+     *      Debit mode when it matures (executeLendOptOut), so credit-mode simulations must route as Debit.
+     *      A not-yet-matured request is treated the same way — like the incoming-mode handling above — since
+     *      a spend authorized now can settle on-chain after the request matures. isLendOptedOut is the
+     *      effective view (true once the finalize time passes), lendOptOutFinalizeTime covers the pending window.
+     */
+    function _lendOptOutForcesDebit(address safe) internal view returns (bool) {
+        return cashModule.isLendOptedOut(safe) || cashModule.lendOptOutFinalizeTime(safe) != 0;
     }
 
     function _checkTokenPreferences(address safe, bytes32 txId, address[] memory tokenPreferences, uint256 amountInUsd) internal view returns (address token, bool canSpendResult, string memory declineReason) {
@@ -169,6 +181,7 @@ contract CashLens is UpgradeableProxy, Constants {
         Mode mode = safeData.mode;
         // Update mode if necessary
         if (safeData.incomingModeStartTime != 0) mode = safeData.incomingMode;
+        if (mode == Mode.Credit && _lendOptOutForcesDebit(safe)) mode = Mode.Debit;
 
         // In Credit mode, only one token is allowed
         if (mode == Mode.Credit && tokens.length > 1) return (false, "Only one token allowed in Credit mode");

--- a/src/modules/cash/CashLens.sol
+++ b/src/modules/cash/CashLens.sol
@@ -192,24 +192,9 @@ contract CashLens is UpgradeableProxy, Constants {
 
     /// @notice Credit mode check: the spend must fit the Aave borrowing capacity and the reserve's liquidity
     function _creditCheck(address safe, address token, uint256 totalSpendingInUsd) internal view returns (bool, string memory) {
-        ILendGateway lendGateway = cashModule.getLendGateway();
-        if (!lendGateway.isBorrowable(token)) {
-            return (false, "Not a supported borrow token");
-        }
-
-        if (lendGateway.availableToBorrow(token) < _fromUsd(token, totalSpendingInUsd)) {
-            return (false, "Insufficient liquidity to cover the loan");
-        }
-
-        // availableBorrowsUsd is only the already-supplied position's capacity. This gate deliberately excludes
-        // loose collateral the spend-time resupply can pull in (CashLendLib._resupplyCollateral), since that
-        // capacity exists only by cancelling the safe's pending withdrawal; canSpend must not advertise it as
-        // headroom. So a credit spend declined here may still execute via resupply if it was authorized.
-        if (totalSpendingInUsd > lendGateway.getAccountData(safe).availableBorrowsUsd) {
-            return (false, "Insufficient borrowing power");
-        }
-
-        return (true, "");
+        // Token gate, reserve liquidity, and the health-factor-floor-buffered borrowing power live in the
+        // linked DebitSourcingLib (code size); see creditCheck there for the quote-vs-execution contract.
+        return DebitSourcingLib.creditCheck(cashModule.getLendGateway(), IPriceProvider(dataProvider.getPriceProvider()), safe, token, totalSpendingInUsd);
     }
 
     /// @notice Debit mode check: each token's spendable amount must cover its share of the spend, threading the borrowing headroom across tokens
@@ -220,7 +205,9 @@ contract CashLens is UpgradeableProxy, Constants {
         {
             ILendGateway.AccountData memory account = lendGateway.getAccountData(safe);
             hasDebt = account.debtUsd != 0;
-            borrowHeadroom = hasDebt ? account.availableBorrowsUsd : 0;
+            // Buffered by the health-factor floor: quotes size collateral withdrawals so the position
+            // stays above the floor; debit execution keeps the raw bound (spends always settle)
+            borrowHeadroom = hasDebt ? DebitSourcingLib.bufferedDebitHeadroom(lendGateway, account) : 0;
         }
 
         for (uint256 i = 0; i < tokens.length; i++) {
@@ -375,7 +362,8 @@ contract CashLens is UpgradeableProxy, Constants {
             ILendGateway.AccountData memory account = lendGateway.getAccountData(safe);
             hasDebt = account.debtUsd != 0;
             if (hasDebt) {
-                borrowHeadroom = account.availableBorrowsUsd;
+                // Buffered by the health-factor floor, matching _debitCheck
+                borrowHeadroom = DebitSourcingLib.bufferedDebitHeadroom(lendGateway, account);
             }
         }
 
@@ -417,22 +405,9 @@ contract CashLens is UpgradeableProxy, Constants {
             return CashLensLegacyLib.maxSpendCredit(cashModule, safe);
         }
 
-        ILendGateway lendGateway = cashModule.getLendGateway();
-        uint256 borrowPower = lendGateway.getAccountData(safe).availableBorrowsUsd;
-
-        address[] memory borrowTokens = lendGateway.borrowableAssets();
-        uint256 maxLiquidityUsd = 0;
-        for (uint256 i = 0; i < borrowTokens.length;) {
-            uint256 liquidityUsd = _toUsd(borrowTokens[i], lendGateway.availableToBorrow(borrowTokens[i]));
-            if (liquidityUsd > maxLiquidityUsd) {
-                maxLiquidityUsd = liquidityUsd;
-            }
-            unchecked {
-                ++i;
-            }
-        }
-
-        return borrowPower < maxLiquidityUsd ? borrowPower : maxLiquidityUsd;
+        // Floor-buffered borrowing power bounded by reserve liquidity; lives in the linked
+        // DebitSourcingLib (code size), matching _creditCheck's gates
+        return DebitSourcingLib.maxSpendCredit(cashModule.getLendGateway(), IPriceProvider(dataProvider.getPriceProvider()), safe);
     }
 
     /**
@@ -473,8 +448,11 @@ contract CashLens is UpgradeableProxy, Constants {
             return looseAvailable;
         }
 
-        ILendGateway.AccountData memory account = gateway().getAccountData(safe);
-        return looseAvailable + _withdrawableSupplied(safe, token, account.availableBorrowsUsd, account.debtUsd != 0);
+        ILendGateway lendGateway = gateway();
+        ILendGateway.AccountData memory account = lendGateway.getAccountData(safe);
+        // Buffered by the health-factor floor: withdrawal sourcing enforces the floor at execution, so
+        // this quote is exactly what a request (or module sandwich) can actually pull
+        return looseAvailable + _withdrawableSupplied(safe, token, DebitSourcingLib.bufferedDebitHeadroom(lendGateway, account), account.debtUsd != 0);
     }
 
     /**

--- a/src/modules/cash/CashLens.sol
+++ b/src/modules/cash/CashLens.sol
@@ -204,7 +204,8 @@ contract CashLens is UpgradeableProxy, Constants {
         uint256 borrowHeadroom;
         {
             ILendGateway.AccountData memory account = lendGateway.getAccountData(safe);
-            hasDebt = account.debtUsd != 0;
+            // Raw per-asset debt, not the 6-decimal-floored debtUsd: dust debt must still cap withdrawals
+            hasDebt = lendGateway.hasDebt(safe);
             // Buffered by the health-factor floor: quotes size collateral withdrawals so the position
             // stays above the floor; debit execution keeps the raw bound (spends always settle)
             borrowHeadroom = hasDebt ? DebitSourcingLib.bufferedDebitHeadroom(lendGateway, account) : 0;
@@ -360,7 +361,8 @@ contract CashLens is UpgradeableProxy, Constants {
         uint256 borrowHeadroom;
         {
             ILendGateway.AccountData memory account = lendGateway.getAccountData(safe);
-            hasDebt = account.debtUsd != 0;
+            // Raw per-asset debt, not the 6-decimal-floored debtUsd: dust debt must still cap withdrawals
+            hasDebt = lendGateway.hasDebt(safe);
             if (hasDebt) {
                 // Buffered by the health-factor floor, matching _debitCheck
                 borrowHeadroom = DebitSourcingLib.bufferedDebitHeadroom(lendGateway, account);
@@ -451,8 +453,9 @@ contract CashLens is UpgradeableProxy, Constants {
         ILendGateway lendGateway = gateway();
         ILendGateway.AccountData memory account = lendGateway.getAccountData(safe);
         // Buffered by the health-factor floor: withdrawal sourcing enforces the floor at execution, so
-        // this quote is exactly what a request (or module sandwich) can actually pull
-        return looseAvailable + _withdrawableSupplied(safe, token, DebitSourcingLib.bufferedDebitHeadroom(lendGateway, account), account.debtUsd != 0);
+        // this quote is exactly what a request (or module sandwich) can actually pull. hasDebt reads raw
+        // per-asset debt, not the 6-decimal-floored debtUsd, so dust debt still caps the quote.
+        return looseAvailable + _withdrawableSupplied(safe, token, DebitSourcingLib.bufferedDebitHeadroom(lendGateway, account), lendGateway.hasDebt(safe));
     }
 
     /**

--- a/src/modules/cash/CashLens.sol
+++ b/src/modules/cash/CashLens.sol
@@ -127,7 +127,6 @@ contract CashLens is UpgradeableProxy, Constants {
         SafeData memory safeData = cashModule.getData(safe);
         if (safeData.incomingModeStartTime != 0) mode = safeData.incomingMode;
         else mode = safeData.mode;
-        if (mode == Mode.Credit && _lendOptOutForcesDebit(safe)) mode = Mode.Debit;
 
         address[] memory tokenPreferences = mode == Mode.Debit ? debitModeTokenPreferences : creditModeTokenPreferences;
 
@@ -138,17 +137,6 @@ contract CashLens is UpgradeableProxy, Constants {
         (token, canSpendResult, declineReason) = _checkTokenPreferences(safe, txId, tokenPreferences, amountInUsd);
 
         return (mode, token, canSpendResult, declineReason);
-    }
-
-    /**
-     * @dev Mirrors the spend path's lazy opt-out processing: a pending lend opt-out forces the safe into
-     *      Debit mode when it matures (executeLendOptOut), so credit-mode simulations must route as Debit.
-     *      A not-yet-matured request is treated the same way — like the incoming-mode handling above — since
-     *      a spend authorized now can settle on-chain after the request matures. isLendOptedOut is the
-     *      effective view (true once the finalize time passes), lendOptOutFinalizeTime covers the pending window.
-     */
-    function _lendOptOutForcesDebit(address safe) internal view returns (bool) {
-        return cashModule.isLendOptedOut(safe) || cashModule.lendOptOutFinalizeTime(safe) != 0;
     }
 
     function _checkTokenPreferences(address safe, bytes32 txId, address[] memory tokenPreferences, uint256 amountInUsd) internal view returns (address token, bool canSpendResult, string memory declineReason) {
@@ -179,9 +167,7 @@ contract CashLens is UpgradeableProxy, Constants {
         SafeData memory safeData = cashModule.getData(safe);
 
         Mode mode = safeData.mode;
-        // Update mode if necessary
         if (safeData.incomingModeStartTime != 0) mode = safeData.incomingMode;
-        if (mode == Mode.Credit && _lendOptOutForcesDebit(safe)) mode = Mode.Debit;
 
         // In Credit mode, only one token is allowed
         if (mode == Mode.Credit && tokens.length > 1) return (false, "Only one token allowed in Credit mode");

--- a/src/modules/cash/CashModuleCore.sol
+++ b/src/modules/cash/CashModuleCore.sol
@@ -325,7 +325,7 @@ contract CashModuleCore is CashModuleStorageContract {
         CashModuleStorage storage $ = _getCashModuleStorage();
         SafeCashConfig storage safeConfig = $.safeCashConfig[safe];
         if (safeConfig.lendOptOutFinalizeTime == 0) revert NoPendingLendOptOut();
-        if (block.timestamp < safeConfig.lendOptOutFinalizeTime) revert LendOptOutNotReady();
+        if (block.timestamp <= safeConfig.lendOptOutFinalizeTime) revert LendOptOutNotReady();
         if (CashLendLib.hasOpenBorrows($, safe)) revert HasOpenBorrows();
         CashLendLib.executeLendOptOut($, safe);
     }

--- a/src/modules/cash/CashModuleCore.sol
+++ b/src/modules/cash/CashModuleCore.sol
@@ -256,18 +256,20 @@ contract CashModuleCore is CashModuleStorageContract {
      * @return True if the safe uses the gateway engine and has not opted out
      */
     function isLendActive(address safe) external view returns (bool) {
-        return _usesLendGateway(safe) && !_getCashModuleStorage().safeCashConfig[safe].lendOptedOut;
+        return _usesLendGateway(safe) && !CashLendLib.isLendOptedOut(_getCashModuleStorage(), safe);
     }
 
     /**
-     * @notice The user's raw lend opt-out preference, independent of the safe's engine
+     * @notice The user's effective lend opt-out state, independent of the safe's engine
      * @dev The gateway's supply/collateral gates read this (not isLendActive), since a safe is supplied into
-     *      Aave during migration before its engine flag flips.
+     *      Aave during migration before its engine flag flips. Effective: a pending opt-out whose finalize
+     *      time has passed reports true even before processLendOptOut runs, mirroring how getMode honors a
+     *      matured incoming mode.
      * @param safe Address of the EtherFi Safe
-     * @return True if the safe has opted out via toggleLend(false) + processLendOptOut
+     * @return True if the safe opted out via toggleLend(false), processed or matured-pending
      */
     function isLendOptedOut(address safe) external view returns (bool) {
-        return _getCashModuleStorage().safeCashConfig[safe].lendOptedOut;
+        return CashLendLib.isLendOptedOut(_getCashModuleStorage(), safe);
     }
 
     /**
@@ -388,6 +390,10 @@ contract CashModuleCore is CashModuleStorageContract {
      */
     function spend(address safe, bytes32 txId, BinSponsor binSponsor, address[] calldata tokens, uint256[] calldata amountsInUsd, Cashback[] calldata cashbacks) external whenNotPaused nonReentrant onlyEtherFiWallet onlyEtherFiSafe(safe) {
         CashModuleStorage storage $ = _getCashModuleStorage();
+
+        // A matured opt-out takes effect before the spend routes: it forces Debit mode (and unwinds the
+        // Aave position), so this must run before _validateSpend reads the mode.
+        CashLendLib.processLendOptOutIfReady($, safe);
 
         uint256 totalSpendingInUsd = _validateSpend($.safeCashConfig[safe], txId, tokens, amountsInUsd);
 
@@ -536,7 +542,10 @@ contract CashModuleCore is CashModuleStorageContract {
      * @custom:throws OnlyBorrowToken if the token cannot carry debt on the safe's engine
      */
     function repay(address safe, address token, uint256 amountInUsd) public whenNotPaused nonReentrant onlyEtherFiWallet onlyEtherFiSafe(safe) {
-        CashLendLib.repay(_getCashModuleStorage(), etherFiDataProvider, safe, token, amountInUsd);
+        CashModuleStorage storage $ = _getCashModuleStorage();
+        CashLendLib.repay($, etherFiDataProvider, safe, token, amountInUsd);
+        // A repay can clear the open borrows that were blocking a matured opt-out from processing
+        CashLendLib.processLendOptOutIfReady($, safe);
     }
 
     /**

--- a/src/modules/cash/CashModuleSetters.sol
+++ b/src/modules/cash/CashModuleSetters.sol
@@ -269,6 +269,8 @@ contract CashModuleSetters is CashModuleStorageContract {
         if (!etherFiDataProvider.isWhitelistedModule(msg.sender)) revert ModuleNotWhitelistedOnDataProvider();
         if (!$.whitelistedModulesCanRequestWithdraw.contains(msg.sender)) revert OnlyWhitelistedModuleCanRequestWithdraw();
 
+        CashLendLib.processLendOptOutIfReady($, safe);
+
         address[] memory tokens = new address[](1);
         uint256[] memory amounts = new uint256[](1);
         tokens[0] = token;

--- a/src/modules/cash/CashModuleSetters.sol
+++ b/src/modules/cash/CashModuleSetters.sol
@@ -204,12 +204,19 @@ contract CashModuleSetters is CashModuleStorageContract {
     function setMode(address safe, Mode mode, address signer, bytes calldata signature) external onlyEtherFiSafe(safe) onlySafeAdmin(safe, signer) {
         CashModuleStorage storage $ = _getCashModuleStorage();
 
-        // A matured opt-out forces Debit and must land before the mode logic reads or changes state
-        CashLendLib.processLendOptOutIfReady($, safe);
+        // While an opt-out request is pending, the mode trajectory belongs to the opt-out: a Credit
+        // request would overwrite the Debit switch the request scheduled on the pending-mode rail, and a
+        // Debit request could only DEFER it (both use modeDelay, so a re-request always lands after the
+        // opt-out's finalize time), reopening the window where a matured-but-blocked opt-out sits in
+        // stored Credit. Opting back in (toggleLend(true)) re-opens setMode. No lazy opt-out processing
+        // here: with the request pending this reverts anyway, so processing could never be persisted.
+        if ($.safeCashConfig[safe].lendOptOutFinalizeTime != 0) revert LendOptedOut();
+
         _setCurrentMode($.safeCashConfig[safe]);
 
         if (mode == $.safeCashConfig[safe].mode) revert ModeAlreadySet();
-        if (mode == Mode.Credit && ($.safeCashConfig[safe].lendOptedOut || $.safeCashConfig[safe].lendOptOutFinalizeTime != 0)) revert LendOptedOut();
+        // Credit mode requires collateral on Lend: a safe that opted out of lend cannot re-enter Credit
+        if (mode == Mode.Credit && $.safeCashConfig[safe].lendOptedOut) revert LendOptedOut();
 
         CashVerificationLib.verifySetModeSig(safe, signer, _useNonce(safe), mode, signature);
 

--- a/src/modules/cash/CashModuleSetters.sol
+++ b/src/modules/cash/CashModuleSetters.sol
@@ -204,11 +204,14 @@ contract CashModuleSetters is CashModuleStorageContract {
     function setMode(address safe, Mode mode, address signer, bytes calldata signature) external onlyEtherFiSafe(safe) onlySafeAdmin(safe, signer) {
         CashModuleStorage storage $ = _getCashModuleStorage();
 
+        // A matured opt-out forces Debit and must land before the mode logic reads or changes state
+        CashLendLib.processLendOptOutIfReady($, safe);
         _setCurrentMode($.safeCashConfig[safe]);
 
         if (mode == $.safeCashConfig[safe].mode) revert ModeAlreadySet();
-        // Credit mode requires lend collateral on Aave; a safe that opted out of lend cannot enter Credit
-        if (mode == Mode.Credit && $.safeCashConfig[safe].lendOptedOut) revert LendOptedOut();
+        // Credit mode requires lend collateral on Aave; a safe that opted out of lend cannot enter Credit.
+        // Effective check: also blocks a matured opt-out that open borrows kept from processing above.
+        if (mode == Mode.Credit && CashLendLib.isLendOptedOut($, safe)) revert LendOptedOut();
 
         CashVerificationLib.verifySetModeSig(safe, signer, _useNonce(safe), mode, signature);
 
@@ -245,6 +248,10 @@ contract CashModuleSetters is CashModuleStorageContract {
         if (_getCashModuleStorage().whitelistedModulesCanRequestWithdraw.contains(msg.sender) || _getCashModuleStorage().whitelistedModulesCanRequestWithdraw.contains(recipient)) {
             revert InvalidWithdrawRequest();
         }
+
+        // A matured opt-out returns all Aave collateral to the safe first, so the withdrawal sources
+        // from loose balances instead of pulling from the lend market
+        CashLendLib.processLendOptOutIfReady(_getCashModuleStorage(), safe);
 
         _requestWithdrawal(safe, tokens, amounts, recipient);
     }

--- a/src/modules/cash/CashModuleSetters.sol
+++ b/src/modules/cash/CashModuleSetters.sol
@@ -209,9 +209,7 @@ contract CashModuleSetters is CashModuleStorageContract {
         _setCurrentMode($.safeCashConfig[safe]);
 
         if (mode == $.safeCashConfig[safe].mode) revert ModeAlreadySet();
-        // Credit mode requires lend collateral on Aave; a safe that opted out of lend cannot enter Credit.
-        // Effective check: also blocks a matured opt-out that open borrows kept from processing above.
-        if (mode == Mode.Credit && CashLendLib.isLendOptedOut($, safe)) revert LendOptedOut();
+        if (mode == Mode.Credit && ($.safeCashConfig[safe].lendOptedOut || $.safeCashConfig[safe].lendOptOutFinalizeTime != 0)) revert LendOptedOut();
 
         CashVerificationLib.verifySetModeSig(safe, signer, _useNonce(safe), mode, signature);
 

--- a/src/modules/etherfi/EtherFiLiquidModule.sol
+++ b/src/modules/etherfi/EtherFiLiquidModule.sol
@@ -277,6 +277,8 @@ contract EtherFiLiquidModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardT
         // Re-supply the receipt token as collateral when the gateway lists it; an unlisted receipt stays loose.
         _resupplyToGateway(safe, liquidAsset, liquidTokenReceived);
 
+        _ensureGatewayFloor(safe);
+
         emit LiquidDeposit(safe, assetToDeposit, liquidAsset, amountToDeposit, liquidTokenReceived);
     }
 
@@ -355,6 +357,10 @@ contract EtherFiLiquidModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardT
         data[1] = abi.encodeWithSelector(IBoringOnChainQueue.requestOnChainWithdraw.selector, assetOut, amountToWithdraw, discount, secondsToDeadline);
 
         IEtherFiSafe(safe).execTransactionFromModule(to, values, data);
+
+        // Risk-increasing flow with no resupply (the queued output arrives later, loose): the end state
+        // takes the gateway's health-factor floor
+        _ensureGatewayFloor(safe);
         
         emit LiquidWithdrawal(safe, liquidAsset, amountToWithdraw, amountOutFromQueue);
     }

--- a/src/modules/etherfi/EtherFiStakeModule.sol
+++ b/src/modules/etherfi/EtherFiStakeModule.sol
@@ -144,6 +144,8 @@ contract EtherFiStakeModule is ModuleBase, ModuleCheckBalance, ModuleLendGateway
         // Re-supply the weETH output as collateral when the gateway lists it; an unlisted output stays loose.
         _resupplyToGateway(safe, weETH, weETHAmtReceived);
 
+        _ensureGatewayFloor(safe);
+
         emit StakeDeposit(safe, assetToDeposit, weETH, amountToDeposit, weETHAmtReceived);
     }
 }

--- a/src/modules/etherfi/LiquidUSDLiquifierOP.sol
+++ b/src/modules/etherfi/LiquidUSDLiquifierOP.sol
@@ -160,7 +160,9 @@ contract LiquidUSDLiquifierOPModule is Constants, UpgradeableProxy, ModuleCheckB
         if (liquidUsdAmountRepaid == 0) revert LiquidUsdAmountZero();
 
         // LiquidUSD is a listed reserve, so a gateway safe's holdings may be supplied to Aave: pull the
-        // shortfall loose before reclaiming (no-op for legacy or opted-out safes).
+        // shortfall loose before reclaiming (no-op for legacy or opted-out safes). This repayment flow is
+        // deliberately EXEMPT from the gateway's health-factor floor (_ensureGatewayFloor): it swaps
+        // collateral for a matching debt reduction, and de-risking must never be blocked by the floor.
         _withdrawShortfall(user, address(LIQUID_USD), liquidUsdAmountRepaid, _getAvailableAmount(user, address(LIQUID_USD)));
         _checkAmountAvailable(user, address(LIQUID_USD), liquidUsdAmountRepaid);
 

--- a/src/modules/etherfi/LiquidUSDLiquifierOP.sol
+++ b/src/modules/etherfi/LiquidUSDLiquifierOP.sol
@@ -160,9 +160,11 @@ contract LiquidUSDLiquifierOPModule is Constants, UpgradeableProxy, ModuleCheckB
         if (liquidUsdAmountRepaid == 0) revert LiquidUsdAmountZero();
 
         // LiquidUSD is a listed reserve, so a gateway safe's holdings may be supplied to Aave: pull the
-        // shortfall loose before reclaiming (no-op for legacy or opted-out safes). This repayment flow is
-        // deliberately EXEMPT from the gateway's health-factor floor (_ensureGatewayFloor): it swaps
-        // collateral for a matching debt reduction, and de-risking must never be blocked by the floor.
+        // shortfall loose before reclaiming (no-op for legacy safes; engine-gated, so it still works for
+        // an opted-out safe — including a matured opt-out whose unwind open borrows block — because this
+        // repayment is exactly the deleveraging that unblocks it). The flow is deliberately EXEMPT from
+        // the gateway's health-factor floor (_ensureGatewayFloor): it swaps collateral for a matching
+        // debt reduction, and de-risking must never be blocked by the floor.
         _withdrawShortfall(user, address(LIQUID_USD), liquidUsdAmountRepaid, _getAvailableAmount(user, address(LIQUID_USD)));
         _checkAmountAvailable(user, address(LIQUID_USD), liquidUsdAmountRepaid);
 

--- a/src/modules/frax/FraxModule.sol
+++ b/src/modules/frax/FraxModule.sol
@@ -200,6 +200,8 @@ contract FraxModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardTransient,
         // Re-supply the fraxUSD output as collateral when the gateway lists it; an unlisted output stays loose.
         _resupplyToGateway(safe, fraxusd, fraxUSDTokenReceived);
 
+        _ensureGatewayFloor(safe);
+
         emit Deposit(safe, assetToDeposit, amountToDeposit, fraxUSDTokenReceived);
     }
 
@@ -271,6 +273,9 @@ contract FraxModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardTransient,
 
         // Re-supply the output as collateral when the gateway lists it; an unlisted output stays loose.
         _resupplyToGateway(safe, outputAsset, assetReceived);
+
+        // Risk-increasing flow: the end state takes the gateway's health-factor floor
+        _ensureGatewayFloor(safe);
 
         emit Withdrawal(safe, outputAsset, amountToWithdraw, assetReceived);
     }

--- a/src/modules/hype/BeHYPEStakeModule.sol
+++ b/src/modules/hype/BeHYPEStakeModule.sol
@@ -169,6 +169,10 @@ contract BeHYPEStakeModule is ModuleBase, ModuleCheckBalance, ModuleLendGatewayS
             _refundExcessFee(msg.sender, excessFee);
         }
 
+        // Risk-increasing flow with no resupply (the beHYPE output arrives later, loose): the end state
+        // takes the gateway's health-factor floor
+        _ensureGatewayFloor(safe);
+
         emit StakeDeposit(safe, whype, beHYPE, amountToStake);
     }
 

--- a/src/modules/lend-gateway/LendGateway.sol
+++ b/src/modules/lend-gateway/LendGateway.sol
@@ -71,6 +71,9 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
         mapping(address driver => bool authorized) isDriver;
         /// @notice The tokens the card can settle a debit spend in; admin-declared, a subset of `assets`
         EnumerableSetLib.AddressSet spendAssets;
+        /// @notice Post-op health-factor floor (WAD) for user-extraction ops (borrow page, withdrawal
+        /// sourcing, collateral flag off). 0 = disabled. Spends and repays are deliberately exempt.
+        uint256 minHealthFactor;
     }
 
     // keccak256(abi.encode(uint256(keccak256("etherfi.storage.LendGateway")) - 1)) & ~bytes32(uint256(0xff))
@@ -96,6 +99,8 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
     event Repaid(address indexed safe, address indexed asset, uint256 amount);
     /// @notice Emitted when collateral usage is toggled for a safe
     event CollateralUsageSet(address indexed safe, address indexed asset, bool useAsCollateral);
+    /// @notice Emitted when the post-op health-factor floor is updated
+    event MinHealthFactorSet(uint256 minHealthFactor);
 
     /// @notice Thrown when the caller is not an authorized driver
     error OnlyDriver();
@@ -111,6 +116,10 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
     error LendOptedOut();
     /// @notice Thrown when de-registering a reserve that still has outstanding debt or supplied balance
     error ReserveStillInUse();
+    /// @notice Thrown when an operation would leave the safe's health factor below the configured floor
+    error HealthFactorBelowMinimum();
+    /// @notice Thrown when setting a health-factor floor outside [1e18, 2e18] (0 disables)
+    error InvalidMinHealthFactor();
 
     /**
      * @param _etherFiDataProvider Address of the EtherFiDataProvider
@@ -197,6 +206,22 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
         delete $.reserveId[asset];
 
         emit ReserveDeregistered(asset);
+    }
+
+    /**
+     * @notice Sets the post-op health-factor floor for user-extraction operations
+     * @dev Applies to the borrow page, withdrawal sourcing from Aave, and turning a collateral flag off —
+     *      the ops where a user actively extracts risk headroom. Card spends and repays are deliberately
+     *      exempt: settlement obligations must never fail on the floor, and de-risking must always work.
+     *      Aave still liquidates at HF < 1e18 regardless; this floor only keeps ether.fi-initiated
+     *      extraction from parking a position near that line.
+     * @param value The floor in WAD (1e18); 0 disables the check, otherwise bounded to [1e18, 2e18]
+     * @custom:throws InvalidMinHealthFactor if value is non-zero and outside [1e18, 2e18]
+     */
+    function setMinHealthFactor(uint256 value) external onlyRole(LEND_GATEWAY_ADMIN_ROLE) {
+        if (value != 0 && (value < 1e18 || value > 2e18)) revert InvalidMinHealthFactor();
+        _getLendGatewayStorage().minHealthFactor = value;
+        emit MinHealthFactorSet(value);
     }
 
     /**
@@ -390,12 +415,34 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
         // supplied position from collateral (e.g. one left on Aave after processLendOptOut). It only de-risks.
         if (useAsCollateral && _isLendOptedOut(safe)) revert LendOptedOut();
         spoke.setUsingAsCollateral(_reserveIdOf(asset), useAsCollateral, safe);
+        // Dropping a flag with open debt directly cuts the health factor, so it takes the floor; with no
+        // debt the health factor is unbounded and the check passes (the opted-out residual-cleanup case)
+        if (!useAsCollateral) ensureMinHealthFactor(safe);
         emit CollateralUsageSet(safe, asset, useAsCollateral);
     }
 
     // ---------------------------------------------------------------------
     // ILendGateway reads
     // ---------------------------------------------------------------------
+
+    /// @notice The post-op health-factor floor (WAD) for user-extraction ops; 0 = disabled
+    function minHealthFactor() external view returns (uint256) {
+        return _getLendGatewayStorage().minHealthFactor;
+    }
+
+    /**
+     * @notice Reverts when `safe`'s health factor sits below the configured floor
+     * @dev The enforcement hook for the extraction paths: called after the borrow-page borrow, after a
+     *      withdrawal request pulls from Aave, and after a collateral flag is turned off. A safe with no
+     *      debt has an unbounded health factor and always passes. No-op while the floor is disabled.
+     * @param safe The safe to check
+     * @custom:throws HealthFactorBelowMinimum if the floor is set and the safe's health factor is below it
+     */
+    function ensureMinHealthFactor(address safe) public view {
+        uint256 floor = _getLendGatewayStorage().minHealthFactor;
+        if (floor == 0) return;
+        if (spoke.getUserAccountData(safe).healthFactor < floor) revert HealthFactorBelowMinimum();
+    }
 
     /**
      * @notice Returns `safe`'s Aave position summary (collateral, debt, borrow headroom, health factor)

--- a/src/modules/lend-gateway/LendGateway.sol
+++ b/src/modules/lend-gateway/LendGateway.sol
@@ -425,7 +425,30 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
     // ILendGateway reads
     // ---------------------------------------------------------------------
 
-    /// @notice The post-op health-factor floor (WAD) for user-extraction ops; 0 = disabled
+    /**
+     * @notice Whether the safe carries any raw debt on Aave
+     * @dev Checks raw per-asset debt, not getAccountData's USD aggregate: debtUsd floors at 6 decimals,
+     *      so sub-$0.000001 dust reads as zero there while Aave still enforces it on withdrawals — a
+     *      debt-free answer here must mean truly debt-free, or quotes overstate what Aave allows.
+     * @param safe The safe to check
+     * @return True when any registered asset carries debt for the safe
+     */
+    function hasDebt(address safe) public view returns (bool) {
+        LendGatewayStorage storage $ = _getLendGatewayStorage();
+        uint256 len = $.assets.length();
+        for (uint256 i = 0; i < len;) {
+            if (spoke.getUserTotalDebt($.reserveId[$.assets.at(i)], safe) != 0) return true;
+            unchecked {
+                ++i;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @notice The post-op health-factor floor (WAD) for user-extraction ops; 0 = disabled
+     * @return The floor in WAD
+     */
     function minHealthFactor() external view returns (uint256) {
         return _getLendGatewayStorage().minHealthFactor;
     }
@@ -473,7 +496,10 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
             }
 
             uint256 debt = spoke.getUserTotalDebt(reserveId, safe);
-            if (debt != 0) data.debtUsd += _toUsd(asset, debt, priceProvider);
+            // Debt rounds UP: flooring lets sub-micro-dollar dust vanish from debtUsd (and inflate
+            // availableBorrowsUsd) while Aave still enforces it, so quotes sized on these aggregates
+            // would overstate what a withdraw or borrow can actually do
+            if (debt != 0) data.debtUsd += _toUsdCeil(asset, debt, priceProvider);
 
             unchecked {
                 ++i;
@@ -708,6 +734,12 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
     /// @dev Converts a token amount to 6-decimal USD via the PriceProvider (matching CashLens)
     function _toUsd(address asset, uint256 amount, IPriceProvider priceProvider) internal view returns (uint256) {
         return (amount * priceProvider.price(asset)) / (10 ** IERC20Metadata(asset).decimals());
+    }
+
+    /// @dev _toUsd rounding up: used for debt legs, where flooring would understate the obligation
+    function _toUsdCeil(address asset, uint256 amount, IPriceProvider priceProvider) internal view returns (uint256) {
+        uint256 unit = 10 ** IERC20Metadata(asset).decimals();
+        return (amount * priceProvider.price(asset) + unit - 1) / unit;
     }
 
     /// @dev Returns the ERC-7201 storage struct

--- a/src/modules/midas/MidasModule.sol
+++ b/src/modules/midas/MidasModule.sol
@@ -195,6 +195,8 @@ contract MidasModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardTransient
         // Re-supply the Midas-token output as collateral when the gateway lists it; an unlisted output stays loose.
         _resupplyToGateway(safe, midasToken, midasTokenReceived);
 
+        _ensureGatewayFloor(safe);
+
         emit Deposit(safe, asset, amount, midasToken, midasTokenReceived);
     }
 
@@ -263,6 +265,11 @@ contract MidasModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardTransient
         data[1] = abi.encodeWithSelector(IMidasVault.redeemRequest.selector, asset, amount, safe);
 
         IEtherFiSafe(safe).execTransactionFromModule(to, values, data);
+
+        // Risk-increasing flow with no resupply (the redemption output arrives later, loose): the end
+        // state takes the gateway's health-factor floor
+        _ensureGatewayFloor(safe);
+
         emit Withdrawal(safe, amount, asset, midasToken);
     }
 

--- a/src/modules/openocean-swap/OpenOceanSwapModule.sol
+++ b/src/modules/openocean-swap/OpenOceanSwapModule.sol
@@ -192,6 +192,8 @@ contract OpenOceanSwapModule is ModuleBase, ModuleCheckBalance, ModuleLendGatewa
         // Re-supply the output as collateral when the gateway lists it; an unlisted output (or ETH) stays loose.
         _resupplyToGateway(safe, toAsset, receivedAmt);
 
+        _ensureGatewayFloor(safe);
+
         emit SwapOnOpenOcean(safe, fromAsset, toAsset, fromAssetAmount, minToAssetAmount, receivedAmt);
     }
 

--- a/test/safe/modules/ModuleLendGatewaySandwich.t.sol
+++ b/test/safe/modules/ModuleLendGatewaySandwich.t.sol
@@ -22,6 +22,8 @@ contract SandwichHarness is ModuleLendGatewaySandwich {
 
     /// @dev A real consumer computes this from cashModule.isLendActive; the harness sets it directly (defaults on).
     bool public lendActive = true;
+    /// @dev A real consumer computes this from cashModule.usesLendGateway; the harness sets it directly (defaults on).
+    bool public onGatewayEngine = true;
 
     constructor(address _gateway, address _dataProvider) ModuleCheckBalance(_dataProvider) {
         mockGateway = ILendGateway(_gateway);
@@ -37,6 +39,14 @@ contract SandwichHarness is ModuleLendGatewaySandwich {
 
     function _lendActive(address) internal view override returns (bool) {
         return lendActive;
+    }
+
+    function setOnGatewayEngine(bool onEngine) external {
+        onGatewayEngine = onEngine;
+    }
+
+    function _onGatewayEngine(address) internal view override returns (bool) {
+        return onGatewayEngine;
     }
 
     function withdrawShortfall(address safe, address asset, uint256 amount, uint256 looseAvailable) external {
@@ -119,15 +129,29 @@ contract ModuleLendGatewaySandwichTest is Test {
         assertEq(amount, 0);
     }
 
-    // When lend is disabled for the safe, the withdraw bookend is a no-op: its assets already sit in the safe.
-    function test_withdraw_noOpWhenLendOptedOut() public {
-        harness.setLendActive(false);
+    // Off the gateway engine (legacy safe) the withdraw bookend is a no-op: nothing is supplied on Aave.
+    function test_withdraw_noOpWhenOffGatewayEngine() public {
+        harness.setOnGatewayEngine(false);
         gateway.setSuppliedOf(safe, asset, AMOUNT);
         harness.withdrawShortfall(safe, asset, AMOUNT, 0);
 
         (address s,, uint256 amount,) = gateway.lastWithdraw();
         assertEq(s, address(0), "no withdraw call recorded");
         assertEq(amount, 0);
+    }
+
+    // The withdraw bookend is ENGINE-gated, not lend-active-gated: an opted-out safe (e.g. a matured
+    // opt-out whose unwind open borrows still block) can hold supplied funds, and reclaiming them is an
+    // exit op the repayment paths depend on (repayUsingLiquidUSD sourcing supplied LiquidUSD).
+    function test_withdraw_stillPullsForOptedOutSafeOnEngine() public {
+        harness.setLendActive(false); // opted out...
+        gateway.setSuppliedOf(safe, asset, AMOUNT); // ...but funds still supplied on Aave
+        harness.withdrawShortfall(safe, asset, AMOUNT, 0);
+
+        (address s, address a, uint256 amount,) = gateway.lastWithdraw();
+        assertEq(s, safe, "withdraw pulled for the opted-out safe");
+        assertEq(a, asset);
+        assertEq(amount, AMOUNT);
     }
 
     // When lend is disabled, the resupply bookend is a no-op: the output stays in the safe, nothing goes to Aave.

--- a/test/safe/modules/cash/lend/CashLendOptOut.t.sol
+++ b/test/safe/modules/cash/lend/CashLendOptOut.t.sol
@@ -345,16 +345,21 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
 
     // ----------------------------------------------------------------- effective state & lazy processing
 
-    /// isLendOptedOut / isLendActive report the opt-out as soon as the finalize time passes — before
-    /// processLendOptOut runs — mirroring how getMode honors a matured incoming mode.
+    /// isLendOptedOut / isLendActive report the opt-out as soon as the finalize time PASSES — before
+    /// processLendOptOut runs — with the same strictly-after comparison as the mode rail (getMode /
+    /// _setCurrentMode), so the effective flag and the scheduled Debit switch always flip in the same second.
     function test_isLendOptedOut_effectiveOnceDelayElapses() public {
         _requestOptOut();
         assertFalse(cashModule.isLendOptedOut(address(safe)), "not opted out during the delay");
         assertTrue(cashModule.isLendActive(address(safe)), "still active during the delay");
 
+        // At exactly the finalize time the window is still open, matching the mode rail's strict >
         vm.warp(block.timestamp + MODE_DELAY);
-        assertTrue(cashModule.isLendOptedOut(address(safe)), "effectively opted out at the finalize time");
-        assertFalse(cashModule.isLendActive(address(safe)), "lend inactive at the finalize time");
+        assertFalse(cashModule.isLendOptedOut(address(safe)), "boundary second still inside the window");
+
+        vm.warp(block.timestamp + 1);
+        assertTrue(cashModule.isLendOptedOut(address(safe)), "effectively opted out once the finalize time passes");
+        assertFalse(cashModule.isLendActive(address(safe)), "lend inactive once the finalize time passes");
         assertTrue(cashModule.lendOptOutFinalizeTime(address(safe)) != 0, "not yet processed");
     }
 
@@ -420,7 +425,8 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
         // Borrow during the delay window (allowed: the opt-out has not matured yet)
         _buildGatewayPosition(address(safe), address(weETH), 5 ether, address(usdc), 1000e6);
 
-        vm.warp(block.timestamp + MODE_DELAY);
+        // The effective flag flips strictly after the finalize time, like the mode rail
+        vm.warp(block.timestamp + MODE_DELAY + 1);
         assertTrue(cashModule.isLendOptedOut(address(safe)), "effectively opted out while debt blocks processing");
 
         // The explicit processor still reverts on open borrows
@@ -443,7 +449,8 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
     function test_borrow_revertsOnMaturedUnprocessedOptOut() public {
         _supplyToGateway(address(safe), address(weETH), 5 ether);
         _requestOptOut();
-        vm.warp(block.timestamp + MODE_DELAY);
+        // The effective flag flips strictly after the finalize time, like the mode rail
+        vm.warp(block.timestamp + MODE_DELAY + 1);
 
         (address[] memory signers, bytes[] memory sigs) = _borrowSig(address(usdc), 100e6);
         vm.expectRevert(ICashModule.LendOptedOut.selector);
@@ -629,7 +636,8 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
     function test_optInToLend_cancelsMaturedUnprocessedRequest() public {
         _supplyToGateway(address(safe), address(weETH), 5 ether);
         _requestOptOut();
-        vm.warp(block.timestamp + MODE_DELAY);
+        // The effective flag flips strictly after the finalize time, like the mode rail
+        vm.warp(block.timestamp + MODE_DELAY + 1);
         assertTrue(cashModule.isLendOptedOut(address(safe)), "effectively opted out");
 
         _optIn();

--- a/test/safe/modules/cash/lend/CashLendOptOut.t.sol
+++ b/test/safe/modules/cash/lend/CashLendOptOut.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.28;
 
 import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
-import { BinSponsor, Cashback, ICashModule, Mode } from "../../../../../src/interfaces/ICashModule.sol";
+import { BinSponsor, Cashback, ICashModule, Mode, SafeData } from "../../../../../src/interfaces/ICashModule.sol";
 import { ILendGateway } from "../../../../../src/interfaces/ILendGateway.sol";
 import { CashVerificationLib } from "../../../../../src/libraries/CashVerificationLib.sol";
 import { SignatureUtils } from "../../../../../src/libraries/SignatureUtils.sol";
@@ -474,6 +474,125 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
         deal(address(usdc), address(safe), 100e6);
         (Mode mode,,,) = cashLens.canSpendSingleToken(address(safe), txId, _tokens(address(usdc)), _tokens(address(usdc)), 50e6);
         assertEq(uint8(mode), uint8(Mode.Debit), "pending opt-out routes as Debit");
+    }
+
+    /// Execution stays on the CURRENT mode during the delay window: a credit-mode safe with a pending
+    /// (unmatured) opt-out still spends in credit — a card tapped before the request settles as the user
+    /// expects, even if they hold no debit-spendable assets. (The lens simulates new auths defensively as
+    /// Debit meanwhile; execution demotes only at maturity.)
+    function test_spend_creditMode_pendingOptOut_executesCredit() public {
+        _supplyToGateway(address(safe), address(weETH), 5 ether);
+        _setModeCredit();
+        _requestOptOut();
+        // Still inside the delay window
+        assertFalse(cashModule.isLendOptedOut(address(safe)), "not yet effective");
+
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, _tokens(address(usdc)), _amounts(50e6), _noCashback());
+
+        assertTrue(cashModule.transactionCleared(address(safe), txId), "credit spend settled");
+        assertApproxEqAbs(gw.debtOf(address(safe), address(usdc)), 50e6, 1e5, "spent on credit (Aave debt taken)");
+    }
+
+    /// A credit-mode safe whose matured opt-out is BLOCKED from processing by open borrows must still
+    /// spend as Debit from its loose balance — matching the lens, which routes it as Debit — instead of
+    /// reaching spendCredit's LendOptedOut revert (an approved auth would otherwise fail at settlement).
+    /// The forced Debit arrives through the pending-mode rail requestLendOptOut scheduled, so the stored
+    /// mode flips at maturity even though the collateral unwind stays blocked.
+    function test_spend_creditMode_maturedOptOutBlockedByBorrows_spendsDebitFromLooseBalance() public {
+        _setModeCredit();
+        _requestOptOut();
+        // Borrow during the delay window so the unwind is blocked at maturity
+        _buildGatewayPosition(address(safe), address(weETH), 5 ether, address(usdc), 1000e6);
+        // The mode rail applies strictly after the start time, so step past the finalize time
+        vm.warp(block.timestamp + MODE_DELAY + 1);
+        assertTrue(cashModule.isLendOptedOut(address(safe)), "effectively opted out, unwind blocked");
+        assertEq(uint8(cashModule.getMode(address(safe))), uint8(Mode.Debit), "scheduled Debit switch matured");
+
+        // The lens routes this safe as Debit; the spend must agree and use the loose balance
+        deal(address(usdc), address(safe), 100e6);
+        (Mode lensMode,, bool lensCanSpend,) = cashLens.canSpendSingleToken(address(safe), txId, _tokens(address(usdc)), _tokens(address(usdc)), 50e6);
+        assertEq(uint8(lensMode), uint8(Mode.Debit), "lens routes as Debit");
+        assertTrue(lensCanSpend, "lens approves the debit spend");
+
+        uint256 debtBefore = gw.debtOf(address(safe), address(usdc));
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, _tokens(address(usdc)), _amounts(50e6), _noCashback());
+
+        assertTrue(cashModule.transactionCleared(address(safe), txId), "spend went through as debit");
+        assertEq(gw.debtOf(address(safe), address(usdc)), debtBefore, "no new Aave debt taken");
+        assertTrue(cashModule.lendOptOutFinalizeTime(address(safe)) != 0, "opt-out still pending (debt blocks unwind)");
+        assertApproxEqAbs(gw.suppliedOf(address(safe), address(weETH)), 5 ether, 2, "collateral still on Aave");
+    }
+
+    /// A multi-token credit spend attempt reverts on the one-token rule without burning the txId: the
+    /// same txId spends fine afterward.
+    function test_spend_creditMode_multiTokenRevertDoesNotBurnTxId() public {
+        _supplyToGateway(address(safe), address(weETH), 5 ether);
+        _setModeCredit();
+
+        address[] memory twoTokens = new address[](2);
+        twoTokens[0] = address(usdc);
+        twoTokens[1] = address(weETH);
+        uint256[] memory twoAmounts = new uint256[](2);
+        twoAmounts[0] = 30e6;
+        twoAmounts[1] = 20e6;
+
+        vm.prank(etherFiWallet);
+        vm.expectRevert(ICashModule.OnlyOneTokenAllowedInCreditMode.selector);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, twoTokens, twoAmounts, _noCashback());
+
+        assertFalse(cashModule.transactionCleared(address(safe), txId), "txId not burned by the failed attempt");
+
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, _tokens(address(usdc)), _amounts(50e6), _noCashback());
+        assertTrue(cashModule.transactionCleared(address(safe), txId), "txId spendable after the failed attempt");
+    }
+
+    /// requestLendOptOut schedules the forced Debit switch on the standard pending-mode rail: the lens and
+    /// getMode see it through the ordinary incoming-mode convention, and the stored mode flips at maturity
+    /// with no processing call at all.
+    function test_requestLendOptOut_schedulesIncomingDebit() public {
+        _setModeCredit();
+        uint256 expectedFinalize = block.timestamp + MODE_DELAY;
+        _requestOptOut();
+
+        SafeData memory data = cashModule.getData(address(safe));
+        assertEq(uint8(data.incomingMode), uint8(Mode.Debit), "incoming Debit scheduled");
+        assertEq(data.incomingModeStartTime, expectedFinalize, "scheduled for the finalize time");
+        assertEq(uint8(cashModule.getMode(address(safe))), uint8(Mode.Credit), "still Credit during the window");
+
+        vm.warp(expectedFinalize + 1);
+        assertEq(uint8(cashModule.getMode(address(safe))), uint8(Mode.Debit), "Debit at maturity, no processing needed");
+    }
+
+    /// setMode(Credit) is rejected while an opt-out request is pending — it would also overwrite the
+    /// scheduled Debit switch. Opting back in re-opens Credit.
+    function test_setMode_pendingOptOut_blocksCredit() public {
+        _requestOptOut();
+
+        uint256 nonce = cashModule.getNonce(address(safe));
+        bytes32 digest = keccak256(abi.encodePacked(CashVerificationLib.SET_MODE_METHOD, block.chainid, address(safe), nonce, abi.encode(Mode.Credit))).toEthSignedMessageHash();
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Pk, digest);
+        vm.expectRevert(ICashModule.LendOptedOut.selector);
+        cashModule.setMode(address(safe), Mode.Credit, owner1, abi.encodePacked(r, s, v));
+    }
+
+    /// Opting back in during the window voids the scheduled Debit switch: the safe stays in Credit.
+    function test_optInToLend_cancelsScheduledDebitSwitch() public {
+        _setModeCredit();
+        _requestOptOut();
+        assertEq(uint8(cashModule.getData(address(safe)).incomingMode), uint8(Mode.Debit), "Debit scheduled");
+
+        _optIn();
+
+        SafeData memory data = cashModule.getData(address(safe));
+        assertEq(data.incomingModeStartTime, 0, "scheduled switch voided");
+        assertEq(uint8(cashModule.getMode(address(safe))), uint8(Mode.Credit), "still Credit");
+
+        // And the voided switch never fires
+        vm.warp(block.timestamp + MODE_DELAY + 1);
+        assertEq(uint8(cashModule.getMode(address(safe))), uint8(Mode.Credit), "Credit after the would-be finalize time");
     }
 
     /// Opting back in after the request matured (but before processing) cancels it — the collateral

--- a/test/safe/modules/cash/lend/CashLendOptOut.t.sol
+++ b/test/safe/modules/cash/lend/CashLendOptOut.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.28;
 
 import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
-import { BinSponsor, ICashModule, Mode } from "../../../../../src/interfaces/ICashModule.sol";
+import { BinSponsor, Cashback, ICashModule, Mode } from "../../../../../src/interfaces/ICashModule.sol";
 import { ILendGateway } from "../../../../../src/interfaces/ILendGateway.sol";
 import { CashVerificationLib } from "../../../../../src/libraries/CashVerificationLib.sol";
 import { SignatureUtils } from "../../../../../src/libraries/SignatureUtils.sol";
@@ -343,6 +343,153 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
         cashModule.processLendOptOut(address(safe));
     }
 
+    // ----------------------------------------------------------------- effective state & lazy processing
+
+    /// isLendOptedOut / isLendActive report the opt-out as soon as the finalize time passes — before
+    /// processLendOptOut runs — mirroring how getMode honors a matured incoming mode.
+    function test_isLendOptedOut_effectiveOnceDelayElapses() public {
+        _requestOptOut();
+        assertFalse(cashModule.isLendOptedOut(address(safe)), "not opted out during the delay");
+        assertTrue(cashModule.isLendActive(address(safe)), "still active during the delay");
+
+        vm.warp(block.timestamp + MODE_DELAY);
+        assertTrue(cashModule.isLendOptedOut(address(safe)), "effectively opted out at the finalize time");
+        assertFalse(cashModule.isLendActive(address(safe)), "lend inactive at the finalize time");
+        assertTrue(cashModule.lendOptOutFinalizeTime(address(safe)) != 0, "not yet processed");
+    }
+
+    /// A spend lazily executes a matured opt-out before routing: the collateral comes home, the flag is
+    /// set, and the spend runs as a debit from the loose balance.
+    function test_spend_processesMaturedOptOut() public {
+        _supplyToGateway(address(safe), address(weETH), 5 ether);
+        _requestOptOut();
+        vm.warp(block.timestamp + MODE_DELAY);
+
+        deal(address(usdc), address(safe), 100e6);
+
+        vm.expectEmit(true, false, false, false, address(cashEventEmitter));
+        emit CashEventEmitter.LendOptOutExecuted(address(safe));
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, _tokens(address(usdc)), _amounts(50e6), _noCashback());
+
+        assertTrue(cashModule.isLendOptedOut(address(safe)), "opted out");
+        assertEq(cashModule.lendOptOutFinalizeTime(address(safe)), 0, "processed, not just matured");
+        assertApproxEqAbs(weETH.balanceOf(address(safe)), 5 ether, 2, "collateral back in the safe");
+        assertTrue(cashModule.transactionCleared(address(safe), txId), "spend went through");
+    }
+
+    /// A credit-mode safe with a matured opt-out spends as Debit: the lazy processing forces the mode
+    /// before spend reads it, so no new Aave debt is ever taken.
+    function test_spend_creditMode_maturedOptOut_routesDebit() public {
+        _setModeCredit();
+        _requestOptOut();
+        vm.warp(block.timestamp + MODE_DELAY);
+
+        deal(address(usdc), address(safe), 100e6);
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, _tokens(address(usdc)), _amounts(50e6), _noCashback());
+
+        assertEq(uint8(cashModule.getMode(address(safe))), uint8(Mode.Debit), "forced to Debit");
+        assertEq(gw.debtOf(address(safe), address(usdc)), 0, "no Aave debt taken");
+        assertApproxEqAbs(usdc.balanceOf(address(safe)), 50e6, 1e5, "spent from the loose balance");
+    }
+
+    /// The auto-supply sweep lazily executes a matured opt-out and then skips supplying.
+    function test_supplyToLend_processesMaturedOptOutAndSkips() public {
+        _supplyToGateway(address(safe), address(weETH), 5 ether);
+        _requestOptOut();
+        vm.warp(block.timestamp + MODE_DELAY);
+
+        deal(address(weETH), address(safe), 1 ether); // loose funds the sweep would otherwise supply
+
+        vm.expectEmit(true, false, false, false, address(cashEventEmitter));
+        emit CashEventEmitter.LendOptOutExecuted(address(safe));
+        vm.prank(etherFiWallet);
+        cashModule.supplyToLend(address(safe), _tokens(address(weETH)));
+
+        assertLe(gw.suppliedOf(address(safe), address(weETH)), 2, "nothing supplied");
+        assertApproxEqAbs(weETH.balanceOf(address(safe)), 6 ether, 2, "loose + returned collateral stay in the safe");
+        assertTrue(cashModule.isLendOptedOut(address(safe)), "opted out");
+        assertEq(cashModule.lendOptOutFinalizeTime(address(safe)), 0, "processed");
+    }
+
+    /// A borrow taken during the delay window blocks processing but not the effective state: the views
+    /// report opted out, credit is blocked, and the repay that clears the debt completes the opt-out.
+    function test_repay_completesOptOutBlockedByOpenBorrows() public {
+        _requestOptOut();
+        // Borrow during the delay window (allowed: the opt-out has not matured yet)
+        _buildGatewayPosition(address(safe), address(weETH), 5 ether, address(usdc), 1000e6);
+
+        vm.warp(block.timestamp + MODE_DELAY);
+        assertTrue(cashModule.isLendOptedOut(address(safe)), "effectively opted out while debt blocks processing");
+
+        // The explicit processor still reverts on open borrows
+        vm.expectRevert(ICashModule.HasOpenBorrows.selector);
+        cashModule.processLendOptOut(address(safe));
+
+        // Repaying the debt completes the opt-out in the same call
+        deal(address(usdc), address(safe), 2000e6);
+        vm.expectEmit(true, false, false, false, address(cashEventEmitter));
+        emit CashEventEmitter.LendOptOutExecuted(address(safe));
+        vm.prank(etherFiWallet);
+        cashModule.repay(address(safe), address(usdc), 1100e6); // over-quote; capped at the live debt
+
+        assertEq(gw.debtOf(address(safe), address(usdc)), 0, "debt cleared");
+        assertEq(cashModule.lendOptOutFinalizeTime(address(safe)), 0, "opt-out completed by the repay");
+        assertApproxEqAbs(weETH.balanceOf(address(safe)), 5 ether, 2, "collateral unwound to the safe");
+    }
+
+    /// CashModule.borrow rejects a matured-but-unprocessed opt-out (the effective check).
+    function test_borrow_revertsOnMaturedUnprocessedOptOut() public {
+        _supplyToGateway(address(safe), address(weETH), 5 ether);
+        _requestOptOut();
+        vm.warp(block.timestamp + MODE_DELAY);
+
+        (address[] memory signers, bytes[] memory sigs) = _borrowSig(address(usdc), 100e6);
+        vm.expectRevert(ICashModule.LendOptedOut.selector);
+        cashModule.borrow(address(safe), address(usdc), 100e6, signers, sigs);
+    }
+
+    /// setMode(Credit) is blocked while a matured opt-out awaits processing (the effective check).
+    function test_setMode_maturedOptOut_blocksCredit() public {
+        _requestOptOut();
+        vm.warp(block.timestamp + MODE_DELAY);
+
+        uint256 nonce = cashModule.getNonce(address(safe));
+        bytes32 digest = keccak256(abi.encodePacked(CashVerificationLib.SET_MODE_METHOD, block.chainid, address(safe), nonce, abi.encode(Mode.Credit))).toEthSignedMessageHash();
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Pk, digest);
+
+        vm.expectRevert(ICashModule.LendOptedOut.selector);
+        cashModule.setMode(address(safe), Mode.Credit, owner1, abi.encodePacked(r, s, v));
+    }
+
+    /// The lens routes a credit-mode safe with a pending opt-out as Debit, matching the spend path's
+    /// lazy processing (and the incoming-mode convention: pending counts, since the spend can settle
+    /// after the request matures).
+    function test_canSpendSingleToken_pendingOptOutForcesDebit() public {
+        _supplyToGateway(address(safe), address(weETH), 5 ether);
+        _setModeCredit();
+        _requestOptOut();
+
+        deal(address(usdc), address(safe), 100e6);
+        (Mode mode,,,) = cashLens.canSpendSingleToken(address(safe), txId, _tokens(address(usdc)), _tokens(address(usdc)), 50e6);
+        assertEq(uint8(mode), uint8(Mode.Debit), "pending opt-out routes as Debit");
+    }
+
+    /// Opting back in after the request matured (but before processing) cancels it — the collateral
+    /// never left Aave and lend is immediately active again.
+    function test_optInToLend_cancelsMaturedUnprocessedRequest() public {
+        _supplyToGateway(address(safe), address(weETH), 5 ether);
+        _requestOptOut();
+        vm.warp(block.timestamp + MODE_DELAY);
+        assertTrue(cashModule.isLendOptedOut(address(safe)), "effectively opted out");
+
+        _optIn();
+        assertFalse(cashModule.isLendOptedOut(address(safe)), "opt-out cancelled");
+        assertTrue(cashModule.isLendActive(address(safe)), "lend active again");
+        assertApproxEqAbs(gw.suppliedOf(address(safe), address(weETH)), 5 ether, 2, "collateral never left Aave");
+    }
+
     // ----------------------------------------------------------------- signing helpers
 
     function _requestOptOut() internal {
@@ -369,5 +516,37 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
         cashModule.setMode(address(safe), Mode.Credit, owner1, abi.encodePacked(r, s, v));
         // Credit takes effect after the mode delay
         vm.warp(block.timestamp + MODE_DELAY + 1);
+    }
+
+    /// @dev Builds the owner quorum (owner1 + owner2, the safe's threshold) signing a borrow intent.
+    function _borrowSig(address token, uint256 amountInUsd) internal view returns (address[] memory, bytes[] memory) {
+        bytes32 digest = keccak256(abi.encodePacked(CashVerificationLib.BORROW_METHOD, block.chainid, address(safe), safe.nonce(), abi.encode(token, amountInUsd))).toEthSignedMessageHash();
+        (uint8 v1, bytes32 r1, bytes32 s1) = vm.sign(owner1Pk, digest);
+        (uint8 v2, bytes32 r2, bytes32 s2) = vm.sign(owner2Pk, digest);
+
+        address[] memory signers = new address[](2);
+        signers[0] = owner1;
+        signers[1] = owner2;
+
+        bytes[] memory signatures = new bytes[](2);
+        signatures[0] = abi.encodePacked(r1, s1, v1);
+        signatures[1] = abi.encodePacked(r2, s2, v2);
+        return (signers, signatures);
+    }
+
+    function _tokens(address token) internal pure returns (address[] memory) {
+        address[] memory arr = new address[](1);
+        arr[0] = token;
+        return arr;
+    }
+
+    function _amounts(uint256 amount) internal pure returns (uint256[] memory) {
+        uint256[] memory arr = new uint256[](1);
+        arr[0] = amount;
+        return arr;
+    }
+
+    function _noCashback() internal pure returns (Cashback[] memory) {
+        return new Cashback[](0);
     }
 }

--- a/test/safe/modules/cash/lend/CashLendOptOut.t.sol
+++ b/test/safe/modules/cash/lend/CashLendOptOut.t.sol
@@ -73,7 +73,7 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
         assertTrue(cashModule.isLendActive(address(safe)), "still active until executed");
 
         // Execute after the delay: permissionless
-        vm.warp(block.timestamp + MODE_DELAY);
+        vm.warp(block.timestamp + MODE_DELAY + 1);
         vm.expectEmit(true, false, false, false, address(cashEventEmitter));
         emit CashEventEmitter.LendOptOutExecuted(address(safe));
         cashModule.processLendOptOut(address(safe));
@@ -106,7 +106,7 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
         assertEq(uint8(cashModule.getMode(address(safe))), uint8(Mode.Credit), "in credit mode");
 
         _requestOptOut();
-        vm.warp(block.timestamp + MODE_DELAY);
+        vm.warp(block.timestamp + MODE_DELAY + 1);
         cashModule.processLendOptOut(address(safe));
 
         assertEq(uint8(cashModule.getMode(address(safe))), uint8(Mode.Debit), "credit dropped to debit");
@@ -116,7 +116,7 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
     function test_processLendOptOut_noCollateral_marksOptedOut() public {
         // No Aave position at all: opting out is still valid and just flips the flag
         _requestOptOut();
-        vm.warp(block.timestamp + MODE_DELAY);
+        vm.warp(block.timestamp + MODE_DELAY + 1);
         cashModule.processLendOptOut(address(safe));
 
         assertTrue(cashModule.isLendOptedOut(address(safe)), "opted out with no collateral");
@@ -130,7 +130,7 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
         deal(address(weETH), address(safe), 5 ether);
 
         _requestOptOut();
-        vm.warp(block.timestamp + MODE_DELAY);
+        vm.warp(block.timestamp + MODE_DELAY + 1);
         cashModule.processLendOptOut(address(safe));
 
         assertTrue(cashModule.isLendOptedOut(address(safe)), "legacy safe opted out");
@@ -180,7 +180,7 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
     /// Requesting the opt-out reverts when lend is already disabled.
     function test_requestLendOptOut_revertsWhenAlreadyOptedOut() public {
         _requestOptOut();
-        vm.warp(block.timestamp + MODE_DELAY);
+        vm.warp(block.timestamp + MODE_DELAY + 1);
         cashModule.processLendOptOut(address(safe));
 
         (address signer, bytes memory sig) = _toggleLendSig(false);
@@ -223,10 +223,16 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
         cashModule.processLendOptOut(address(safe));
     }
 
-    /// processLendOptOut reverts while still inside the mode-change delay.
+    /// processLendOptOut reverts while still inside the mode-change delay — including at exactly the
+    /// finalize time: processing is strictly after it, matching isLendOptedOut and the mode rail.
     function test_processLendOptOut_revertsWhenNotReady() public {
         _requestOptOut();
         // Still inside the delay window
+        vm.expectRevert(ICashModule.LendOptOutNotReady.selector);
+        cashModule.processLendOptOut(address(safe));
+
+        // The boundary second is still inside the window
+        vm.warp(block.timestamp + MODE_DELAY);
         vm.expectRevert(ICashModule.LendOptOutNotReady.selector);
         cashModule.processLendOptOut(address(safe));
     }
@@ -243,7 +249,7 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
         gw.borrow(address(safe), address(usdc), 1000e6, driver);
         vm.stopPrank();
 
-        vm.warp(block.timestamp + MODE_DELAY);
+        vm.warp(block.timestamp + MODE_DELAY + 1);
         vm.expectRevert(ICashModule.HasOpenBorrows.selector);
         cashModule.processLendOptOut(address(safe));
     }
@@ -269,7 +275,7 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
     ///      lend-disabled safe; only turning it ON is a lend op that a disabled safe is blocked from.
     function test_setUsingAsCollateralFalse_allowedWhenLendOptedOut() public {
         _requestOptOut();
-        vm.warp(block.timestamp + MODE_DELAY);
+        vm.warp(block.timestamp + MODE_DELAY + 1);
         cashModule.processLendOptOut(address(safe));
         assertTrue(cashModule.isLendOptedOut(address(safe)));
 
@@ -285,7 +291,7 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
     /// A lend-disabled safe cannot switch into Credit mode.
     function test_afterOptOut_cannotEnterCreditMode() public {
         _requestOptOut();
-        vm.warp(block.timestamp + MODE_DELAY);
+        vm.warp(block.timestamp + MODE_DELAY + 1);
         cashModule.processLendOptOut(address(safe));
 
         uint256 nonce = cashModule.getNonce(address(safe));
@@ -302,7 +308,7 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
     /// Re-enabling lend flips the flag back on and resumes auto-supply.
     function test_optInToLend_reenablesAndResumesSupply() public {
         _requestOptOut();
-        vm.warp(block.timestamp + MODE_DELAY);
+        vm.warp(block.timestamp + MODE_DELAY + 1);
         cashModule.processLendOptOut(address(safe));
         assertTrue(cashModule.isLendOptedOut(address(safe)));
 
@@ -338,7 +344,7 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
         assertTrue(cashModule.isLendActive(address(safe)), "still active");
 
         // With the request cancelled, executing must revert
-        vm.warp(block.timestamp + MODE_DELAY);
+        vm.warp(block.timestamp + MODE_DELAY + 1);
         vm.expectRevert(ICashModule.NoPendingLendOptOut.selector);
         cashModule.processLendOptOut(address(safe));
     }
@@ -368,7 +374,7 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
     function test_spend_processesMaturedOptOut() public {
         _supplyToGateway(address(safe), address(weETH), 5 ether);
         _requestOptOut();
-        vm.warp(block.timestamp + MODE_DELAY);
+        vm.warp(block.timestamp + MODE_DELAY + 1);
 
         deal(address(usdc), address(safe), 100e6);
 
@@ -388,7 +394,7 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
     function test_spend_creditMode_maturedOptOut_routesDebit() public {
         _setModeCredit();
         _requestOptOut();
-        vm.warp(block.timestamp + MODE_DELAY);
+        vm.warp(block.timestamp + MODE_DELAY + 1);
 
         deal(address(usdc), address(safe), 100e6);
         vm.prank(etherFiWallet);
@@ -403,7 +409,7 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
     function test_supplyToLend_processesMaturedOptOutAndSkips() public {
         _supplyToGateway(address(safe), address(weETH), 5 ether);
         _requestOptOut();
-        vm.warp(block.timestamp + MODE_DELAY);
+        vm.warp(block.timestamp + MODE_DELAY + 1);
 
         deal(address(weETH), address(safe), 1 ether); // loose funds the sweep would otherwise supply
 
@@ -460,7 +466,7 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
     /// setMode(Credit) is blocked while a matured opt-out awaits processing (the effective check).
     function test_setMode_maturedOptOut_blocksCredit() public {
         _requestOptOut();
-        vm.warp(block.timestamp + MODE_DELAY);
+        vm.warp(block.timestamp + MODE_DELAY + 1);
 
         uint256 nonce = cashModule.getNonce(address(safe));
         bytes32 digest = keccak256(abi.encodePacked(CashVerificationLib.SET_MODE_METHOD, block.chainid, address(safe), nonce, abi.encode(Mode.Credit))).toEthSignedMessageHash();
@@ -585,6 +591,57 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
         cashModule.setMode(address(safe), Mode.Credit, owner1, abi.encodePacked(r, s, v));
     }
 
+    /// setMode(Debit) is also rejected while an opt-out request is pending: a re-request restarts the
+    /// mode delay, so it could only DEFER the Debit switch past the opt-out's finalize time — reopening
+    /// the window where a matured-but-blocked opt-out sits in stored Credit.
+    function test_setMode_pendingOptOut_blocksDebitToo() public {
+        _setModeCredit();
+        _requestOptOut();
+
+        uint256 nonce = cashModule.getNonce(address(safe));
+        bytes32 digest = keccak256(abi.encodePacked(CashVerificationLib.SET_MODE_METHOD, block.chainid, address(safe), nonce, abi.encode(Mode.Debit))).toEthSignedMessageHash();
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Pk, digest);
+        vm.expectRevert(ICashModule.LendOptedOut.selector);
+        cashModule.setMode(address(safe), Mode.Debit, owner1, abi.encodePacked(r, s, v));
+
+        // The scheduled switch is untouched and fires at the original finalize time
+        vm.warp(block.timestamp + MODE_DELAY + 1);
+        assertEq(uint8(cashModule.getMode(address(safe))), uint8(Mode.Debit), "original deadline preserved");
+    }
+
+    /// The lazy unwind is best-effort: a paused reserve must not revert the unrelated action that
+    /// triggered it. The opt-out stays pending (nothing is marked processed until everything is actually
+    /// withdrawn), the explicit processor still surfaces the error, and the next touch after unpausing
+    /// completes the opt-out.
+    function test_processLendOptOutIfReady_bestEffort_pausedReserveDoesNotBlock() public {
+        _supplyToGateway(address(safe), address(weETH), 5 ether);
+        _requestOptOut();
+        vm.warp(block.timestamp + MODE_DELAY + 1);
+        _setAaveReservePaused(weethReserveId, true);
+
+        // An unrelated debit spend from loose funds settles; the blocked unwind stays pending
+        deal(address(usdc), address(safe), 100e6);
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, _tokens(address(usdc)), _amounts(50e6), _noCashback());
+        assertTrue(cashModule.transactionCleared(address(safe), txId), "unrelated spend went through");
+        assertTrue(cashModule.lendOptOutFinalizeTime(address(safe)) != 0, "opt-out still pending, not marked processed");
+        assertApproxEqAbs(gw.suppliedOf(address(safe), address(weETH)), 5 ether, 2, "collateral still on Aave");
+        assertTrue(cashModule.isLendOptedOut(address(safe)), "effective view unaffected");
+
+        // The explicit processor stays strict and surfaces the paused reserve
+        vm.expectRevert();
+        cashModule.processLendOptOut(address(safe));
+
+        // Unpaused: the next touch completes the opt-out
+        _setAaveReservePaused(weethReserveId, false);
+        vm.expectEmit(true, false, false, false, address(cashEventEmitter));
+        emit CashEventEmitter.LendOptOutExecuted(address(safe));
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), keccak256("second-spend"), BinSponsor.Reap, _tokens(address(usdc)), _amounts(25e6), _noCashback());
+        assertEq(cashModule.lendOptOutFinalizeTime(address(safe)), 0, "opt-out processed");
+        assertApproxEqAbs(weETH.balanceOf(address(safe)), 5 ether, 2, "collateral unwound to the safe");
+    }
+
     /// Opting back in during the window voids the scheduled Debit switch: the safe stays in Credit.
     function test_optInToLend_cancelsScheduledDebitSwitch() public {
         _setModeCredit();
@@ -618,7 +675,7 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
 
         _supplyToGateway(address(safe), address(weETH), 5 ether);
         _requestOptOut();
-        vm.warp(block.timestamp + MODE_DELAY);
+        vm.warp(block.timestamp + MODE_DELAY + 1);
 
         vm.expectEmit(true, false, false, false, address(cashEventEmitter));
         emit CashEventEmitter.LendOptOutExecuted(address(safe));

--- a/test/safe/modules/cash/lend/CashLendOptOut.t.sol
+++ b/test/safe/modules/cash/lend/CashLendOptOut.t.sol
@@ -595,6 +595,35 @@ contract CashLendOptOutTest is CashGatewayTestSetup {
         assertEq(uint8(cashModule.getMode(address(safe))), uint8(Mode.Credit), "Credit after the would-be finalize time");
     }
 
+    /// A module withdrawal request lazily executes a matured opt-out just like the owner path: all the
+    /// collateral comes home first, so the request sources loose funds instead of pulling only the
+    /// shortfall and leaving the rest supplied on a safe the views already report as opted out.
+    function test_requestWithdrawalByModule_processesMaturedOptOut() public {
+        address module = makeAddr("withdrawModule");
+        address[] memory modules = new address[](1);
+        modules[0] = module;
+        bool[] memory shouldWhitelist = new bool[](1);
+        shouldWhitelist[0] = true;
+        vm.startPrank(owner);
+        dataProvider.configureModules(modules, shouldWhitelist);
+        cashModule.configureModulesCanRequestWithdraw(modules, shouldWhitelist);
+        vm.stopPrank();
+
+        _supplyToGateway(address(safe), address(weETH), 5 ether);
+        _requestOptOut();
+        vm.warp(block.timestamp + MODE_DELAY);
+
+        vm.expectEmit(true, false, false, false, address(cashEventEmitter));
+        emit CashEventEmitter.LendOptOutExecuted(address(safe));
+        vm.prank(module);
+        cashModule.requestWithdrawalByModule(address(safe), address(weETH), 1 ether);
+
+        assertTrue(cashModule.isLendOptedOut(address(safe)), "opted out");
+        assertEq(cashModule.lendOptOutFinalizeTime(address(safe)), 0, "fully processed, not left half-honored");
+        assertLe(gw.suppliedOf(address(safe), address(weETH)), 2, "nothing left supplied on Aave");
+        assertApproxEqAbs(weETH.balanceOf(address(safe)), 5 ether, 2, "all collateral loose in the safe");
+    }
+
     /// Opting back in after the request matured (but before processing) cancels it — the collateral
     /// never left Aave and lend is immediately active again.
     function test_optInToLend_cancelsMaturedUnprocessedRequest() public {

--- a/test/safe/modules/cash/lend/EtherFiLiquidGateway.t.sol
+++ b/test/safe/modules/cash/lend/EtherFiLiquidGateway.t.sol
@@ -6,6 +6,7 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
 import { EtherFiLiquidModule } from "../../../../../src/modules/etherfi/EtherFiLiquidModule.sol";
+import { LendGateway } from "../../../../../src/modules/lend-gateway/LendGateway.sol";
 import { ILayerZeroTeller, BoringVault } from "../../../../../src/interfaces/ILayerZeroTeller.sol";
 import { CashGatewayTestSetup } from "./CashGatewayTestSetup.t.sol";
 
@@ -143,6 +144,29 @@ contract EtherFiLiquidGatewayTest is CashGatewayTestSetup {
 
         assertEq(liquidVault.balanceOf(address(safe)), amount, "receipt stays loose when the re-supply is rejected");
         assertEq(gw.suppliedOf(address(safe), address(liquidVault)), 0, "nothing supplied to the frozen reserve");
+    }
+
+    // A queued withdrawal is a risk-increasing flow with no resupply (the receipt is escrowed away), so
+    // its end state takes the gateway's health-factor floor: a pull Aave itself would allow (HF stays
+    // >= 1) reverts when it lands below the floor, and a smaller pull clears it.
+    function test_withdraw_takesGatewayHealthFactorFloor() public {
+        _supplyToGateway(address(safe), address(liquidVault), 10_000e6);
+        _borrowOnGateway(address(safe), address(usdc), 4000e6, recipient);
+        vm.prank(owner);
+        gw.setMinHealthFactor(1.05e18);
+
+        // Aave allows up to 5000e6 out (HF -> 1.0); 4900e6 lands ~1.02, below the 1.05 floor
+        uint128 tooMuch = 4900e6;
+        bytes memory sig = _withdrawSig(tooMuch, tooMuch, 0, 1 days);
+        vm.expectRevert(LendGateway.HealthFactorBelowMinimum.selector);
+        liquidModule.withdraw(address(safe), address(liquidVault), address(usdc), tooMuch, tooMuch, 0, 1 days, owner1, sig);
+
+        // 4000e6 lands HF = 0.8 * 6000 / 4000 = 1.2, above the floor
+        uint128 fine = 4000e6;
+        liquidModule.withdraw(address(safe), address(liquidVault), address(usdc), fine, fine, 0, 1 days, owner1, _withdrawSig(fine, fine, 0, 1 days));
+        // Read the health factor from the spoke: the mock receipt has no PriceProvider oracle, so the
+        // gateway's USD-deriving getAccountData cannot price it (the floor check itself is spoke-based)
+        assertGe(spoke.getUserAccountData(address(safe)).healthFactor, 1.05e18, "end state above the floor");
     }
 
     function _depositSig(address assetToDeposit, uint256 amount, uint256 minReturn) internal view returns (bytes memory) {

--- a/test/safe/modules/cash/lend/LiquidUsdLiquifierGateway.t.sol
+++ b/test/safe/modules/cash/lend/LiquidUsdLiquifierGateway.t.sol
@@ -9,6 +9,9 @@ import { LiquidUSDLiquifierOPModule } from "../../../../../src/modules/etherfi/L
 import { AccountantWithRateProviders, ILayerZeroTeller } from "../../../../../src/interfaces/ILayerZeroTeller.sol";
 import { PriceProvider } from "../../../../../src/oracle/PriceProvider.sol";
 import { ChainConfig } from "../../../../utils/Utils.sol";
+import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+
+import { CashVerificationLib } from "../../../../../src/libraries/CashVerificationLib.sol";
 import { CashGatewayTestSetup } from "./CashGatewayTestSetup.t.sol";
 
 /**
@@ -19,6 +22,8 @@ import { CashGatewayTestSetup } from "./CashGatewayTestSetup.t.sol";
  *         DebtManager twin lives in test/safe/modules/etherfi/LiquidUSDLiquifier.t.sol.
  */
 contract LiquidUsdLiquifierGatewayTest is CashGatewayTestSetup {
+    using MessageHashUtils for bytes32;
+
     LiquidUSDLiquifierOPModule internal liquifier;
     IERC20 internal liquidUsd;
 
@@ -65,6 +70,39 @@ contract LiquidUsdLiquifierGatewayTest is CashGatewayTestSetup {
         _buildGatewayPosition(address(safe), address(weETH), 1 ether, address(usdc), debtAmount);
         _supplyToGateway(address(safe), address(liquidUsd), liquidUsdSupplied);
         deal(address(usdc), address(liquifier), 1000e6);
+    }
+
+    // The repayment/exit path stays open for an effectively opted-out safe: a matured opt-out whose
+    // unwind open borrows block leaves LiquidUSD supplied while isLendActive reads false — the reclaim's
+    // withdraw bookend is engine-gated (not lend-active-gated), so this deleveraging repayment (the very
+    // thing that unblocks the opt-out) still sources the supplied LiquidUSD instead of reverting on the
+    // balance check. New supply and borrows stay blocked for the safe.
+    function test_repay_worksWhileMaturedOptOutBlockedByDebt() public {
+        // Request the opt-out debt-free, borrow during the window (blocking the unwind), then mature it
+        _requestOptOut();
+        _buildDebtAndSuppliedLiquidUsd(500e6, 1000e6);
+        (,, uint64 modeDelay) = cashModule.getDelays();
+        vm.warp(block.timestamp + modeDelay + 1);
+        assertTrue(cashModule.isLendOptedOut(address(safe)), "effectively opted out");
+        assertFalse(cashModule.isLendActive(address(safe)), "lend inactive");
+
+        uint256 usdAmount = 200e6;
+        uint256 debtBefore = gw.debtOf(address(safe), address(usdc));
+        uint256 expectedLiquidUsd = liquifier.convertUsdToLiquidUSD(usdAmount);
+
+        vm.prank(etherFiWallet);
+        liquifier.repayUsingLiquidUSD(address(safe), usdAmount);
+
+        assertApproxEqAbs(gw.debtOf(address(safe), address(usdc)), debtBefore - usdAmount, 1, "Aave debt not reduced");
+        assertApproxEqAbs(gw.suppliedOf(address(safe), address(liquidUsd)), 1000e6 - expectedLiquidUsd, 2, "supplied LiquidUSD not reclaimed");
+        assertTrue(cashModule.lendOptOutFinalizeTime(address(safe)) != 0, "opt-out still pending until the debt clears");
+    }
+
+    function _requestOptOut() internal {
+        uint256 nonce = cashModule.getNonce(address(safe));
+        bytes32 digest = keccak256(abi.encodePacked(CashVerificationLib.TOGGLE_LEND_METHOD, block.chainid, address(safe), nonce, abi.encode(false))).toEthSignedMessageHash();
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Pk, digest);
+        cashModule.toggleLend(address(safe), false, owner1, abi.encodePacked(r, s, v));
     }
 
     // The repay reduces the safe's Aave debt with the liquifier's float and reclaims the equivalent

--- a/test/safe/modules/cash/lend/MinHealthFactor.t.sol
+++ b/test/safe/modules/cash/lend/MinHealthFactor.t.sol
@@ -5,6 +5,10 @@ import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/Mes
 
 import { BinSponsor, Cashback, Mode } from "../../../../../src/interfaces/ICashModule.sol";
 import { CashVerificationLib } from "../../../../../src/libraries/CashVerificationLib.sol";
+import { IAaveV4Spoke } from "../../../../../src/interfaces/IAaveV4Spoke.sol";
+import { ILendGateway } from "../../../../../src/interfaces/ILendGateway.sol";
+import { DebitSourcingLib } from "../../../../../src/libraries/DebitSourcingLib.sol";
+import { MockLendGateway } from "../../../../../src/mocks/MockLendGateway.sol";
 import { LendGateway } from "../../../../../src/modules/lend-gateway/LendGateway.sol";
 import { CashGatewayTestSetup } from "./CashGatewayTestSetup.t.sol";
 
@@ -186,6 +190,44 @@ contract MinHealthFactorTest is CashGatewayTestSetup {
         _setFloor(0);
         vm.prank(driver);
         gw.setUsingAsCollateral(address(safe), address(usdc), false); // Aave's own check still passes
+    }
+
+    // ----------------------------------------------------------------- rounding & dust
+
+    /// bufferedDebitHeadroom rounds the required (post-floor) debt cover UP: `required` is a minimum, so
+    /// rounding it down would let the exact max quote sit one micro-dollar past the floor and fail the
+    /// post-op health check on a fractional boundary.
+    function test_bufferedDebitHeadroom_roundsRequiredUp() public {
+        MockLendGateway mock = new MockLendGateway();
+        mock.setMinHealthFactor(1.05e18);
+
+        // debt 1 micro-dollar: required = ceil(1 * 1.05) = 2, so headroom = (10 + 1) - 2 = 9.
+        // A round-down would say 10 and overquote by one micro-dollar.
+        ILendGateway.AccountData memory account = ILendGateway.AccountData({ collateralUsd: 100, debtUsd: 1, availableBorrowsUsd: 10, healthFactor: 0 });
+        assertEq(DebitSourcingLib.bufferedDebitHeadroom(ILendGateway(address(mock)), account), 9, "fractional boundary rounds up");
+
+        // Exactly divisible: debt 100 -> required 105, headroom = 110 - 105 = 5
+        account.debtUsd = 100;
+        account.availableBorrowsUsd = 10;
+        assertEq(DebitSourcingLib.bufferedDebitHeadroom(ILendGateway(address(mock)), account), 5, "exact boundary unchanged");
+    }
+
+    /// Dust debt below the 6-decimal USD floor must still cap the quotes: Aave enforces it on withdrawals
+    /// even when flooring would read it as zero. Two guards pin that: debt legs round UP in
+    /// getAccountData (so the headroom reserves cover), and hasDebt reads raw per-asset debt — the quote
+    /// stays below the full supplied balance instead of overquoting and reverting on Aave's health check.
+    function test_hasDebt_dustDebtStillCapsQuotes() public {
+        _supplyToGateway(address(safe), address(weETH), 5 ether);
+        // 1 wei of raw weETH debt injected at the spoke read the gateway derives from: ~3e-9 USD, far
+        // below the 6-decimal USD floor (weETH itself is collateral-only, so it cannot be borrowed for real)
+        vm.mockCall(address(spoke), abi.encodeWithSelector(IAaveV4Spoke.getUserTotalDebt.selector, weethReserveId, address(safe)), abi.encode(uint256(1)));
+
+        // Debt legs round UP in getAccountData, so even sub-micro dust registers as one micro-dollar
+        assertEq(gw.getAccountData(address(safe)).debtUsd, 1, "dust debt ceils to one micro-dollar");
+        assertTrue(gw.hasDebt(address(safe)), "raw read sees the debt too");
+
+        uint256 max = cashLens.getMaxSourceable(address(safe), address(weETH));
+        assertLt(max, 5 ether, "dust debt caps the quote below the full supplied balance");
     }
 
     // ----------------------------------------------------------------- lens quotes are buffered

--- a/test/safe/modules/cash/lend/MinHealthFactor.t.sol
+++ b/test/safe/modules/cash/lend/MinHealthFactor.t.sol
@@ -1,0 +1,316 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+
+import { BinSponsor, Cashback, Mode } from "../../../../../src/interfaces/ICashModule.sol";
+import { CashVerificationLib } from "../../../../../src/libraries/CashVerificationLib.sol";
+import { LendGateway } from "../../../../../src/modules/lend-gateway/LendGateway.sol";
+import { CashGatewayTestSetup } from "./CashGatewayTestSetup.t.sol";
+
+/**
+ * @title MinHealthFactorTest
+ * @notice The post-op health-factor floor on user-extraction ops: the borrow page, withdrawal requests
+ *         that pull from Aave, and turning a collateral flag off enforce getAccountData().healthFactor >=
+ *         minHealthFactor after the op. Card spends (credit and debit) and repays are deliberately exempt:
+ *         settlement obligations must never fail on the floor and de-risking must always stay open.
+ *         Liquidation still happens at HF < 1e18 on Aave regardless — the floor only keeps ether.fi-initiated
+ *         extraction from parking a position near that line.
+ * @dev Run with: source .env && FOUNDRY_PROFILE=lend TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test --match-path test/safe/modules/cash/lend/MinHealthFactor.t.sol
+ */
+contract MinHealthFactorTest is CashGatewayTestSetup {
+    using MessageHashUtils for bytes32;
+
+    uint256 internal constant FLOOR = 1.05e18;
+
+    function _setFloor(uint256 value) internal {
+        vm.prank(owner);
+        gw.setMinHealthFactor(value);
+    }
+
+    // ----------------------------------------------------------------- admin setter
+
+    function test_setMinHealthFactor_adminOnlyBoundsAndEvent() public {
+        vm.expectRevert();
+        gw.setMinHealthFactor(FLOOR); // no role
+
+        vm.startPrank(owner);
+        vm.expectRevert(LendGateway.InvalidMinHealthFactor.selector);
+        gw.setMinHealthFactor(0.9e18);
+        vm.expectRevert(LendGateway.InvalidMinHealthFactor.selector);
+        gw.setMinHealthFactor(2.1e18);
+
+        vm.expectEmit(false, false, false, true, address(gw));
+        emit LendGateway.MinHealthFactorSet(FLOOR);
+        gw.setMinHealthFactor(FLOOR);
+        assertEq(gw.minHealthFactor(), FLOOR, "floor stored");
+
+        gw.setMinHealthFactor(0);
+        assertEq(gw.minHealthFactor(), 0, "0 disables");
+        vm.stopPrank();
+    }
+
+    // ----------------------------------------------------------------- borrow page
+
+    /// A borrow-page borrow that would land the health factor below the floor reverts. The borrow page
+    /// re-supplies its proceeds as collateral, so a single borrow from a clean position cannot breach the
+    /// floor — the check bites on a position already levered up (e.g. by earlier borrows).
+    function test_borrow_revertsBelowFloor() public {
+        _supplyToGateway(address(safe), address(weETH), 5 ether);
+        _borrowOnGateway(address(safe), address(usdc), (gw.getAccountData(address(safe)).availableBorrowsUsd * 99) / 100, recipient); // HF ~1.01
+        _setFloor(FLOOR);
+
+        uint256 amountInUsd = gw.getAccountData(address(safe)).availableBorrowsUsd / 2;
+        (address[] memory signers, bytes[] memory sigs) = _borrowSig(address(usdc), amountInUsd);
+        vm.expectRevert(LendGateway.HealthFactorBelowMinimum.selector);
+        cashModule.borrow(address(safe), address(usdc), amountInUsd, signers, sigs);
+    }
+
+    /// A borrow that keeps the health factor above the floor goes through.
+    function test_borrow_okWithinFloor() public {
+        _supplyToGateway(address(safe), address(weETH), 5 ether);
+        _setFloor(FLOOR);
+
+        uint256 amountInUsd = (gw.getAccountData(address(safe)).availableBorrowsUsd * 80) / 100; // HF ~1.25
+        (address[] memory signers, bytes[] memory sigs) = _borrowSig(address(usdc), amountInUsd);
+        cashModule.borrow(address(safe), address(usdc), amountInUsd, signers, sigs);
+
+        assertGe(gw.getAccountData(address(safe)).healthFactor, FLOOR, "landed above the floor");
+    }
+
+    /// With the floor disabled (default), the same borrow on the same levered position goes through.
+    function test_borrow_rawMaxOkWhenFloorDisabled() public {
+        _supplyToGateway(address(safe), address(weETH), 5 ether);
+        _borrowOnGateway(address(safe), address(usdc), (gw.getAccountData(address(safe)).availableBorrowsUsd * 99) / 100, recipient); // HF ~1.01
+        assertEq(gw.minHealthFactor(), 0, "floor disabled by default");
+
+        uint256 amountInUsd = gw.getAccountData(address(safe)).availableBorrowsUsd / 2;
+        (address[] memory signers, bytes[] memory sigs) = _borrowSig(address(usdc), amountInUsd);
+        cashModule.borrow(address(safe), address(usdc), amountInUsd, signers, sigs);
+
+        assertLt(gw.getAccountData(address(safe)).healthFactor, FLOOR, "below 1.05 by design");
+    }
+
+    // ----------------------------------------------------------------- withdrawal requests
+
+    /// A withdrawal pulling from Aave that Aave itself would allow (HF stays >= 1) reverts on the
+    /// stricter floor: the raw-LTV max quote is no longer requestable once the floor is set.
+    function test_requestWithdrawal_aavePullRevertsBelowFloor() public {
+        _buildGatewayPosition(address(safe), address(weETH), 10 ether, address(usdc), 5000e6);
+        uint256 max = cashLens.getMaxSourceable(address(safe), address(weETH)); // raw-LTV bound: post-pull HF ~1.0
+        _setFloor(FLOOR);
+
+        (address[] memory signers, bytes[] memory signatures) = _signRequestWithdrawal(_addr1(address(weETH)), _uint1(max), withdrawRecipient);
+        vm.expectRevert(LendGateway.HealthFactorBelowMinimum.selector);
+        cashModule.requestWithdrawal(address(safe), _addr1(address(weETH)), _uint1(max), withdrawRecipient, signers, signatures);
+    }
+
+    /// A loose-balance-only withdrawal never touches the Aave position, so it stays open even while the
+    /// safe already sits below the floor.
+    function test_requestWithdrawal_looseOnlyOkBelowFloor() public {
+        _supplyToGateway(address(safe), address(weETH), 5 ether);
+        _borrowOnGateway(address(safe), address(usdc), (gw.getAccountData(address(safe)).availableBorrowsUsd * 99) / 100, recipient);
+        _setFloor(FLOOR);
+        assertLt(gw.getAccountData(address(safe)).healthFactor, FLOOR, "already below the floor");
+
+        deal(address(usdc), address(safe), 100e6);
+        _requestWithdrawal(_addr1(address(usdc)), _uint1(100e6), withdrawRecipient);
+    }
+
+    // ----------------------------------------------------------------- spends are exempt
+
+    /// A credit spend goes through even when it leaves the health factor below the floor: card
+    /// settlement must never fail on the buffer.
+    function test_spendCredit_alwaysGoesThroughBelowFloor() public {
+        _supplyToGateway(address(safe), address(weETH), 5 ether);
+        _setModeCredit();
+        _setFloor(FLOOR);
+
+        uint256 amountInUsd = (gw.getAccountData(address(safe)).availableBorrowsUsd * 97) / 100; // HF ~1.03
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, _addr1(address(usdc)), _uint1(amountInUsd), _noCashback());
+
+        assertTrue(cashModule.transactionCleared(address(safe), txId), "credit spend settled");
+        uint256 hf = gw.getAccountData(address(safe)).healthFactor;
+        assertLt(hf, FLOOR, "spend was allowed to cross the floor");
+        assertGe(hf, 1e18, "still above Aave's liquidation line");
+    }
+
+    /// A debit spend on a safe already below the floor still settles.
+    function test_spendDebit_alwaysGoesThroughBelowFloor() public {
+        _supplyToGateway(address(safe), address(weETH), 5 ether);
+        _borrowOnGateway(address(safe), address(usdc), (gw.getAccountData(address(safe)).availableBorrowsUsd * 99) / 100, recipient);
+        _setFloor(FLOOR);
+        assertLt(gw.getAccountData(address(safe)).healthFactor, FLOOR, "already below the floor");
+
+        deal(address(usdc), address(safe), 100e6);
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, _addr1(address(usdc)), _uint1(50e6), _noCashback());
+
+        assertTrue(cashModule.transactionCleared(address(safe), txId), "debit spend settled");
+    }
+
+    // ----------------------------------------------------------------- repay is exempt
+
+    /// Repaying is always open below the floor — de-risking must never be blocked.
+    function test_repay_alwaysOpenBelowFloor() public {
+        _supplyToGateway(address(safe), address(weETH), 5 ether);
+        _borrowOnGateway(address(safe), address(usdc), (gw.getAccountData(address(safe)).availableBorrowsUsd * 99) / 100, recipient);
+        _setFloor(FLOOR);
+        uint256 hfBefore = gw.getAccountData(address(safe)).healthFactor;
+        assertLt(hfBefore, FLOOR, "starts below the floor");
+
+        deal(address(usdc), address(safe), 2000e6);
+        vm.prank(etherFiWallet);
+        cashModule.repay(address(safe), address(usdc), 1000e6);
+
+        assertGt(gw.getAccountData(address(safe)).healthFactor, hfBefore, "repay improved the position");
+    }
+
+    // ----------------------------------------------------------------- collateral flag off
+
+    /// Dropping a collateral flag that Aave would allow (HF stays >= 1) reverts on the stricter floor;
+    /// disabling the floor re-opens it.
+    function test_setUsingAsCollateralFalse_revertsBelowFloor() public {
+        _supplyToGateway(address(safe), address(weETH), 5 ether);
+        uint256 weethOnlyAvail = gw.getAccountData(address(safe)).availableBorrowsUsd;
+        _supplyToGateway(address(safe), address(usdc), 1000e6);
+        // Debt sized so weETH alone still covers it (Aave allows the drop) but lands HF ~1.01 (< floor)
+        _borrowOnGateway(address(safe), address(usdc), (weethOnlyAvail * 99) / 100, recipient);
+        _setFloor(FLOOR);
+
+        vm.prank(driver);
+        vm.expectRevert(LendGateway.HealthFactorBelowMinimum.selector);
+        gw.setUsingAsCollateral(address(safe), address(usdc), false);
+
+        _setFloor(0);
+        vm.prank(driver);
+        gw.setUsingAsCollateral(address(safe), address(usdc), false); // Aave's own check still passes
+    }
+
+    // ----------------------------------------------------------------- lens quotes are buffered
+
+    /// The lens quotes credit capacity buffered by the floor: an amount inside the buffer is approved and
+    /// settles landing above the floor; between the buffer and Aave's raw bound it is declined.
+    function test_lens_creditQuoteBuffered() public {
+        _supplyToGateway(address(safe), address(weETH), 5 ether);
+        _setModeCredit();
+        uint256 rawMax = cashLens.getMaxSpendCredit(address(safe));
+
+        _setFloor(FLOOR);
+        uint256 bufferedMax = cashLens.getMaxSpendCredit(address(safe));
+        assertLt(bufferedMax, rawMax, "floor shrinks the credit quote");
+        assertApproxEqRel(bufferedMax, (rawMax * 1e18) / FLOOR, 0.001e18, "buffered = raw / floor with no debt");
+
+        (bool ok,) = cashLens.canSpend(address(safe), txId, _addr1(address(usdc)), _uint1(bufferedMax));
+        assertTrue(ok, "quote is approvable");
+        (bool okOver, string memory reason) = cashLens.canSpend(address(safe), txId, _addr1(address(usdc)), _uint1((bufferedMax + rawMax) / 2));
+        assertFalse(okOver, "past the buffer is declined");
+        assertEq(reason, "Insufficient borrowing power");
+
+        // Spending exactly the buffered quote settles and lands at (or above) the floor
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, _addr1(address(usdc)), _uint1(bufferedMax), _noCashback());
+        assertGe(gw.getAccountData(address(safe)).healthFactor, FLOOR - 0.002e18, "landed at the floor (rounding tolerance)");
+    }
+
+    /// Soft enforcement: an amount the lens declines (between the buffer and Aave's raw bound) still
+    /// SETTLES if it was authorized earlier — spend execution keeps the raw bound.
+    function test_lens_declinedCreditSpendStillSettles() public {
+        _supplyToGateway(address(safe), address(weETH), 5 ether);
+        _setModeCredit();
+        _setFloor(FLOOR);
+
+        uint256 amount = (gw.getAccountData(address(safe)).availableBorrowsUsd * 97) / 100; // inside raw, past buffer
+        (bool ok,) = cashLens.canSpend(address(safe), txId, _addr1(address(usdc)), _uint1(amount));
+        assertFalse(ok, "new auths at this size are declined");
+
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, _addr1(address(usdc)), _uint1(amount), _noCashback());
+        assertTrue(cashModule.transactionCleared(address(safe), txId), "previously authorized spend settled");
+        assertLt(gw.getAccountData(address(safe)).healthFactor, FLOOR, "past the floor, by design");
+    }
+
+    /// The debit quote shrinks under the floor and spending exactly the quote lands at or above it.
+    function test_lens_debitQuoteBuffered() public {
+        _supplyToGateway(address(safe), address(usdc), 10_000e6);
+        _borrowOnGateway(address(safe), address(usdc), 4000e6, recipient);
+        uint256 rawQuote = cashLens.getMaxSpendDebit(address(safe), _addr1(address(usdc))).totalSpendableInUsd;
+
+        _setFloor(FLOOR);
+        uint256 bufferedQuote = cashLens.getMaxSpendDebit(address(safe), _addr1(address(usdc))).totalSpendableInUsd;
+        assertLt(bufferedQuote, rawQuote, "floor shrinks the debit quote");
+
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, _addr1(address(usdc)), _uint1(bufferedQuote), _noCashback());
+        assertGe(gw.getAccountData(address(safe)).healthFactor, FLOOR - 0.002e18, "landed at the floor (rounding tolerance)");
+    }
+
+    /// With the floor set, getMaxSourceable is exactly requestable: the quote passes the post-pull check
+    /// and one weETH-cent more reverts on it (closes the quote/enforcement gap for withdrawals).
+    function test_getMaxSourceable_quoteExactlyRequestableWithFloor() public {
+        _buildGatewayPosition(address(safe), address(weETH), 10 ether, address(usdc), 5000e6);
+        _setFloor(FLOOR);
+
+        uint256 max = cashLens.getMaxSourceable(address(safe), address(weETH));
+        assertLt(max, 10 ether, "debt caps the withdrawable balance");
+
+        (address[] memory signers, bytes[] memory signatures) = _signRequestWithdrawal(_addr1(address(weETH)), _uint1(max + 0.01 ether), withdrawRecipient);
+        vm.expectRevert(LendGateway.HealthFactorBelowMinimum.selector);
+        cashModule.requestWithdrawal(address(safe), _addr1(address(weETH)), _uint1(max + 0.01 ether), withdrawRecipient, signers, signatures);
+
+        _requestWithdrawal(_addr1(address(weETH)), _uint1(max), withdrawRecipient);
+        assertGe(gw.getAccountData(address(safe)).healthFactor, FLOOR, "quote respects the floor");
+    }
+
+    // ----------------------------------------------------------------- helpers
+
+    function _setModeCredit() internal {
+        uint256 nonce = cashModule.getNonce(address(safe));
+        bytes32 digest = keccak256(abi.encodePacked(CashVerificationLib.SET_MODE_METHOD, block.chainid, address(safe), nonce, abi.encode(Mode.Credit))).toEthSignedMessageHash();
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner1Pk, digest);
+        cashModule.setMode(address(safe), Mode.Credit, owner1, abi.encodePacked(r, s, v));
+        (,, uint64 modeDelay) = cashModule.getDelays();
+        vm.warp(block.timestamp + modeDelay + 1);
+    }
+
+    function _borrowSig(address token, uint256 amountInUsd) internal view returns (address[] memory, bytes[] memory) {
+        bytes32 digest = keccak256(abi.encodePacked(CashVerificationLib.BORROW_METHOD, block.chainid, address(safe), safe.nonce(), abi.encode(token, amountInUsd))).toEthSignedMessageHash();
+        (uint8 v1, bytes32 r1, bytes32 s1) = vm.sign(owner1Pk, digest);
+        (uint8 v2, bytes32 r2, bytes32 s2) = vm.sign(owner2Pk, digest);
+
+        address[] memory signers = new address[](2);
+        signers[0] = owner1;
+        signers[1] = owner2;
+
+        bytes[] memory signatures = new bytes[](2);
+        signatures[0] = abi.encodePacked(r1, s1, v1);
+        signatures[1] = abi.encodePacked(r2, s2, v2);
+        return (signers, signatures);
+    }
+
+    function _signRequestWithdrawal(address[] memory tokens, uint256[] memory amounts, address recipient_) internal view returns (address[] memory, bytes[] memory) {
+        bytes32 digestHash = keccak256(abi.encodePacked(CashVerificationLib.REQUEST_WITHDRAWAL_METHOD, block.chainid, address(safe), safe.nonce(), abi.encode(tokens, amounts, recipient_))).toEthSignedMessageHash();
+        (uint8 v1, bytes32 r1, bytes32 s1) = vm.sign(owner1Pk, digestHash);
+        (uint8 v2, bytes32 r2, bytes32 s2) = vm.sign(owner2Pk, digestHash);
+
+        address[] memory signers = new address[](2);
+        signers[0] = owner1;
+        signers[1] = owner2;
+
+        bytes[] memory signatures = new bytes[](2);
+        signatures[0] = abi.encodePacked(r1, s1, v1);
+        signatures[1] = abi.encodePacked(r2, s2, v2);
+        return (signers, signatures);
+    }
+
+    function _uint1(uint256 a) internal pure returns (uint256[] memory) {
+        uint256[] memory arr = new uint256[](1);
+        arr[0] = a;
+        return arr;
+    }
+
+    function _noCashback() internal pure returns (Cashback[] memory) {
+        return new Cashback[](0);
+    }
+}

--- a/test/safe/modules/cash/lend/Spend.t.sol
+++ b/test/safe/modules/cash/lend/Spend.t.sol
@@ -325,3 +325,34 @@ contract CashModuleSpendAaveTest is CashGatewayTestSetup {
         return cashbacks;
     }
 }
+
+/// @dev Runs the suite's setup with weETH's reserve flipped to borrowable while it stays OFF the
+///      spend-asset list: a credit spend settles the card, so a borrowable-but-not-settleable token must
+///      be rejected on both the check side and the execution side.
+contract SpendCreditTokenGateTest is CashModuleSpendAaveTest {
+    function _weethBorrowable() internal pure override returns (bool) {
+        return true;
+    }
+
+    function test_creditSpend_rejectsBorrowableNonSpendAsset() public {
+        _supplyToGateway(address(safe), address(weETH), 5 ether);
+        _setMode(Mode.Credit);
+
+        assertTrue(gw.isBorrowable(address(weETH)), "premise: weETH borrowable");
+        assertFalse(gw.isSpendAsset(address(weETH)), "premise: weETH not a spend asset");
+
+        // The lens declines it...
+        (bool ok, string memory reason) = cashLens.canSpend(address(safe), txId, _tokens(address(weETH)), _amounts(100e6));
+        assertFalse(ok, "lens declines the non-settleable token");
+        assertEq(reason, "Not a supported borrow token");
+
+        // ...and execution rejects it identically (check/execution parity)
+        vm.prank(etherFiWallet);
+        vm.expectRevert(ICashModule.UnsupportedToken.selector);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, _tokens(address(weETH)), _amounts(100e6), _noCashback());
+
+        // The card settlement token (borrowable AND spend asset) is unaffected
+        (bool okUsdc,) = cashLens.canSpend(address(safe), txId, _tokens(address(usdc)), _amounts(100e6));
+        assertTrue(okUsdc, "usdc credit spend unaffected");
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes core Aave gateway risk controls, spend/lens math, and lend opt-out timing across CashModule and multiple consumer modules; misalignment could block withdrawals or allow inconsistent auth vs settlement.
> 
> **Overview**
> Adds a configurable **post-op health-factor floor** on `LendGateway` (admin `setMinHealthFactor`, 0 disables, otherwise 1.0–2.0 WAD). **User-extraction** paths enforce it after the op: signed borrow, Aave-sourced withdrawal requests, turning collateral off, and risk-increasing module sandwich flows via `_ensureGatewayFloor`. **Card spends and repays stay exempt** so settlement and de-risking are not blocked.
> 
> **Lens and execution alignment** moves credit/debit sizing into `DebitSourcingLib`: floor-buffered credit/debit headroom for `canSpend` / max-spend quotes, `hasDebt` (raw per-asset) instead of floored `debtUsd`, and credit spends gated on **borrowable + card settleable (`spendAssets`)** reserves. `getAccountData` **rounds debt USD up** to avoid dust under-quoting.
> 
> **Lend opt-out** becomes *effective* once the finalize time has passed (strictly after, like mode rails), with **lazy `processLendOptOutIfReady`** on spend, repay, withdrawals, and `supplyToLend`; opt-out requests **schedule incoming Debit** and **block `setMode`** while pending. Collateral unwind is refactored to **best-effort** on lazy paths vs strict on `processLendOptOut`. Module **withdraw shortfall** is **gateway-engine** gated so opted-out safes can still reclaim supplied collateral (e.g. LiquidUSD repay).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1297c4ae149b1791da789d34e27445687ab49675. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->