### PR TITLE
fix: credit repay-freed headroom with Aave's restore rounding

### DIFF
--- a/src/interfaces/ILendGateway.sol
+++ b/src/interfaces/ILendGateway.sol
@@ -199,12 +199,24 @@ interface ILendGateway {
 
     /**
      * @notice The weighted collateral value a borrow of `amount` of `asset` requires at Aave's 1.00 bound
-     * @dev Also the value a repay of `amount` frees.
+     * @dev The value a repay frees is repayValue, which follows Aave's restore rounding instead.
      * @param asset The borrow asset (must be registered)
-     * @param amount The borrow or repay in asset units
+     * @param amount The borrow in asset units
      * @return The required weighted collateral value
      */
     function borrowValue(address asset, uint256 amount) external view returns (uint256);
+
+    /**
+     * @notice The weighted collateral value a repay of `amount` of `asset` frees at Aave's 1.00 bound
+     * @dev Exact against Aave's restore share rounding (premium clears first, drawn shares restore rounded
+     *      down), so repay sizing can credit it as headroom without overshooting Aave's post-withdraw
+     *      health check.
+     * @param safe The Safe whose debt is repaid
+     * @param asset The repaid asset (must be registered)
+     * @param amount The repay in asset units
+     * @return The freed weighted collateral value
+     */
+    function repayValue(address safe, address asset, uint256 amount) external view returns (uint256);
 
     /**
      * @notice Amount of `asset` to supply so the position gains `value` of weighted collateral value

--- a/src/libraries/DebitSourcingLib.sol
+++ b/src/libraries/DebitSourcingLib.sol
@@ -84,12 +84,14 @@ library DebitSourcingLib {
      * @notice Amount of `token` withdrawable from `safe`'s supplied balance to fund a repay whose loose leg
      *         repays `fromLoose` first
      * @dev Repaying the loose leg lowers the debt while the collateral is untouched, so the withdraw leg
-     *      sizes against the headroom that repay frees (borrowValue). Raw headroom: a repay de-risks the
-     *      position, so it is floor-exempt like spends. Callers only get here with debt remaining after
-     *      the loose leg, so the headroom cap always applies.
+     *      sizes against the headroom that repay frees (repayValue, exact against Aave's restore share
+     *      rounding — the ideal borrowValue can overstate the freed cover by a share and fail Aave's
+     *      health check at the exact boundary). Raw headroom: a repay de-risks the position, so it is
+     *      floor-exempt like spends. Callers only get here with debt remaining after the loose leg, so
+     *      the headroom cap always applies.
      */
     function repayWithdrawable(ILendGateway gateway, address safe, address token, uint256 fromLoose) public view returns (uint256) {
-        uint256 headroom = gateway.rawWithdrawHeadroom(safe) + gateway.borrowValue(token, fromLoose);
+        uint256 headroom = gateway.rawWithdrawHeadroom(safe) + gateway.repayValue(safe, token, fromLoose);
         return withdrawableSupplied(gateway, safe, token, headroom, true);
     }
 

--- a/src/mocks/MockLendGateway.sol
+++ b/src/mocks/MockLendGateway.sol
@@ -190,6 +190,11 @@ contract MockLendGateway is ILendGateway {
         return amount;
     }
 
+    /// @dev Inert 1:1 conversion, matching borrowValue
+    function repayValue(address, address, uint256 amount) external pure returns (uint256) {
+        return amount;
+    }
+
     /// @dev Inert 1:1 conversion
     function collateralForValue(address, uint256 value) external pure returns (uint256) {
         return value;

--- a/src/modules/lend-gateway/LendCapacityLib.sol
+++ b/src/modules/lend-gateway/LendCapacityLib.sol
@@ -20,6 +20,8 @@ import { IAaveV4Spoke } from "../../interfaces/IAaveV4Spoke.sol";
 library LendCapacityLib {
     /// @notice Converts collateral weighted by BPS into Aave Value units scaled by RAY, then applies a WAD health factor
     uint256 internal constant WEIGHTED_COLLATERAL_TO_DEBT_RAY = 1e41;
+    /// @notice Aave's RAY scale for debt share accounting
+    uint256 internal constant RAY = 1e27;
 
     struct BorrowCapacityData {
         uint256 weightedCollateralValueBps;
@@ -158,6 +160,45 @@ library LendCapacityLib {
         uint256 price = IAaveV4Oracle(spoke.ORACLE()).getReservePrice(targetReserveId);
         uint256 decimals = spoke.getReserve(targetReserveId).decimals;
         return amount * price * (10 ** (18 - decimals)) * 10_000;
+    }
+
+    /**
+     * @notice The weighted collateral value a repay of `amount` of `targetReserveId`'s asset frees at Aave's
+     *         1.00 health-factor bound
+     * @dev Exact against Aave's own restore math (Spoke.repay via calculateRestoreAmount): the payment
+     *      clears premium debt first — a sub-premium payment removes exactly amount * RAY of debt — and the
+     *      drawn remainder restores shares rounded down, so the debt actually removed can sit a share short
+     *      of the paid amount. Crediting the ideal borrowValue there would overstate the freed headroom and
+     *      let an exact-boundary repay quote fail Aave's health check on its withdraw leg. The final
+     *      conversion also rounds down, so the credit never exceeds what the repay actually frees.
+     * @param spoke The Aave Spoke holding the position
+     * @param safe The Safe whose debt is repaid
+     * @param targetReserveId The reserve being repaid
+     * @param amount The repay in asset units
+     * @return The freed weighted collateral value (see withdrawHeadroom for the unit)
+     */
+    function repayValue(IAaveV4Spoke spoke, address safe, uint256 targetReserveId, uint256 amount) external view returns (uint256) {
+        IAaveV4Spoke.Reserve memory reserve = spoke.getReserve(targetReserveId);
+        uint256 drawnIndex = IAaveV4Hub(reserve.hub).getAssetDrawnIndex(reserve.assetId);
+        uint256 premiumDebtRay = spoke.getUserPremiumDebtRay(targetReserveId, safe);
+
+        // Mirrors UserPositionUtils.calculateRestoreAmount: premium (rounded up to asset units) is cleared
+        // first, the drawn remainder restores shares rounded down (Spoke.repay's rayDivDown), capped at the
+        // drawn shares held
+        uint256 premiumDebt = Math.ceilDiv(premiumDebtRay, RAY);
+        uint256 freedDebtRay;
+        if (amount < premiumDebt) {
+            freedDebtRay = amount * RAY;
+        } else {
+            uint256 restoredShares = ((amount - premiumDebt) * RAY) / drawnIndex;
+            uint256 drawnShares = spoke.getUserPosition(targetReserveId, safe).drawnShares;
+            if (restoredShares > drawnShares) restoredShares = drawnShares;
+            freedDebtRay = premiumDebtRay + restoredShares * drawnIndex;
+        }
+
+        uint256 valueFactor = IAaveV4Oracle(spoke.ORACLE()).getReservePrice(targetReserveId) * (10 ** (18 - reserve.decimals));
+        // The freed RAY debt Value over the 1.00-bound divisor (1e41 / 1e18 WAD), rounded down
+        return Math.mulDiv(freedDebtRay, valueFactor, WEIGHTED_COLLATERAL_TO_DEBT_RAY / 1e18);
     }
 
     /**

--- a/src/modules/lend-gateway/LendGateway.sol
+++ b/src/modules/lend-gateway/LendGateway.sol
@@ -674,13 +674,26 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
 
     /**
      * @notice The weighted collateral value a borrow of `amount` of `asset` requires at Aave's 1.00 bound
-     * @dev Also the value a repay of `amount` frees.
+     * @dev The value a repay frees is repayValue, which follows Aave's restore rounding instead.
      * @param asset The borrow asset (must be registered)
-     * @param amount The borrow or repay in asset units
+     * @param amount The borrow in asset units
      * @return The required weighted collateral value
      */
     function borrowValue(address asset, uint256 amount) external view returns (uint256) {
         return LendCapacityLib.borrowValue(spoke, _reserveIdOf(asset), amount);
+    }
+
+    /**
+     * @notice The weighted collateral value a repay of `amount` of `asset` frees at Aave's 1.00 bound
+     * @dev Exact against Aave's restore share rounding, so repay sizing can credit it as headroom without
+     *      overshooting Aave's post-withdraw health check (see LendCapacityLib.repayValue).
+     * @param safe The Safe whose debt is repaid
+     * @param asset The repaid asset (must be registered)
+     * @param amount The repay in asset units
+     * @return The freed weighted collateral value
+     */
+    function repayValue(address safe, address asset, uint256 amount) external view returns (uint256) {
+        return LendCapacityLib.repayValue(spoke, safe, _reserveIdOf(asset), amount);
     }
 
     /**

--- a/test/safe/modules/cash/lend/RepaySourcing.t.sol
+++ b/test/safe/modules/cash/lend/RepaySourcing.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.28;
 import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
 import { ICashModule } from "../../../../../src/interfaces/ICashModule.sol";
+import { DebitSourcingLib } from "../../../../../src/libraries/DebitSourcingLib.sol";
 import { CashEventEmitter } from "../../../../../src/modules/cash/CashEventEmitter.sol";
 import { CashGatewayTestSetup } from "./CashGatewayTestSetup.t.sol";
 
@@ -157,6 +158,54 @@ contract RepaySourcingTest is CashGatewayTestSetup {
         cashModule.repay(address(safe), address(usdc), debtUsd);
 
         assertApproxEqAbs(gw.debtOf(address(safe), address(usdc)), 0, 2, "debt repaid from loose plus supplied while frozen");
+    }
+
+    // ----------------------------------------------------------------- freed-headroom credit (repayValue)
+
+    /// repayValue is an exact lower bound on the headroom an actual repay frees: Aave restores drawn shares
+    /// rounded down, so the ideal borrowValue credit can overstate the freed cover by a share — crediting it
+    /// would let an exact-boundary repay overshoot Aave's health check on its withdraw leg.
+    function testFuzz_repayValue_lowerBoundsActualFreedHeadroom(uint256 repayBps, uint256 accrual) public {
+        repayBps = bound(repayBps, 100, 9900);
+        accrual = bound(accrual, 1 hours, 20 days); // off round numbers, within oracle staleness
+        _buildGatewayPosition(address(safe), address(weETH), 5 ether, address(usdc), 2000e6);
+        vm.warp(block.timestamp + accrual);
+
+        uint256 repayAmt = (gw.debtOf(address(safe), address(usdc)) * repayBps) / 10_000;
+        uint256 credited = gw.repayValue(address(safe), address(usdc), repayAmt);
+        assertLe(credited, gw.borrowValue(address(usdc), repayAmt), "restore rounding can only lower the credit");
+
+        uint256 headroomBefore = gw.rawWithdrawHeadroom(address(safe));
+        deal(address(usdc), address(safe), repayAmt);
+        vm.prank(driver);
+        gw.repay(address(safe), address(usdc), repayAmt);
+        uint256 freed = gw.rawWithdrawHeadroom(address(safe)) - headroomBefore;
+
+        assertGe(freed, credited, "credit never exceeds the actually freed headroom");
+        assertLe(freed - credited, 1, "and is exact up to the required-cover ceil");
+    }
+
+    /// The exact max-sourcing quote (loose leg first, repayWithdrawable-sized withdraw leg) executes after
+    /// interest accrual: CashLendLib.repay's leg order with the sizing's own numbers, straight on Aave.
+    function testFuzz_repay_exactMaxSourcingQuoteExecutes(uint256 accrual) public {
+        accrual = bound(accrual, 1 hours, 20 days);
+        // Borrow near the position's power so the headroom cap, not the supplied balance, binds the quote
+        _supplyToGateway(address(safe), address(weETH), 1 ether);
+        _supplyToGateway(address(safe), address(usdc), 3000e6);
+        _borrowOnGateway(address(safe), address(usdc), (gw.getAccountData(address(safe)).availableBorrowsUsd * 90) / 100, recipient);
+        vm.warp(block.timestamp + accrual);
+
+        uint256 fromLoose = 500e6;
+        uint256 quote = DebitSourcingLib.repayWithdrawable(gw, address(safe), address(usdc), fromLoose);
+        assertGt(quote, 0, "position quotes a supplied leg");
+        assertLt(quote, gw.suppliedOf(address(safe), address(usdc)), "the headroom cap binds the quote");
+
+        deal(address(usdc), address(safe), fromLoose);
+        vm.startPrank(driver);
+        gw.repay(address(safe), address(usdc), fromLoose);
+        gw.withdraw(address(safe), address(usdc), quote, address(safe));
+        vm.stopPrank();
+        assertGe(spoke.getUserAccountData(address(safe)).healthFactor, 1e18, "exact quote lands at or above Aave's bound");
     }
 
     function _uint1(uint256 a) internal pure returns (uint256[] memory) {


### PR DESCRIPTION
repayWithdrawable credited borrowValue(fromLoose) as the headroom the loose repay leg frees, but Spoke.repay restores drawn shares rounded down (rayDivDown), so the debt actually removed can sit a share short of the paid amount. The overstated credit let an exact-boundary max repay pass sizing and then revert inside Aave's health check on the withdraw leg — the same failure class the migration re-borrow pad fixed, on the repay path.

Add LendCapacityLib.repayValue, an exact mirror of Aave's restore math (premium clears first and exactly; the drawn remainder floors to shares; the final conversion rounds down), expose it on the gateway, and size the repay withdraw leg with it. Fuzzed on the fork: the credit lower-bounds the actually freed headroom within one required-cover unit, and the exact max-sourcing quote executes after accrual; reverting to the ideal credit makes the bound test fail with a concrete counterexample.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Aave health-factor quoting on the repay-withdraw path; incorrect math could still allow boundary reverts or undersized withdraws, but the fix is conservative (lower-bound credit) and is covered by new fork fuzz tests.
> 
> **Overview**
> **Repay withdraw sizing** no longer treats freed collateral headroom as the symmetric `borrowValue` of the loose repay leg. Aave clears premium first and restores drawn shares with **downward** rounding, so the ideal borrow credit could overshoot real debt removed and let a max repay pass quoting then **revert on the supplied withdraw** at the health-factor boundary.
> 
> The PR adds **`repayValue(safe, asset, amount)`** on `ILendGateway` / `LendGateway`, implemented in **`LendCapacityLib`** to mirror Aave’s restore math (premium handling, floored share restore, down-rounded conversion). **`DebitSourcingLib.repayWithdrawable`** now adds `repayValue` instead of `borrowValue` when sizing the withdraw leg after the loose repay. **`MockLendGateway`** stubs the new view; fork fuzz tests assert the credit lower-bounds actually freed headroom and that the exact max-sourcing quote still executes after accrual.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5981467edbe4b85f2f7af6db2f22116506153bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->