### PR TITLE
fix: gate withdrawal ensureHealth on legacy engine to unbrick gateway safes

### DIFF
--- a/src/debt-manager/DebtManagerCore.sol
+++ b/src/debt-manager/DebtManagerCore.sol
@@ -217,10 +217,14 @@ contract DebtManagerCore is DebtManagerStorageContract {
 
     /**
      * @notice Verifies that a user's position is healthy (not liquidatable)
-     * @dev Reverts if total borrowing exceeds maximum borrowing based on LTV
+     * @dev Reverts if legacy borrowing exceeds max borrowing based on LTV. A no-op for gateway safes: they
+     *      carry no DebtManager debt and Aave enforces their health, so the check is skipped. Calling it for a
+     *      gateway safe would revert once getMaxBorrowAmount prices a supplied Aave asset that DebtManager does
+     *      not list as collateral. This is the catch-all behind the per-call-site guards.
      * @param user Address of the user to check
      */
     function ensureHealth(address user) public view {
+        if (ICashModule(etherFiDataProvider.getCashModule()).usesLendGateway(user)) return;
         (, uint256 totalBorrowings) = borrowingOf(user);
         if (totalBorrowings > getMaxBorrowAmount(user, true)) revert AccountUnhealthy();
     }

--- a/src/modules/cash/CashModuleSetters.sol
+++ b/src/modules/cash/CashModuleSetters.sol
@@ -427,9 +427,11 @@ contract CashModuleSetters is CashModuleStorageContract {
         $$.pendingWithdrawalRequest = WithdrawalRequest({ tokens: tokens, amounts: amounts, recipient: recipient, finalizeTime: finalTime });
         $.cashEventEmitter.emitWithdrawalRequested(safe, tokens, amounts, recipient, finalTime);
 
-        // Deliberately unconditional: load-bearing for legacy safes (loose tokens are DebtManager collateral)
-        // and provably a no-op for gateway safes, whose DebtManager books are zero by construction.
-        _getDebtManager().ensureHealth(safe);
+        // Legacy safes only: their loose tokens are DebtManager collateral, so a withdrawal can worsen the
+        // legacy position. Gateway safes are health-gated by Aave on the pull in sourceWithdrawal; calling
+        // ensureHealth here would revert once getMaxBorrowAmount prices a supplied Aave asset that DebtManager
+        // does not list as collateral (the two registries diverge by design as DebtManager is retired).
+        if (!_usesLendGateway(safe)) _getDebtManager().ensureHealth(safe);
 
         if ($.withdrawalDelay == 0) _processWithdrawal(safe);
     }

--- a/src/modules/cash/CashModuleStorageContract.sol
+++ b/src/modules/cash/CashModuleStorageContract.sol
@@ -300,8 +300,8 @@ contract CashModuleStorageContract is UpgradeableProxy, ModuleBase {
 
         delete $$.pendingWithdrawalRequest;
 
-        // Deliberately unconditional: load-bearing for legacy safes (loose tokens are DebtManager collateral)
-        // and provably a no-op for gateway safes, whose DebtManager books are zero by construction.
-        $.debtManager.ensureHealth(safe);
+        // Legacy safes only: see _requestWithdrawal. Gateway safes are health-gated by Aave at request time
+        // and would revert here if DebtManager cannot price a supplied Aave asset.
+        if (!_usesLendGateway(safe)) $.debtManager.ensureHealth(safe);
     }
 }

--- a/test/safe/modules/cash/lend/WithdrawalSourcing.t.sol
+++ b/test/safe/modules/cash/lend/WithdrawalSourcing.t.sol
@@ -140,6 +140,30 @@ contract WithdrawalSourcingTest is CashGatewayTestSetup {
         assertEq(usdc.balanceOf(withdrawRecipient), max, "recipient paid the full quote");
     }
 
+    /// Regression: a gateway safe supplied in an Aave asset that DebtManager no longer lists as collateral
+    /// must still be able to withdraw. Both withdrawal paths call DebtManager.ensureHealth, whose
+    /// getMaxBorrowAmount walks the safe's Aave-supplied assets and reverts UnsupportedCollateralToken for
+    /// any asset missing from the (separate, shrinking) DebtManager collateral registry. The call is gated on
+    /// !usesLendGateway, so a gateway safe skips it entirely; Aave already health-checks the pull.
+    function test_requestWithdrawal_notBrickedWhenSuppliedAssetDelistedFromDebtManager() public {
+        _supplyToGateway(address(safe), address(weETH), 3 ether); // gateway-registered Aave collateral
+        deal(address(usdc), address(safe), 4000e6); // unrelated loose USDC the safe wants to withdraw
+
+        // DebtManager retires weETH as legacy collateral while the gateway safe still holds it on Aave: the
+        // two registries diverge, which is the intended end state as the legacy engine is wound down.
+        vm.prank(owner);
+        debtManager.unsupportCollateralToken(address(weETH));
+
+        // requestWithdrawal (the first gated ensureHealth) must not revert.
+        _requestWithdrawal(_addr1(address(usdc)), _uint1(4000e6), withdrawRecipient);
+
+        // processWithdrawal (the second gated ensureHealth) must also pay out.
+        (uint64 withdrawalDelay,,) = cashModule.getDelays();
+        vm.warp(block.timestamp + withdrawalDelay + 1);
+        cashModule.processWithdrawal(address(safe));
+        assertEq(usdc.balanceOf(withdrawRecipient), 4000e6, "recipient paid despite the delisted supplied asset");
+    }
+
     /// Builds the owner signatures for a withdrawal request, so revert-path tests can place expectRevert
     /// immediately before the module call.
     function _signRequestWithdrawal(address[] memory tokens, uint256[] memory amounts, address recipient_) internal view returns (address[] memory, bytes[] memory) {

--- a/test/safe/modules/cash/lend/WithdrawalSourcing.t.sol
+++ b/test/safe/modules/cash/lend/WithdrawalSourcing.t.sol
@@ -164,6 +164,18 @@ contract WithdrawalSourcingTest is CashGatewayTestSetup {
         assertEq(usdc.balanceOf(withdrawRecipient), 4000e6, "recipient paid despite the delisted supplied asset");
     }
 
+    /// Catch-all: DebtManager.ensureHealth is a no-op for a gateway safe even when called directly, so any
+    /// future caller that forgets the !usesLendGateway guard stays safe. Without the internal guard this
+    /// reverts UnsupportedCollateralToken once weETH is delisted while the safe still holds it supplied on Aave.
+    function test_ensureHealth_isNoOpForGatewaySafeWithDelistedSuppliedAsset() public {
+        _supplyToGateway(address(safe), address(weETH), 3 ether);
+
+        vm.prank(owner);
+        debtManager.unsupportCollateralToken(address(weETH));
+
+        debtManager.ensureHealth(address(safe)); // must not revert
+    }
+
     /// Builds the owner signatures for a withdrawal request, so revert-path tests can place expectRevert
     /// immediately before the module call.
     function _signRequestWithdrawal(address[] memory tokens, uint256[] memory amounts, address recipient_) internal view returns (address[] memory, bytes[] memory) {


### PR DESCRIPTION
## What

Gate the `DebtManager.ensureHealth` call in both withdrawal paths (`_requestWithdrawal`, `_processWithdrawal`) on `!usesLendGateway(safe)`, matching what `EtherFiHook.postOpHook` already does.

## Why

Both paths called `ensureHealth` unconditionally, with a comment claiming it is a no-op for gateway safes. It is not a no-op, it reverts. For a gateway safe `totalBorrowings` is 0, but Solidity still evaluates the right-hand side of the comparison, `getMaxBorrowAmount`, which walks the safe's Aave-supplied assets via `CashLens.getUserTotalCollateral` and calls `convertCollateralTokenToUsd`. That reverts `UnsupportedCollateralToken` for any supplied asset the DebtManager collateral registry does not list.

The gateway's registered-asset set and the DebtManager collateral set are separate and diverge by design, and fully once DebtManager is retired via `unsupportCollateralToken` (which has no still-supplied guard). So a gateway safe holding a gateway-only supplied asset had all of its withdrawals bricked, including unrelated loose tokens. Aave already health-gates a gateway safe's collateral pull at request time (`sourceWithdrawal` calls `gateway.ensureMinHealthFactor`), so the legacy check is only meaningful for legacy safes.

Found during the feat/lend pre-audit review (COR-1079).

## Testing

- New regression test `WithdrawalSourcing.t.sol::test_requestWithdrawal_notBrickedWhenSuppliedAssetDelistedFromDebtManager`: supplies weETH on the gateway, retires it from DebtManager via `unsupportCollateralToken`, then asserts the safe can still request and process a withdrawal. Reverts `UnsupportedCollateralToken()` on the pre-fix code, passes after.
- All 9 `WithdrawalSourcing.t.sol` gateway tests pass.
- All 38 `Withdrawals.t.sol` legacy tests pass, including the unhealthy-withdrawal reverts, confirming legacy safes still get the check.
- `forge lint` clean on the changed files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches withdrawal safety checks on a critical user-funds path; behavior change is narrow (gateway-only skip) with legacy checks preserved and a targeted regression test.
> 
> **Overview**
> **Gateway safes could not complete withdrawals** when they still held Aave-supplied assets that `DebtManager` no longer lists as collateral. Both `_requestWithdrawal` and `_processWithdrawal` always called `DebtManager.ensureHealth`, which still runs `getMaxBorrowAmount` and can revert `UnsupportedCollateralToken` even when legacy borrowings are zero.
> 
> **This change** runs `ensureHealth` only when `!_usesLendGateway(safe)`, aligned with `EtherFiHook.postOpHook`. Legacy safes keep the post-withdrawal health check on loose collateral; gateway safes rely on Aave health at pull time in `sourceWithdrawal`.
> 
> A regression test covers supply on the gateway, delist collateral in `DebtManager`, then request and process withdrawal of unrelated loose tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7552bbddb0c509733694bf141f5507a6c7d191d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->