### PR TITLE
fix: account for safe balance for gateway safes as well

### DIFF
--- a/src/modules/cash/CashLens.sol
+++ b/src/modules/cash/CashLens.sol
@@ -40,8 +40,13 @@ import { CashLensLegacyLib } from "./CashLensLegacyLib.sol";
  *      spendable is exactly what a gateway withdraw allows; there is no separate module-side health gate.
  *
  *      A pending withdrawal sits against the loose Safe balance, not the supplied position. CashLens reserves
- *      it from the loose balance and uses the gateway's figures (collateral, maxBorrow, credit/debit headroom)
+ *      it from the loose balance and uses the gateway's figures (maxBorrow, credit/debit headroom)
  *      for the supplied position as-is.
+ *
+ *      Collateral views (getSafeCashData totals, getUserTotalCollateral, getUserCollateralForToken) report a
+ *      gateway safe's supplied position plus its idle balance of registered assets — loose funds net of any
+ *      pending-withdrawal reservation. Idle funds show as collateral but carry no borrowing power until
+ *      supplied, so maxBorrow and the spend ceilings stay gateway-derived.
  * @author ether.fi
  */
 contract CashLens is UpgradeableProxy, Constants {
@@ -280,12 +285,15 @@ contract CashLens is UpgradeableProxy, Constants {
             collateralTokens = lendGateway.registeredAssets();
             debitSpendTokens = lendGateway.spendAssets();
             ILendGateway.AccountData memory account = lendGateway.getAccountData(safe);
-            data.collateralBalances = _suppliedBalances(safe, collateralTokens);
+            uint256 idleUsd;
+            (data.collateralBalances, idleUsd) = _collateralBalances(safe, collateralTokens, safeData);
             // Debt can sit on any registered reserve, including one that stopped being borrowable after
             // the borrow (borrowable flag turned off, or the reserve frozen/paused), so walk all
             // registered assets here to match totalBorrow and hasOpenBorrows.
             data.borrows = _debtBalances(safe, collateralTokens);
-            data.totalCollateral = account.collateralUsd;
+            // Supplied position (the gateway's Aave-priced aggregate) plus idle registered assets
+            // (PriceProvider-priced, same 6-decimal scale). Idle funds add no borrowing power.
+            data.totalCollateral = account.collateralUsd + idleUsd;
             data.totalBorrow = account.debtUsd;
             // Gross borrowing power (collateral weighted by LTV): the gateway headroom plus current debt
             data.maxBorrow = account.availableBorrowsUsd + account.debtUsd;
@@ -467,8 +475,8 @@ contract CashLens is UpgradeableProxy, Constants {
 
     /**
      * @notice Gets the effective collateral amount for a specific token
-     * @dev A gateway safe's collateral is its Aave-supplied balance (pending withdrawals reserve loose funds,
-     *      not the supplied position). A legacy safe's collateral is its raw balance minus pending
+     * @dev A gateway safe's collateral is its Aave-supplied balance plus its idle balance (loose funds net
+     *      of any pending-withdrawal reservation). A legacy safe's collateral is its raw balance minus pending
      *      withdrawals — DebtManager reads this branch for its health and borrow checks, so it must keep the
      *      exact pre-gateway semantics until the legacy engine is retired.
      * @param safe Address of the safe
@@ -487,12 +495,13 @@ contract CashLens is UpgradeableProxy, Constants {
 
         ILendGateway lendGateway = gateway();
         if (!lendGateway.isRegistered(token)) revert NotACollateralToken();
-        return lendGateway.suppliedOf(safe, token);
+        return lendGateway.suppliedOf(safe, token) + _idleBalance(safe, token, cashModule.getData(safe));
     }
 
     /**
      * @notice Gets all effective collateral balances for a safe
-     * @dev A gateway safe's collateral is its Aave-supplied balances; a legacy safe's is its raw balances
+     * @dev A gateway safe's collateral is its Aave-supplied balances plus its idle balances of registered
+     *      assets (loose funds net of pending-withdrawal reservations); a legacy safe's is its raw balances
      *      minus pending withdrawals. DebtManager reads the legacy branch for its health and borrow checks,
      *      so that branch must keep the exact pre-gateway semantics until the legacy engine is retired.
      * @param safe Address of the safe
@@ -503,7 +512,8 @@ contract CashLens is UpgradeableProxy, Constants {
             return CashLensLegacyLib.userTotalCollateral(cashModule, safe, cashModule.getDebtManager().getCollateralTokens());
         }
 
-        return _suppliedBalances(safe, gateway().registeredAssets());
+        (IDebtManager.TokenData[] memory collateral,) = _collateralBalances(safe, gateway().registeredAssets(), cashModule.getData(safe));
+        return collateral;
     }
 
     /**
@@ -542,13 +552,19 @@ contract CashLens is UpgradeableProxy, Constants {
         return rawAfterPending + withdrawableSupplied;
     }
 
-    /// @notice Per-token supplied position in the Safe's Aave account, skipping zero balances
-    function _suppliedBalances(address safe, address[] memory tokens) internal view returns (IDebtManager.TokenData[] memory) {
+    /// @notice Per-token collateral of a gateway safe: the Aave-supplied position plus the idle Safe balance
+    ///         (loose funds net of any pending-withdrawal reservation), skipping zero balances. Also returns
+    ///         the idle part's total USD value (6 decimals) so getSafeCashData can extend the gateway's
+    ///         Aave-priced collateral aggregate in the same scale.
+    function _collateralBalances(address safe, address[] memory tokens, SafeData memory safeData) internal view returns (IDebtManager.TokenData[] memory, uint256) {
         ILendGateway lendGateway = cashModule.getLendGateway();
         IDebtManager.TokenData[] memory out = new IDebtManager.TokenData[](tokens.length);
+        uint256 idleUsd = 0;
         uint256 m = 0;
         for (uint256 i = 0; i < tokens.length;) {
-            uint256 amount = lendGateway.suppliedOf(safe, tokens[i]);
+            uint256 idle = _idleBalance(safe, tokens[i], safeData);
+            if (idle != 0) idleUsd += _toUsd(tokens[i], idle);
+            uint256 amount = lendGateway.suppliedOf(safe, tokens[i]) + idle;
             if (amount != 0) {
                 out[m] = IDebtManager.TokenData({ token: tokens[i], amount: amount });
                 unchecked {
@@ -564,7 +580,14 @@ contract CashLens is UpgradeableProxy, Constants {
             mstore(out, m)
         }
 
-        return out;
+        return (out, idleUsd);
+    }
+
+    /// @notice Idle balance of `token` in the Safe: the loose balance less any pending-withdrawal reservation
+    function _idleBalance(address safe, address token, SafeData memory safeData) internal view returns (uint256) {
+        uint256 loose = IERC20(token).balanceOf(safe);
+        uint256 pending = _getPendingWithdrawalAmount(safeData, token);
+        return loose > pending ? loose - pending : 0;
     }
 
     /// @notice Per-token debt in the Safe's Aave account, skipping zero balances

--- a/test/safe/modules/cash/lend/CashLens.t.sol
+++ b/test/safe/modules/cash/lend/CashLens.t.sol
@@ -14,18 +14,56 @@ import { CashGatewayTestSetup } from "./CashGatewayTestSetup.t.sol";
  * @dev Run with: source .env && FOUNDRY_PROFILE=lend TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test --match-path "test/safe/modules/cash/lend/CashLens.t.sol"
  */
 contract CashLensAaveTest is CashGatewayTestSetup {
-    /// A gateway safe's collateral is its Aave-supplied balance; loose funds don't count.
-    function test_getUserCollateralForToken_gatewaySafe_readsSuppliedBalance() public {
-        deal(address(weETH), address(safe), 5 ether); // loose, not collateral for a gateway safe
-        assertEq(cashLens.getUserCollateralForToken(address(safe), address(weETH)), 0, "loose balance is not collateral");
+    /// A gateway safe's collateral is its Aave-supplied balance plus any idle loose balance.
+    function test_getUserCollateralForToken_gatewaySafe_countsSuppliedPlusIdle() public {
+        deal(address(weETH), address(safe), 5 ether); // idle funds count as collateral
+        assertEq(cashLens.getUserCollateralForToken(address(safe), address(weETH)), 5 ether, "idle balance is collateral");
 
-        _supplyToGateway(address(safe), address(weETH), 3 ether);
-        assertApproxEqAbs(cashLens.getUserCollateralForToken(address(safe), address(weETH)), 3 ether, 2, "supplied balance is the collateral");
+        _supplyToGateway(address(safe), address(weETH), 3 ether); // deals 3 more and supplies them, so the idle 5 stay put
+        assertApproxEqAbs(cashLens.getUserCollateralForToken(address(safe), address(weETH)), 8 ether, 2, "supplied plus idle");
 
         IDebtManager.TokenData[] memory collateral = cashLens.getUserTotalCollateral(address(safe));
-        assertEq(collateral.length, 1, "only the supplied token shows up");
+        assertEq(collateral.length, 1, "only the weETH position shows up");
         assertEq(collateral[0].token, address(weETH));
-        assertApproxEqAbs(collateral[0].amount, 3 ether, 2);
+        assertApproxEqAbs(collateral[0].amount, 8 ether, 2);
+    }
+
+    /// A pending withdrawal reserves loose funds, so only the unreserved idle part counts as collateral.
+    function test_getUserCollateralForToken_pendingWithdrawalReservesIdle() public {
+        _supplyToGateway(address(safe), address(weETH), 3 ether);
+        deal(address(weETH), address(safe), 5 ether);
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(weETH);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 2 ether;
+        _requestWithdrawal(tokens, amounts, withdrawRecipient);
+
+        // supplied 3, plus idle = 5 loose - 2 pending; the supplied side is never reserved
+        assertApproxEqAbs(cashLens.getUserCollateralForToken(address(safe), address(weETH)), 6 ether, 2, "pending reserves the loose part only");
+    }
+
+    /// getSafeCashData's totalCollateral extends the gateway's Aave-priced aggregate with idle balances
+    /// priced by the PriceProvider, and the per-token breakdown lists idle-only positions.
+    function test_getSafeCashData_totalCollateralIncludesIdle() public {
+        _supplyToGateway(address(safe), address(weETH), 5 ether);
+        deal(address(usdc), address(safe), 3000e6); // idle, never supplied
+
+        SafeCashData memory data = cashLens.getSafeCashData(address(safe), new address[](0));
+        ILendGateway.AccountData memory account = gw.getAccountData(address(safe));
+
+        uint256 idleUsd = (3000e6 * priceProvider.price(address(usdc))) / 1e6;
+        assertEq(data.totalCollateral, account.collateralUsd + idleUsd, "gateway aggregate plus idle USD");
+
+        assertEq(data.collateralBalances.length, 2, "supplied weETH and idle USDC both listed");
+        for (uint256 i = 0; i < data.collateralBalances.length; i++) {
+            if (data.collateralBalances[i].token == address(usdc)) {
+                assertEq(data.collateralBalances[i].amount, 3000e6, "idle-only USDC listed at its idle balance");
+            }
+        }
+
+        // Idle funds carry no borrowing power: maxBorrow stays the gateway's figure.
+        assertEq(data.maxBorrow, account.availableBorrowsUsd + account.debtUsd, "maxBorrow unaffected by idle funds");
     }
 
     /// getSafeCashData reports collateral entries, debit mode, and a pending withdrawal for a gateway safe with no borrows.
@@ -55,9 +93,10 @@ contract CashLensAaveTest is CashGatewayTestSetup {
         assertEq(data.withdrawalRequest.tokens[0], address(usdc), "Withdrawal token should be USDC");
         assertEq(data.withdrawalRequest.amounts[0], 5000e6, "Withdrawal amount should be 5000 USDC");
 
-        // Totals come straight from the gateway's account data, the same source CashLens reads.
+        // The 5000 loose USDC is fully reserved by the pending withdrawal, so idle is zero and the
+        // total is exactly the gateway's account data.
         ILendGateway.AccountData memory account = gw.getAccountData(address(safe));
-        assertEq(data.totalCollateral, account.collateralUsd, "Total collateral matches gateway");
+        assertEq(data.totalCollateral, account.collateralUsd, "Total collateral matches gateway when idle is fully reserved");
         assertEq(data.totalBorrow, 0, "Total borrow should be zero initially");
         assertEq(data.maxBorrow, account.availableBorrowsUsd + account.debtUsd, "Max borrow matches gateway headroom plus debt");
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how collateral is reported for gateway safes and feeds DebtManager’s CashLens-backed collateral reads; borrowing limits are unchanged but USD totals mix gateway and PriceProvider pricing.
> 
> **Overview**
> **Gateway safes** now treat collateral as **supplied Aave position plus idle registered assets** (loose wallet balance minus pending-withdrawal reservations), aligning lens reads with legacy-style “effective balance” semantics for display and health-adjacent views.
> 
> `getUserCollateralForToken`, `getUserTotalCollateral`, and `getSafeCashData` switch from supplied-only (`_suppliedBalances`) to **`_collateralBalances` / `_idleBalance`**: per-token amounts sum `suppliedOf` + idle, and **`totalCollateral`** becomes `account.collateralUsd` plus **PriceProvider-valued idle USD** (same 6-decimal scale). **`maxBorrow`**, credit/debit headroom, and spend checks stay **gateway-derived**—idle funds are documented and tested as **non-borrowing** until supplied.
> 
> Legacy `DebtManager` paths are unchanged. Tests in `CashLens.t.sol` (lend profile) cover idle-only collateral, supplied+idle, pending withdrawal reserving only loose funds, and `totalCollateral` / breakdown behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70058ead85aaff0d10a108097c81922f01d5778e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->