### PR TITLE
fix: guard L2 oracle reads after sequencer recovery

### DIFF
--- a/scripts/aave-v4/AddSummerLendCollateral.s.sol
+++ b/scripts/aave-v4/AddSummerLendCollateral.s.sol
@@ -78,6 +78,7 @@ contract AddSummerLendCollateral is Utils {
     address constant BTC_USD = 0xD702DD976Fb76Fffc2D3963D037dfDae5b04E593;
     address constant EUR_USD = 0x3626369857A10CcC6cc3A6e4f5C2f5984a519F20;
     address constant OP_USD = 0x0D276FC14719f9292D5C1eA2198673d1f4269246;
+    address constant SEQUENCER_UPTIME_FEED = 0x371EAD81c9102C9BF4874A9075FFFf170F2Ee389;
 
     // --- Pyth per-pair oracles (OP, 16-dec price(); see scripts/gnosis-txs/SetPythOraclesOP.s.sol) ---
     uint8 constant PYTH_ORACLE_DECIMALS = 16;
@@ -107,6 +108,7 @@ contract AddSummerLendCollateral is Utils {
     uint256 constant VEDA_RATE_MAX_STALENESS = 2 days;
     // The Midas proxies update roughly weekly (the PriceProvider config allows 7 days)
     uint256 constant MIDAS_RATE_MAX_STALENESS = 7 days;
+    uint256 constant SEQUENCER_GRACE_PERIOD = 1 hours;
 
     IHub hub;
     ISpoke spoke;
@@ -219,14 +221,14 @@ contract AddSummerLendCollateral is Utils {
 
     /// @dev Deploys a ChainlinkPriceFeed over a Chainlink oracle, optionally composed on an underlying feed
     function _chainlink(address oracle, address underlyingUsdFeed, uint256 maxStaleness, bool stable, string memory desc) internal returns (address) {
-        ChainlinkPriceFeed feed = new ChainlinkPriceFeed(IAggregatorV3(oracle), IAaveV4PriceFeed(underlyingUsdFeed), FEED_DECIMALS, maxStaleness, stable, desc);
+        ChainlinkPriceFeed feed = new ChainlinkPriceFeed(IAggregatorV3(oracle), IAaveV4PriceFeed(underlyingUsdFeed), FEED_DECIMALS, maxStaleness, stable, desc, IAggregatorV3(SEQUENCER_UPTIME_FEED), SEQUENCER_GRACE_PERIOD);
         _requireLivePrice(address(feed), desc);
         return address(feed);
     }
 
     /// @dev Deploys a PythPriceFeed over a per-pair oracle, optionally composed on an underlying feed
     function _pyth(address pairOracle, address underlyingUsdFeed, string memory desc) internal returns (address) {
-        PythPriceFeed feed = new PythPriceFeed(IPythPairOracle(pairOracle), PYTH_ORACLE_DECIMALS, FEED_DECIMALS, IAaveV4PriceFeed(underlyingUsdFeed), PYTH_MAX_STALENESS, false, desc);
+        PythPriceFeed feed = new PythPriceFeed(IPythPairOracle(pairOracle), PYTH_ORACLE_DECIMALS, FEED_DECIMALS, IAaveV4PriceFeed(underlyingUsdFeed), PYTH_MAX_STALENESS, false, desc, IAggregatorV3(SEQUENCER_UPTIME_FEED), SEQUENCER_GRACE_PERIOD);
         _requireLivePrice(address(feed), desc);
         return address(feed);
     }
@@ -234,7 +236,7 @@ contract AddSummerLendCollateral is Utils {
     /// @dev Deploys a VedaAccountantPriceFeed, resolving the accountant from the teller on-chain
     function _veda(address teller, address underlyingUsdFeed, string memory desc) internal returns (address) {
         IVedaAccountant accountant = IVedaAccountant(address(ILayerZeroTeller(teller).accountant()));
-        VedaAccountantPriceFeed feed = new VedaAccountantPriceFeed(accountant, IAaveV4PriceFeed(underlyingUsdFeed), FEED_DECIMALS, VEDA_RATE_MAX_STALENESS, false, desc);
+        VedaAccountantPriceFeed feed = new VedaAccountantPriceFeed(accountant, IAaveV4PriceFeed(underlyingUsdFeed), FEED_DECIMALS, VEDA_RATE_MAX_STALENESS, false, desc, IAggregatorV3(SEQUENCER_UPTIME_FEED), SEQUENCER_GRACE_PERIOD);
         _requireLivePrice(address(feed), desc);
         return address(feed);
     }

--- a/scripts/aave-v4/DeployAaveV4TestInstance.s.sol
+++ b/scripts/aave-v4/DeployAaveV4TestInstance.s.sol
@@ -74,6 +74,8 @@ contract DeployAaveV4TestInstance is Utils {
     // Chainlink staleness bounds for the composite weETH/USD feed: the weETH/WETH exchange-rate feed
     // has a 24h heartbeat, ETH/USD updates far more often; 2 days keeps a quiet dev instance usable.
     uint256 constant RATE_FEED_MAX_STALENESS = 1 days;
+    address constant SEQUENCER_UPTIME_FEED = 0x371EAD81c9102C9BF4874A9075FFFf170F2Ee389;
+    uint256 constant SEQUENCER_GRACE_PERIOD = 1 hours;
 
     IAccessManager accessManager;
     IHub hub;
@@ -108,9 +110,11 @@ contract DeployAaveV4TestInstance is Utils {
         spoke.updateLiquidationConfig(ISpoke.LiquidationConfig({ targetHealthFactor: 1.05e18, healthFactorForMaxBonus: 0.7e18, liquidationBonusFactor: 2000 }));
 
         // weETH priced via weETH/WETH exchange rate x ETH/USD (8-decimal USD), USDC via its direct feed
-        weethUsdFeed = new ChainlinkPriceFeed(IAggregatorV3(cfg.weEthWethOracle), IAaveV4PriceFeed(cfg.ethUsdcOracle), 8, RATE_FEED_MAX_STALENESS, false, "weETH / USD");
+        ChainlinkPriceFeed ethUsdFeed = _chainlinkFeed(cfg.ethUsdcOracle, address(0), "ETH / USD");
+        weethUsdFeed = _chainlinkFeed(cfg.weEthWethOracle, address(ethUsdFeed), "weETH / USD");
+        ChainlinkPriceFeed usdcUsdFeed = _chainlinkFeed(cfg.usdcUsdOracle, address(0), "USDC / USD");
         weethReserveId = _addReserve(cfg.weETH, address(weethUsdFeed), WEETH_COLLATERAL_FACTOR_BPS, false);
-        usdcReserveId = _addReserve(cfg.usdc, cfg.usdcUsdOracle, USDC_COLLATERAL_FACTOR_BPS, true);
+        usdcReserveId = _addReserve(cfg.usdc, address(usdcUsdFeed), USDC_COLLATERAL_FACTOR_BPS, true);
 
         address positionManager = vm.envOr("POSITION_MANAGER", address(0));
         if (positionManager != address(0)) {
@@ -128,6 +132,10 @@ contract DeployAaveV4TestInstance is Utils {
         vm.stopBroadcast();
 
         _logAndRecord();
+    }
+
+    function _chainlinkFeed(address rateFeed, address underlyingUsdFeed, string memory description) internal returns (ChainlinkPriceFeed) {
+        return new ChainlinkPriceFeed(IAggregatorV3(rateFeed), IAaveV4PriceFeed(underlyingUsdFeed), 8, RATE_FEED_MAX_STALENESS, false, description, IAggregatorV3(SEQUENCER_UPTIME_FEED), SEQUENCER_GRACE_PERIOD);
     }
 
     /// @dev Deploys LiquidationLogic to its pinned CREATE2 address (no-op if already there). Reads the

--- a/scripts/gnosis-txs/UpgradePriceProviderV2SequencerGuard.s.sol
+++ b/scripts/gnosis-txs/UpgradePriceProviderV2SequencerGuard.s.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import { stdJson } from "forge-std/StdJson.sol";
+
+import { PriceProviderV2 } from "../../src/oracle/PriceProviderV2.sol";
+import { GnosisHelpers } from "../utils/GnosisHelpers.sol";
+import { Utils } from "../utils/Utils.sol";
+
+/// @notice Upgrades the live OP PriceProviderV2 and enables its sequencer guard atomically.
+contract UpgradePriceProviderV2SequencerGuard is GnosisHelpers, Utils {
+    address internal constant CASH_CONTROLLER_SAFE = 0xA6cf33124cb342D1c604cAC87986B965F428AAC4;
+    address internal constant SEQUENCER_UPTIME_FEED = 0x371EAD81c9102C9BF4874A9075FFFf170F2Ee389;
+    uint256 internal constant SEQUENCER_GRACE_PERIOD = 1 hours;
+
+    function run() public {
+        require(block.chainid == 10, "Must run on Optimism (10)");
+
+        string memory deployments = readDeploymentFile();
+        address priceProvider = stdJson.readAddress(deployments, ".addresses.PriceProvider");
+
+        vm.startBroadcast(vm.envUint("PRIVATE_KEY"));
+        address implementation = address(new PriceProviderV2());
+
+        bytes memory configureGuard = abi.encodeCall(PriceProviderV2.setSequencerConfig, (SEQUENCER_UPTIME_FEED, SEQUENCER_GRACE_PERIOD));
+        bytes memory upgrade = abi.encodeCall(UUPSUpgradeable.upgradeToAndCall, (implementation, configureGuard));
+
+        string memory txs = _getGnosisHeader(vm.toString(block.chainid), addressToHex(CASH_CONTROLLER_SAFE));
+        txs = string(abi.encodePacked(txs, _getGnosisTransaction(addressToHex(priceProvider), iToHex(upgrade), "0", true)));
+
+        vm.createDir("./output", true);
+        string memory path = "./output/UpgradePriceProviderV2SequencerGuard.json";
+        vm.writeFile(path, txs);
+        vm.stopBroadcast();
+
+        executeGnosisTransactionBundle(path);
+        require(PriceProviderV2(priceProvider).sequencerUptimeFeed() == SEQUENCER_UPTIME_FEED, "sequencer feed not set");
+        require(PriceProviderV2(priceProvider).sequencerGracePeriod() == SEQUENCER_GRACE_PERIOD, "grace period not set");
+    }
+}

--- a/src/interfaces/ICashEventEmitter.sol
+++ b/src/interfaces/ICashEventEmitter.sol
@@ -137,6 +137,14 @@ interface ICashEventEmitter {
     function emitRepay(address safe, address token, uint256 amount, uint256 amountInUsd) external;
 
     /**
+     * @notice Emits an event when Aave debt is repaid using a token-denominated amount
+     * @param safe Address of the safe whose debt was repaid
+     * @param token Address of the token repaid
+     * @param amount Amount of token actually repaid
+     */
+    function emitRepayLendTokenAmount(address safe, address token, uint256 amount) external;
+
+    /**
      * @notice Emits an event when loose collateral is supplied to cover a credit spend's borrowing shortfall
      * @param safe Address of the safe
      * @param token Collateral token supplied

--- a/src/interfaces/ICashModule.sol
+++ b/src/interfaces/ICashModule.sol
@@ -699,6 +699,16 @@ interface ICashModule {
     function repay(address safe, address token, uint256 amountInUsd) external;
 
     /**
+     * @notice Repays Aave debt using token units without reading a price oracle
+     * @dev Only available to safes on the lend gateway. The amount is capped at the live debt.
+     * @param safe Address of the EtherFi Safe
+     * @param token Address of the token to repay
+     * @param amount Amount to repay in token units
+     * @custom:throws OnlyLendGatewaySafe if the safe runs on the legacy DebtManager engine
+     */
+    function repayLendTokenAmount(address safe, address token, uint256 amount) external;
+
+    /**
      * @notice Supplies a safe's loose token balances into the Aave lend market (the auto-supply sweep)
      * @dev Per token: supplies the loose balance net of any pending-withdrawal reservation and flags it
      *      as collateral; zero and unregistered tokens are skipped. No-op for an opted-out safe; reverts

--- a/src/libraries/L2SequencerGuardLib.sol
+++ b/src/libraries/L2SequencerGuardLib.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { IAggregatorV3 } from "../interfaces/IAggregatorV3.sol";
+
+/// @notice Protects L2 price reads while the sequencer is down and immediately after it recovers.
+library L2SequencerGuardLib {
+    error SequencerDown();
+    error GracePeriodNotOver();
+
+    function validate(IAggregatorV3 sequencerUptimeFeed, uint256 gracePeriod) internal view {
+        if (address(sequencerUptimeFeed) == address(0)) return;
+
+        (, int256 answer, uint256 startedAt,,) = sequencerUptimeFeed.latestRoundData();
+        if (answer != 0) revert SequencerDown();
+        if (startedAt == 0 || startedAt > block.timestamp || block.timestamp - startedAt <= gracePeriod) {
+            revert GracePeriodNotOver();
+        }
+    }
+}

--- a/src/modules/cash/CashEventEmitter.sol
+++ b/src/modules/cash/CashEventEmitter.sol
@@ -95,6 +95,9 @@ contract CashEventEmitter is UpgradeableProxy {
      */
     event Repay(address indexed safe, address indexed token, uint256 debtAmount, uint256 debtAmountInUsd);
 
+    /// @notice Emitted for an Aave repayment that intentionally avoids a USD oracle lookup
+    event RepayLendTokenAmount(address indexed safe, address indexed token, uint256 debtAmount);
+
     /**
      * @notice Emitted when a safe requests to opt out of lend (the Aave market)
      * @param safe Address of the safe
@@ -437,6 +440,10 @@ contract CashEventEmitter is UpgradeableProxy {
 
     function emitRepay(address safe, address token, uint256 amount, uint256 amountInUsd) external onlyCashModule {
         emit Repay(safe, token, amount, amountInUsd);
+    }
+
+    function emitRepayLendTokenAmount(address safe, address token, uint256 amount) external onlyCashModule {
+        emit RepayLendTokenAmount(safe, token, amount);
     }
 
     /**

--- a/src/modules/cash/CashLendLib.sol
+++ b/src/modules/cash/CashLendLib.sol
@@ -177,25 +177,41 @@ library CashLendLib {
         }
         if (amount == 0) revert AmountZero();
 
-        (uint256 fromLoose, uint256 fromSupplied, bool cancelWithdrawal) = _sourceRepay($, gateway, safe, token, amount);
-        if (cancelWithdrawal) cancelOldWithdrawal($, dataProvider, safe);
-
-        // A full repay passes the max sentinel on its last leg so no interest dust survives the
-        // exact-amount rounding.
-        uint256 repaid;
-        if (fromSupplied == 0) {
-            // Loose covers the whole amount
-            repaid = gateway.repay(safe, token, amount == debt ? type(uint256).max : amount);
-        } else {
-            if (fromLoose != 0) repaid = gateway.repay(safe, token, fromLoose);
-            gateway.withdraw(safe, token, fromSupplied, safe);
-            repaid += gateway.repay(safe, token, amount == debt ? type(uint256).max : fromSupplied);
-        }
+        uint256 repaid = _executeGatewayRepay($, dataProvider, gateway, safe, token, amount, debt);
 
         // The gateway may repay less than requested (dust refund, or the live Aave debt being smaller than
         // the quote), so report the USD value of what was actually repaid, not the requested amount.
         uint256 repaidInUsd = repaid == amount ? amountInUsd : LendSourcingLib.toUsd(priceProvider, token, repaid);
         $.cashEventEmitter.emitRepay(safe, token, repaid, repaidInUsd);
+    }
+
+    /**
+     * @notice Repays gateway debt using token units, without reading the price provider
+     * @dev Restricted to migrated Aave safes by _requireGateway. A max amount repays the full live debt.
+     */
+    function repayLendTokenAmount(CashModuleStorageContract.CashModuleStorage storage $, IEtherFiDataProvider dataProvider, address safe, address token, uint256 amount) external {
+        ILendGateway gateway = _requireGateway($, safe);
+        if (!gateway.isRegistered(token)) revert OnlyBorrowToken();
+
+        uint256 debt = gateway.debtOf(safe, token);
+        if (amount > debt) amount = debt;
+        if (amount == 0) revert AmountZero();
+
+        uint256 repaid = _executeGatewayRepay($, dataProvider, gateway, safe, token, amount, debt);
+        $.cashEventEmitter.emitRepayLendTokenAmount(safe, token, repaid);
+    }
+
+    function _executeGatewayRepay(CashModuleStorageContract.CashModuleStorage storage $, IEtherFiDataProvider dataProvider, ILendGateway gateway, address safe, address token, uint256 amount, uint256 debt) private returns (uint256 repaid) {
+        (uint256 fromLoose, uint256 fromSupplied, bool cancelWithdrawal) = _sourceRepay($, gateway, safe, token, amount);
+        if (cancelWithdrawal) cancelOldWithdrawal($, dataProvider, safe);
+
+        if (fromSupplied == 0) {
+            return gateway.repay(safe, token, amount == debt ? type(uint256).max : amount);
+        }
+
+        if (fromLoose != 0) repaid = gateway.repay(safe, token, fromLoose);
+        gateway.withdraw(safe, token, fromSupplied, safe);
+        repaid += gateway.repay(safe, token, amount == debt ? type(uint256).max : fromSupplied);
     }
 
     /**

--- a/src/modules/cash/CashModuleCore.sol
+++ b/src/modules/cash/CashModuleCore.sol
@@ -549,6 +549,17 @@ contract CashModuleCore is CashModuleStorageContract {
     }
 
     /**
+     * @notice Repays Aave debt in token units without requiring an oracle price
+     * @dev This is intentionally restricted to safes on the lend gateway. Legacy DebtManager repayment
+     *      remains USD-denominated and unchanged.
+     */
+    function repayLendTokenAmount(address safe, address token, uint256 amount) external whenNotPaused nonReentrant onlyEtherFiWallet onlyEtherFiSafe(safe) {
+        CashModuleStorage storage $ = _getCashModuleStorage();
+        CashLendLib.repayLendTokenAmount($, etherFiDataProvider, safe, token, amount);
+        CashLendLib.processLendOptOutIfReady($, safe);
+    }
+
+    /**
      * @notice Supplies a safe's loose token balances into the Aave lend market (the auto-supply sweep)
      * @dev Only callable by the EtherFi wallet (the cash-be sweeper). Per token: supplies the loose balance
      *      net of any pending-withdrawal reservation and flags it as collateral; zero and unregistered

--- a/src/oracle/ChainlinkPriceFeed.sol
+++ b/src/oracle/ChainlinkPriceFeed.sol
@@ -6,6 +6,7 @@ import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
 import { IAaveV4PriceFeed } from "../interfaces/IAaveV4PriceFeed.sol";
 import { IAggregatorV3 } from "../interfaces/IAggregatorV3.sol";
+import { L2SequencerGuard } from "./L2SequencerGuard.sol";
 import { StablePriceLib } from "./StablePriceLib.sol";
 
 /**
@@ -22,7 +23,7 @@ import { StablePriceLib } from "./StablePriceLib.sol";
  *      Chainlink feed is stale, or either leg is non-positive or reverts.
  * @author ether.fi
  */
-contract ChainlinkPriceFeed is IAaveV4PriceFeed {
+contract ChainlinkPriceFeed is IAaveV4PriceFeed, L2SequencerGuard {
     using Math for uint256;
     using SafeCast for uint256;
     using SafeCast for int256;
@@ -51,7 +52,7 @@ contract ChainlinkPriceFeed is IAaveV4PriceFeed {
     /// @notice Thrown when the staleness bound is zero
     error InvalidMaxStaleness();
 
-    constructor(IAggregatorV3 _rateFeed, IAaveV4PriceFeed _underlyingUsdFeed, uint8 _feedDecimals, uint256 _rateMaxStaleness, bool _isStableToken, string memory feedDescription) {
+    constructor(IAggregatorV3 _rateFeed, IAaveV4PriceFeed _underlyingUsdFeed, uint8 _feedDecimals, uint256 _rateMaxStaleness, bool _isStableToken, string memory feedDescription, IAggregatorV3 _sequencerUptimeFeed, uint256 _sequencerGracePeriod) L2SequencerGuard(_sequencerUptimeFeed, _sequencerGracePeriod) {
         require(_rateMaxStaleness > 0, InvalidMaxStaleness());
         rateFeed = _rateFeed;
         underlyingUsdFeed = _underlyingUsdFeed;
@@ -81,6 +82,7 @@ contract ChainlinkPriceFeed is IAaveV4PriceFeed {
      *      underlying leg enforces its own staleness.
      */
     function latestAnswer() external view returns (int256) {
+        _validateSequencer();
         uint256 rate = _readFeed(rateFeed, rateMaxStaleness);
 
         // USD-quoted feed: scale straight to feed decimals.

--- a/src/oracle/L2SequencerGuard.sol
+++ b/src/oracle/L2SequencerGuard.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { IAggregatorV3 } from "../interfaces/IAggregatorV3.sol";
+import { L2SequencerGuardLib } from "../libraries/L2SequencerGuardLib.sol";
+
+/// @notice Shared immutable sequencer configuration for L2 price-feed adapters.
+abstract contract L2SequencerGuard {
+    IAggregatorV3 public immutable sequencerUptimeFeed;
+    uint256 public immutable sequencerGracePeriod;
+
+    error InvalidSequencerConfig();
+
+    constructor(IAggregatorV3 _sequencerUptimeFeed, uint256 _sequencerGracePeriod) {
+        if ((address(_sequencerUptimeFeed) == address(0)) != (_sequencerGracePeriod == 0)) {
+            revert InvalidSequencerConfig();
+        }
+        sequencerUptimeFeed = _sequencerUptimeFeed;
+        sequencerGracePeriod = _sequencerGracePeriod;
+    }
+
+    function _validateSequencer() internal view {
+        L2SequencerGuardLib.validate(sequencerUptimeFeed, sequencerGracePeriod);
+    }
+}

--- a/src/oracle/PriceProviderV2.sol
+++ b/src/oracle/PriceProviderV2.sol
@@ -6,6 +6,7 @@ import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 import {IPriceProvider} from "../interfaces/IPriceProvider.sol";
 import {IAggregatorV3} from "../interfaces/IAggregatorV3.sol";
 import {UpgradeableProxy} from "../utils/UpgradeableProxy.sol";
+import {L2SequencerGuardLib} from "../libraries/L2SequencerGuardLib.sol";
 
 /**
  * @title PriceProviderV2
@@ -65,6 +66,12 @@ contract PriceProviderV2 is UpgradeableProxy {
 
         /// @notice Mapping of token addresses to whether they are base assets
         mapping(address token => bool isBaseAsset) isBaseAsset;
+
+        /// @notice L2 sequencer uptime feed. Zero disables the guard for non-L2 deployments.
+        IAggregatorV3 sequencerUptimeFeed;
+
+        /// @notice Time prices remain unavailable after the sequencer reports recovery.
+        uint256 sequencerGracePeriod;
     }
 
     /**
@@ -112,6 +119,8 @@ contract PriceProviderV2 is UpgradeableProxy {
      * @param isBaseAsset Whether the base asset is set to true or false
      */
     event BaseAssetSet(address baseAsset, bool isBaseAsset);
+
+    event SequencerConfigSet(address sequencerUptimeFeed, uint256 gracePeriod);
 
     /**
      * @notice Thrown when trying to get a price for a token with no configured oracle
@@ -161,6 +170,7 @@ contract PriceProviderV2 is UpgradeableProxy {
      * @notice Thrown when a base asset is removed
      */
     error BaseAssetCannotBeRemoved();
+    error InvalidSequencerConfig();
 
     /**
      * @notice Constructor that disables initializers
@@ -206,6 +216,14 @@ contract PriceProviderV2 is UpgradeableProxy {
         return _getPriceProviderV2Storage().isBaseAsset[token];
     }
 
+    function sequencerUptimeFeed() external view returns (address) {
+        return address(_getPriceProviderV2Storage().sequencerUptimeFeed);
+    }
+
+    function sequencerGracePeriod() external view returns (uint256) {
+        return _getPriceProviderV2Storage().sequencerGracePeriod;
+    }
+
     /**
      * @notice Updates the price oracle configurations for multiple tokens
      * @dev Only callable by addresses with PRICE_PROVIDER_ADMIN_ROLE
@@ -240,6 +258,15 @@ contract PriceProviderV2 is UpgradeableProxy {
         emit BaseAssetSet(_baseAsset, _isBaseAsset);
     }
 
+    /// @notice Configures the L2 sequencer uptime guard used by every price read.
+    function setSequencerConfig(address _sequencerUptimeFeed, uint256 _gracePeriod) external onlyRole(PRICE_PROVIDER_ADMIN_ROLE) {
+        if (_sequencerUptimeFeed == address(0) || _gracePeriod == 0) revert InvalidSequencerConfig();
+        PriceProviderV2Storage storage $ = _getPriceProviderV2Storage();
+        $.sequencerUptimeFeed = IAggregatorV3(_sequencerUptimeFeed);
+        $.sequencerGracePeriod = _gracePeriod;
+        emit SequencerConfigSet(_sequencerUptimeFeed, _gracePeriod);
+    }
+
     /**
      * @notice Gets the normalized USD price for a token with standard decimal precision
      * @dev If the token has a base asset configured, the raw oracle price is multiplied
@@ -248,7 +275,10 @@ contract PriceProviderV2 is UpgradeableProxy {
      * @return Price in USD with DECIMALS decimal places
      */
     function price(address token) external view returns (uint256) {
-        Config memory config = _getPriceProviderV2Storage().tokenConfig[token];
+        PriceProviderV2Storage storage $ = _getPriceProviderV2Storage();
+        L2SequencerGuardLib.validate($.sequencerUptimeFeed, $.sequencerGracePeriod);
+
+        Config memory config = $.tokenConfig[token];
         if (config.oracle == address(0)) revert TokenOracleNotSet();
 
         uint256 rawPrice = _fetchRawPrice(config);
@@ -258,7 +288,7 @@ contract PriceProviderV2 is UpgradeableProxy {
         }
 
         if (config.baseAsset != address(0)) {
-            Config memory baseConfig = _getPriceProviderV2Storage().tokenConfig[config.baseAsset];
+            Config memory baseConfig = $.tokenConfig[config.baseAsset];
             if (baseConfig.oracle == address(0)) revert TokenOracleNotSet();
             if (baseConfig.baseAsset != address(0)) revert InvalidBaseAsset();
 

--- a/src/oracle/PythPriceFeed.sol
+++ b/src/oracle/PythPriceFeed.sol
@@ -5,6 +5,8 @@ import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
 import { IAaveV4PriceFeed } from "../interfaces/IAaveV4PriceFeed.sol";
+import { IAggregatorV3 } from "../interfaces/IAggregatorV3.sol";
+import { L2SequencerGuard } from "./L2SequencerGuard.sol";
 import { StablePriceLib } from "./StablePriceLib.sol";
 
 /// @notice The slice of the MorphoPythOracle adapters (deployed per pair on OP) the feed reads: the
@@ -48,7 +50,7 @@ interface IPyth {
  *      Fails closed: latestAnswer reverts on a stale Pyth publish time, or a zero/reverting price.
  * @author ether.fi
  */
-contract PythPriceFeed is IAaveV4PriceFeed {
+contract PythPriceFeed is IAaveV4PriceFeed, L2SequencerGuard {
     using Math for uint256;
     using SafeCast for uint256;
 
@@ -85,15 +87,7 @@ contract PythPriceFeed is IAaveV4PriceFeed {
     /// @notice Thrown when the staleness bound is zero
     error InvalidMaxStaleness();
 
-    constructor(
-        IPythPairOracle _oracle,
-        uint8 _oracleDecimals,
-        uint8 _feedDecimals,
-        IAaveV4PriceFeed _underlyingUsdFeed,
-        uint256 _maxStaleness,
-        bool _isStableToken,
-        string memory feedDescription
-    ) {
+    constructor(IPythPairOracle _oracle, uint8 _oracleDecimals, uint8 _feedDecimals, IAaveV4PriceFeed _underlyingUsdFeed, uint256 _maxStaleness, bool _isStableToken, string memory feedDescription, IAggregatorV3 _sequencerUptimeFeed, uint256 _sequencerGracePeriod) L2SequencerGuard(_sequencerUptimeFeed, _sequencerGracePeriod) {
         if (address(_underlyingUsdFeed) == address(0)) {
             // USD-quoted pair: scaling is a plain division, so the oracle must be at least as precise
             require(_oracleDecimals >= _feedDecimals, UnsupportedDecimals());
@@ -128,6 +122,7 @@ contract PythPriceFeed is IAaveV4PriceFeed {
 
     /// @notice The latest USD price: the pair price, times the underlying USD price when configured
     function latestAnswer() external view returns (int256) {
+        _validateSequencer();
         _requireFresh(feedId1);
         _requireFresh(feedId2);
         _requireFresh(feedId3);

--- a/src/oracle/VedaAccountantPriceFeed.sol
+++ b/src/oracle/VedaAccountantPriceFeed.sol
@@ -5,7 +5,9 @@ import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
 import { IAaveV4PriceFeed } from "../interfaces/IAaveV4PriceFeed.sol";
+import { IAggregatorV3 } from "../interfaces/IAggregatorV3.sol";
 import { IVedaAccountant } from "../interfaces/IVedaAccountant.sol";
+import { L2SequencerGuard } from "./L2SequencerGuard.sol";
 import { StablePriceLib } from "./StablePriceLib.sol";
 
 /**
@@ -14,7 +16,7 @@ import { StablePriceLib } from "./StablePriceLib.sol";
  *      or stale accountant, a non-positive or reverting underlying, or a zero rate.
  * @author ether.fi
  */
-contract VedaAccountantPriceFeed is IAaveV4PriceFeed {
+contract VedaAccountantPriceFeed is IAaveV4PriceFeed, L2SequencerGuard {
     using Math for uint256;
     using SafeCast for uint256;
     using SafeCast for int256;
@@ -42,7 +44,7 @@ contract VedaAccountantPriceFeed is IAaveV4PriceFeed {
     /// @notice Thrown when the staleness bound is zero
     error InvalidMaxStaleness();
 
-    constructor(IVedaAccountant _accountant, IAaveV4PriceFeed _underlyingUsdFeed, uint8 _feedDecimals, uint256 _rateMaxStaleness, bool _isStableToken, string memory feedDescription) {
+    constructor(IVedaAccountant _accountant, IAaveV4PriceFeed _underlyingUsdFeed, uint8 _feedDecimals, uint256 _rateMaxStaleness, bool _isStableToken, string memory feedDescription, IAggregatorV3 _sequencerUptimeFeed, uint256 _sequencerGracePeriod) L2SequencerGuard(_sequencerUptimeFeed, _sequencerGracePeriod) {
         require(_rateMaxStaleness > 0, InvalidMaxStaleness());
         accountant = _accountant;
         underlyingUsdFeed = _underlyingUsdFeed;
@@ -72,6 +74,7 @@ contract VedaAccountantPriceFeed is IAaveV4PriceFeed {
      *      or the rate is zero
      */
     function latestAnswer() external view returns (int256) {
+        _validateSequencer();
         IVedaAccountant.AccountantState memory state = accountant.accountantState();
         if (block.timestamp > state.lastUpdateTimestamp + rateMaxStaleness) revert StalePrice();
 

--- a/test/price-provider/ChainlinkPriceFeed.t.sol
+++ b/test/price-provider/ChainlinkPriceFeed.t.sol
@@ -49,6 +49,7 @@ contract ChainlinkPriceFeedTest is Test {
         assertEq(feed.description(), "weETH / USD");
     }
 
+    /// @notice A Chainlink-backed Aave feed rejects prices while the L2 sequencer is down.
     function test_latestAnswer_revertsWhenSequencerIsDown() public {
         address sequencer = makeAddr("sequencer");
         vm.mockCall(sequencer, abi.encodeWithSelector(IAggregatorV3.latestRoundData.selector), abi.encode(uint80(1), int256(1), block.timestamp - 2 hours, block.timestamp, uint80(1)));

--- a/test/price-provider/ChainlinkPriceFeed.t.sol
+++ b/test/price-provider/ChainlinkPriceFeed.t.sol
@@ -6,6 +6,7 @@ import { Test } from "forge-std/Test.sol";
 
 import { IAaveV4PriceFeed } from "../../src/interfaces/IAaveV4PriceFeed.sol";
 import { IAggregatorV3 } from "../../src/interfaces/IAggregatorV3.sol";
+import { L2SequencerGuardLib } from "../../src/libraries/L2SequencerGuardLib.sol";
 import { ChainlinkPriceFeed } from "../../src/oracle/ChainlinkPriceFeed.sol";
 
 /// @notice Fork tests on Optimism, using the live weETH/ETH rate feed and ETH/USD feed.
@@ -24,7 +25,7 @@ contract ChainlinkPriceFeedTest is Test {
     function setUp() public {
         vm.createSelectFork(vm.envOr("OPTIMISM_RPC", string("https://mainnet.optimism.io")));
         // A raw Chainlink aggregator satisfies IAaveV4PriceFeed; any deployed feed can be the USD leg
-        feed = new ChainlinkPriceFeed(IAggregatorV3(rateFeed), IAaveV4PriceFeed(ethUsdOracle), FEED_DECIMALS, RATE_MAX_STALENESS, false, "weETH / USD");
+        feed = new ChainlinkPriceFeed(IAggregatorV3(rateFeed), IAaveV4PriceFeed(ethUsdOracle), FEED_DECIMALS, RATE_MAX_STALENESS, false, "weETH / USD", IAggregatorV3(address(0)), 0);
     }
 
     /// @notice The reported price equals rate x underlying, and lands in a sane USD range.
@@ -48,6 +49,15 @@ contract ChainlinkPriceFeedTest is Test {
         assertEq(feed.description(), "weETH / USD");
     }
 
+    function test_latestAnswer_revertsWhenSequencerIsDown() public {
+        address sequencer = makeAddr("sequencer");
+        vm.mockCall(sequencer, abi.encodeWithSelector(IAggregatorV3.latestRoundData.selector), abi.encode(uint80(1), int256(1), block.timestamp - 2 hours, block.timestamp, uint80(1)));
+        ChainlinkPriceFeed guardedFeed = new ChainlinkPriceFeed(IAggregatorV3(rateFeed), IAaveV4PriceFeed(ethUsdOracle), FEED_DECIMALS, RATE_MAX_STALENESS, false, "weETH / USD", IAggregatorV3(sequencer), 1 hours);
+
+        vm.expectRevert(L2SequencerGuardLib.SequencerDown.selector);
+        guardedFeed.latestAnswer();
+    }
+
     /// @notice Reverts when the rate feed is older than its staleness limit.
     function test_reverts_whenRateStale() public {
         (uint80 roundId, int256 rate, uint256 startedAt,, uint80 answeredInRound) = IAggregatorV3(rateFeed).latestRoundData();
@@ -60,7 +70,7 @@ contract ChainlinkPriceFeedTest is Test {
     /// @notice Reverts at construction when the staleness bound is zero.
     function test_constructor_revertsOnZeroStaleness() public {
         vm.expectRevert(ChainlinkPriceFeed.InvalidMaxStaleness.selector);
-        new ChainlinkPriceFeed(IAggregatorV3(rateFeed), IAaveV4PriceFeed(ethUsdOracle), FEED_DECIMALS, 0, false, "weETH / USD");
+        new ChainlinkPriceFeed(IAggregatorV3(rateFeed), IAaveV4PriceFeed(ethUsdOracle), FEED_DECIMALS, 0, false, "weETH / USD", IAggregatorV3(address(0)), 0);
     }
 
     /// @notice Reverts when the rate feed price is zero or negative.
@@ -81,14 +91,14 @@ contract ChainlinkPriceFeedTest is Test {
 
     /// @notice Without an underlying feed, the price is the USD-quoted Chainlink answer scaled to feed decimals.
     function test_noUnderlying_latestAnswer_isScaledAnswer() public {
-        ChainlinkPriceFeed usdFeed = new ChainlinkPriceFeed(IAggregatorV3(ethUsdOracle), IAaveV4PriceFeed(address(0)), FEED_DECIMALS, RATE_MAX_STALENESS, false, "ETH / USD");
+        ChainlinkPriceFeed usdFeed = new ChainlinkPriceFeed(IAggregatorV3(ethUsdOracle), IAaveV4PriceFeed(address(0)), FEED_DECIMALS, RATE_MAX_STALENESS, false, "ETH / USD", IAggregatorV3(address(0)), 0);
         (, int256 raw,,,) = IAggregatorV3(ethUsdOracle).latestRoundData();
         assertEq(usdFeed.latestAnswer(), raw); // ETH/USD is already 8 decimals
     }
 
     /// @notice A stable feed snaps to exactly 1 USD inside the 1% band and passes the raw price outside it.
     function test_stable_snapsWithinOnePercent() public {
-        ChainlinkPriceFeed stableFeed = new ChainlinkPriceFeed(IAggregatorV3(ethUsdOracle), IAaveV4PriceFeed(address(0)), FEED_DECIMALS, RATE_MAX_STALENESS, true, "USDC / USD");
+        ChainlinkPriceFeed stableFeed = new ChainlinkPriceFeed(IAggregatorV3(ethUsdOracle), IAaveV4PriceFeed(address(0)), FEED_DECIMALS, RATE_MAX_STALENESS, true, "USDC / USD", IAggregatorV3(address(0)), 0);
         _mockAnswer(0.995e8);
         assertEq(stableFeed.latestAnswer(), 1e8);
         _mockAnswer(0.99e8); // the 1% band edge is exclusive
@@ -103,7 +113,7 @@ contract ChainlinkPriceFeedTest is Test {
 
     /// @notice The no-underlying mode still enforces staleness on the Chainlink feed.
     function test_noUnderlying_revertsOnStale() public {
-        ChainlinkPriceFeed usdFeed = new ChainlinkPriceFeed(IAggregatorV3(ethUsdOracle), IAaveV4PriceFeed(address(0)), FEED_DECIMALS, RATE_MAX_STALENESS, false, "ETH / USD");
+        ChainlinkPriceFeed usdFeed = new ChainlinkPriceFeed(IAggregatorV3(ethUsdOracle), IAaveV4PriceFeed(address(0)), FEED_DECIMALS, RATE_MAX_STALENESS, false, "ETH / USD", IAggregatorV3(address(0)), 0);
         (uint80 roundId, int256 answer, uint256 startedAt,, uint80 answeredInRound) = IAggregatorV3(ethUsdOracle).latestRoundData();
         uint256 staleUpdatedAt = block.timestamp - RATE_MAX_STALENESS - 1;
         vm.mockCall(ethUsdOracle, abi.encodeWithSelector(IAggregatorV3.latestRoundData.selector), abi.encode(roundId, answer, startedAt, staleUpdatedAt, answeredInRound));

--- a/test/price-provider/PriceProviderV2.t.sol
+++ b/test/price-provider/PriceProviderV2.t.sol
@@ -153,6 +153,7 @@ contract PriceProviderV2Test is Test {
         assertEq(priceProvider.price(eth), expected);
     }
 
+    /// @notice Price reads revert while the configured L2 sequencer is down.
     function test_price_revertsWhenSequencerIsDown() public {
         MockSequencerUptimeFeed sequencerFeed = new MockSequencerUptimeFeed(1, block.timestamp - 1 hours);
         vm.prank(owner);
@@ -162,6 +163,7 @@ contract PriceProviderV2Test is Test {
         priceProvider.price(eth);
     }
 
+    /// @notice Price reads remain blocked during the recovery grace period.
     function test_price_revertsDuringSequencerRecoveryGracePeriod() public {
         MockSequencerUptimeFeed sequencerFeed = new MockSequencerUptimeFeed(0, block.timestamp - 30 minutes);
         vm.prank(owner);
@@ -171,6 +173,7 @@ contract PriceProviderV2Test is Test {
         priceProvider.price(eth);
     }
 
+    /// @notice Price reads resume after the recovery grace period has elapsed.
     function test_price_worksAfterSequencerRecoveryGracePeriod() public {
         MockSequencerUptimeFeed sequencerFeed = new MockSequencerUptimeFeed(0, block.timestamp - 1 hours - 1);
         vm.prank(owner);
@@ -179,6 +182,7 @@ contract PriceProviderV2Test is Test {
         assertGt(priceProvider.price(eth), 0);
     }
 
+    /// @notice The admin setter emits and stores the sequencer feed and grace period.
     function test_setSequencerConfig_emitsAndStoresConfig() public {
         MockSequencerUptimeFeed sequencerFeed = new MockSequencerUptimeFeed(0, block.timestamp - 2 hours);
 
@@ -191,6 +195,7 @@ contract PriceProviderV2Test is Test {
         assertEq(priceProvider.sequencerGracePeriod(), 1 hours);
     }
 
+    /// @notice Accounts without the price-provider admin role cannot configure the sequencer guard.
     function test_setSequencerConfig_revertsForUnauthorizedCaller() public {
         MockSequencerUptimeFeed sequencerFeed = new MockSequencerUptimeFeed(0, block.timestamp - 2 hours);
 
@@ -198,6 +203,7 @@ contract PriceProviderV2Test is Test {
         priceProvider.setSequencerConfig(address(sequencerFeed), 1 hours);
     }
 
+    /// @notice The sequencer guard rejects a zero feed or grace period.
     function test_setSequencerConfig_revertsForInvalidConfig() public {
         vm.prank(owner);
         vm.expectRevert(PriceProviderV2.InvalidSequencerConfig.selector);

--- a/test/price-provider/PriceProviderV2.t.sol
+++ b/test/price-provider/PriceProviderV2.t.sol
@@ -10,6 +10,7 @@ import {IWeETH} from "../../src/interfaces/IWeETH.sol";
 import {UUPSProxy} from "../../src/UUPSProxy.sol";
 import {RoleRegistry} from "../../src/role-registry/RoleRegistry.sol";
 import {UpgradeableProxy} from "../../src/utils/UpgradeableProxy.sol";
+import {L2SequencerGuardLib} from "../../src/libraries/L2SequencerGuardLib.sol";
 
 contract PriceProviderV2Test is Test {
     PriceProviderV2 priceProvider;
@@ -150,6 +151,57 @@ contract PriceProviderV2Test is Test {
         uint256 oracleDecimals = IAggregatorV3(ethUsdOracle).decimals();
         uint256 expected = (uint256(ethAns) * 10 ** priceProvider.decimals()) / 10 ** oracleDecimals;
         assertEq(priceProvider.price(eth), expected);
+    }
+
+    function test_price_revertsWhenSequencerIsDown() public {
+        MockSequencerUptimeFeed sequencerFeed = new MockSequencerUptimeFeed(1, block.timestamp - 1 hours);
+        vm.prank(owner);
+        priceProvider.setSequencerConfig(address(sequencerFeed), 1 hours);
+
+        vm.expectRevert(L2SequencerGuardLib.SequencerDown.selector);
+        priceProvider.price(eth);
+    }
+
+    function test_price_revertsDuringSequencerRecoveryGracePeriod() public {
+        MockSequencerUptimeFeed sequencerFeed = new MockSequencerUptimeFeed(0, block.timestamp - 30 minutes);
+        vm.prank(owner);
+        priceProvider.setSequencerConfig(address(sequencerFeed), 1 hours);
+
+        vm.expectRevert(L2SequencerGuardLib.GracePeriodNotOver.selector);
+        priceProvider.price(eth);
+    }
+
+    function test_price_worksAfterSequencerRecoveryGracePeriod() public {
+        MockSequencerUptimeFeed sequencerFeed = new MockSequencerUptimeFeed(0, block.timestamp - 1 hours - 1);
+        vm.prank(owner);
+        priceProvider.setSequencerConfig(address(sequencerFeed), 1 hours);
+
+        assertGt(priceProvider.price(eth), 0);
+    }
+
+    function test_setSequencerConfig_emitsAndStoresConfig() public {
+        MockSequencerUptimeFeed sequencerFeed = new MockSequencerUptimeFeed(0, block.timestamp - 2 hours);
+
+        vm.prank(owner);
+        vm.expectEmit(true, true, true, true);
+        emit PriceProviderV2.SequencerConfigSet(address(sequencerFeed), 1 hours);
+        priceProvider.setSequencerConfig(address(sequencerFeed), 1 hours);
+
+        assertEq(priceProvider.sequencerUptimeFeed(), address(sequencerFeed));
+        assertEq(priceProvider.sequencerGracePeriod(), 1 hours);
+    }
+
+    function test_setSequencerConfig_revertsForUnauthorizedCaller() public {
+        MockSequencerUptimeFeed sequencerFeed = new MockSequencerUptimeFeed(0, block.timestamp - 2 hours);
+
+        vm.expectRevert(UpgradeableProxy.Unauthorized.selector);
+        priceProvider.setSequencerConfig(address(sequencerFeed), 1 hours);
+    }
+
+    function test_setSequencerConfig_revertsForInvalidConfig() public {
+        vm.prank(owner);
+        vm.expectRevert(PriceProviderV2.InvalidSequencerConfig.selector);
+        priceProvider.setSequencerConfig(address(0), 1 hours);
     }
 
     function test_price_directUsd_btc() public view {
@@ -1112,6 +1164,20 @@ contract MockChainlinkOracle {
 
     function decimals() external view returns (uint8) {
         return _decimals;
+    }
+}
+
+contract MockSequencerUptimeFeed {
+    int256 private immutable _answer;
+    uint256 private immutable _startedAt;
+
+    constructor(int256 answer_, uint256 startedAt_) {
+        _answer = answer_;
+        _startedAt = startedAt_;
+    }
+
+    function latestRoundData() external view returns (uint80, int256, uint256, uint256, uint80) {
+        return (0, _answer, _startedAt, block.timestamp, 0);
     }
 }
 

--- a/test/price-provider/PythPriceFeed.t.sol
+++ b/test/price-provider/PythPriceFeed.t.sol
@@ -72,6 +72,7 @@ contract PythPriceFeedTest is Test {
         assertEq(feed.latestAnswer(), 0.40918676e8);
     }
 
+    /// @notice A Pyth-backed Aave feed rejects prices while the L2 sequencer is down.
     function test_latestAnswer_revertsWhenSequencerIsDown() public {
         address sequencer = makeAddr("sequencer");
         vm.mockCall(sequencer, abi.encodeWithSelector(IAggregatorV3.latestRoundData.selector), abi.encode(uint80(1), int256(1), block.timestamp - 2 hours, block.timestamp, uint80(1)));

--- a/test/price-provider/PythPriceFeed.t.sol
+++ b/test/price-provider/PythPriceFeed.t.sol
@@ -5,6 +5,8 @@ import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import { Test } from "forge-std/Test.sol";
 
 import { IAaveV4PriceFeed } from "../../src/interfaces/IAaveV4PriceFeed.sol";
+import { IAggregatorV3 } from "../../src/interfaces/IAggregatorV3.sol";
+import { L2SequencerGuardLib } from "../../src/libraries/L2SequencerGuardLib.sol";
 import { IPyth, IPythPairOracle, PythPriceFeed } from "../../src/oracle/PythPriceFeed.sol";
 
 contract MockPyth {
@@ -59,15 +61,24 @@ contract PythPriceFeedTest is Test {
         mockPyth = new MockPyth();
         mockOracle = new MockPythPairOracle(address(mockPyth), FEED_ID);
         mockPyth.setPublishTime(FEED_ID, block.timestamp);
-        feed = new PythPriceFeed(mockOracle, ORACLE_DECIMALS, FEED_DECIMALS, IAaveV4PriceFeed(address(0)), MAX_STALENESS, false, "MOCK / USD");
+        feed = new PythPriceFeed(mockOracle, ORACLE_DECIMALS, FEED_DECIMALS, IAaveV4PriceFeed(address(0)), MAX_STALENESS, false, "MOCK / USD", IAggregatorV3(address(0)), 0);
 
         mockUnderlying = new MockUsdFeed(8);
-        compositeFeed = new PythPriceFeed(mockOracle, ORACLE_DECIMALS, FEED_DECIMALS, mockUnderlying, MAX_STALENESS, false, "MOCK / USD via ETH");
+        compositeFeed = new PythPriceFeed(mockOracle, ORACLE_DECIMALS, FEED_DECIMALS, mockUnderlying, MAX_STALENESS, false, "MOCK / USD via ETH", IAggregatorV3(address(0)), 0);
     }
 
     function test_latestAnswer_scalesToFeedDecimals() public {
         mockOracle.setPrice(4.0918676e15); // $0.40918676 at 16 decimals
         assertEq(feed.latestAnswer(), 0.40918676e8);
+    }
+
+    function test_latestAnswer_revertsWhenSequencerIsDown() public {
+        address sequencer = makeAddr("sequencer");
+        vm.mockCall(sequencer, abi.encodeWithSelector(IAggregatorV3.latestRoundData.selector), abi.encode(uint80(1), int256(1), block.timestamp - 2 hours, block.timestamp, uint80(1)));
+        PythPriceFeed guardedFeed = new PythPriceFeed(mockOracle, ORACLE_DECIMALS, FEED_DECIMALS, IAaveV4PriceFeed(address(0)), MAX_STALENESS, false, "MOCK / USD", IAggregatorV3(sequencer), 1 hours);
+
+        vm.expectRevert(L2SequencerGuardLib.SequencerDown.selector);
+        guardedFeed.latestAnswer();
     }
 
     function test_latestAnswer_revertsOnZeroPrice() public {
@@ -85,7 +96,7 @@ contract PythPriceFeedTest is Test {
 
     /// @notice A stable feed snaps to exactly 1 USD inside the 1% band and passes the raw price outside it.
     function test_stable_snapsWithinOnePercent() public {
-        PythPriceFeed stableFeed = new PythPriceFeed(mockOracle, ORACLE_DECIMALS, FEED_DECIMALS, IAaveV4PriceFeed(address(0)), MAX_STALENESS, true, "STABLE / USD");
+        PythPriceFeed stableFeed = new PythPriceFeed(mockOracle, ORACLE_DECIMALS, FEED_DECIMALS, IAaveV4PriceFeed(address(0)), MAX_STALENESS, true, "STABLE / USD", IAggregatorV3(address(0)), 0);
         mockOracle.setPrice(0.995e16);
         assertEq(stableFeed.latestAnswer(), 1e8);
         mockOracle.setPrice(1.02e16);
@@ -101,12 +112,12 @@ contract PythPriceFeedTest is Test {
 
     function test_constructor_revertsOnUnsupportedDecimals() public {
         vm.expectRevert(PythPriceFeed.UnsupportedDecimals.selector);
-        new PythPriceFeed(mockOracle, 6, 8, IAaveV4PriceFeed(address(0)), MAX_STALENESS, false, "BAD / USD");
+        new PythPriceFeed(mockOracle, 6, 8, IAaveV4PriceFeed(address(0)), MAX_STALENESS, false, "BAD / USD", IAggregatorV3(address(0)), 0);
     }
 
     function test_constructor_revertsOnZeroStaleness() public {
         vm.expectRevert(PythPriceFeed.InvalidMaxStaleness.selector);
-        new PythPriceFeed(mockOracle, ORACLE_DECIMALS, FEED_DECIMALS, IAaveV4PriceFeed(address(0)), 0, false, "BAD / USD");
+        new PythPriceFeed(mockOracle, ORACLE_DECIMALS, FEED_DECIMALS, IAaveV4PriceFeed(address(0)), 0, false, "BAD / USD", IAggregatorV3(address(0)), 0);
     }
 
     function test_decimalsAndDescription() public view {
@@ -125,7 +136,7 @@ contract PythPriceFeedTest is Test {
 
     function test_underlying_normalizesUnderlyingDecimals() public {
         MockUsdFeed underlying18 = new MockUsdFeed(18);
-        PythPriceFeed composite18 = new PythPriceFeed(mockOracle, ORACLE_DECIMALS, FEED_DECIMALS, underlying18, MAX_STALENESS, false, "MOCK / USD via 18-dec");
+        PythPriceFeed composite18 = new PythPriceFeed(mockOracle, ORACLE_DECIMALS, FEED_DECIMALS, underlying18, MAX_STALENESS, false, "MOCK / USD via 18-dec", IAggregatorV3(address(0)), 0);
         mockOracle.setPrice(0.05e16);
         underlying18.set(2000e18);
         assertEq(composite18.latestAnswer(), 100e8);
@@ -143,7 +154,7 @@ contract PythPriceFeedTest is Test {
     /// @notice Live adapter: wiring is discovered on-chain, price matches, staleness bound holds.
     function test_fork_latestAnswer_matchesLiveOracle() public {
         vm.createSelectFork(vm.envOr("OPTIMISM_RPC", string("https://mainnet.optimism.io")));
-        PythPriceFeed liveFeed = new PythPriceFeed(IPythPairOracle(ETHFI_USD_ORACLE), ORACLE_DECIMALS, FEED_DECIMALS, IAaveV4PriceFeed(address(0)), 1 days, false, "ETHFI / USD");
+        PythPriceFeed liveFeed = new PythPriceFeed(IPythPairOracle(ETHFI_USD_ORACLE), ORACLE_DECIMALS, FEED_DECIMALS, IAaveV4PriceFeed(address(0)), 1 days, false, "ETHFI / USD", IAggregatorV3(address(0)), 0);
 
         assertEq(address(liveFeed.pyth()), IPythPairOracle(ETHFI_USD_ORACLE).pyth());
         assertEq(liveFeed.feedId1(), IPythPairOracle(ETHFI_USD_ORACLE).BASE_FEED_1());

--- a/test/price-provider/VedaAccountantPriceFeed.t.sol
+++ b/test/price-provider/VedaAccountantPriceFeed.t.sol
@@ -50,6 +50,7 @@ contract VedaAccountantPriceFeedTest is Test {
         assertEq(feed.description(), "liquidETH / USD");
     }
 
+    /// @notice A Veda-backed Aave feed rejects prices while the L2 sequencer is down.
     function test_latestAnswer_revertsWhenSequencerIsDown() public {
         address sequencer = makeAddr("sequencer");
         vm.mockCall(sequencer, abi.encodeWithSelector(IAggregatorV3.latestRoundData.selector), abi.encode(uint80(1), int256(1), block.timestamp - 2 hours, block.timestamp, uint80(1)));

--- a/test/price-provider/VedaAccountantPriceFeed.t.sol
+++ b/test/price-provider/VedaAccountantPriceFeed.t.sol
@@ -7,6 +7,7 @@ import { Test } from "forge-std/Test.sol";
 import { IAaveV4PriceFeed } from "../../src/interfaces/IAaveV4PriceFeed.sol";
 import { IAggregatorV3 } from "../../src/interfaces/IAggregatorV3.sol";
 import { IVedaAccountant } from "../../src/interfaces/IVedaAccountant.sol";
+import { L2SequencerGuardLib } from "../../src/libraries/L2SequencerGuardLib.sol";
 import { VedaAccountantPriceFeed } from "../../src/oracle/VedaAccountantPriceFeed.sol";
 
 /// @notice Fork tests on Optimism, using the live liquidETH accountant and ETH/USD feed.
@@ -25,7 +26,7 @@ contract VedaAccountantPriceFeedTest is Test {
 
     function setUp() public {
         vm.createSelectFork(vm.envOr("OPTIMISM_RPC", string("https://mainnet.optimism.io")));
-        feed = new VedaAccountantPriceFeed(accountant, IAaveV4PriceFeed(ethUsdOracle), FEED_DECIMALS, RATE_MAX_STALENESS, false, "liquidETH / USD");
+        feed = new VedaAccountantPriceFeed(accountant, IAaveV4PriceFeed(ethUsdOracle), FEED_DECIMALS, RATE_MAX_STALENESS, false, "liquidETH / USD", IAggregatorV3(address(0)), 0);
     }
 
     /// @notice The reported price equals rate x underlying, and lands in a sane USD range.
@@ -49,6 +50,15 @@ contract VedaAccountantPriceFeedTest is Test {
         assertEq(feed.description(), "liquidETH / USD");
     }
 
+    function test_latestAnswer_revertsWhenSequencerIsDown() public {
+        address sequencer = makeAddr("sequencer");
+        vm.mockCall(sequencer, abi.encodeWithSelector(IAggregatorV3.latestRoundData.selector), abi.encode(uint80(1), int256(1), block.timestamp - 2 hours, block.timestamp, uint80(1)));
+        VedaAccountantPriceFeed guardedFeed = new VedaAccountantPriceFeed(accountant, IAaveV4PriceFeed(ethUsdOracle), FEED_DECIMALS, RATE_MAX_STALENESS, false, "liquidETH / USD", IAggregatorV3(sequencer), 1 hours);
+
+        vm.expectRevert(L2SequencerGuardLib.SequencerDown.selector);
+        guardedFeed.latestAnswer();
+    }
+
     /// @notice Reverts when the Veda accountant rate is older than the staleness limit.
     function test_reverts_whenRateStale() public {
         uint64 staleLastUpdateTimestamp = (block.timestamp - RATE_MAX_STALENESS - 1).toUint64();
@@ -68,7 +78,7 @@ contract VedaAccountantPriceFeedTest is Test {
     /// @notice Reverts at construction when the staleness bound is zero.
     function test_constructor_revertsOnZeroStaleness() public {
         vm.expectRevert(VedaAccountantPriceFeed.InvalidMaxStaleness.selector);
-        new VedaAccountantPriceFeed(accountant, IAaveV4PriceFeed(ethUsdOracle), FEED_DECIMALS, 0, false, "liquidETH / USD");
+        new VedaAccountantPriceFeed(accountant, IAaveV4PriceFeed(ethUsdOracle), FEED_DECIMALS, 0, false, "liquidETH / USD", IAggregatorV3(address(0)), 0);
     }
 
     /// @notice Reverts when the accountant has paused itself (getRateSafe reverts).
@@ -87,7 +97,7 @@ contract VedaAccountantPriceFeedTest is Test {
 
     /// @notice Without an underlying feed, the price is the accountant rate scaled to feed decimals.
     function test_noUnderlying_latestAnswer_isScaledRate() public {
-        VedaAccountantPriceFeed usdFeed = new VedaAccountantPriceFeed(accountant, IAaveV4PriceFeed(address(0)), FEED_DECIMALS, RATE_MAX_STALENESS, false, "liquidETH / ETH");
+        VedaAccountantPriceFeed usdFeed = new VedaAccountantPriceFeed(accountant, IAaveV4PriceFeed(address(0)), FEED_DECIMALS, RATE_MAX_STALENESS, false, "liquidETH / ETH", IAggregatorV3(address(0)), 0);
         uint256 rate = accountant.getRateSafe();
         uint256 expected = rate * (10 ** FEED_DECIMALS) / (10 ** usdFeed.rateDecimals());
         assertEq(usdFeed.latestAnswer().toUint256(), expected);
@@ -95,7 +105,7 @@ contract VedaAccountantPriceFeedTest is Test {
 
     /// @notice A stable feed snaps to exactly 1 USD inside the 1% band and passes the raw price outside it.
     function test_stable_snapsWithinOnePercent() public {
-        VedaAccountantPriceFeed stableFeed = new VedaAccountantPriceFeed(accountant, IAaveV4PriceFeed(address(0)), FEED_DECIMALS, RATE_MAX_STALENESS, true, "STABLE / USD");
+        VedaAccountantPriceFeed stableFeed = new VedaAccountantPriceFeed(accountant, IAaveV4PriceFeed(address(0)), FEED_DECIMALS, RATE_MAX_STALENESS, true, "STABLE / USD", IAggregatorV3(address(0)), 0);
         vm.mockCall(address(accountant), abi.encodeWithSelector(IVedaAccountant.getRateSafe.selector), abi.encode(uint256(0.995e18)));
         assertEq(stableFeed.latestAnswer(), 1e8);
         vm.mockCall(address(accountant), abi.encodeWithSelector(IVedaAccountant.getRateSafe.selector), abi.encode(uint256(1.02e18)));

--- a/test/safe/modules/cash/lend/CashGatewayTestSetup.t.sol
+++ b/test/safe/modules/cash/lend/CashGatewayTestSetup.t.sol
@@ -8,8 +8,8 @@ import { IAaveV4PriceFeed } from "../../../../../src/interfaces/IAaveV4PriceFeed
 import { IAggregatorV3 } from "../../../../../src/interfaces/IAggregatorV3.sol";
 import { LendGateway } from "../../../../../src/modules/lend-gateway/LendGateway.sol";
 import { ChainlinkPriceFeed } from "../../../../../src/oracle/ChainlinkPriceFeed.sol";
-import { AaveV4Fixture } from "./helpers/AaveV4Fixture.sol";
 import { CashModuleTestSetup } from "../CashModuleTestSetup.t.sol";
+import { AaveV4Fixture } from "./helpers/AaveV4Fixture.sol";
 
 /**
  * @title CashGatewayTestSetup
@@ -32,6 +32,7 @@ import { CashModuleTestSetup } from "../CashModuleTestSetup.t.sol";
  *         spend agree, so the check side and the execution side never diverge.
  */
 abstract contract CashGatewayTestSetup is CashModuleTestSetup, AaveV4Fixture {
+    address internal constant SEQUENCER_UPTIME_FEED = 0x371EAD81c9102C9BF4874A9075FFFf170F2Ee389;
     LendGateway internal gw;
     address internal driver = makeAddr("gwDriver"); // arranges Aave positions directly in tests
     address internal recipient = makeAddr("gwRecipient");
@@ -45,9 +46,11 @@ abstract contract CashGatewayTestSetup is CashModuleTestSetup, AaveV4Fixture {
 
         // Real Aave v4 instance on the fork, weETH + USDC reserves priced by live Chainlink feeds
         _deployAaveV4();
-        address weethSource = address(new ChainlinkPriceFeed(IAggregatorV3(weEthWethOracle), IAaveV4PriceFeed(ethUsdcOracle), 8, 30 days, false, "weETH / USD"));
+        address ethSource = address(new ChainlinkPriceFeed(IAggregatorV3(ethUsdcOracle), IAaveV4PriceFeed(address(0)), 8, 30 days, false, "ETH / USD", IAggregatorV3(SEQUENCER_UPTIME_FEED), 1 hours));
+        address weethSource = address(new ChainlinkPriceFeed(IAggregatorV3(weEthWethOracle), IAaveV4PriceFeed(ethSource), 8, 30 days, false, "weETH / USD", IAggregatorV3(SEQUENCER_UPTIME_FEED), 1 hours));
+        address usdcSource = address(new ChainlinkPriceFeed(IAggregatorV3(usdcUsdOracle), IAaveV4PriceFeed(address(0)), 8, 30 days, true, "USDC / USD", IAggregatorV3(SEQUENCER_UPTIME_FEED), 1 hours));
         weethReserveId = _addAaveReserve(address(weETH), weethSource, _weethCollateralFactorBps(), _weethBorrowable());
-        usdcReserveId = _addAaveReserve(address(usdc), usdcUsdOracle, _usdcCollateralFactorBps(), true);
+        usdcReserveId = _addAaveReserve(address(usdc), usdcSource, _usdcCollateralFactorBps(), true);
         _seedInitialLiquidity();
 
         // LendGateway proxy pointing at the fresh spoke, wired as the CashModule's live lend engine

--- a/test/safe/modules/cash/lend/RepaySourcing.t.sol
+++ b/test/safe/modules/cash/lend/RepaySourcing.t.sol
@@ -21,6 +21,7 @@ import { CashGatewayTestSetup } from "./CashGatewayTestSetup.t.sol";
 contract RepaySourcingTest is CashGatewayTestSetup {
     using MessageHashUtils for bytes32;
 
+    /// @notice A migrated safe can repay Aave debt in token units while the price oracle is unavailable.
     function test_repayLendTokenAmount_worksWhenPriceOracleReverts() public {
         uint256 borrowedUsdc = 300e6;
         _buildGatewayPosition(address(safe), address(weETH), 5 ether, address(usdc), borrowedUsdc);
@@ -38,6 +39,7 @@ contract RepaySourcingTest is CashGatewayTestSetup {
         assertEq(gw.debtOf(address(safe), address(usdc)), 0, "full debt repaid without an oracle read");
     }
 
+    /// @notice Token-denominated repayment is unavailable to safes still using DebtManager.
     function test_repayLendTokenAmount_revertsForLegacySafe() public {
         _forceLegacyEngine(address(safe));
 

--- a/test/safe/modules/cash/lend/RepaySourcing.t.sol
+++ b/test/safe/modules/cash/lend/RepaySourcing.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.28;
 import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
 import { ICashModule } from "../../../../../src/interfaces/ICashModule.sol";
+import { IPriceProvider } from "../../../../../src/interfaces/IPriceProvider.sol";
 import { LendSourcingLib } from "../../../../../src/libraries/LendSourcingLib.sol";
 import { CashEventEmitter } from "../../../../../src/modules/cash/CashEventEmitter.sol";
 import { CashGatewayTestSetup } from "./CashGatewayTestSetup.t.sol";
@@ -19,6 +20,31 @@ import { CashGatewayTestSetup } from "./CashGatewayTestSetup.t.sol";
  */
 contract RepaySourcingTest is CashGatewayTestSetup {
     using MessageHashUtils for bytes32;
+
+    function test_repayLendTokenAmount_worksWhenPriceOracleReverts() public {
+        uint256 borrowedUsdc = 300e6;
+        _buildGatewayPosition(address(safe), address(weETH), 5 ether, address(usdc), borrowedUsdc);
+        deal(address(usdc), address(safe), borrowedUsdc);
+
+        address priceProvider = dataProvider.getPriceProvider();
+        vm.mockCallRevert(priceProvider, abi.encodeWithSelector(IPriceProvider.price.selector, address(usdc)), "oracle unavailable");
+
+        uint256 debt = gw.debtOf(address(safe), address(usdc));
+        vm.expectEmit(true, true, true, true);
+        emit CashEventEmitter.RepayLendTokenAmount(address(safe), address(usdc), debt);
+        vm.prank(etherFiWallet);
+        cashModule.repayLendTokenAmount(address(safe), address(usdc), type(uint256).max);
+
+        assertEq(gw.debtOf(address(safe), address(usdc)), 0, "full debt repaid without an oracle read");
+    }
+
+    function test_repayLendTokenAmount_revertsForLegacySafe() public {
+        _forceLegacyEngine(address(safe));
+
+        vm.prank(etherFiWallet);
+        vm.expectRevert(ICashModule.OnlyLendGatewaySafe.selector);
+        cashModule.repayLendTokenAmount(address(safe), address(usdc), 1);
+    }
 
     /// A fully swept safe (borrowed USDC auto-supplied, zero loose) repays its whole debt from the
     /// supplied balance; the sentinel path leaves no dust.


### PR DESCRIPTION
## Summary

- fail closed on all PriceProviderV2 and Aave adapter price reads while the OP sequencer is down and for a one-hour recovery grace period
- wrap direct Aave USD feeds too, and add an atomic production PriceProviderV2 upgrade/configuration script
- add Aave-only repayLendTokenAmount so migrated safes can repay in token units without an oracle lookup
- leave DebtManager unchanged

## Tests

- forge build
- 33 Aave price-feed tests
- 52 PriceProviderV2 regression tests, plus sequencer configuration coverage
- 11 Aave repayment sourcing tests, including oracle failure and legacy-safe rejection

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes when all L2 oracle and Aave collateral pricing is allowed (sequencer downtime and post-recovery), plus a production UUPS upgrade path for PriceProviderV2; incorrect guard config could block repayments, borrows, and liquidations cluster-wide on OP.
> 
> **Overview**
> **L2 sequencer protection** is added across oracle surfaces so price reads **fail closed** while the Optimism sequencer is down and for a **one-hour grace period** after recovery. Shared `L2SequencerGuardLib` / `L2SequencerGuard` back `PriceProviderV2.price()` (new storage + `setSequencerConfig`) and Aave adapter feeds (`ChainlinkPriceFeed`, `PythPriceFeed`, `VedaAccountantPriceFeed`), with constructors extended to take the Chainlink uptime feed and grace period (zero feed disables the guard).
> 
> Deploy and ops scripts pass the live OP sequencer feed into new feeds (`AddSummerLendCollateral`, `DeployAaveV4TestInstance` now wraps USDC/weETH in guarded `ChainlinkPriceFeed`s). A Gnosis script **`UpgradePriceProviderV2SequencerGuard`** upgrades live `PriceProviderV2` and sets the guard in one `upgradeToAndCall`.
> 
> **Cash / lend:** `repayLendTokenAmount` lets **lend-gateway** safes repay Aave debt in **token units** without `PriceProvider` (refactored shared `_executeGatewayRepay`; new `RepayLendTokenAmount` event). Legacy DebtManager USD `repay` is unchanged.
> 
> Tests cover sequencer revert/grace behavior on feeds and `PriceProviderV2`, plus oracle-failure repay and legacy-safe rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90cb186b8c6d01d4cc84a9b3369c9a30b9874539. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->