### PR TITLE
feat: add token-denominated Aave repay for gateway safes

### DIFF
--- a/src/interfaces/ICashEventEmitter.sol
+++ b/src/interfaces/ICashEventEmitter.sol
@@ -137,6 +137,14 @@ interface ICashEventEmitter {
     function emitRepay(address safe, address token, uint256 amount, uint256 amountInUsd) external;
 
     /**
+     * @notice Emits an event when Aave debt is repaid using a token-denominated amount
+     * @param safe Address of the safe whose debt was repaid
+     * @param token Address of the token repaid
+     * @param amount Amount of token actually repaid
+     */
+    function emitRepayLendTokenAmount(address safe, address token, uint256 amount) external;
+
+    /**
      * @notice Emits an event when loose collateral is supplied to cover a credit spend's borrowing shortfall
      * @param safe Address of the safe
      * @param token Collateral token supplied

--- a/src/interfaces/ICashModule.sol
+++ b/src/interfaces/ICashModule.sol
@@ -699,6 +699,16 @@ interface ICashModule {
     function repay(address safe, address token, uint256 amountInUsd) external;
 
     /**
+     * @notice Repays Aave debt using token units without reading the Cash PriceProvider
+     * @dev Only available to safes on the lend gateway. The amount is capped at the live debt.
+     * @param safe Address of the EtherFi Safe
+     * @param token Address of the token to repay
+     * @param amount Amount to repay in token units
+     * @custom:throws OnlyLendGatewaySafe if the safe runs on the legacy DebtManager engine
+     */
+    function repayLendTokenAmount(address safe, address token, uint256 amount) external;
+
+    /**
      * @notice Supplies a safe's loose token balances into the Aave lend market (the auto-supply sweep)
      * @dev Per token: supplies the loose balance net of any pending-withdrawal reservation and flags it
      *      as collateral; zero and unregistered tokens are skipped. No-op for an opted-out safe; reverts

--- a/src/modules/cash/CashEventEmitter.sol
+++ b/src/modules/cash/CashEventEmitter.sol
@@ -96,6 +96,14 @@ contract CashEventEmitter is UpgradeableProxy {
     event Repay(address indexed safe, address indexed token, uint256 debtAmount, uint256 debtAmountInUsd);
 
     /**
+     * @notice Emitted for an Aave repayment that intentionally avoids a USD oracle lookup.
+     * @param safe Address of the safe whose debt was repaid.
+     * @param token Address of the token used to repay.
+     * @param debtAmount Amount of token actually repaid.
+     */
+    event RepayLendTokenAmount(address indexed safe, address indexed token, uint256 debtAmount);
+
+    /**
      * @notice Emitted when a safe requests to opt out of lend (the Aave market)
      * @param safe Address of the safe
      * @param finalizeTime Timestamp after which the request can be executed
@@ -437,6 +445,17 @@ contract CashEventEmitter is UpgradeableProxy {
 
     function emitRepay(address safe, address token, uint256 amount, uint256 amountInUsd) external onlyCashModule {
         emit Repay(safe, token, amount, amountInUsd);
+    }
+
+    /**
+     * @notice Emits the token-denominated Aave repayment event.
+     * @dev Only callable by the Cash Module.
+     * @param safe Address of the safe whose debt was repaid.
+     * @param token Address of the token used to repay.
+     * @param amount Amount of token actually repaid.
+     */
+    function emitRepayLendTokenAmount(address safe, address token, uint256 amount) external onlyCashModule {
+        emit RepayLendTokenAmount(safe, token, amount);
     }
 
     /**

--- a/src/modules/cash/CashLendLib.sol
+++ b/src/modules/cash/CashLendLib.sol
@@ -177,25 +177,61 @@ library CashLendLib {
         }
         if (amount == 0) revert AmountZero();
 
-        (uint256 fromLoose, uint256 fromSupplied, bool cancelWithdrawal) = _sourceRepay($, gateway, safe, token, amount);
-        if (cancelWithdrawal) cancelOldWithdrawal($, dataProvider, safe);
-
-        // A full repay passes the max sentinel on its last leg so no interest dust survives the
-        // exact-amount rounding.
-        uint256 repaid;
-        if (fromSupplied == 0) {
-            // Loose covers the whole amount
-            repaid = gateway.repay(safe, token, amount == debt ? type(uint256).max : amount);
-        } else {
-            if (fromLoose != 0) repaid = gateway.repay(safe, token, fromLoose);
-            gateway.withdraw(safe, token, fromSupplied, safe);
-            repaid += gateway.repay(safe, token, amount == debt ? type(uint256).max : fromSupplied);
-        }
+        uint256 repaid = _executeGatewayRepay($, dataProvider, gateway, safe, token, amount, debt);
 
         // The gateway may repay less than requested (dust refund, or the live Aave debt being smaller than
         // the quote), so report the USD value of what was actually repaid, not the requested amount.
         uint256 repaidInUsd = repaid == amount ? amountInUsd : LendSourcingLib.toUsd(priceProvider, token, repaid);
         $.cashEventEmitter.emitRepay(safe, token, repaid, repaidInUsd);
+    }
+
+    /**
+     * @notice Repays gateway debt using token units, without reading the price provider
+     * @dev Restricted to migrated Aave safes by _requireGateway. A max amount repays the full live debt.
+     * @param $ Cash Module storage.
+     * @param dataProvider Data provider used if a competing withdrawal must be cancelled.
+     * @param safe Address of the safe whose debt is repaid.
+     * @param token Address of the debt token.
+     * @param amount Maximum amount to repay in token units.
+     * @custom:throws OnlyLendGatewaySafe if the safe still uses DebtManager.
+     * @custom:throws OnlyBorrowToken if the token is not registered on the gateway.
+     * @custom:throws AmountZero if the amount or live debt is zero.
+     */
+    function repayLendTokenAmount(CashModuleStorageContract.CashModuleStorage storage $, IEtherFiDataProvider dataProvider, address safe, address token, uint256 amount) external {
+        ILendGateway gateway = _requireGateway($, safe);
+        if (!gateway.isRegistered(token)) revert OnlyBorrowToken();
+
+        uint256 debt = gateway.debtOf(safe, token);
+        if (amount > debt) amount = debt;
+        if (amount == 0) revert AmountZero();
+
+        uint256 repaid = _executeGatewayRepay($, dataProvider, gateway, safe, token, amount, debt);
+        $.cashEventEmitter.emitRepayLendTokenAmount(safe, token, repaid);
+    }
+
+    /**
+     * @notice Sources and executes a token-denominated gateway repayment.
+     * @dev Uses the max sentinel for a full repayment so accrued interest dust is cleared.
+     * @param $ Cash Module storage.
+     * @param dataProvider Data provider used if a competing withdrawal must be cancelled.
+     * @param gateway Lend gateway that owns the Aave position.
+     * @param safe Address of the safe whose debt is repaid.
+     * @param token Address of the debt token.
+     * @param amount Capped amount to repay in token units.
+     * @param debt Live token debt before repayment.
+     * @return repaid Amount of token actually repaid.
+     */
+    function _executeGatewayRepay(CashModuleStorageContract.CashModuleStorage storage $, IEtherFiDataProvider dataProvider, ILendGateway gateway, address safe, address token, uint256 amount, uint256 debt) private returns (uint256 repaid) {
+        (uint256 fromLoose, uint256 fromSupplied, bool cancelWithdrawal) = _sourceRepay($, gateway, safe, token, amount);
+        if (cancelWithdrawal) cancelOldWithdrawal($, dataProvider, safe);
+
+        if (fromSupplied == 0) {
+            return gateway.repay(safe, token, amount == debt ? type(uint256).max : amount);
+        }
+
+        if (fromLoose != 0) repaid = gateway.repay(safe, token, fromLoose);
+        gateway.withdraw(safe, token, fromSupplied, safe);
+        repaid += gateway.repay(safe, token, amount == debt ? type(uint256).max : fromSupplied);
     }
 
     /**

--- a/src/modules/cash/CashModuleCore.sol
+++ b/src/modules/cash/CashModuleCore.sol
@@ -549,6 +549,23 @@ contract CashModuleCore is CashModuleStorageContract {
     }
 
     /**
+     * @notice Repays Aave debt in token units without reading the Cash PriceProvider
+     * @dev This is intentionally restricted to safes on the lend gateway. Legacy DebtManager repayment
+     *      remains USD-denominated and unchanged.
+     * @param safe Address of the EtherFi Safe whose debt is repaid.
+     * @param token Address of the debt token.
+     * @param amount Maximum amount to repay in token units.
+     * @custom:throws OnlyLendGatewaySafe if the safe still uses DebtManager.
+     * @custom:throws OnlyBorrowToken if the token is not registered on the gateway.
+     * @custom:throws AmountZero if the amount or live debt is zero.
+     */
+    function repayLendTokenAmount(address safe, address token, uint256 amount) external whenNotPaused nonReentrant onlyEtherFiWallet onlyEtherFiSafe(safe) {
+        CashModuleStorage storage $ = _getCashModuleStorage();
+        CashLendLib.repayLendTokenAmount($, etherFiDataProvider, safe, token, amount);
+        CashLendLib.processLendOptOutIfReady($, safe);
+    }
+
+    /**
      * @notice Supplies a safe's loose token balances into the Aave lend market (the auto-supply sweep)
      * @dev Only callable by the EtherFi wallet (the cash-be sweeper). Per token: supplies the loose balance
      *      net of any pending-withdrawal reservation and flags it as collateral; zero and unregistered

--- a/test/safe/modules/cash/lend/RepaySourcing.t.sol
+++ b/test/safe/modules/cash/lend/RepaySourcing.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.28;
 import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
 import { ICashModule } from "../../../../../src/interfaces/ICashModule.sol";
+import { IPriceProvider } from "../../../../../src/interfaces/IPriceProvider.sol";
 import { LendSourcingLib } from "../../../../../src/libraries/LendSourcingLib.sol";
 import { CashEventEmitter } from "../../../../../src/modules/cash/CashEventEmitter.sol";
 import { CashGatewayTestSetup } from "./CashGatewayTestSetup.t.sol";
@@ -19,6 +20,48 @@ import { CashGatewayTestSetup } from "./CashGatewayTestSetup.t.sol";
  */
 contract RepaySourcingTest is CashGatewayTestSetup {
     using MessageHashUtils for bytes32;
+
+    /// @notice A gateway safe can repay Aave debt in token units while the Cash PriceProvider is unavailable.
+    function test_repayLendTokenAmount_worksWhenPriceOracleReverts() public {
+        uint256 borrowedUsdc = 300e6;
+        _buildGatewayPosition(address(safe), address(weETH), 5 ether, address(usdc), borrowedUsdc);
+        deal(address(usdc), address(safe), borrowedUsdc);
+
+        address priceProvider = dataProvider.getPriceProvider();
+        vm.mockCallRevert(priceProvider, abi.encodeWithSelector(IPriceProvider.price.selector, address(usdc)), "oracle unavailable");
+
+        uint256 debt = gw.debtOf(address(safe), address(usdc));
+        vm.expectEmit(true, true, true, true);
+        emit CashEventEmitter.RepayLendTokenAmount(address(safe), address(usdc), debt);
+        vm.prank(etherFiWallet);
+        cashModule.repayLendTokenAmount(address(safe), address(usdc), type(uint256).max);
+
+        assertEq(gw.debtOf(address(safe), address(usdc)), 0, "full debt repaid without an oracle read");
+    }
+
+    /// @notice Token repayment can source supplied funds while the Cash PriceProvider is unavailable.
+    function test_repayLendTokenAmount_worksFromSuppliedWhenPriceProviderReverts() public {
+        uint256 borrowedUsdc = 300e6;
+        _buildGatewayPosition(address(safe), address(weETH), 5 ether, address(usdc), borrowedUsdc);
+        _supplyToGateway(address(safe), address(usdc), borrowedUsdc);
+
+        address priceProvider = dataProvider.getPriceProvider();
+        vm.mockCallRevert(priceProvider, abi.encodeWithSelector(IPriceProvider.price.selector, address(usdc)), "oracle unavailable");
+
+        vm.prank(etherFiWallet);
+        cashModule.repayLendTokenAmount(address(safe), address(usdc), type(uint256).max);
+
+        assertEq(gw.debtOf(address(safe), address(usdc)), 0, "full debt repaid from supplied funds");
+    }
+
+    /// @notice Token-denominated repayment is unavailable to safes still using DebtManager.
+    function test_repayLendTokenAmount_revertsForLegacySafe() public {
+        _forceLegacyEngine(address(safe));
+
+        vm.prank(etherFiWallet);
+        vm.expectRevert(ICashModule.OnlyLendGatewaySafe.selector);
+        cashModule.repayLendTokenAmount(address(safe), address(usdc), 1);
+    }
 
     /// A fully swept safe (borrowed USDC auto-supplied, zero loose) repays its whole debt from the
     /// supplied balance; the sentinel path leaves no dust.


### PR DESCRIPTION
## Summary
- Adds `repayLendTokenAmount`, so gateway safes can repay Aave debt in token units without a Cash PriceProvider read
- Useful when the price oracle is stale or reverting, since the existing `repay` needs a USD price to size the repayment
- Caps the amount at the live debt, and shares the sourcing and repay logic with the existing `repay` path through a new `_executeGatewayRepay` helper
- Restricted to gateway safes. Legacy DebtManager safes get `OnlyLendGatewaySafe`
- Adds a `RepayLendTokenAmount` event for the token-denominated path

## Test plan
- [x] `test_repayLendTokenAmount_worksWhenPriceOracleReverts` passes
- [x] `test_repayLendTokenAmount_worksFromSuppliedWhenPriceProviderReverts` passes
- [x] `test_repayLendTokenAmount_revertsForLegacySafe` passes
- [x] Existing `RepaySourcing.t.sol` suite still passes (12/12)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new wallet-gated debt repayment path on the lend gateway; risk is moderated by reusing extracted gateway repay logic and leaving legacy USD repay unchanged.
> 
> **Overview**
> Adds **`repayLendTokenAmount`** so the EtherFi wallet can repay **gateway (Aave) debt in token units** without calling the Cash **PriceProvider**—intended when the oracle is stale or reverting, while existing **`repay`** stays USD-sized.
> 
> The new path is **gateway-only** (legacy DebtManager safes still get **`OnlyLendGatewaySafe`**), caps at live debt, reuses the same loose → supplied → reserved-loose sourcing, and emits **`RepayLendTokenAmount`** (no USD field). USD gateway **`repay`** now delegates execution to a shared **`_executeGatewayRepay`** helper so behavior stays aligned.
> 
> Fork tests cover full repay with a mocked oracle revert (loose and supplied sourcing) and the legacy-safe revert.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15022b6b9aec92ef7003881f67a2eb30a985bef5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->