### PR TITLE
fix: make the collateral toggle best-effort after a gateway supply

### DIFF
--- a/src/interfaces/ILendGateway.sol
+++ b/src/interfaces/ILendGateway.sol
@@ -31,6 +31,16 @@ interface ILendGateway {
     function supply(address safe, address asset, uint256 amount) external;
 
     /**
+     * @notice Supplies `asset` and then attempts to enable it as collateral
+     * @dev A failed collateral toggle does not revert the successful supply, so the asset still earns yield.
+     * @param safe The safe whose position is credited
+     * @param asset The asset being supplied
+     * @param amount The amount to supply
+     * @return collateralEnabled Whether the asset is enabled as collateral after the supply
+     */
+    function supplyAndTryEnableCollateral(address safe, address asset, uint256 amount) external returns (bool collateralEnabled);
+
+    /**
      * @notice Withdraws `amount` of `asset` from `safe`'s Aave position to `to`
      * @param safe The safe whose position is debited
      * @param asset The asset being withdrawn

--- a/src/mocks/MockLendGateway.sol
+++ b/src/mocks/MockLendGateway.sol
@@ -91,6 +91,12 @@ contract MockLendGateway is ILendGateway {
         lastSupply = Call(safe, asset, amount, address(0));
     }
 
+    function supplyAndTryEnableCollateral(address safe, address asset, uint256 amount) external returns (bool collateralEnabled) {
+        lastSupply = Call(safe, asset, amount, address(0));
+        usingAsCollateral[safe][asset] = true;
+        return true;
+    }
+
     function withdraw(address safe, address asset, uint256 amount, address to) external {
         lastWithdraw = Call(safe, asset, amount, to);
     }

--- a/src/modules/ModuleLendGatewaySandwich.sol
+++ b/src/modules/ModuleLendGatewaySandwich.sol
@@ -80,9 +80,10 @@ abstract contract ModuleLendGatewaySandwich is ModuleCheckBalance {
     }
 
     /**
-     * @notice Supplies an asset from the safe back into Aave and marks it as collateral, best-effort
+     * @notice Supplies an asset from the safe back into Aave and tries to mark it as collateral, best-effort
      * @dev No-op for an unregistered asset. A rejected supply (frozen, paused, capped) is swallowed rather
-     *      than reverting the action that already ran; the output stays loose and the next sweep restores it.
+     *      than reverting the action that already ran. If only the collateral toggle fails, the supply remains
+     *      earning yield and the gateway emits CollateralEnablementFailed for monitoring.
      * @param safe The safe whose position is credited
      * @param asset The asset to supply
      * @param amount The amount to supply
@@ -91,9 +92,7 @@ abstract contract ModuleLendGatewaySandwich is ModuleCheckBalance {
         if (!_lendActive(safe)) return;
         ILendGateway lendGateway = gateway();
         if (!lendGateway.isRegistered(asset)) return;
-        try lendGateway.supply(safe, asset, amount) {
-            lendGateway.setUsingAsCollateral(safe, asset, true);
-        } catch { }
+        try lendGateway.supplyAndTryEnableCollateral(safe, asset, amount) returns (bool) { } catch { }
     }
 
     /**

--- a/src/modules/cash/CashLendLib.sol
+++ b/src/modules/cash/CashLendLib.sol
@@ -308,7 +308,7 @@ library CashLendLib {
             uint256 pending = _pendingWithdrawalAmount($, safe, tokens[i]);
             amount = amount > pending ? amount - pending : 0;
             if (amount == 0) continue;
-            _supplyAsCollateral($, gateway, safe, tokens[i], amount);
+            _supplyAndTryEnableCollateral($, gateway, safe, tokens[i], amount);
         }
     }
 
@@ -347,7 +347,7 @@ library CashLendLib {
         if (amount == 0) revert AmountZero();
 
         gateway.borrow(safe, token, amount, safe);
-        _supplyAsCollateral($, gateway, safe, token, amount);
+        _supplyAndTryEnableCollateral($, gateway, safe, token, amount);
         // The borrow page takes the health-factor floor (post-resupply end state); card spends are exempt
         gateway.ensureMinHealthFactor(safe);
         $.cashEventEmitter.emitLendBorrowed(safe, token, amount, amountInUsd);
@@ -361,13 +361,11 @@ library CashLendLib {
         return gateway;
     }
 
-    /// @dev Best-effort supply of `amount` of `token` into the lend market as collateral. A supply the
-    ///      reserve rejects (frozen, paused, at its supply cap, or the Hub spoke halted) is swallowed so the
-    ///      funds stay loose for the next sweep. Used by the sweep and the borrow auto-supply, where leaving
-    ///      the funds loose is fine; callers that must not proceed without the supply do not use this.
-    function _supplyAsCollateral(CashModuleStorageContract.CashModuleStorage storage $, ILendGateway gateway, address safe, address token, uint256 amount) private {
-        try gateway.supply(safe, token, amount) {
-            gateway.setUsingAsCollateral(safe, token, true);
+    /// @dev Best-effort supply of `amount` of `token` into the lend market with an attempted collateral toggle.
+    ///      A rejected supply is swallowed so the funds stay loose. If only the collateral toggle fails, the
+    ///      supply remains earning yield and the gateway emits CollateralEnablementFailed for monitoring.
+    function _supplyAndTryEnableCollateral(CashModuleStorageContract.CashModuleStorage storage $, ILendGateway gateway, address safe, address token, uint256 amount) private {
+        try gateway.supplyAndTryEnableCollateral(safe, token, amount) returns (bool) {
             $.cashEventEmitter.emitLendSupplied(safe, token, amount);
         } catch { }
     }

--- a/src/modules/lend-gateway/LendGateway.sol
+++ b/src/modules/lend-gateway/LendGateway.sol
@@ -97,6 +97,8 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
     event PositionManagerApproved(address indexed safe);
     /// @notice Emitted on a supply on a safe's behalf
     event Supplied(address indexed safe, address indexed asset, uint256 amount);
+    /// @notice Emitted when a supply succeeds but Aave rejects enabling the asset as collateral
+    event CollateralEnablementFailed(address indexed safe, address indexed asset, uint256 amount);
     /// @notice Emitted on a withdraw on a safe's behalf
     event Withdrawn(address indexed safe, address indexed asset, uint256 amount, address indexed to);
     /// @notice Emitted on a borrow on a safe's behalf
@@ -314,8 +316,36 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
      * @custom:throws AssetNotRegistered if asset has no registered reserveId
      */
     function supply(address safe, address asset, uint256 amount) external onlyDriver onlyEtherFiSafe(safe) whenNotPaused nonReentrant whenNotOptedOut(safe) ensuresApproval(safe) {
+        _supply(safe, asset, amount);
+    }
+
+    /**
+     * @notice Supplies `amount` of `asset` and attempts to enable it as collateral
+     * @dev A collateral-toggle failure is swallowed after emitting CollateralEnablementFailed. The completed
+     *      supply remains on Aave and continues earning yield. A supply failure still reverts normally.
+     * @param safe The safe whose position is credited
+     * @param asset The asset being supplied (must be a registered reserve)
+     * @param amount The amount to supply
+     * @return collateralEnabled Whether Aave enabled the asset as collateral
+     * @custom:throws OnlyDriver if the caller is not the CashModule or an authorized driver
+     * @custom:throws LendOptedOut if the safe has opted out of lend
+     * @custom:throws ZeroAmount if amount is zero
+     * @custom:throws AssetNotRegistered if asset has no registered reserveId
+     */
+    function supplyAndTryEnableCollateral(address safe, address asset, uint256 amount) external onlyDriver onlyEtherFiSafe(safe) whenNotPaused nonReentrant whenNotOptedOut(safe) ensuresApproval(safe) returns (bool collateralEnabled) {
+        uint256 reserveId = _supply(safe, asset, amount);
+        try spoke.setUsingAsCollateral(reserveId, true, safe) {
+            emit CollateralUsageSet(safe, asset, true);
+            return true;
+        } catch {
+            emit CollateralEnablementFailed(safe, asset, amount);
+            return false;
+        }
+    }
+
+    function _supply(address safe, address asset, uint256 amount) private returns (uint256 reserveId) {
         if (amount == 0) revert ZeroAmount();
-        uint256 reserveId = _reserveIdOf(asset);
+        reserveId = _reserveIdOf(asset);
 
         // Spoke pulls the asset from the caller (this gateway), so bring it in from the safe and approve.
         _pullFromSafe(safe, asset, amount);

--- a/src/top-up/TopUpDest.sol
+++ b/src/top-up/TopUpDest.sol
@@ -237,8 +237,7 @@ contract TopUpDest is UpgradeableProxy {
         ILendGateway lendGateway = cashModule.getLendGateway();
         if (!lendGateway.isRegistered(token)) return;
 
-        lendGateway.supply(safe, token, amount);
-        lendGateway.setUsingAsCollateral(safe, token, true);
+        lendGateway.supplyAndTryEnableCollateral(safe, token, amount);
     }
 
     /**

--- a/test/safe/modules/cash/lend/LendGatewayAaveV4.t.sol
+++ b/test/safe/modules/cash/lend/LendGatewayAaveV4.t.sol
@@ -414,6 +414,8 @@ contract LendGatewayAaveV4Test is CashGatewayTestSetup {
     function test_mutatingOps_onlyDriver() public {
         vm.startPrank(makeAddr("notADriver"));
         vm.expectRevert(LendGateway.OnlyDriver.selector);
+        gw.supplyAndTryEnableCollateral(address(safe), address(weETH), 1);
+        vm.expectRevert(LendGateway.OnlyDriver.selector);
         gw.withdraw(address(safe), address(weETH), 1, recipient);
         vm.expectRevert(LendGateway.OnlyDriver.selector);
         gw.borrow(address(safe), address(usdc), 1, recipient);
@@ -430,6 +432,8 @@ contract LendGatewayAaveV4Test is CashGatewayTestSetup {
         vm.startPrank(driver);
         vm.expectRevert(ModuleBase.OnlyEtherFiSafe.selector);
         gw.supply(notSafe, address(weETH), 1);
+        vm.expectRevert(ModuleBase.OnlyEtherFiSafe.selector);
+        gw.supplyAndTryEnableCollateral(notSafe, address(weETH), 1);
         vm.expectRevert(ModuleBase.OnlyEtherFiSafe.selector);
         gw.withdraw(notSafe, address(weETH), 1, notSafe);
         vm.expectRevert(ModuleBase.OnlyEtherFiSafe.selector);
@@ -448,6 +452,8 @@ contract LendGatewayAaveV4Test is CashGatewayTestSetup {
         vm.expectRevert(notRegistered);
         gw.supply(address(safe), unreg, 1e18);
         vm.expectRevert(notRegistered);
+        gw.supplyAndTryEnableCollateral(address(safe), unreg, 1e18);
+        vm.expectRevert(notRegistered);
         gw.withdraw(address(safe), unreg, 1e18, recipient);
         vm.expectRevert(notRegistered);
         gw.borrow(address(safe), unreg, 1e18, recipient);
@@ -462,6 +468,8 @@ contract LendGatewayAaveV4Test is CashGatewayTestSetup {
         vm.startPrank(driver);
         vm.expectRevert(LendGateway.ZeroAmount.selector);
         gw.supply(address(safe), address(weETH), 0);
+        vm.expectRevert(LendGateway.ZeroAmount.selector);
+        gw.supplyAndTryEnableCollateral(address(safe), address(weETH), 0);
         vm.expectRevert(LendGateway.ZeroAmount.selector);
         gw.withdraw(address(safe), address(weETH), 0, recipient);
         vm.expectRevert(LendGateway.ZeroAmount.selector);
@@ -533,6 +541,37 @@ contract LendGatewayAaveV4Test is CashGatewayTestSetup {
         (bool disabled,) = spoke.getUserReserveStatus(weethReserveId, address(safe));
         assertFalse(disabled, "collateral disabled");
         vm.stopPrank();
+    }
+
+    /// A successful combined supply reports and enables the asset as collateral.
+    function test_supplyAndTryEnableCollateral_enablesCollateral() public {
+        uint256 amount = 5 ether;
+        deal(address(weETH), address(safe), amount);
+
+        vm.prank(driver);
+        bool collateralEnabled = gw.supplyAndTryEnableCollateral(address(safe), address(weETH), amount);
+
+        assertTrue(collateralEnabled, "collateral enablement reported as successful");
+        assertEq(gw.suppliedOf(address(safe), address(weETH)), amount, "asset supplied to Aave");
+        (bool enabled,) = spoke.getUserReserveStatus(weethReserveId, address(safe));
+        assertTrue(enabled, "supplied asset is collateral");
+    }
+
+    /// A failed collateral toggle keeps the successful supply earning yield and emits a monitoring event.
+    function test_supplyAndTryEnableCollateral_keepsSupplyWhenCollateralEnableFails() public {
+        uint256 amount = 5 ether;
+        deal(address(weETH), address(safe), amount);
+        vm.mockCallRevert(address(spoke), abi.encodeCall(ISpoke.setUsingAsCollateral, (weethReserveId, true, address(safe))), abi.encodeWithSelector(ISpoke.MaximumUserReservesExceeded.selector));
+
+        vm.expectEmit(true, true, true, true, address(gw));
+        emit LendGateway.CollateralEnablementFailed(address(safe), address(weETH), amount);
+        vm.prank(driver);
+        bool collateralEnabled = gw.supplyAndTryEnableCollateral(address(safe), address(weETH), amount);
+
+        assertFalse(collateralEnabled, "collateral enablement reported as failed");
+        assertEq(gw.suppliedOf(address(safe), address(weETH)), amount, "supply remains on Aave");
+        (bool enabled,) = spoke.getUserReserveStatus(weethReserveId, address(safe));
+        assertFalse(enabled, "supplied asset is not collateral");
     }
 
     function test_isApprovedBy_reflectsApprovalState() public {


### PR DESCRIPTION
## Summary
- Adds `supplyAndTryEnableCollateral` on the gateway: supply first, then try the collateral toggle inside a try/catch
- Fixes the old caller-side pattern where a toggle revert either bubbled up (module sandwich, TopUpDest) or was mis-scoped, even though the supply itself had succeeded
- A failed toggle now keeps the supply on Aave earning yield and emits `CollateralEnablementFailed` for monitoring
- Callers migrated: CashLendLib sweep and borrow auto-supply, ModuleLendGatewaySandwich resupply, TopUpDest top-up driver
- Behavior change to flag: TopUpDest previously reverted the top-up if the toggle failed; it now succeeds with the asset supplied but not collateral

## Test plan
- [x] `test_supplyAndTryEnableCollateral_enablesCollateral` passes
- [x] `test_supplyAndTryEnableCollateral_keepsSupplyWhenCollateralEnableFails` passes (mocked `MaximumUserReservesExceeded` toggle revert)
- [x] New entrypoint added to the driver/safe/registered/zero-amount guard tests
- [x] Full `LendGatewayAaveV4Test`, `AutoSupplyTest`, `TopUpAutoSupplyTest` suites pass (66/66)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core lend supply/collateral flows and changes TopUpDest failure semantics when Aave rejects collateral enablement, which can leave positions supplied but not counting as collateral until a later sweep.
> 
> **Overview**
> Introduces **`supplyAndTryEnableCollateral`** on the lend gateway: it runs the existing supply, then tries to mark the asset as collateral inside a **try/catch**. A failed toggle no longer reverts a successful supply; funds stay on Aave earning yield, the call returns `false`, and **`CollateralEnablementFailed`** is emitted for monitoring.
> 
> **CashLendLib** (auto-supply sweep and post-borrow auto-supply), **ModuleLendGatewaySandwich** resupply, and **TopUpDest** now use this single entrypoint instead of **`supply` + `setUsingAsCollateral`**, which could revert after supply had already succeeded or mishandle errors at the caller.
> 
> **Behavior change:** **TopUpDest** used to fail the lend leg when collateral enable reverted; it now completes the top-up with assets supplied but possibly **not** collateralized (still wrapped in the outer try/catch for other failures).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2834c93f46b5c6fbeecb825bf11fc643ebcf1b0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->