### PR TITLE
refactor: extract a shared BaseAaveV4PriceFeed for the three feeds

### DIFF
--- a/src/oracle/BaseAaveV4PriceFeed.sol
+++ b/src/oracle/BaseAaveV4PriceFeed.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+
+import { IAaveV4PriceFeed } from "../interfaces/IAaveV4PriceFeed.sol";
+import { StablePriceLib } from "./StablePriceLib.sol";
+
+/**
+ * @title BaseAaveV4PriceFeed
+ * @notice Shared state and math for the Aave v4 receipt-token price feeds. Every feed reports a
+ *         feedDecimals-scaled USD price in one of two modes: a USD-quoted source scaled straight to feed
+ *         decimals, or a rate in an underlying asset multiplied by that underlying's USD price (any
+ *         IAaveV4PriceFeed, which enforces its own staleness). A derived feed supplies only the raw rate
+ *         and its decimals from its own source; this base owns the two-mode compose, the stable snap,
+ *         decimals(), description(), and the shared errors.
+ * @author ether.fi
+ */
+abstract contract BaseAaveV4PriceFeed is IAaveV4PriceFeed {
+    using Math for uint256;
+    using SafeCast for uint256;
+    using SafeCast for int256;
+
+    /// @notice The feed for the underlying asset's USD price; address(0) when the rate is USD-quoted
+    IAaveV4PriceFeed public immutable underlyingUsdFeed;
+    /// @notice The decimals of the underlying feed (0 when unset)
+    uint8 public immutable underlyingDecimals;
+    /// @notice The decimals of the price this feed reports
+    uint8 public immutable feedDecimals;
+    /// @notice Whether the price snaps to exactly 1 USD when within 1% of it (USD stables only)
+    bool public immutable isStableToken;
+
+    string private _description;
+
+    /// @notice Thrown when a price source reports a zero or negative price
+    error InvalidPrice();
+    /// @notice Thrown when a price source is older than its staleness limit
+    error StalePrice();
+    /// @notice Thrown when the staleness bound is zero
+    error InvalidMaxStaleness();
+
+    constructor(IAaveV4PriceFeed _underlyingUsdFeed, uint8 _feedDecimals, bool _isStableToken, string memory feedDescription) {
+        underlyingUsdFeed = _underlyingUsdFeed;
+        if (address(_underlyingUsdFeed) != address(0)) {
+            underlyingDecimals = _underlyingUsdFeed.decimals();
+        }
+        feedDecimals = _feedDecimals;
+        isStableToken = _isStableToken;
+        _description = feedDescription;
+    }
+
+    /// @notice The number of decimals used to represent the price
+    function decimals() external view returns (uint8) {
+        return feedDecimals;
+    }
+
+    /// @notice A human-readable description of the feed
+    function description() external view returns (string memory) {
+        return _description;
+    }
+
+    /**
+     * @dev Composes the reported price from a raw `rate` in `rateDecimals`: scaled straight to feed
+     *      decimals when USD-quoted, else multiplied by the underlying USD price and normalized from
+     *      (rateDecimals + underlyingDecimals) to feedDecimals. Snaps to 1 USD for stables, and reverts
+     *      when the underlying leg is non-positive.
+     */
+    function _composeUsd(uint256 rate, uint8 rateDecimals) internal view returns (int256) {
+        if (address(underlyingUsdFeed) == address(0)) {
+            return StablePriceLib.snap(rate.mulDiv(10 ** feedDecimals, 10 ** rateDecimals), isStableToken, feedDecimals).toInt256();
+        }
+
+        int256 underlyingAnswer = underlyingUsdFeed.latestAnswer();
+        if (underlyingAnswer <= 0) revert InvalidPrice();
+
+        uint256 price = rate.mulDiv(underlyingAnswer.toUint256() * 10 ** feedDecimals, 10 ** (rateDecimals + underlyingDecimals));
+        return StablePriceLib.snap(price, isStableToken, feedDecimals).toInt256();
+    }
+}

--- a/src/oracle/ChainlinkPriceFeed.sol
+++ b/src/oracle/ChainlinkPriceFeed.sol
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
 import { IAaveV4PriceFeed } from "../interfaces/IAaveV4PriceFeed.sol";
 import { IAggregatorV3 } from "../interfaces/IAggregatorV3.sol";
-import { StablePriceLib } from "./StablePriceLib.sol";
+import { BaseAaveV4PriceFeed } from "./BaseAaveV4PriceFeed.sol";
 
 /**
  * @title ChainlinkPriceFeed
@@ -22,57 +21,21 @@ import { StablePriceLib } from "./StablePriceLib.sol";
  *      Chainlink feed is stale, or either leg is non-positive or reverts.
  * @author ether.fi
  */
-contract ChainlinkPriceFeed is IAaveV4PriceFeed {
-    using Math for uint256;
-    using SafeCast for uint256;
+contract ChainlinkPriceFeed is BaseAaveV4PriceFeed {
     using SafeCast for int256;
 
     /// @notice The Chainlink feed: a USD price (no underlying) or a rate in the underlying asset
     IAggregatorV3 public immutable rateFeed;
-    /// @notice The feed for the underlying asset's USD price; address(0) when the rate is USD-quoted
-    IAaveV4PriceFeed public immutable underlyingUsdFeed;
     /// @notice The decimals of the rate feed
     uint8 public immutable rateDecimals;
-    /// @notice The decimals of the underlying feed (0 when unset)
-    uint8 public immutable underlyingDecimals;
-    /// @notice The decimals of the price this feed reports
-    uint8 public immutable feedDecimals;
     /// @notice The maximum age in seconds for the rate feed before it is rejected
     uint256 public immutable rateMaxStaleness;
-    /// @notice Whether the price snaps to exactly 1 USD when within 1% of it (USD stables only)
-    bool public immutable isStableToken;
 
-    string private _description;
-
-    /// @notice Thrown when the rate feed price is older than its staleness limit
-    error StalePrice();
-    /// @notice Thrown when either leg's price is zero or negative
-    error InvalidPrice();
-    /// @notice Thrown when the staleness bound is zero
-    error InvalidMaxStaleness();
-
-    constructor(IAggregatorV3 _rateFeed, IAaveV4PriceFeed _underlyingUsdFeed, uint8 _feedDecimals, uint256 _rateMaxStaleness, bool _isStableToken, string memory feedDescription) {
+    constructor(IAggregatorV3 _rateFeed, IAaveV4PriceFeed _underlyingUsdFeed, uint8 _feedDecimals, uint256 _rateMaxStaleness, bool _isStableToken, string memory feedDescription) BaseAaveV4PriceFeed(_underlyingUsdFeed, _feedDecimals, _isStableToken, feedDescription) {
         require(_rateMaxStaleness > 0, InvalidMaxStaleness());
         rateFeed = _rateFeed;
-        underlyingUsdFeed = _underlyingUsdFeed;
         rateDecimals = _rateFeed.decimals();
-        if (address(_underlyingUsdFeed) != address(0)) {
-            underlyingDecimals = _underlyingUsdFeed.decimals();
-        }
-        feedDecimals = _feedDecimals;
         rateMaxStaleness = _rateMaxStaleness;
-        isStableToken = _isStableToken;
-        _description = feedDescription;
-    }
-
-    /// @notice The number of decimals used to represent the price
-    function decimals() external view returns (uint8) {
-        return feedDecimals;
-    }
-
-    /// @notice A human-readable description of the feed
-    function description() external view returns (string memory) {
-        return _description;
     }
 
     /**
@@ -81,21 +44,7 @@ contract ChainlinkPriceFeed is IAaveV4PriceFeed {
      *      underlying leg enforces its own staleness.
      */
     function latestAnswer() external view returns (int256) {
-        uint256 rate = _readFeed(rateFeed, rateMaxStaleness);
-
-        // USD-quoted feed: scale straight to feed decimals.
-        if (address(underlyingUsdFeed) == address(0)) {
-            return StablePriceLib.snap(rate.mulDiv(10 ** feedDecimals, 10 ** rateDecimals), isStableToken, feedDecimals).toInt256();
-        }
-
-        int256 underlyingAnswer = underlyingUsdFeed.latestAnswer();
-        if (underlyingAnswer <= 0) revert InvalidPrice();
-        uint256 underlyingPrice = underlyingAnswer.toUint256();
-
-        // price = rate * underlyingPrice, normalized from (rateDecimals + underlyingDecimals) to feedDecimals
-        uint256 price = rate.mulDiv(underlyingPrice * 10 ** feedDecimals, 10 ** (rateDecimals + underlyingDecimals));
-
-        return StablePriceLib.snap(price, isStableToken, feedDecimals).toInt256();
+        return _composeUsd(_readFeed(rateFeed, rateMaxStaleness), rateDecimals);
     }
 
     /// @dev Reads a Chainlink feed, reverting if the price is non-positive or older than maxStaleness

--- a/src/oracle/PythPriceFeed.sol
+++ b/src/oracle/PythPriceFeed.sol
@@ -1,11 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
-import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
-
 import { IAaveV4PriceFeed } from "../interfaces/IAaveV4PriceFeed.sol";
-import { StablePriceLib } from "./StablePriceLib.sol";
+import { BaseAaveV4PriceFeed } from "./BaseAaveV4PriceFeed.sol";
 
 /// @notice The slice of the MorphoPythOracle adapters (deployed per pair on OP) the feed reads: the
 ///         fixed-decimals price, plus the Pyth contract and feed ids baked into the adapter, so the
@@ -48,10 +45,7 @@ interface IPyth {
  *      Fails closed: latestAnswer reverts on a stale Pyth publish time, or a zero/reverting price.
  * @author ether.fi
  */
-contract PythPriceFeed is IAaveV4PriceFeed {
-    using Math for uint256;
-    using SafeCast for uint256;
-
+contract PythPriceFeed is BaseAaveV4PriceFeed {
     /// @notice The MorphoPythOracle pair adapter supplying the price
     IPythPairOracle public immutable oracle;
     /// @notice The Pyth core contract, discovered from the adapter
@@ -65,41 +59,13 @@ contract PythPriceFeed is IAaveV4PriceFeed {
     uint256 public immutable maxStaleness;
     /// @notice The decimals of the oracle's price
     uint8 public immutable oracleDecimals;
-    /// @notice The decimals of the price this feed reports
-    uint8 public immutable feedDecimals;
-    /// @notice USD feed for the pair's underlying; address(0) when the pair is USD-quoted
-    IAaveV4PriceFeed public immutable underlyingUsdFeed;
-    /// @notice The decimals of the underlying feed (0 when unset)
-    uint8 public immutable underlyingDecimals;
-    /// @notice Whether the price snaps to exactly 1 USD when within 1% of it (USD stables only)
-    bool public immutable isStableToken;
 
-    string private _description;
-
-    /// @notice Thrown when the oracle or the underlying reports a zero or negative price
-    error InvalidPrice();
-    /// @notice Thrown when a Pyth feed's publish time is older than maxStaleness
-    error StalePrice();
     /// @notice Thrown when a USD-quoted oracle's decimals are lower than the feed decimals
     error UnsupportedDecimals();
-    /// @notice Thrown when the staleness bound is zero
-    error InvalidMaxStaleness();
 
-    constructor(
-        IPythPairOracle _oracle,
-        uint8 _oracleDecimals,
-        uint8 _feedDecimals,
-        IAaveV4PriceFeed _underlyingUsdFeed,
-        uint256 _maxStaleness,
-        bool _isStableToken,
-        string memory feedDescription
-    ) {
-        if (address(_underlyingUsdFeed) == address(0)) {
-            // USD-quoted pair: scaling is a plain division, so the oracle must be at least as precise
-            require(_oracleDecimals >= _feedDecimals, UnsupportedDecimals());
-        } else {
-            underlyingDecimals = _underlyingUsdFeed.decimals();
-        }
+    constructor(IPythPairOracle _oracle, uint8 _oracleDecimals, uint8 _feedDecimals, IAaveV4PriceFeed _underlyingUsdFeed, uint256 _maxStaleness, bool _isStableToken, string memory feedDescription) BaseAaveV4PriceFeed(_underlyingUsdFeed, _feedDecimals, _isStableToken, feedDescription) {
+        // USD-quoted pair: the oracle must be at least as precise as the reported feed decimals
+        if (address(_underlyingUsdFeed) == address(0)) require(_oracleDecimals >= _feedDecimals, UnsupportedDecimals());
         require(_maxStaleness > 0, InvalidMaxStaleness());
 
         oracle = _oracle;
@@ -110,20 +76,6 @@ contract PythPriceFeed is IAaveV4PriceFeed {
         feedId4 = _oracle.QUOTE_FEED_2();
         maxStaleness = _maxStaleness;
         oracleDecimals = _oracleDecimals;
-        feedDecimals = _feedDecimals;
-        underlyingUsdFeed = _underlyingUsdFeed;
-        isStableToken = _isStableToken;
-        _description = feedDescription;
-    }
-
-    /// @notice The number of decimals used to represent the price
-    function decimals() external view returns (uint8) {
-        return feedDecimals;
-    }
-
-    /// @notice A human-readable description of the feed
-    function description() external view returns (string memory) {
-        return _description;
     }
 
     /// @notice The latest USD price: the pair price, times the underlying USD price when configured
@@ -136,15 +88,7 @@ contract PythPriceFeed is IAaveV4PriceFeed {
         uint256 price = oracle.price();
         require(price > 0, InvalidPrice());
 
-        if (address(underlyingUsdFeed) == address(0)) {
-            return StablePriceLib.snap(price / 10 ** (oracleDecimals - feedDecimals), isStableToken, feedDecimals).toInt256();
-        }
-
-        int256 underlyingPrice = underlyingUsdFeed.latestAnswer();
-        require(underlyingPrice > 0, InvalidPrice());
-
-        // price = pair rate * underlying USD, normalized from (oracleDecimals + underlyingDecimals) to feedDecimals
-        return StablePriceLib.snap(price.mulDiv(uint256(underlyingPrice) * 10 ** feedDecimals, 10 ** (oracleDecimals + underlyingDecimals)), isStableToken, feedDecimals).toInt256();
+        return _composeUsd(price, oracleDecimals);
     }
 
     /// @dev Enforces the feed's own staleness bound against the Pyth publish time; zero ids are unused slots

--- a/src/oracle/VedaAccountantPriceFeed.sol
+++ b/src/oracle/VedaAccountantPriceFeed.sol
@@ -1,12 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
-import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
-
 import { IAaveV4PriceFeed } from "../interfaces/IAaveV4PriceFeed.sol";
 import { IVedaAccountant } from "../interfaces/IVedaAccountant.sol";
-import { StablePriceLib } from "./StablePriceLib.sol";
+import { BaseAaveV4PriceFeed } from "./BaseAaveV4PriceFeed.sol";
 
 /**
  * @title VedaAccountantPriceFeed
@@ -14,56 +11,19 @@ import { StablePriceLib } from "./StablePriceLib.sol";
  *      or stale accountant, a non-positive or reverting underlying, or a zero rate.
  * @author ether.fi
  */
-contract VedaAccountantPriceFeed is IAaveV4PriceFeed {
-    using Math for uint256;
-    using SafeCast for uint256;
-    using SafeCast for int256;
-
+contract VedaAccountantPriceFeed is BaseAaveV4PriceFeed {
     /// @notice The Veda accountant that provides the vault exchange rate
     IVedaAccountant public immutable accountant;
-    /// @notice The feed for the underlying asset's USD price; address(0) when the rate is USD-quoted
-    IAaveV4PriceFeed public immutable underlyingUsdFeed;
     /// @notice The decimals of the exchange rate from the accountant
     uint8 public immutable rateDecimals;
-    /// @notice The decimals of the underlying feed (0 when unset)
-    uint8 public immutable underlyingDecimals;
-    /// @notice The decimals of the price this feed reports
-    uint8 public immutable feedDecimals;
     /// @notice The maximum age in seconds for the Veda rate before it is rejected
     uint256 public immutable rateMaxStaleness;
-    /// @notice Whether the price snaps to exactly 1 USD when within 1% of it (USD stables only)
-    bool public immutable isStableToken;
-    string private _description;
 
-    /// @notice Thrown when either price source is older than its staleness limit
-    error StalePrice();
-    /// @notice Thrown when the rate or the underlying price is zero or negative
-    error InvalidPrice();
-    /// @notice Thrown when the staleness bound is zero
-    error InvalidMaxStaleness();
-
-    constructor(IVedaAccountant _accountant, IAaveV4PriceFeed _underlyingUsdFeed, uint8 _feedDecimals, uint256 _rateMaxStaleness, bool _isStableToken, string memory feedDescription) {
+    constructor(IVedaAccountant _accountant, IAaveV4PriceFeed _underlyingUsdFeed, uint8 _feedDecimals, uint256 _rateMaxStaleness, bool _isStableToken, string memory feedDescription) BaseAaveV4PriceFeed(_underlyingUsdFeed, _feedDecimals, _isStableToken, feedDescription) {
         require(_rateMaxStaleness > 0, InvalidMaxStaleness());
         accountant = _accountant;
-        underlyingUsdFeed = _underlyingUsdFeed;
         rateDecimals = _accountant.decimals();
-        if (address(_underlyingUsdFeed) != address(0)) {
-            underlyingDecimals = _underlyingUsdFeed.decimals();
-        }
-        feedDecimals = _feedDecimals;
         rateMaxStaleness = _rateMaxStaleness;
-        isStableToken = _isStableToken;
-        _description = feedDescription;
-    }
-
-    /// @notice The number of decimals used to represent the price
-    function decimals() external view returns (uint8) {
-        return feedDecimals;
-    }
-
-    /// @notice A human-readable description of the feed
-    function description() external view returns (string memory) {
-        return _description;
     }
 
     /**
@@ -79,16 +39,6 @@ contract VedaAccountantPriceFeed is IAaveV4PriceFeed {
         uint256 rate = accountant.getRateSafe();
         if (rate == 0) revert InvalidPrice();
 
-        if (address(underlyingUsdFeed) == address(0)) {
-            return StablePriceLib.snap(rate.mulDiv(10 ** feedDecimals, 10 ** rateDecimals), isStableToken, feedDecimals).toInt256();
-        }
-
-        int256 answer = underlyingUsdFeed.latestAnswer();
-        if (answer <= 0) revert InvalidPrice();
-
-        // price = rate * underlyingPrice, normalized from (rateDecimals + underlyingDecimals) to feedDecimals
-        uint256 price = rate.mulDiv(answer.toUint256() * 10 ** feedDecimals, 10 ** (rateDecimals + underlyingDecimals));
-
-        return StablePriceLib.snap(price, isStableToken, feedDecimals).toInt256();
+        return _composeUsd(rate, rateDecimals);
     }
 }

--- a/test/price-provider/ChainlinkPriceFeed.t.sol
+++ b/test/price-provider/ChainlinkPriceFeed.t.sol
@@ -6,6 +6,7 @@ import { Test } from "forge-std/Test.sol";
 
 import { IAaveV4PriceFeed } from "../../src/interfaces/IAaveV4PriceFeed.sol";
 import { IAggregatorV3 } from "../../src/interfaces/IAggregatorV3.sol";
+import { BaseAaveV4PriceFeed } from "../../src/oracle/BaseAaveV4PriceFeed.sol";
 import { ChainlinkPriceFeed } from "../../src/oracle/ChainlinkPriceFeed.sol";
 
 /// @notice Fork tests on Optimism, using the live weETH/ETH rate feed and ETH/USD feed.
@@ -53,27 +54,27 @@ contract ChainlinkPriceFeedTest is Test {
         (uint80 roundId, int256 rate, uint256 startedAt,, uint80 answeredInRound) = IAggregatorV3(rateFeed).latestRoundData();
         uint256 staleUpdatedAt = block.timestamp - RATE_MAX_STALENESS - 1;
         vm.mockCall(rateFeed, abi.encodeWithSelector(IAggregatorV3.latestRoundData.selector), abi.encode(roundId, rate, startedAt, staleUpdatedAt, answeredInRound));
-        vm.expectRevert(ChainlinkPriceFeed.StalePrice.selector);
+        vm.expectRevert(BaseAaveV4PriceFeed.StalePrice.selector);
         feed.latestAnswer();
     }
 
     /// @notice Reverts at construction when the staleness bound is zero.
     function test_constructor_revertsOnZeroStaleness() public {
-        vm.expectRevert(ChainlinkPriceFeed.InvalidMaxStaleness.selector);
+        vm.expectRevert(BaseAaveV4PriceFeed.InvalidMaxStaleness.selector);
         new ChainlinkPriceFeed(IAggregatorV3(rateFeed), IAaveV4PriceFeed(ethUsdOracle), FEED_DECIMALS, 0, false, "weETH / USD");
     }
 
     /// @notice Reverts when the rate feed price is zero or negative.
     function test_reverts_whenRateNotPositive() public {
         vm.mockCall(rateFeed, abi.encodeWithSelector(IAggregatorV3.latestRoundData.selector), abi.encode(uint80(1), int256(0), block.timestamp, block.timestamp, uint80(1)));
-        vm.expectRevert(ChainlinkPriceFeed.InvalidPrice.selector);
+        vm.expectRevert(BaseAaveV4PriceFeed.InvalidPrice.selector);
         feed.latestAnswer();
     }
 
     /// @notice Reverts when the underlying price is zero or negative.
     function test_reverts_whenUnderlyingNotPositive() public {
         vm.mockCall(ethUsdOracle, abi.encodeWithSelector(IAaveV4PriceFeed.latestAnswer.selector), abi.encode(int256(0)));
-        vm.expectRevert(ChainlinkPriceFeed.InvalidPrice.selector);
+        vm.expectRevert(BaseAaveV4PriceFeed.InvalidPrice.selector);
         feed.latestAnswer();
     }
 
@@ -107,7 +108,7 @@ contract ChainlinkPriceFeedTest is Test {
         (uint80 roundId, int256 answer, uint256 startedAt,, uint80 answeredInRound) = IAggregatorV3(ethUsdOracle).latestRoundData();
         uint256 staleUpdatedAt = block.timestamp - RATE_MAX_STALENESS - 1;
         vm.mockCall(ethUsdOracle, abi.encodeWithSelector(IAggregatorV3.latestRoundData.selector), abi.encode(roundId, answer, startedAt, staleUpdatedAt, answeredInRound));
-        vm.expectRevert(ChainlinkPriceFeed.StalePrice.selector);
+        vm.expectRevert(BaseAaveV4PriceFeed.StalePrice.selector);
         usdFeed.latestAnswer();
     }
 }

--- a/test/price-provider/PythPriceFeed.t.sol
+++ b/test/price-provider/PythPriceFeed.t.sol
@@ -5,6 +5,7 @@ import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import { Test } from "forge-std/Test.sol";
 
 import { IAaveV4PriceFeed } from "../../src/interfaces/IAaveV4PriceFeed.sol";
+import { BaseAaveV4PriceFeed } from "../../src/oracle/BaseAaveV4PriceFeed.sol";
 import { IPyth, IPythPairOracle, PythPriceFeed } from "../../src/oracle/PythPriceFeed.sol";
 
 contract MockPyth {
@@ -72,14 +73,14 @@ contract PythPriceFeedTest is Test {
 
     function test_latestAnswer_revertsOnZeroPrice() public {
         mockOracle.setPrice(0);
-        vm.expectRevert(PythPriceFeed.InvalidPrice.selector);
+        vm.expectRevert(BaseAaveV4PriceFeed.InvalidPrice.selector);
         feed.latestAnswer();
     }
 
     function test_latestAnswer_revertsOnStalePublishTime() public {
         mockOracle.setPrice(4.0918676e15);
         vm.warp(block.timestamp + MAX_STALENESS + 1);
-        vm.expectRevert(PythPriceFeed.StalePrice.selector);
+        vm.expectRevert(BaseAaveV4PriceFeed.StalePrice.selector);
         feed.latestAnswer();
     }
 
@@ -105,7 +106,7 @@ contract PythPriceFeedTest is Test {
     }
 
     function test_constructor_revertsOnZeroStaleness() public {
-        vm.expectRevert(PythPriceFeed.InvalidMaxStaleness.selector);
+        vm.expectRevert(BaseAaveV4PriceFeed.InvalidMaxStaleness.selector);
         new PythPriceFeed(mockOracle, ORACLE_DECIMALS, FEED_DECIMALS, IAaveV4PriceFeed(address(0)), 0, false, "BAD / USD");
     }
 
@@ -134,7 +135,7 @@ contract PythPriceFeedTest is Test {
     function test_underlying_revertsOnNonPositiveUnderlying() public {
         mockOracle.setPrice(0.05e16);
         mockUnderlying.set(0);
-        vm.expectRevert(PythPriceFeed.InvalidPrice.selector);
+        vm.expectRevert(BaseAaveV4PriceFeed.InvalidPrice.selector);
         compositeFeed.latestAnswer();
     }
 

--- a/test/price-provider/VedaAccountantPriceFeed.t.sol
+++ b/test/price-provider/VedaAccountantPriceFeed.t.sol
@@ -7,6 +7,7 @@ import { Test } from "forge-std/Test.sol";
 import { IAaveV4PriceFeed } from "../../src/interfaces/IAaveV4PriceFeed.sol";
 import { IAggregatorV3 } from "../../src/interfaces/IAggregatorV3.sol";
 import { IVedaAccountant } from "../../src/interfaces/IVedaAccountant.sol";
+import { BaseAaveV4PriceFeed } from "../../src/oracle/BaseAaveV4PriceFeed.sol";
 import { VedaAccountantPriceFeed } from "../../src/oracle/VedaAccountantPriceFeed.sol";
 
 /// @notice Fork tests on Optimism, using the live liquidETH accountant and ETH/USD feed.
@@ -61,13 +62,13 @@ contract VedaAccountantPriceFeedTest is Test {
 
         vm.mockCall(address(accountant), abi.encodeWithSelector(IVedaAccountant.accountantState.selector), abi.encode(state));
 
-        vm.expectRevert(VedaAccountantPriceFeed.StalePrice.selector);
+        vm.expectRevert(BaseAaveV4PriceFeed.StalePrice.selector);
         feed.latestAnswer();
     }
 
     /// @notice Reverts at construction when the staleness bound is zero.
     function test_constructor_revertsOnZeroStaleness() public {
-        vm.expectRevert(VedaAccountantPriceFeed.InvalidMaxStaleness.selector);
+        vm.expectRevert(BaseAaveV4PriceFeed.InvalidMaxStaleness.selector);
         new VedaAccountantPriceFeed(accountant, IAaveV4PriceFeed(ethUsdOracle), FEED_DECIMALS, 0, false, "liquidETH / USD");
     }
 
@@ -81,7 +82,7 @@ contract VedaAccountantPriceFeedTest is Test {
     /// @notice Reverts when the rate is zero.
     function test_reverts_whenRateZero() public {
         vm.mockCall(address(accountant), abi.encodeWithSelector(IVedaAccountant.getRateSafe.selector), abi.encode(uint256(0)));
-        vm.expectRevert(VedaAccountantPriceFeed.InvalidPrice.selector);
+        vm.expectRevert(BaseAaveV4PriceFeed.InvalidPrice.selector);
         feed.latestAnswer();
     }
 
@@ -105,7 +106,7 @@ contract VedaAccountantPriceFeedTest is Test {
     /// @notice Reverts when the underlying price is zero or negative.
     function test_reverts_whenUnderlyingNotPositive() public {
         vm.mockCall(ethUsdOracle, abi.encodeWithSelector(IAaveV4PriceFeed.latestAnswer.selector), abi.encode(int256(0)));
-        vm.expectRevert(VedaAccountantPriceFeed.InvalidPrice.selector);
+        vm.expectRevert(BaseAaveV4PriceFeed.InvalidPrice.selector);
         feed.latestAnswer();
     }
 }


### PR DESCRIPTION
Extracts the duplicated state and math shared by the three Aave v4 price feeds into an abstract `BaseAaveV4PriceFeed`, to shrink the feed code. Behavior-preserving.

Stacks on the price-feeds work (PR #199) — the feeds are byte-identical on `feat/lend-price-feeds` and `feat/lend`, so this lands cleanest alongside/after #199. Retarget onto #199's branch if preferred.

## What it does
- New `BaseAaveV4PriceFeed` owns the shared immutables (`underlyingUsdFeed`, `underlyingDecimals`, `feedDecimals`, `isStableToken`, `_description`), the `InvalidPrice`/`StalePrice`/`InvalidMaxStaleness` errors, `decimals()`, `description()`, and the two-mode `_composeUsd(rate, rateDecimals)`.
- `ChainlinkPriceFeed`, `VedaAccountantPriceFeed`, `PythPriceFeed` now supply only their own rate source + staleness and call `_composeUsd`. Net ~-65 src lines.

## The one thing to eyeball
Pyth's USD-quoted branch changed from `price / 10 ** (oracleDecimals - feedDecimals)` to `_composeUsd(price, oracleDecimals)`, i.e. `price.mulDiv(10 ** feedDecimals, 10 ** oracleDecimals)`. These are mathematically identical for `oracleDecimals >= feedDecimals`, which Pyth's constructor still enforces (`UnsupportedDecimals`). The underlying-leg formula is unchanged.

## Testing
`forge build` + `forge fmt`/`forge lint` clean. All 30 feed tests pass (`test/price-provider/{Chainlink,VedaAccountant,Pyth}PriceFeed.t.sol`), including the Pyth fork test and `test_latestAnswer_scalesToFeedDecimals` which exercises the division→mulDiv equivalence. 13 test error references were repointed at the base (the errors moved there); `PythPriceFeed.UnsupportedDecimals` stays on Pyth.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches collateral/oracle pricing paths for Aave v4; intended as behavior-preserving but any mistake in shared `_composeUsd` would affect all three feeds.
> 
> **Overview**
> Introduces abstract **`BaseAaveV4PriceFeed`** so **`ChainlinkPriceFeed`**, **`PythPriceFeed`**, and **`VedaAccountantPriceFeed`** no longer duplicate shared wiring and USD math. The base holds underlying-feed immutables, **`decimals()`** / **`description()`**, shared errors (`InvalidPrice`, `StalePrice`, `InvalidMaxStaleness`), and **`_composeUsd`** (USD-quoted scaling vs rate × underlying USD, plus stable snap via **`StablePriceLib`**). Each concrete feed only reads its own rate source, enforces its staleness rules, and delegates composition to the base.
> 
> For **Pyth**’s USD-quoted path, pricing now goes through **`_composeUsd(price, oracleDecimals)`** (`mulDiv` scaling) instead of explicit division; behavior stays the same where **`oracleDecimals >= feedDecimals`** (still enforced by **`UnsupportedDecimals`**). Tests were updated so most expected reverts target **`BaseAaveV4PriceFeed`** errors; **`PythPriceFeed.UnsupportedDecimals`** remains on Pyth.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b63be6ec1fefbcac82fe3d5ff8657fc43a28e5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->