### PR TITLE
fix: reject a zero-scaled feed price and staleness-check the composite USD leg

### DIFF
--- a/src/oracle/BaseAaveV4PriceFeed.sol
+++ b/src/oracle/BaseAaveV4PriceFeed.sol
@@ -22,7 +22,11 @@ abstract contract BaseAaveV4PriceFeed is IAaveV4PriceFeed {
     using SafeCast for uint256;
     using SafeCast for int256;
 
-    /// @notice The feed for the underlying asset's USD price; address(0) when the rate is USD-quoted
+    /**
+     * @notice The feed for the underlying asset's USD price; address(0) when the rate is USD-quoted
+     * @dev Must be a staleness-checking IAaveV4PriceFeed (another of our feeds), never a raw Chainlink
+     *      aggregator: _composeUsd trusts its latestAnswer for freshness and does not re-check its age.
+     */
     IAaveV4PriceFeed public immutable underlyingUsdFeed;
     /// @notice The decimals of the underlying feed (0 when unset)
     uint8 public immutable underlyingDecimals;
@@ -63,18 +67,22 @@ abstract contract BaseAaveV4PriceFeed is IAaveV4PriceFeed {
     /**
      * @dev Composes the reported price from a raw `rate` in `rateDecimals`: scaled straight to feed
      *      decimals when USD-quoted, else multiplied by the underlying USD price and normalized from
-     *      (rateDecimals + underlyingDecimals) to feedDecimals. Snaps to 1 USD for stables, and reverts
-     *      when the underlying leg is non-positive.
+     *      (rateDecimals + underlyingDecimals) to feedDecimals. Snaps to 1 USD for stables. Reverts when
+     *      the underlying leg is non-positive, or when the scaled price floors to zero (a tiny rate lost
+     *      to integer division), so the feed never reports a zero collateral price.
      */
     function _composeUsd(uint256 rate, uint8 rateDecimals) internal view returns (int256) {
+        uint256 price;
         if (address(underlyingUsdFeed) == address(0)) {
-            return StablePriceLib.snap(rate.mulDiv(10 ** feedDecimals, 10 ** rateDecimals), isStableToken, feedDecimals).toInt256();
+            price = rate.mulDiv(10 ** feedDecimals, 10 ** rateDecimals);
+        } else {
+            int256 underlyingAnswer = underlyingUsdFeed.latestAnswer();
+            if (underlyingAnswer <= 0) revert InvalidPrice();
+            price = rate.mulDiv(underlyingAnswer.toUint256() * 10 ** feedDecimals, 10 ** (rateDecimals + underlyingDecimals));
         }
 
-        int256 underlyingAnswer = underlyingUsdFeed.latestAnswer();
-        if (underlyingAnswer <= 0) revert InvalidPrice();
-
-        uint256 price = rate.mulDiv(underlyingAnswer.toUint256() * 10 ** feedDecimals, 10 ** (rateDecimals + underlyingDecimals));
-        return StablePriceLib.snap(price, isStableToken, feedDecimals).toInt256();
+        price = StablePriceLib.snap(price, isStableToken, feedDecimals);
+        if (price == 0) revert InvalidPrice();
+        return price.toInt256();
     }
 }

--- a/test/price-provider/ChainlinkPriceFeed.t.sol
+++ b/test/price-provider/ChainlinkPriceFeed.t.sol
@@ -21,11 +21,13 @@ contract ChainlinkPriceFeedTest is Test {
     uint256 constant RATE_MAX_STALENESS = 1 days;
 
     ChainlinkPriceFeed feed;
+    ChainlinkPriceFeed ethUsdFeed;
 
     function setUp() public {
         vm.createSelectFork(vm.envOr("OPTIMISM_RPC", string("https://mainnet.optimism.io")));
-        // A raw Chainlink aggregator satisfies IAaveV4PriceFeed; any deployed feed can be the USD leg
-        feed = new ChainlinkPriceFeed(IAggregatorV3(rateFeed), IAaveV4PriceFeed(ethUsdOracle), FEED_DECIMALS, RATE_MAX_STALENESS, false, "weETH / USD");
+        // The USD leg must be a staleness-checking feed, never a raw aggregator, so wrap ETH/USD in one.
+        ethUsdFeed = new ChainlinkPriceFeed(IAggregatorV3(ethUsdOracle), IAaveV4PriceFeed(address(0)), FEED_DECIMALS, RATE_MAX_STALENESS, false, "ETH / USD");
+        feed = new ChainlinkPriceFeed(IAggregatorV3(rateFeed), ethUsdFeed, FEED_DECIMALS, RATE_MAX_STALENESS, false, "weETH / USD");
     }
 
     /// @notice The reported price equals rate x underlying, and lands in a sane USD range.
@@ -73,8 +75,17 @@ contract ChainlinkPriceFeedTest is Test {
 
     /// @notice Reverts when the underlying price is zero or negative.
     function test_reverts_whenUnderlyingNotPositive() public {
-        vm.mockCall(ethUsdOracle, abi.encodeWithSelector(IAaveV4PriceFeed.latestAnswer.selector), abi.encode(int256(0)));
+        vm.mockCall(ethUsdOracle, abi.encodeWithSelector(IAggregatorV3.latestRoundData.selector), abi.encode(uint80(1), int256(0), block.timestamp, block.timestamp, uint80(1)));
         vm.expectRevert(BaseAaveV4PriceFeed.InvalidPrice.selector);
+        feed.latestAnswer();
+    }
+
+    /// @notice A stale underlying USD leg fails closed: the composite reverts even while the rate leg is fresh.
+    function test_reverts_whenUnderlyingStale() public {
+        (uint80 roundId, int256 answer, uint256 startedAt,, uint80 answeredInRound) = IAggregatorV3(ethUsdOracle).latestRoundData();
+        uint256 staleUpdatedAt = block.timestamp - RATE_MAX_STALENESS - 1;
+        vm.mockCall(ethUsdOracle, abi.encodeWithSelector(IAggregatorV3.latestRoundData.selector), abi.encode(roundId, answer, startedAt, staleUpdatedAt, answeredInRound));
+        vm.expectRevert(BaseAaveV4PriceFeed.StalePrice.selector);
         feed.latestAnswer();
     }
 

--- a/test/price-provider/PythPriceFeed.t.sol
+++ b/test/price-provider/PythPriceFeed.t.sol
@@ -77,6 +77,13 @@ contract PythPriceFeedTest is Test {
         feed.latestAnswer();
     }
 
+    /// @notice A positive price that floors to zero after scaling to feed decimals is rejected, not returned as 0.
+    function test_latestAnswer_revertsWhenScaledPriceFloorsToZero() public {
+        mockOracle.setPrice(1e7); // positive at 16 decimals, but < 10**(oracleDecimals-feedDecimals), so floors to 0
+        vm.expectRevert(BaseAaveV4PriceFeed.InvalidPrice.selector);
+        feed.latestAnswer();
+    }
+
     function test_latestAnswer_revertsOnStalePublishTime() public {
         mockOracle.setPrice(4.0918676e15);
         vm.warp(block.timestamp + MAX_STALENESS + 1);

--- a/test/price-provider/VedaAccountantPriceFeed.t.sol
+++ b/test/price-provider/VedaAccountantPriceFeed.t.sol
@@ -8,6 +8,7 @@ import { IAaveV4PriceFeed } from "../../src/interfaces/IAaveV4PriceFeed.sol";
 import { IAggregatorV3 } from "../../src/interfaces/IAggregatorV3.sol";
 import { IVedaAccountant } from "../../src/interfaces/IVedaAccountant.sol";
 import { BaseAaveV4PriceFeed } from "../../src/oracle/BaseAaveV4PriceFeed.sol";
+import { ChainlinkPriceFeed } from "../../src/oracle/ChainlinkPriceFeed.sol";
 import { VedaAccountantPriceFeed } from "../../src/oracle/VedaAccountantPriceFeed.sol";
 
 /// @notice Fork tests on Optimism, using the live liquidETH accountant and ETH/USD feed.
@@ -23,10 +24,13 @@ contract VedaAccountantPriceFeedTest is Test {
     uint256 constant RATE_MAX_STALENESS = 2 days;
 
     VedaAccountantPriceFeed feed;
+    ChainlinkPriceFeed ethUsdFeed;
 
     function setUp() public {
         vm.createSelectFork(vm.envOr("OPTIMISM_RPC", string("https://mainnet.optimism.io")));
-        feed = new VedaAccountantPriceFeed(accountant, IAaveV4PriceFeed(ethUsdOracle), FEED_DECIMALS, RATE_MAX_STALENESS, false, "liquidETH / USD");
+        // The USD leg must be a staleness-checking feed, never a raw aggregator, so wrap ETH/USD in one.
+        ethUsdFeed = new ChainlinkPriceFeed(IAggregatorV3(ethUsdOracle), IAaveV4PriceFeed(address(0)), FEED_DECIMALS, RATE_MAX_STALENESS, false, "ETH / USD");
+        feed = new VedaAccountantPriceFeed(accountant, ethUsdFeed, FEED_DECIMALS, RATE_MAX_STALENESS, false, "liquidETH / USD");
     }
 
     /// @notice The reported price equals rate x underlying, and lands in a sane USD range.
@@ -105,8 +109,17 @@ contract VedaAccountantPriceFeedTest is Test {
 
     /// @notice Reverts when the underlying price is zero or negative.
     function test_reverts_whenUnderlyingNotPositive() public {
-        vm.mockCall(ethUsdOracle, abi.encodeWithSelector(IAaveV4PriceFeed.latestAnswer.selector), abi.encode(int256(0)));
+        vm.mockCall(ethUsdOracle, abi.encodeWithSelector(IAggregatorV3.latestRoundData.selector), abi.encode(uint80(1), int256(0), block.timestamp, block.timestamp, uint80(1)));
         vm.expectRevert(BaseAaveV4PriceFeed.InvalidPrice.selector);
+        feed.latestAnswer();
+    }
+
+    /// @notice A stale underlying USD leg fails closed: the composite reverts even while the rate is fresh.
+    function test_reverts_whenUnderlyingStale() public {
+        (uint80 roundId, int256 answer, uint256 startedAt,, uint80 answeredInRound) = IAggregatorV3(ethUsdOracle).latestRoundData();
+        uint256 staleUpdatedAt = block.timestamp - RATE_MAX_STALENESS - 1;
+        vm.mockCall(ethUsdOracle, abi.encodeWithSelector(IAggregatorV3.latestRoundData.selector), abi.encode(roundId, answer, startedAt, staleUpdatedAt, answeredInRound));
+        vm.expectRevert(BaseAaveV4PriceFeed.StalePrice.selector);
         feed.latestAnswer();
     }
 }


### PR DESCRIPTION
Addresses two Bugbot findings on the Aave v4 price feeds (raised on #199). Both are behavior-preserving hardening; also pushed to `feat/lend-price-feeds` so #199/master stays in sync.

## Context
Neither issue was introduced by the recent `BaseAaveV4PriceFeed` extraction — both existed verbatim in the original feeds. The extraction just centralized the logic into `_composeUsd`, which is now the single place to fix them. The production listing script (`AddSummerLendCollateral`) already wires the safe pattern; the unsafe wiring only lived in the fork tests.

## Fixes
- **Stale USD leg (High):** the composite only staleness-checked the rate leg; the USD leg's freshness was trusted. `_composeUsd` can't check the underlying's age (the `IAaveV4PriceFeed` interface has no timestamp), so the invariant is now documented in NatSpec — the underlying **must** be a staleness-checking feed, never a raw aggregator. The fork tests were rewired to wrap ETH/USD in a `ChainlinkPriceFeed` (the pattern prod already uses), and a new `test_reverts_whenUnderlyingStale` proves a stale underlying makes the composite revert `StalePrice`.
- **Zero scaled price (Medium):** a positive rate could floor to zero after decimal scaling and be returned as a valid `0`. `_composeUsd` now reverts `InvalidPrice` on a zero result (matching `PriceProviderV2`). New `test_latestAnswer_revertsWhenScaledPriceFloorsToZero` covers it.

## Testing
`forge build` clean, `forge fmt`/`forge lint` clean. All 33 feed tests pass (`test/price-provider/{Chainlink,VedaAccountant,Pyth}PriceFeed.t.sol`), including the 3 new ones.

## Follow-up (not in this PR)
`scripts/aave-v4/DeployAaveV4TestInstance.s.sol` (a dev test-instance deployer, not prod) still wires a raw ETH/USD aggregator as the underlying. Worth aligning to the wrapped pattern for consistency, but it's dev-only and doesn't affect deployed feeds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes oracle collateral pricing invariants (no zero prices, composite staleness via wiring); behavior-preserving hardening but affects lending risk if misconfigured underlying feeds remain in production.
> 
> **Overview**
> Hardens **Aave v4 composite price feeds** in `BaseAaveV4PriceFeed._composeUsd` so collateral prices cannot be reported as **0** after decimal scaling, and documents how the **USD leg** must be wired for freshness.
> 
> **`_composeUsd`** now uses a single path through stable snapping, then **reverts `InvalidPrice` if the result is zero** (e.g. a positive rate that floors away in integer division). NatSpec also states that **`underlyingUsdFeed` must be a staleness-checking `IAaveV4PriceFeed`**, not a raw Chainlink aggregator, because the base trusts `latestAnswer()` and does not re-check timestamps on that leg.
> 
> Fork tests for **Chainlink** and **VedaAccountant** composites were updated to wrap ETH/USD in a **`ChainlinkPriceFeed`** (matching production wiring), with new **`test_reverts_whenUnderlyingStale`** cases. **Pyth** adds **`test_latestAnswer_revertsWhenScaledPriceFloorsToZero`** for the zero-after-scaling case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 454f0c023469998b3feee60d5b88f18007dbc448. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->