### PR TITLE
feat: deployed updated oracles

### DIFF
--- a/deployments/dev/10/aave-v4-test.json
+++ b/deployments/dev/10/aave-v4-test.json
@@ -12,79 +12,79 @@
   "details": {
     "weETH": {
       "assetId": 0,
-      "oracle": "0xf66Eff556E36bBb5544a03997d00022C752E507e"
+      "oracle": "0xa0DbCeA7167FfdBA9D6724f670c9A8D759769b7E"
     },
     "USDC": {
       "assetId": 1,
-      "oracle": "0x4E3f45040b9740F2eF3088F94f89c7023551c5A7"
+      "oracle": "0x78814D8AFa1185aef0E870b743a2C8f6FF31D4de"
     },
     "ETHFI": {
       "assetId": 2,
-      "oracle": "0x70e6Fc02DAFB89524d5Dde1ef9FC62D0649C1813"
+      "oracle": "0x91BbD308dC1ac62078F3627473e78BA8BDe8eEd1"
     },
     "WHYPE": {
       "assetId": 3,
-      "oracle": "0x5687ff73Ac71962a79fe9c38720Eea7Ed84aF897"
+      "oracle": "0x8483AAA831033A1e2A79E74E2947495A33E6E754"
     },
     "beHYPE": {
       "assetId": 4,
-      "oracle": "0xeFE1D06b73cc1B78aB0f4e30Fba02A2F7c017Ee3"
+      "oracle": "0xE4AB9a072925994431bd07670847B33AC4ab11fB"
     },
     "EURC": {
       "assetId": 5,
-      "oracle": "0xB82D272a17Bd79368dEc85B0CDe30B1D94f487Bc"
+      "oracle": "0x5F0917Fd1A759e592e5108847D02F16F6bFCD0C5"
     },
     "sETHFI": {
       "assetId": 6,
-      "oracle": "0xe1fC91a292CE0add33b0EF3De877A7904E41e7Ad"
+      "oracle": "0xd1e16B2404482BaaD6C37859563edA954d3eAA1A"
     },
     "liquidETH": {
       "assetId": 7,
-      "oracle": "0xa5db43c48F6c3f09D8Ff8d3939770722f1576ddc"
+      "oracle": "0x46cb6d93304743a3244255879677Da66FCe3E6BF"
     },
     "liquidBTC": {
       "assetId": 8,
-      "oracle": "0xB57ab7E2Be000Be79d18e4Bc570D9F5E46206A52"
+      "oracle": "0xd2b05D6a178C089E98b707256A43B81b7Fa4d6Ed"
     },
     "liquidUSD": {
       "assetId": 9,
-      "oracle": "0x6dC246370EFF05A47ac9D5B9CB4b0C316336F510"
+      "oracle": "0x116065e62Cc54490bad17801C22f0ED8a04Fe690"
     },
     "eBTC": {
       "assetId": 10,
-      "oracle": "0x894ed889eFC501fe59775F964686Dc8364c1Eb8C"
+      "oracle": "0x5E841D4F2e87edc09244A38bF6135A91a6d12574"
     },
     "eUSD": {
       "assetId": 11,
-      "oracle": "0xD4A430A71C549Abe7ecE93Bdd6aB1ACf517272b2"
+      "oracle": "0xC199c659937Bf7C99DA78818eE714710Df805726"
     },
     "liquidRESERVE": {
       "assetId": 19,
-      "oracle": "0x2bc92Ad3A748ae3980e0a739c56C9022F9737e2d"
+      "oracle": "0x8516181424c96c71c6aE5e7E2e5f0BE577B83Ea1"
     },
     "weEUR": {
       "assetId": 13,
-      "oracle": "0x884f2254ce1D7Af96B393cF1CA7c378827E45Cdd"
+      "oracle": "0x49500E2ec16C40d78F39a5400D2cfe8979e756b8"
     },
     "liquidRWA": {
       "assetId": 14,
-      "oracle": "0xC5d61d4DA336f115b8C8c8E1C4C3e24686003EED"
+      "oracle": "0x09Ad2D7Ddb75F3F9FC4e5fb35fEecdbd1E427557"
     },
     "USDT": {
       "assetId": 15,
-      "oracle": "0x683f70fC596884A10c48C48F02d7e6F16CA91D56"
+      "oracle": "0x71E80BCc003D10768f7136b834adc2713c13e7a0"
     },
     "WETH": {
       "assetId": 16,
-      "oracle": "0x569fF3929Dcea762B599e966E31821F4bcADbcf9"
+      "oracle": "0x07e6F3817f157c5387EcCd731947F87e89fE5192"
     },
     "OP": {
       "assetId": 17,
-      "oracle": "0xD75b780f007e8d67DE88d901B6E4556537b2d36D"
+      "oracle": "0x86c04b605066A9Ab065376501018c4C28208c6B0"
     },
     "frxUSD": {
       "assetId": 18,
-      "oracle": "0x79bACd5F0697eb3799b64C5c148d8b0375EF4A12"
+      "oracle": "0x5438c334ECB6a665144055d7659f5D3c85F83822"
     }
   }
 }

--- a/scripts/aave-v4/RefreshSummerLendOracles.s.sol
+++ b/scripts/aave-v4/RefreshSummerLendOracles.s.sol
@@ -25,7 +25,7 @@ import { AddSummerLendCollateral } from "./AddSummerLendCollateral.s.sol";
  * Usage (simulate by dropping --broadcast; the broadcast wallet must hold SPOKE_ADMIN_ROLE):
  *   source .env && ENV=dev FOUNDRY_PROFILE=aave-deploy forge script \
  *     scripts/aave-v4/RefreshSummerLendOracles.s.sol:RefreshSummerLendOracles \
- *     --rpc-url $OPTIMISM_RPC --broadcast -vvvv
+ *     --rpc-url $OPTIMISM_RPC --broadcast --verify --etherscan-api-key $ETHERSCAN_KEY -vvvv
  */
 contract RefreshSummerLendOracles is AddSummerLendCollateral {
     function run() public override {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Replacing reserve price sources affects liquidations, LTV, and all collateral valuation on the test instance; incorrect feeds would be protocol-critical even in dev.
> 
> **Overview**
> Records the **outcome of a Summer Lend oracle refresh** on the dev Optimism (chain 10) Aave v4 test deployment: every entry under `details.<symbol>.oracle` in `deployments/dev/10/aave-v4-test.json` is updated to the newly deployed feed addresses (weETH, USDC, ETHFI, WHYPE, beHYPE, EURC, sETHFI, liquid tokens, eBTC/eUSD, weEUR, liquidRWA, USDT, WETH, OP, frxUSD, liquidRESERVE).
> 
> The **`RefreshSummerLendOracles`** script usage comment now documents running with **`--verify`** and **`--etherscan-api-key $ETHERSCAN_KEY`** alongside `--broadcast`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d340c919c074c30234383a18d63ca0fa80bf408. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->