### PR TITLE
fix: skip zero-amount loose transfers in CashLendLib

### DIFF
--- a/src/modules/cash/CashLendLib.sol
+++ b/src/modules/cash/CashLendLib.sol
@@ -968,17 +968,26 @@ library CashLendLib {
         s.fromLoose[i] = fromLoose;
     }
 
-    /// @dev Transfers each token's loose amount from the safe to the dispatcher in one batched module call.
+    /// @dev Transfers each non-zero loose amount from the safe to the dispatcher in one batched module call.
     function _transferLoose(address safe, address dispatcher, address[] calldata tokens, uint256[] memory amounts) internal {
-        address[] memory to = new address[](tokens.length);
-        bytes[] memory data = new bytes[](tokens.length);
-        uint256[] memory values = new uint256[](tokens.length);
+        uint256 len = tokens.length;
+        address[] memory to = new address[](len);
+        bytes[] memory data = new bytes[](len);
+        uint256 counter;
 
-        for (uint256 i = 0; i < tokens.length; i++) {
-            to[i] = tokens[i];
-            data[i] = abi.encodeWithSelector(IERC20.transfer.selector, dispatcher, amounts[i]);
+        for (uint256 i = 0; i < len; i++) {
+            if (amounts[i] == 0) continue;
+            to[counter] = tokens[i];
+            data[counter] = abi.encodeWithSelector(IERC20.transfer.selector, dispatcher, amounts[i]);
+            counter++;
         }
-        IEtherFiSafe(safe).execTransactionFromModule(to, values, data);
+
+        if (counter == 0) return;
+        assembly ("memory-safe") {
+            mstore(to, counter)
+            mstore(data, counter)
+        }
+        IEtherFiSafe(safe).execTransactionFromModule(to, new uint256[](counter), data);
     }
 
     /// @dev The amount of `token` reserved by the safe's pending withdrawal request, or 0 if none holds it.

--- a/test/safe/modules/cash/Spend.t.sol
+++ b/test/safe/modules/cash/Spend.t.sol
@@ -45,6 +45,91 @@ contract CashModuleSpendTest is CashModuleTestSetup {
         assertEq(usdc.balanceOf(address(settlementDispatcherReap)), settlementDispatcherBalBefore + amount);
     }
 
+    /// A gateway-only debit spend must not issue a zero-value loose transfer.
+    function test_spend_debit_gatewaySkipsTransferWhenLooseBalanceIsZero() public {
+        uint256 amount = 100e6;
+        gateway.setSuppliedOf(address(safe), address(usdc), amount);
+        gateway.setWithdrawalLiquidity(address(usdc), amount);
+        deal(address(usdc), address(safe), 0);
+
+        vm.expectCall(address(usdc), abi.encodeCall(IERC20.transfer, (address(settlementDispatcherReap), 0)), 0);
+        vm.prank(etherFiWallet);
+        address[] memory spendTokens = new address[](1);
+        spendTokens[0] = address(usdc);
+        uint256[] memory spendAmounts = new uint256[](1);
+        spendAmounts[0] = amount;
+        Cashback[] memory cashbacks;
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
+
+        (address withdrawnSafe, address withdrawnAsset, uint256 withdrawnAmount, address withdrawnTo) = gateway.lastWithdraw();
+        assertEq(withdrawnSafe, address(safe));
+        assertEq(withdrawnAsset, address(usdc));
+        assertEq(withdrawnAmount, amount);
+        assertEq(withdrawnTo, address(settlementDispatcherReap));
+    }
+
+    /// Fully reserved loose balance must not produce a zero-value transfer.
+    function test_spend_debit_gatewaySkipsTransferWhenLooseBalanceIsFullyReserved() public {
+        uint256 reserved = 100e6;
+        uint256 amount = 50e6;
+        deal(address(usdc), address(safe), reserved);
+        _requestWithdrawal(_singleAddress(address(usdc)), _singleUint(reserved), withdrawRecipient);
+        gateway.setSuppliedOf(address(safe), address(usdc), amount);
+        gateway.setWithdrawalLiquidity(address(usdc), amount);
+
+        vm.expectCall(address(usdc), abi.encodeCall(IERC20.transfer, (address(settlementDispatcherReap), 0)), 0);
+        vm.prank(etherFiWallet);
+        Cashback[] memory cashbacks;
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, _singleAddress(address(usdc)), _singleUint(amount), cashbacks);
+
+        assertEq(usdc.balanceOf(address(safe)), reserved);
+        assertEq(cashModule.getPendingWithdrawalAmount(address(safe), address(usdc)), reserved);
+        (,, uint256 withdrawnAmount,) = gateway.lastWithdraw();
+        assertEq(withdrawnAmount, amount);
+    }
+
+    /// A mixed-token spend must compact zero loose legs without misaligning the batch.
+    function test_spend_debit_gatewayCompactsMixedLooseTransfers() public {
+        uint256 amountInUsd = 100e6;
+        uint256 weETHAmount = debtManager.convertUsdToCollateralToken(address(weETH), amountInUsd);
+        gateway.setSpendAsset(address(weETH), true);
+        gateway.setSuppliedOf(address(safe), address(usdc), amountInUsd);
+        gateway.setWithdrawalLiquidity(address(usdc), amountInUsd);
+        deal(address(usdc), address(safe), 0);
+        deal(address(weETH), address(safe), weETHAmount);
+
+        address[] memory spendTokens = new address[](2);
+        spendTokens[0] = address(usdc);
+        spendTokens[1] = address(weETH);
+        uint256[] memory spendAmounts = new uint256[](2);
+        spendAmounts[0] = amountInUsd;
+        spendAmounts[1] = amountInUsd;
+        Cashback[] memory cashbacks;
+
+        uint256 dispatcherWeETHBefore = weETH.balanceOf(address(settlementDispatcherReap));
+        vm.expectCall(address(usdc), abi.encodeCall(IERC20.transfer, (address(settlementDispatcherReap), 0)), 0);
+        vm.expectCall(address(weETH), abi.encodeCall(IERC20.transfer, (address(settlementDispatcherReap), weETHAmount)), 1);
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, spendTokens, spendAmounts, cashbacks);
+
+        assertEq(weETH.balanceOf(address(settlementDispatcherReap)), dispatcherWeETHBefore + weETHAmount);
+        (address withdrawnSafe, address withdrawnAsset, uint256 withdrawnAmount, address withdrawnTo) = gateway.lastWithdraw();
+        assertEq(withdrawnSafe, address(safe));
+        assertEq(withdrawnAsset, address(usdc));
+        assertEq(withdrawnAmount, amountInUsd);
+        assertEq(withdrawnTo, address(settlementDispatcherReap));
+    }
+
+    function _singleAddress(address value) private pure returns (address[] memory values) {
+        values = new address[](1);
+        values[0] = value;
+    }
+
+    function _singleUint(uint256 value) private pure returns (uint256[] memory values) {
+        values = new uint256[](1);
+        values[0] = value;
+    }
+
     function test_spend_worksWithMultipleToken_inDebitMode() public {
         vm.prank(owner);
         debtManager.supportBorrowToken(address(weETH), borrowApyPerSecond, minShares);


### PR DESCRIPTION
## Summary
- `_transferLoose` now skips any token whose loose amount is zero instead of issuing a zero-value `transfer` call, compacting the batched `to`/`data` arrays in place with inline assembly.

## Test plan
- Added `test_spend_debit_gatewaySkipsTransferWhenLooseBalanceIsZero`, `test_spend_debit_gatewaySkipsTransferWhenLooseBalanceIsFullyReserved`, and `test_spend_debit_gatewayCompactsMixedLooseTransfers` to `Spend.t.sol`, each asserting via `vm.expectCall(..., 0)` that no zero-value transfer is made.
- `FOUNDRY_PROFILE=lend TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test --match-path test/safe/modules/cash/Spend.t.sol` — 27 passed, 0 failed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow execution-path fix for batched transfers on debit spend; behavior change is skipping no-op transfers, with targeted Foundry coverage.
> 
> **Overview**
> Gateway **debit spends** that fund a token entirely from Aave (no loose balance, or loose fully reserved for withdrawal) no longer enqueue a **zero-value `IERC20.transfer`** in the batched safe module call.
> 
> **`_transferLoose`** now omits legs with `amounts[i] == 0`, compacts `to`/`data` in place (same pattern as `postLiquidateTransfers`), shrinks array lengths via inline assembly, and **returns without** `execTransactionFromModule` when every loose leg is zero. Multi-token spends still align non-zero transfers with the correct tokens (e.g. USDC supplied-only + weETH from loose).
> 
> **Tests** in `Spend.t.sol` assert `vm.expectCall(..., 0)` for zero transfers and verify gateway withdraw / balances for supplied-only and mixed legs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e559e28229450e44989fe4bd9b7e1bb11c814031. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->