### PR TITLE
fix: skip zero-amount transfers when processing withdrawals

### DIFF
--- a/src/modules/cash/CashModuleStorageContract.sol
+++ b/src/modules/cash/CashModuleStorageContract.sol
@@ -285,17 +285,30 @@ contract CashModuleStorageContract is UpgradeableProxy, ModuleBase {
 
         address[] memory to = new address[](len);
         bytes[] memory data = new bytes[](len);
+        uint256 counter;
 
         for (uint256 i = 0; i < len;) {
-            to[i] = $$.pendingWithdrawalRequest.tokens[i];
-            data[i] = abi.encodeWithSelector(IERC20.transfer.selector, recipient, $$.pendingWithdrawalRequest.amounts[i]);
+            uint256 amount = $$.pendingWithdrawalRequest.amounts[i];
+            if (amount != 0) {
+                to[counter] = $$.pendingWithdrawalRequest.tokens[i];
+                data[counter] = abi.encodeWithSelector(IERC20.transfer.selector, recipient, amount);
+                unchecked {
+                    ++counter;
+                }
+            }
 
             unchecked {
                 ++i;
             }
         }
 
-        IEtherFiSafe(safe).execTransactionFromModule(to, new uint256[](len), data);
+        if (counter != 0) {
+            assembly ("memory-safe") {
+                mstore(to, counter)
+                mstore(data, counter)
+            }
+            IEtherFiSafe(safe).execTransactionFromModule(to, new uint256[](counter), data);
+        }
         _getCashModuleStorage().cashEventEmitter.emitWithdrawalProcessed(safe, $$.pendingWithdrawalRequest.tokens, $$.pendingWithdrawalRequest.amounts, recipient);
 
         delete $$.pendingWithdrawalRequest;

--- a/test/safe/modules/cash/Withdrawals.t.sol
+++ b/test/safe/modules/cash/Withdrawals.t.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
+import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
+
 import { Mode, BinSponsor, Cashback } from "../../../../src/interfaces/ICashModule.sol";
 import { ArrayDeDupLib } from "../../../../src/libraries/ArrayDeDupLib.sol";
 import { ModuleBase } from "../../../../src/modules/ModuleBase.sol";
@@ -180,6 +182,46 @@ contract CashModuleWithdrawalTest is CashModuleTestSetup {
 
         // Verify pending withdrawal is 0
         assertEq(cashModule.getPendingWithdrawalAmount(address(safe), address(usdc)), 0);
+    }
+
+    /// A zero-amount withdrawal must not issue a zero-value ERC-20 transfer.
+    function test_processWithdrawals_skipsZeroAmount() external {
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+
+        _requestWithdrawal(tokens, amounts, withdrawRecipient);
+
+        (uint64 withdrawalDelay,,) = cashModule.getDelays();
+        vm.warp(block.timestamp + withdrawalDelay);
+
+        vm.expectCall(address(usdc), abi.encodeCall(IERC20.transfer, (withdrawRecipient, 0)), 0);
+        cashModule.processWithdrawal(address(safe));
+
+        assertEq(cashModule.getData(address(safe)).pendingWithdrawalRequest.tokens.length, 0);
+    }
+
+    /// A mixed withdrawal must compact zero amounts without misaligning the remaining transfers.
+    function test_processWithdrawals_compactsMixedZeroAmounts() external {
+        uint256 weETHAmount = 1 ether;
+        deal(address(weETH), address(safe), weETHAmount);
+
+        address[] memory tokens = new address[](2);
+        tokens[0] = address(usdc);
+        tokens[1] = address(weETH);
+        uint256[] memory amounts = new uint256[](2);
+        amounts[1] = weETHAmount;
+
+        _requestWithdrawal(tokens, amounts, withdrawRecipient);
+
+        (uint64 withdrawalDelay,,) = cashModule.getDelays();
+        vm.warp(block.timestamp + withdrawalDelay);
+
+        vm.expectCall(address(usdc), abi.encodeCall(IERC20.transfer, (withdrawRecipient, 0)), 0);
+        vm.expectCall(address(weETH), abi.encodeCall(IERC20.transfer, (withdrawRecipient, weETHAmount)), 1);
+        cashModule.processWithdrawal(address(safe));
+
+        assertEq(weETH.balanceOf(withdrawRecipient), weETHAmount);
     }
 
     function test_processWithdrawals_fails_whenAssetIsNotWhitelistedWithdrawAsset() external {


### PR DESCRIPTION
## Summary
- `_processWithdrawal` (in `CashModuleStorageContract`) now skips any pending withdrawal leg with a zero amount instead of issuing a zero-value `transfer` call, compacting the batched `to`/`data` arrays in place with inline assembly.

## Test plan
- Added `test_processWithdrawals_skipsZeroAmount` and `test_processWithdrawals_compactsMixedZeroAmounts` to `Withdrawals.t.sol`, each asserting via `vm.expectCall(..., 0)` that no zero-value transfer is made.
- `FOUNDRY_PROFILE=lend TEST_CHAIN=10 TEST_RPC="$OPTIMISM_RPC" forge test --match-path test/safe/modules/cash/Withdrawals.t.sol` — 40 passed, 0 failed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to withdrawal execution batching; skips no-op transfers and avoids module calls when every leg is zero, with targeted tests.
> 
> **Overview**
> **`_processWithdrawal`** no longer batches `IERC20.transfer` calls for pending legs with **zero amount**. Non-zero legs are written into compacted `to`/`data` arrays (length adjusted via inline assembly), and **`execTransactionFromModule`** runs only when at least one leg has a positive amount.
> 
> Withdrawal tests were added to assert **no zero-value USDC transfer** for an all-zero request, and that a **mixed** request still transfers only the non-zero token without misaligned batch calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ebbbb83d5489313f2fad5bd38ae73a26913006c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->