### PR TITLE
fix: reset Across SpokePool allowance

### DIFF
--- a/src/across/AcrossSwapModule.sol
+++ b/src/across/AcrossSwapModule.sol
@@ -364,14 +364,16 @@ contract AcrossSwapModule is ModuleBase, UpgradeableProxy {
         bytes memory depositData = _encodeDepositV3(safe, $.multicallHandler, order, depositArgs, message);
         address spokePool = $.spokePool;
 
-        address[] memory to = new address[](2);
-        uint256[] memory values = new uint256[](2);
-        bytes[] memory data = new bytes[](2);
+        address[] memory to = new address[](3);
+        uint256[] memory values = new uint256[](3);
+        bytes[] memory data = new bytes[](3);
 
         to[0] = order.srcToken;
         data[0] = abi.encodeCall(IERC20.approve, (spokePool, order.srcAmount));
         to[1] = spokePool;
         data[1] = depositData;
+        to[2] = order.srcToken;
+        data[2] = abi.encodeCall(IERC20.approve, (spokePool, 0));
 
         IEtherFiSafe(safe).execTransactionFromModule(to, values, data);
     }

--- a/test/across/AcrossSwapModule.t.sol
+++ b/test/across/AcrossSwapModule.t.sol
@@ -188,7 +188,7 @@ contract AcrossSwapModuleTest is SafeTestSetup {
 
     // ---- executeSwap ----
 
-    function test_executeSwap_dispatchesApproveAndDepositV3() public {
+    function test_executeSwap_dispatchesApproveDepositAndReset() public {
         AcrossSwapModule.Order memory order = _baseOrder();
         _request(order);
         _warpPastDelay();
@@ -198,7 +198,7 @@ contract AcrossSwapModuleTest is SafeTestSetup {
         assertEq(spokePool.callCount(), 1);
         assertEq(module.getOrder(address(safe)).srcToken, address(0));
         assertEq(cashModule.getData(address(safe)).pendingWithdrawalRequest.recipient, address(0));
-        assertEq(usdc.allowance(address(safe), address(spokePool)), SRC_AMOUNT);
+        assertEq(usdc.allowance(address(safe), address(spokePool)), 0);
         _checkDepositV3Args(order);
     }
 


### PR DESCRIPTION
Fixes Certora I-08 by resetting the SpokePool allowance after `depositV3`.
