### PR TITLE
fix: clarify destination removal error

### DIFF
--- a/src/interfaces/IOwnershipBridgeSender.sol
+++ b/src/interfaces/IOwnershipBridgeSender.sol
@@ -120,9 +120,6 @@ interface IOwnershipBridgeSender {
     /// @notice Reverts when the safe address isn't recognised by `EtherFiDataProvider`.
     error NotEtherFiSafe();
 
-    /// @notice Reverts when `configureDestination(eid, _, false)` is called for a destination that isn't present.
-    error DestinationAlreadyInState();
-
     /**
      * @notice Reverts when an enabled destination has no LayerZero peer configured.
      * @param destEid The destination EID that is missing a peer.
@@ -213,7 +210,7 @@ interface IOwnershipBridgeSender {
      * @param destEid LayerZero EID of the destination chain.
      * @param options Per-destination LZ options (executor gas, msg type, etc.). Ignored when removing.
      * @param enabled True to add or update; false to remove.
-     * @custom:throws DestinationAlreadyInState If removing a destination that isn't present.
+     * @custom:throws DestinationNotConfigured If removing a destination that isn't present.
      */
     function configureDestination(uint32 destEid, bytes calldata options, bool enabled) external;
 

--- a/src/ownership-bridge/OwnershipBridgeSender.sol
+++ b/src/ownership-bridge/OwnershipBridgeSender.sol
@@ -230,7 +230,7 @@ contract OwnershipBridgeSender is IOwnershipBridgeSender, OAppSender, Pausable {
      * @param destEid LayerZero EID of the destination chain.
      * @param options Per-destination LZ options (executor gas, msg type, etc.). Ignored when removing.
      * @param enabled True to add or update; false to remove.
-     * @custom:throws DestinationAlreadyInState If removing a destination that isn't present.
+     * @custom:throws DestinationNotConfigured If removing a destination that isn't present.
      */
     function configureDestination(uint32 destEid, bytes calldata options, bool enabled) external onlyOwner {
         OwnershipBridgeSenderStorage storage $ = _getOwnershipBridgeSenderStorage();
@@ -240,7 +240,7 @@ contract OwnershipBridgeSender is IOwnershipBridgeSender, OAppSender, Pausable {
             $.destinations.add(uint256(destEid));
             emit DestinationConfigured(destEid, options, true);
         } else {
-            if (!$.destinations.remove(uint256(destEid))) revert DestinationAlreadyInState();
+            if (!$.destinations.remove(uint256(destEid))) revert DestinationNotConfigured(destEid);
             delete $.destOptions[destEid];
             emit DestinationRemoved(destEid);
         }

--- a/test/ownership-bridge/OwnershipBridgeSender.t.sol
+++ b/test/ownership-bridge/OwnershipBridgeSender.t.sol
@@ -341,6 +341,14 @@ contract OwnershipBridgeSenderTest is Test {
         sender.configureDestination(MAINNET_EID, "", false);
     }
 
+    function test_configureDestination_revertsWhenRemovingUnconfiguredDestination() public {
+        uint32 unconfiguredEid = 42_424;
+
+        vm.expectRevert(abi.encodeWithSelector(IOwnershipBridgeSender.DestinationNotConfigured.selector, unconfiguredEid));
+        vm.prank(delegate);
+        sender.configureDestination(unconfiguredEid, "", false);
+    }
+
     // ---- Enable / disabled-safe short-circuit ----
 
     function test_enable_revertsWhen_callerLacksRole() public {


### PR DESCRIPTION
Fixes Certora I-04 by using `DestinationNotConfigured(destEid)` when removing an unconfigured destination.
