### PR TITLE
refactor: extract Enso cancel digest

### DIFF
--- a/src/enso/EnsoSwapModule.sol
+++ b/src/enso/EnsoSwapModule.sol
@@ -306,9 +306,8 @@ contract EnsoSwapModule is ModuleBase, UpgradeableProxy, IBridgeModule {
         EnsoSwapModuleStorage storage $ = _getEnsoSwapModuleStorage();
         if ($.swaps[safe].order.srcToken == address(0)) revert NoActiveOrder();
 
-        bytes32 digest = keccak256(
-            abi.encodePacked(CANCEL_SWAP_SIG, block.chainid, address(this), IEtherFiSafe(safe).useNonce(), safe)
-        ).toEthSignedMessageHash();
+        uint256 nonce = IEtherFiSafe(safe).useNonce();
+        bytes32 digest = _cancelDigest(safe, nonce);
         if (!IEtherFiSafe(safe).checkSignatures(digest, signers, signatures)) revert InvalidSignatures();
 
         bytes32 swapId = $.swaps[safe].swapId;
@@ -391,6 +390,13 @@ contract EnsoSwapModule is ModuleBase, UpgradeableProxy, IBridgeModule {
                 abi.encode(order),
                 keccak256(swapData)
             )
+        ).toEthSignedMessageHash();
+    }
+
+    /// @dev Digest the safe owners sign to cancel the active swap, bound to the safe nonce.
+    function _cancelDigest(address safe, uint256 nonce) internal view returns (bytes32) {
+        return keccak256(
+            abi.encodePacked(CANCEL_SWAP_SIG, block.chainid, address(this), nonce, safe)
         ).toEthSignedMessageHash();
     }
 


### PR DESCRIPTION
Addresses Certora I-01 by extracting the Enso cancellation digest into a helper.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor with identical digest logic; no auth or fund-flow behavior changes.
> 
> **Overview**
> **Refactors** `cancelSwap` so the owner-signed cancellation message hash is built in a dedicated internal helper `_cancelDigest`, matching how `_requestDigest` handles request signing.
> 
> `cancelSwap` now reads the safe nonce, calls `_cancelDigest(safe, nonce)`, and verifies signatures against that digest. The packed hash (`CANCEL_SWAP_SIG`, chain id, module address, nonce, safe) and EIP-191 wrapping are unchanged—this is structure-only for Certora I-01.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22468a32181e274397b3bf3a22d402e61e710d0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->