### PR TITLE
fix: require swap deadlines to outlast withdrawal delay

### DIFF
--- a/src/across/AcrossSwapModule.sol
+++ b/src/across/AcrossSwapModule.sol
@@ -142,6 +142,8 @@ contract AcrossSwapModule is ModuleBase, UpgradeableProxy {
     error MissingConfig();
     /// @notice Reverts when `executeSwap` runs before the CashModule withdrawal hold matures.
     error WithdrawalDelayNotElapsed();
+    /// @notice Reverts when the order expires before the CashModule withdrawal delay elapses.
+    error DeadlineBeforeWithdrawalDelay();
     /// @notice Reverts when an origin-swap request is made before the periphery is configured.
     error PeripheryNotAllowlisted();
 
@@ -276,6 +278,10 @@ contract AcrossSwapModule is ModuleBase, UpgradeableProxy {
         }
         if ($.swaps[safe].order.srcToken != address(0)) revert OrderAlreadyActive();
         if ($.spokePool == address(0) || $.multicallHandler == address(0)) revert MissingConfig();
+        if (address(cashModule) != address(0)) {
+            (uint64 withdrawalDelay,,) = cashModule.getDelays();
+            if (order.deadline <= block.timestamp + withdrawalDelay) revert DeadlineBeforeWithdrawalDelay();
+        }
     }
 
     /// @dev Stores the verified swap and either places the CashModule hold (OP) or executes

--- a/src/enso/EnsoSwapModule.sol
+++ b/src/enso/EnsoSwapModule.sol
@@ -129,6 +129,8 @@ contract EnsoSwapModule is ModuleBase, UpgradeableProxy, IBridgeModule {
     error MissingConfig();
     /// @notice Reverts when `executeSwap` runs before the CashModule withdrawal hold matures.
     error WithdrawalDelayNotElapsed();
+    /// @notice Reverts when the order expires before the CashModule withdrawal delay elapses.
+    error DeadlineBeforeWithdrawalDelay();
     /// @notice Reverts when the BE-supplied Enso calldata is empty.
     error EmptySwapData();
 
@@ -212,6 +214,10 @@ contract EnsoSwapModule is ModuleBase, UpgradeableProxy, IBridgeModule {
         ) revert InvalidInput();
         if ($.swaps[safe].order.srcToken != address(0)) revert OrderAlreadyActive();
         if ($.ensoRouter == address(0)) revert MissingConfig();
+        if (address(cashModule) != address(0)) {
+            (uint64 withdrawalDelay,,) = cashModule.getDelays();
+            if (order.deadline <= block.timestamp + withdrawalDelay) revert DeadlineBeforeWithdrawalDelay();
+        }
     }
 
     /// @dev Stores the verified swap and either places the CashModule hold (OP) or executes

--- a/test/across/AcrossSwapModule.t.sol
+++ b/test/across/AcrossSwapModule.t.sol
@@ -159,6 +159,16 @@ contract AcrossSwapModuleTest is SafeTestSetup {
         module.requestSwap(address(safe), order, _baseDepositArgs(MIN_OUT), FAKE_MESSAGE, "", signers, sigs);
     }
 
+    function test_requestSwap_revertsWhenDeadlineDoesNotOutlastWithdrawalDelay() public {
+        AcrossSwapModule.Order memory order = _baseOrder();
+        (uint64 withdrawalDelay,,) = cashModule.getDelays();
+        order.deadline = block.timestamp + withdrawalDelay;
+        (address[] memory signers, bytes[] memory sigs) = _signRequest(order);
+
+        vm.expectRevert(AcrossSwapModule.DeadlineBeforeWithdrawalDelay.selector);
+        module.requestSwap(address(safe), order, _baseDepositArgs(MIN_OUT), FAKE_MESSAGE, "", signers, sigs);
+    }
+
     function test_requestSwap_revertsWhenOutputBelowMinOut() public {
         // The deposit-args validation moved to request time: the stored relayer commitment
         // must clear the user's signed minOut.

--- a/test/enso/EnsoSwapModule.t.sol
+++ b/test/enso/EnsoSwapModule.t.sol
@@ -142,6 +142,17 @@ contract EnsoSwapModuleTest is SafeTestSetup {
         module.requestSwap(address(safe), order, swapData, signers, sigs);
     }
 
+    function test_requestSwap_revertsWhenDeadlineDoesNotOutlastWithdrawalDelay() public {
+        EnsoSwapModule.Order memory order = _baseOrder();
+        (uint64 withdrawalDelay,,) = cashModule.getDelays();
+        order.deadline = block.timestamp + withdrawalDelay;
+        bytes memory swapData = _swapData(SRC_AMOUNT);
+        (address[] memory signers, bytes[] memory sigs) = _signRequest(order, swapData);
+
+        vm.expectRevert(EnsoSwapModule.DeadlineBeforeWithdrawalDelay.selector);
+        module.requestSwap(address(safe), order, swapData, signers, sigs);
+    }
+
     function test_requestSwap_revertsForBadSignature() public {
         EnsoSwapModule.Order memory order = _baseOrder();
         EnsoSwapModule.Order memory tampered = _baseOrder();


### PR DESCRIPTION
## Summary
- reject Enso and Across swap requests whose deadlines do not outlast the configured CashModule withdrawal delay
- add a dedicated `DeadlineBeforeWithdrawalDelay` error
- add regression coverage for both swap modules
