### PR TITLE
fix: enforce same-chain Enso swap output

### DIFF
--- a/src/enso/EnsoSwapModule.sol
+++ b/src/enso/EnsoSwapModule.sol
@@ -45,9 +45,10 @@ contract EnsoSwapModule is ModuleBase, UpgradeableProxy, IBridgeModule {
     using MessageHashUtils for bytes32;
 
     /// @notice User-signed swap intent. One per safe at a time.
-    /// @dev `dstChainId`, `dstToken` and `minOut` are carried for the signed intent and
-    ///      events only; they are not enforced on-chain (the Enso calldata owns slippage and
-    ///      routing). For a same-chain swap `dstChainId == block.chainid`.
+    /// @dev For a same-chain swap (`dstChainId == block.chainid`), `dstToken`, `recipient`
+    ///      and `minOut` are enforced with a recipient balance-delta check. For cross-chain
+    ///      swaps they are carried for the signed intent and events only because settlement
+    ///      is non-atomic.
     struct Order {
         address srcToken;
         uint256 srcAmount;
@@ -86,6 +87,7 @@ contract EnsoSwapModule is ModuleBase, UpgradeableProxy, IBridgeModule {
     /// @dev Domain-separator-style prefixes for the digest the user signs.
     bytes32 private constant REQUEST_SWAP_SIG = keccak256("EnsoSwapModule.requestSwap");
     bytes32 private constant CANCEL_SWAP_SIG = keccak256("EnsoSwapModule.cancelSwap");
+    address private constant NATIVE_TOKEN = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
 
     /// @notice CashModule on the same chain. Zero where there is no card spending.
     ICashModule public immutable cashModule;
@@ -131,6 +133,8 @@ contract EnsoSwapModule is ModuleBase, UpgradeableProxy, IBridgeModule {
     error WithdrawalDelayNotElapsed();
     /// @notice Reverts when the BE-supplied Enso calldata is empty.
     error EmptySwapData();
+    /// @notice Reverts when a same-chain swap delivers less than the signed minimum output.
+    error InsufficientOutputAmount();
 
     /// @dev Immutables (`etherFiDataProvider`, `cashModule`) live in the IMPLEMENTATION's
     ///      code — every upgrade impl must be constructed with the same data provider.
@@ -210,6 +214,9 @@ contract EnsoSwapModule is ModuleBase, UpgradeableProxy, IBridgeModule {
             order.srcToken == address(0) || order.srcAmount == 0 ||
             order.recipient == address(0) || order.deadline <= block.timestamp
         ) revert InvalidInput();
+        if (order.dstChainId == block.chainid && (order.dstToken == address(0) || order.minOut == 0)) {
+            revert InvalidInput();
+        }
         if ($.swaps[safe].order.srcToken != address(0)) revert OrderAlreadyActive();
         if ($.ensoRouter == address(0)) revert MissingConfig();
     }
@@ -280,6 +287,11 @@ contract EnsoSwapModule is ModuleBase, UpgradeableProxy, IBridgeModule {
     ///      bridges to the recipient encoded in the calldata.
     function _dispatchSwap(address safe, StoredSwap memory swap) internal {
         address ensoRouter = _getEnsoSwapModuleStorage().ensoRouter;
+        bool validateOutput = swap.order.dstChainId == block.chainid;
+        uint256 balanceBefore;
+        if (validateOutput) {
+            balanceBefore = _balanceOf(swap.order.dstToken, swap.order.recipient);
+        }
 
         address[] memory to = new address[](3);
         uint256[] memory values = new uint256[](3);
@@ -293,6 +305,19 @@ contract EnsoSwapModule is ModuleBase, UpgradeableProxy, IBridgeModule {
         data[2] = abi.encodeCall(IERC20.approve, (ensoRouter, 0));
 
         IEtherFiSafe(safe).execTransactionFromModule(to, values, data);
+
+        if (validateOutput) {
+            uint256 balanceAfter = _balanceOf(swap.order.dstToken, swap.order.recipient);
+            if (
+                balanceAfter < balanceBefore ||
+                balanceAfter - balanceBefore < swap.order.minOut
+            ) revert InsufficientOutputAmount();
+        }
+    }
+
+    function _balanceOf(address token, address account) internal view returns (uint256) {
+        if (token == NATIVE_TOKEN) return account.balance;
+        return IERC20(token).balanceOf(account);
     }
 
     /**

--- a/test/enso/EnsoSwapModule.t.sol
+++ b/test/enso/EnsoSwapModule.t.sol
@@ -6,6 +6,7 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { Vm } from "forge-std/Vm.sol";
 
 import { EnsoSwapModule } from "../../src/enso/EnsoSwapModule.sol";
+import { MockERC20 } from "../../src/mocks/MockERC20.sol";
 import { ModuleBase } from "../../src/modules/ModuleBase.sol";
 import { UpgradeableProxy } from "../../src/utils/UpgradeableProxy.sol";
 import { UUPSProxy } from "../../src/UUPSProxy.sol";
@@ -25,6 +26,36 @@ contract EnsoRouterStub {
         pulled = amount;
         callCount++;
     }
+
+    function swapTo(
+        address srcToken,
+        uint256 srcAmount,
+        address dstToken,
+        address recipient,
+        uint256 dstAmount
+    ) external {
+        lastCaller = msg.sender;
+        IERC20(srcToken).transferFrom(msg.sender, address(this), srcAmount);
+        IERC20(dstToken).transfer(recipient, dstAmount);
+        pulled = srcAmount;
+        callCount++;
+    }
+
+    function swapToNative(
+        address srcToken,
+        uint256 srcAmount,
+        address payable recipient,
+        uint256 dstAmount
+    ) external {
+        lastCaller = msg.sender;
+        IERC20(srcToken).transferFrom(msg.sender, address(this), srcAmount);
+        (bool success,) = recipient.call{ value: dstAmount }("");
+        require(success, "native transfer failed");
+        pulled = srcAmount;
+        callCount++;
+    }
+
+    receive() external payable {}
 }
 
 contract EnsoSwapModuleTest is SafeTestSetup {
@@ -39,6 +70,7 @@ contract EnsoSwapModuleTest is SafeTestSetup {
     uint256 internal constant DST_CHAIN = 1;
     uint256 internal constant SRC_AMOUNT = 1_000e6;
     uint256 internal constant MIN_OUT = 990_000_000_000_000;
+    address internal constant NATIVE_TOKEN = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
 
     function setUp() public override {
         super.setUp();
@@ -178,6 +210,93 @@ contract EnsoSwapModuleTest is SafeTestSetup {
         assertEq(cashModule.getData(address(safe)).pendingWithdrawalRequest.recipient, address(0));
         // Approval is reset to zero after forwarding the swap.
         assertEq(usdc.allowance(address(safe), address(ensoRouter)), 0);
+    }
+
+    function test_executeSwap_sameChainEnforcesRecipientTokenAndMinOut() public {
+        MockERC20 dstToken = new MockERC20("Output", "OUT", 18);
+        uint256 outputAmount = MIN_OUT + 1;
+        dstToken.mint(address(ensoRouter), outputAmount);
+
+        EnsoSwapModule.Order memory order = _baseOrder();
+        order.dstChainId = block.chainid;
+        order.dstToken = address(dstToken);
+        bytes memory swapData = abi.encodeCall(
+            EnsoRouterStub.swapTo,
+            (address(usdc), SRC_AMOUNT, address(dstToken), recipient, outputAmount)
+        );
+        (address[] memory signers, bytes[] memory sigs) = _signRequest(order, swapData);
+        module.requestSwap(address(safe), order, swapData, signers, sigs);
+        _warpPastDelay();
+
+        _executeAsKeeper();
+
+        assertEq(dstToken.balanceOf(recipient), outputAmount);
+    }
+
+    function test_executeSwap_sameChainRevertsWhenOutputBelowMinOut() public {
+        MockERC20 dstToken = new MockERC20("Output", "OUT", 18);
+        uint256 outputAmount = MIN_OUT - 1;
+        dstToken.mint(address(ensoRouter), outputAmount);
+
+        EnsoSwapModule.Order memory order = _baseOrder();
+        order.dstChainId = block.chainid;
+        order.dstToken = address(dstToken);
+        bytes memory swapData = abi.encodeCall(
+            EnsoRouterStub.swapTo,
+            (address(usdc), SRC_AMOUNT, address(dstToken), recipient, outputAmount)
+        );
+        (address[] memory signers, bytes[] memory sigs) = _signRequest(order, swapData);
+        module.requestSwap(address(safe), order, swapData, signers, sigs);
+        _warpPastDelay();
+
+        vm.prank(keeper);
+        vm.expectRevert(EnsoSwapModule.InsufficientOutputAmount.selector);
+        module.executeSwap(address(safe));
+
+        assertEq(module.getOrder(address(safe)).srcToken, address(usdc), "order should remain active");
+        assertEq(dstToken.balanceOf(recipient), 0, "router execution should roll back");
+    }
+
+    function test_executeSwap_sameChainRevertsWhenRouterPaysDifferentRecipient() public {
+        MockERC20 dstToken = new MockERC20("Output", "OUT", 18);
+        address wrongRecipient = makeAddr("wrongRecipient");
+        dstToken.mint(address(ensoRouter), MIN_OUT);
+
+        EnsoSwapModule.Order memory order = _baseOrder();
+        order.dstChainId = block.chainid;
+        order.dstToken = address(dstToken);
+        bytes memory swapData = abi.encodeCall(
+            EnsoRouterStub.swapTo,
+            (address(usdc), SRC_AMOUNT, address(dstToken), wrongRecipient, MIN_OUT)
+        );
+        (address[] memory signers, bytes[] memory sigs) = _signRequest(order, swapData);
+        module.requestSwap(address(safe), order, swapData, signers, sigs);
+        _warpPastDelay();
+
+        vm.prank(keeper);
+        vm.expectRevert(EnsoSwapModule.InsufficientOutputAmount.selector);
+        module.executeSwap(address(safe));
+
+        assertEq(dstToken.balanceOf(wrongRecipient), 0, "wrong-recipient transfer should roll back");
+    }
+
+    function test_executeSwap_sameChainEnforcesNativeOutput() public {
+        deal(address(ensoRouter), MIN_OUT);
+
+        EnsoSwapModule.Order memory order = _baseOrder();
+        order.dstChainId = block.chainid;
+        order.dstToken = NATIVE_TOKEN;
+        bytes memory swapData = abi.encodeCall(
+            EnsoRouterStub.swapToNative,
+            (address(usdc), SRC_AMOUNT, payable(recipient), MIN_OUT)
+        );
+        (address[] memory signers, bytes[] memory sigs) = _signRequest(order, swapData);
+        module.requestSwap(address(safe), order, swapData, signers, sigs);
+        _warpPastDelay();
+
+        _executeAsKeeper();
+
+        assertEq(recipient.balance, MIN_OUT);
     }
 
     function test_executeSwap_permissionless_anyCallerCanExecute() public {


### PR DESCRIPTION
## Summary
- enforce the signed `dstToken`, `recipient`, and `minOut` for same-chain Enso swaps using a recipient balance-delta check
- support both ERC-20 and native-token output validation
- reject same-chain requests with a zero destination token or zero minimum output
- keep cross-chain Enso settlement unchanged because destination delivery is non-atomic

## Across scope
Across was reviewed for the same finding but does not expose a same-chain route. Its direct deposit path already binds `dstToken`, `dstChainId`, and an `outputAmount >= minOut` into `depositV3`; its origin-swap path settles cross-chain, so a source-chain recipient balance check is not applicable. No Across contract changes are included
