### PR TITLE
fix: reject swaps with zero withdrawal delay

### DIFF
--- a/src/across/AcrossSwapModule.sol
+++ b/src/across/AcrossSwapModule.sol
@@ -142,6 +142,8 @@ contract AcrossSwapModule is ModuleBase, UpgradeableProxy {
     error MissingConfig();
     /// @notice Reverts when `executeSwap` runs before the CashModule withdrawal hold matures.
     error WithdrawalDelayNotElapsed();
+    /// @notice Reverts when CashModule would process the withdrawal immediately.
+    error ZeroWithdrawalDelay();
     /// @notice Reverts when an origin-swap request is made before the periphery is configured.
     error PeripheryNotAllowlisted();
 
@@ -276,6 +278,10 @@ contract AcrossSwapModule is ModuleBase, UpgradeableProxy {
         }
         if ($.swaps[safe].order.srcToken != address(0)) revert OrderAlreadyActive();
         if ($.spokePool == address(0) || $.multicallHandler == address(0)) revert MissingConfig();
+        if (address(cashModule) != address(0)) {
+            (uint64 withdrawalDelay,,) = cashModule.getDelays();
+            if (withdrawalDelay == 0) revert ZeroWithdrawalDelay();
+        }
     }
 
     /// @dev Stores the verified swap and either places the CashModule hold (OP) or executes

--- a/src/enso/EnsoSwapModule.sol
+++ b/src/enso/EnsoSwapModule.sol
@@ -129,6 +129,8 @@ contract EnsoSwapModule is ModuleBase, UpgradeableProxy, IBridgeModule {
     error MissingConfig();
     /// @notice Reverts when `executeSwap` runs before the CashModule withdrawal hold matures.
     error WithdrawalDelayNotElapsed();
+    /// @notice Reverts when CashModule would process the withdrawal immediately.
+    error ZeroWithdrawalDelay();
     /// @notice Reverts when the BE-supplied Enso calldata is empty.
     error EmptySwapData();
 
@@ -212,6 +214,10 @@ contract EnsoSwapModule is ModuleBase, UpgradeableProxy, IBridgeModule {
         ) revert InvalidInput();
         if ($.swaps[safe].order.srcToken != address(0)) revert OrderAlreadyActive();
         if ($.ensoRouter == address(0)) revert MissingConfig();
+        if (address(cashModule) != address(0)) {
+            (uint64 withdrawalDelay,,) = cashModule.getDelays();
+            if (withdrawalDelay == 0) revert ZeroWithdrawalDelay();
+        }
     }
 
     /// @dev Stores the verified swap and either places the CashModule hold (OP) or executes

--- a/test/across/AcrossSwapModule.t.sol
+++ b/test/across/AcrossSwapModule.t.sol
@@ -159,6 +159,20 @@ contract AcrossSwapModuleTest is SafeTestSetup {
         module.requestSwap(address(safe), order, _baseDepositArgs(MIN_OUT), FAKE_MESSAGE, "", signers, sigs);
     }
 
+    function test_requestSwap_revertsWhenWithdrawalDelayIsZero() public {
+        vm.prank(owner);
+        cashModule.setDelays(0, 0, 0);
+
+        AcrossSwapModule.Order memory order = _baseOrder();
+        (address[] memory signers, bytes[] memory sigs) = _signRequest(order);
+
+        vm.expectRevert(AcrossSwapModule.ZeroWithdrawalDelay.selector);
+        module.requestSwap(address(safe), order, _baseDepositArgs(MIN_OUT), FAKE_MESSAGE, "", signers, sigs);
+
+        assertEq(module.getOrder(address(safe)).srcToken, address(0));
+        assertEq(usdc.balanceOf(address(module)), 0);
+    }
+
     function test_requestSwap_revertsWhenOutputBelowMinOut() public {
         // The deposit-args validation moved to request time: the stored relayer commitment
         // must clear the user's signed minOut.

--- a/test/enso/EnsoSwapModule.t.sol
+++ b/test/enso/EnsoSwapModule.t.sol
@@ -142,6 +142,21 @@ contract EnsoSwapModuleTest is SafeTestSetup {
         module.requestSwap(address(safe), order, swapData, signers, sigs);
     }
 
+    function test_requestSwap_revertsWhenWithdrawalDelayIsZero() public {
+        vm.prank(owner);
+        cashModule.setDelays(0, 0, 0);
+
+        EnsoSwapModule.Order memory order = _baseOrder();
+        bytes memory swapData = _swapData(SRC_AMOUNT);
+        (address[] memory signers, bytes[] memory sigs) = _signRequest(order, swapData);
+
+        vm.expectRevert(EnsoSwapModule.ZeroWithdrawalDelay.selector);
+        module.requestSwap(address(safe), order, swapData, signers, sigs);
+
+        assertEq(module.getOrder(address(safe)).srcToken, address(0));
+        assertEq(usdc.balanceOf(address(module)), 0);
+    }
+
     function test_requestSwap_revertsForBadSignature() public {
         EnsoSwapModule.Order memory order = _baseOrder();
         EnsoSwapModule.Order memory tampered = _baseOrder();


### PR DESCRIPTION
## Summary
- reject Enso and Across swap requests when CashModule withdrawal delay is zero
- prevent CashModule from immediately moving tokens into the swap module before an executable order exists
- add regression tests confirming no order or module balance is left behind

## Security impact
With a zero delay, `requestWithdrawalByModule` processes synchronously and clears the pending request, leaving later execute and cancellation paths unable to recover. Rejecting before storing or requesting the withdrawal prevents both the permanent active-order DoS and stranded module funds.

## Testing
- `forge test --match-path test/enso/EnsoSwapModule.t.sol` (29 passed)
- `forge test --match-path test/across/AcrossSwapModule.t.sol` (35 passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Targets fund-handling and swap lifecycle safety on OP-style deploys with CashModule; change is a narrow guard with tests and no change to mainnet paths where cashModule is zero.
> 
> **Overview**
> **Enso** and **Across** swap modules now **reject `requestSwap`** when a **CashModule** is configured but **`withdrawalDelay` is 0**, via new **`ZeroWithdrawalDelay`** in shared request validation (before storing the order or calling **`requestWithdrawalByModule`**).
> 
> This blocks a misconfiguration where CashModule would **finalize the withdrawal immediately**, breaking the intended hold-then-**`executeSwap`** flow and risking **stuck active orders** or **tokens left on the module** with no clean execute/cancel path.
> 
> Regression tests assert **`requestSwap`** reverts with no stored order and no module token balance when delays are set to zero.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f8e97b19b2bb934a8d02d2f2a05126881801c57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->