### PR TITLE
fix: reject stale ownership bridge messages

### DIFF
--- a/src/interfaces/IOwnershipBridgeReceiver.sol
+++ b/src/interfaces/IOwnershipBridgeReceiver.sol
@@ -86,8 +86,22 @@ interface IOwnershipBridgeReceiver {
         uint8 kind
     );
 
+    /**
+     * @notice Emitted when an ownership message is older than one already applied.
+     */
+    event StaleOwnershipMessageSkipped(
+        address indexed sourceSafe,
+        address indexed tradingSafe,
+        bytes32 indexed guid,
+        uint8 kind,
+        uint256 sourceNonce,
+        uint256 lastAppliedSourceNonce
+    );
+
     /// @notice Reverts when the LZ packet's source EID doesn't match the configured `SOURCE_EID`.
     error WrongSrcEid();
+    /// @notice Reverts when the ownership envelope uses an unsupported encoding version.
+    error UnsupportedEnvelopeVersion(uint8 version);
 
     /**
      * @notice Reverts when the envelope's `OpKind` discriminator is outside the known set.

--- a/src/interfaces/IOwnershipBridgeSender.sol
+++ b/src/interfaces/IOwnershipBridgeSender.sol
@@ -152,6 +152,7 @@ interface IOwnershipBridgeSender {
      * @param owners Owners to add or remove.
      * @param shouldAdd Per-owner add (true) / remove (false) flag.
      * @param threshold New signature threshold after the change is applied locally.
+     * @param sourceNonce Nonce consumed by the source safe for this operation.
      * @custom:throws CallerNotSafe If `msg.sender != safe`.
      * @custom:throws NotEtherFiSafe If `safe` isn't registered.
      * @custom:throws ArrayLengthMismatch If `owners.length != shouldAdd.length`.
@@ -163,7 +164,8 @@ interface IOwnershipBridgeSender {
         address safe,
         address[] calldata owners,
         bool[] calldata shouldAdd,
-        uint8 threshold
+        uint8 threshold,
+        uint256 sourceNonce
     ) external payable;
 
     /**
@@ -171,13 +173,14 @@ interface IOwnershipBridgeSender {
      * @dev Per-destination EIDs and resulting LZ GUIDs are surfaced via `SetThresholdPublished`.
      * @param safe Source-chain safe.
      * @param threshold New signature threshold.
+     * @param sourceNonce Nonce consumed by the source safe for this operation.
      * @custom:throws CallerNotSafe If `msg.sender != safe`.
      * @custom:throws NotEtherFiSafe If `safe` isn't registered.
      * @custom:throws DestinationNotConfigured If an enabled destEid was later removed from the global config.
      * @custom:throws PeerNotConfigured If an enabled destination has no LZ peer set.
      * @custom:throws InsufficientFee If `msg.value` is below the total LZ fee.
      */
-    function publishSetThreshold(address safe, uint8 threshold) external payable;
+    function publishSetThreshold(address safe, uint8 threshold, uint256 sourceNonce) external payable;
 
     /**
      * @notice Publishes a `recover` operation (timelocked owner replacement) to every destination.
@@ -187,25 +190,32 @@ interface IOwnershipBridgeSender {
      * @param safe Source-chain safe.
      * @param newOwner Incoming owner that will take effect after the destination's timelock.
      * @param incomingOwnerEffectiveAt Source-chain UNIX timestamp at which `newOwner` activates on destinations.
+     * @param sourceNonce Nonce consumed by the source safe for this operation.
      * @custom:throws CallerNotSafe If `msg.sender != safe`.
      * @custom:throws NotEtherFiSafe If `safe` isn't registered.
      * @custom:throws DestinationNotConfigured If an enabled destEid was later removed from the global config.
      * @custom:throws PeerNotConfigured If an enabled destination has no LZ peer set.
      * @custom:throws InsufficientFee If `msg.value` is below the total LZ fee.
      */
-    function publishRecover(address safe, address newOwner, uint256 incomingOwnerEffectiveAt) external payable;
+    function publishRecover(
+        address safe,
+        address newOwner,
+        uint256 incomingOwnerEffectiveAt,
+        uint256 sourceNonce
+    ) external payable;
 
     /**
      * @notice Publishes a `cancelRecovery` operation to every destination.
      * @dev Per-destination EIDs and resulting LZ GUIDs are surfaced via `CancelRecoveryPublished`.
      * @param safe Source-chain safe.
+     * @param sourceNonce Nonce consumed by the source safe for this operation.
      * @custom:throws CallerNotSafe If `msg.sender != safe`.
      * @custom:throws NotEtherFiSafe If `safe` isn't registered.
      * @custom:throws DestinationNotConfigured If an enabled destEid was later removed from the global config.
      * @custom:throws PeerNotConfigured If an enabled destination has no LZ peer set.
      * @custom:throws InsufficientFee If `msg.value` is below the total LZ fee.
      */
-    function publishCancelRecovery(address safe) external payable;
+    function publishCancelRecovery(address safe, uint256 sourceNonce) external payable;
 
     /**
      * @notice Adds, updates, or removes a destination chain.

--- a/src/libraries/OwnershipBridgeMessageLib.sol
+++ b/src/libraries/OwnershipBridgeMessageLib.sol
@@ -6,11 +6,13 @@ pragma solidity 0.8.28;
  * @author ether.fi
  * @notice Encode / decode for the cross-chain ownership-bridge envelope and per-kind payloads.
  * @dev Each safe owner-mutating operation on the source chain is published as one envelope.
- *      The envelope carries an `OpKind` discriminator + source safe address + ABI-encoded
- *      per-kind payload. The receiver decodes by kind and dispatches to the matching
- *      `applyBridge*` function on the destination TradingSafe.
+ *      The envelope carries a version, `OpKind`, source safe address, source operation nonce,
+ *      and ABI-encoded per-kind payload. The receiver uses the nonce for freshness, then
+ *      decodes by kind and dispatches to the matching destination `applyBridge*` function.
  */
 library OwnershipBridgeMessageLib {
+    uint8 internal constant ENVELOPE_VERSION = 1;
+
     /**
      * @notice Identifies which owner-mutating operation an envelope carries.
      * @dev The receiver decodes `opData` against the matching kind-specific struct below.
@@ -24,13 +26,17 @@ library OwnershipBridgeMessageLib {
 
     /**
      * @notice Top-level envelope sent over LayerZero.
+     * @param version Encoding version for forward-compatible decoding.
      * @param kind Discriminator for the operation type.
      * @param safe Source-chain safe address whose state is changing.
+     * @param sourceNonce Nonce consumed by the source safe for this authorized operation.
      * @param opData ABI-encoded kind-specific payload (see per-kind structs).
      */
     struct Envelope {
+        uint8 version;
         OpKind kind;
         address safe;
+        uint256 sourceNonce;
         bytes opData;
     }
 
@@ -74,7 +80,7 @@ library OwnershipBridgeMessageLib {
      * @return The encoded bytes ready to be passed as the LZ message payload.
      */
     function encodeEnvelope(Envelope memory e) internal pure returns (bytes memory) {
-        return abi.encode(uint8(e.kind), e.safe, e.opData);
+        return abi.encode(e.version, uint8(e.kind), e.safe, e.sourceNonce, e.opData);
     }
 
     /**
@@ -84,7 +90,8 @@ library OwnershipBridgeMessageLib {
      */
     function decodeEnvelope(bytes calldata data) internal pure returns (Envelope memory e) {
         uint8 k;
-        (k, e.safe, e.opData) = abi.decode(data, (uint8, address, bytes));
+        (e.version, k, e.safe, e.sourceNonce, e.opData) =
+            abi.decode(data, (uint8, uint8, address, uint256, bytes));
         e.kind = OpKind(k);
     }
 

--- a/src/ownership-bridge/OwnershipBridgeReceiver.sol
+++ b/src/ownership-bridge/OwnershipBridgeReceiver.sol
@@ -19,15 +19,26 @@ import { UpgradeableProxy } from "../utils/UpgradeableProxy.sol";
  * @dev Holds a privileged role on every TradingSafe — TradingSafe gates its
  *      `applyBridge*` functions to this contract's address.
  *
- *      LayerZero v2's default ordered-delivery + GUID-based replay protection are relied on;
- *      no application-level nonce is tracked here. `srcEid` is checked as defence-in-depth
- *      against peer misconfiguration.
+ *      In addition to LayerZero's transport authentication and GUID replay protection, the
+ *      receiver tracks the last applied source-safe nonce. Older or duplicate operations are
+ *      consumed without application so delayed messages cannot overwrite newer owner state.
+ *      `srcEid` is checked as defence-in-depth against peer misconfiguration.
  *
  *      If a message arrives for a TradingSafe that hasn't been deployed yet, we emit
  *      `OwnershipApplyDeferred` and exit cleanly. The eventual lazy-deploy reads the current
  *      source-chain owner state, so the missed bridge update is a no-op in practice.
  */
 contract OwnershipBridgeReceiver is IOwnershipBridgeReceiver, OAppReceiverUpgradeable, UpgradeableProxy {
+    /// @custom:storage-location erc7201:etherfi.storage.OwnershipBridgeReceiver
+    struct OwnershipBridgeReceiverStorage {
+        mapping(address sourceSafe => uint256 nonce) lastAppliedSourceNonce;
+        mapping(address sourceSafe => bool initialized) hasAppliedSourceNonce;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("etherfi.storage.OwnershipBridgeReceiver")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant OwnershipBridgeReceiverStorageLocation =
+        0x0837cfcd8214934b45c9229c8defc12d69d66511b675670079b781633d90bb00;
+
     /// @notice Trusted source EID. Pinned at deploy.
     uint32 public immutable SOURCE_EID;
     /// @notice Mainnet TradingSafe factory used to resolve `sourceSafe → tradingSafe`.
@@ -75,12 +86,17 @@ contract OwnershipBridgeReceiver is IOwnershipBridgeReceiver, OAppReceiverUpgrad
         if (_origin.srcEid != SOURCE_EID) revert WrongSrcEid();
 
         OwnershipBridgeMessageLib.Envelope memory env = OwnershipBridgeMessageLib.decodeEnvelope(_message);
+        if (env.version != OwnershipBridgeMessageLib.ENVELOPE_VERSION) {
+            revert UnsupportedEnvelopeVersion(env.version);
+        }
         address tradingSafe = TRADING_SAFE_FACTORY.getDeterministicAddress(env.safe);
 
         if (tradingSafe.code.length == 0) {
             emit OwnershipApplyDeferred(env.safe, tradingSafe, _guid, uint8(env.kind));
             return;
         }
+
+        if (!_recordSourceNonce(env.safe, tradingSafe, _guid, env.kind, env.sourceNonce)) return;
 
         if (env.kind == OwnershipBridgeMessageLib.OpKind.ConfigureOwners) {
             _applyConfigureOwners(env.safe, tradingSafe, _guid, env.opData);
@@ -143,5 +159,48 @@ contract OwnershipBridgeReceiver is IOwnershipBridgeReceiver, OAppReceiverUpgrad
     function _applyCancelRecovery(address sourceSafe, address tradingSafe, bytes32 guid) internal {
         ITradingSafeBridgeReceiver(tradingSafe).applyBridgeCancelRecovery();
         emit CancelRecoveryApplied(sourceSafe, tradingSafe, guid);
+    }
+
+    function lastAppliedSourceNonce(address sourceSafe) external view returns (uint256 nonce, bool initialized) {
+        OwnershipBridgeReceiverStorage storage $ = _getOwnershipBridgeReceiverStorage();
+        return ($.lastAppliedSourceNonce[sourceSafe], $.hasAppliedSourceNonce[sourceSafe]);
+    }
+
+    function _recordSourceNonce(
+        address sourceSafe,
+        address tradingSafe,
+        bytes32 guid,
+        OwnershipBridgeMessageLib.OpKind kind,
+        uint256 sourceNonce
+    ) internal returns (bool) {
+        OwnershipBridgeReceiverStorage storage $ = _getOwnershipBridgeReceiverStorage();
+        if (
+            $.hasAppliedSourceNonce[sourceSafe] &&
+            sourceNonce <= $.lastAppliedSourceNonce[sourceSafe]
+        ) {
+            emit StaleOwnershipMessageSkipped(
+                sourceSafe,
+                tradingSafe,
+                guid,
+                uint8(kind),
+                sourceNonce,
+                $.lastAppliedSourceNonce[sourceSafe]
+            );
+            return false;
+        }
+
+        $.lastAppliedSourceNonce[sourceSafe] = sourceNonce;
+        $.hasAppliedSourceNonce[sourceSafe] = true;
+        return true;
+    }
+
+    function _getOwnershipBridgeReceiverStorage()
+        private
+        pure
+        returns (OwnershipBridgeReceiverStorage storage $)
+    {
+        assembly {
+            $.slot := OwnershipBridgeReceiverStorageLocation
+        }
     }
 }

--- a/src/ownership-bridge/OwnershipBridgeSender.sol
+++ b/src/ownership-bridge/OwnershipBridgeSender.sol
@@ -79,6 +79,7 @@ contract OwnershipBridgeSender is IOwnershipBridgeSender, OAppSender, Pausable {
      * @param owners Owners to add or remove.
      * @param shouldAdd Per-owner add (true) / remove (false) flag.
      * @param threshold New signature threshold after the change is applied locally.
+     * @param sourceNonce Nonce consumed by the source safe for this operation.
      * @custom:throws CallerNotSafe If `msg.sender != safe`.
      * @custom:throws NotEtherFiSafe If `safe` isn't registered.
      * @custom:throws ArrayLengthMismatch If `owners.length != shouldAdd.length`.
@@ -90,13 +91,15 @@ contract OwnershipBridgeSender is IOwnershipBridgeSender, OAppSender, Pausable {
         address safe,
         address[] calldata owners,
         bool[] calldata shouldAdd,
-        uint8 threshold
+        uint8 threshold,
+        uint256 sourceNonce
     ) external payable whenNotPaused onlyEtherFiSafe(safe) {
         if (_skipIfNotEnabled(safe, OwnershipBridgeMessageLib.OpKind.ConfigureOwners)) return;
         if (owners.length != shouldAdd.length) revert ArrayLengthMismatch();
 
         bytes memory opData = OwnershipBridgeMessageLib.encodeConfigureOwners(owners, shouldAdd, threshold);
-        (bytes32[] memory guids, uint32[] memory destEids) = _dispatch(safe, OwnershipBridgeMessageLib.OpKind.ConfigureOwners, opData);
+        (bytes32[] memory guids, uint32[] memory destEids) =
+            _dispatch(safe, OwnershipBridgeMessageLib.OpKind.ConfigureOwners, sourceNonce, opData);
 
         emit ConfigureOwnersPublished(safe, owners, shouldAdd, threshold, destEids, guids);
     }
@@ -107,17 +110,19 @@ contract OwnershipBridgeSender is IOwnershipBridgeSender, OAppSender, Pausable {
      *      enabled destinations.
      * @param safe Source-chain safe.
      * @param threshold New signature threshold.
+     * @param sourceNonce Nonce consumed by the source safe for this operation.
      * @custom:throws CallerNotSafe If `msg.sender != safe`.
      * @custom:throws NotEtherFiSafe If `safe` isn't registered.
      * @custom:throws DestinationNotConfigured If an enabled destEid was later removed from the global config.
      * @custom:throws PeerNotConfigured If an enabled destination has no LZ peer set.
      * @custom:throws InsufficientFee If `msg.value` is below the total LZ fee.
      */
-    function publishSetThreshold(address safe, uint8 threshold) external payable whenNotPaused onlyEtherFiSafe(safe) {
+    function publishSetThreshold(address safe, uint8 threshold, uint256 sourceNonce) external payable whenNotPaused onlyEtherFiSafe(safe) {
         if (_skipIfNotEnabled(safe, OwnershipBridgeMessageLib.OpKind.SetThreshold)) return;
 
         bytes memory opData = OwnershipBridgeMessageLib.encodeSetThreshold(threshold);
-        (bytes32[] memory guids, uint32[] memory destEids) = _dispatch(safe, OwnershipBridgeMessageLib.OpKind.SetThreshold, opData);
+        (bytes32[] memory guids, uint32[] memory destEids) =
+            _dispatch(safe, OwnershipBridgeMessageLib.OpKind.SetThreshold, sourceNonce, opData);
 
         emit SetThresholdPublished(safe, threshold, destEids, guids);
     }
@@ -129,17 +134,24 @@ contract OwnershipBridgeSender is IOwnershipBridgeSender, OAppSender, Pausable {
      * @param safe Source-chain safe.
      * @param newOwner Incoming owner that will take effect after the destination's timelock.
      * @param incomingOwnerEffectiveAt Source-chain UNIX timestamp at which `newOwner` activates on destinations.
+     * @param sourceNonce Nonce consumed by the source safe for this operation.
      * @custom:throws CallerNotSafe If `msg.sender != safe`.
      * @custom:throws NotEtherFiSafe If `safe` isn't registered.
      * @custom:throws DestinationNotConfigured If an enabled destEid was later removed from the global config.
      * @custom:throws PeerNotConfigured If an enabled destination has no LZ peer set.
      * @custom:throws InsufficientFee If `msg.value` is below the total LZ fee.
      */
-    function publishRecover(address safe, address newOwner, uint256 incomingOwnerEffectiveAt) external payable whenNotPaused onlyEtherFiSafe(safe) {
+    function publishRecover(
+        address safe,
+        address newOwner,
+        uint256 incomingOwnerEffectiveAt,
+        uint256 sourceNonce
+    ) external payable whenNotPaused onlyEtherFiSafe(safe) {
         if (_skipIfNotEnabled(safe, OwnershipBridgeMessageLib.OpKind.Recover)) return;
 
         bytes memory opData = OwnershipBridgeMessageLib.encodeRecover(newOwner, incomingOwnerEffectiveAt);
-        (bytes32[] memory guids, uint32[] memory destEids) = _dispatch(safe, OwnershipBridgeMessageLib.OpKind.Recover, opData);
+        (bytes32[] memory guids, uint32[] memory destEids) =
+            _dispatch(safe, OwnershipBridgeMessageLib.OpKind.Recover, sourceNonce, opData);
 
         emit RecoverPublished(safe, newOwner, incomingOwnerEffectiveAt, destEids, guids);
     }
@@ -149,17 +161,19 @@ contract OwnershipBridgeSender is IOwnershipBridgeSender, OAppSender, Pausable {
      * @dev Callable only by the safe itself; short-circuits with refund if the safe has no
      *      enabled destinations.
      * @param safe Source-chain safe.
+     * @param sourceNonce Nonce consumed by the source safe for this operation.
      * @custom:throws CallerNotSafe If `msg.sender != safe`.
      * @custom:throws NotEtherFiSafe If `safe` isn't registered.
      * @custom:throws DestinationNotConfigured If an enabled destEid was later removed from the global config.
      * @custom:throws PeerNotConfigured If an enabled destination has no LZ peer set.
      * @custom:throws InsufficientFee If `msg.value` is below the total LZ fee.
      */
-    function publishCancelRecovery(address safe) external payable whenNotPaused onlyEtherFiSafe(safe) {
+    function publishCancelRecovery(address safe, uint256 sourceNonce) external payable whenNotPaused onlyEtherFiSafe(safe) {
         if (_skipIfNotEnabled(safe, OwnershipBridgeMessageLib.OpKind.CancelRecovery)) return;
 
         bytes memory opData = OwnershipBridgeMessageLib.encodeCancelRecovery();
-        (bytes32[] memory guids, uint32[] memory destEids) = _dispatch(safe, OwnershipBridgeMessageLib.OpKind.CancelRecovery, opData);
+        (bytes32[] memory guids, uint32[] memory destEids) =
+            _dispatch(safe, OwnershipBridgeMessageLib.OpKind.CancelRecovery, sourceNonce, opData);
 
         emit CancelRecoveryPublished(safe, destEids, guids);
     }
@@ -444,6 +458,7 @@ contract OwnershipBridgeSender is IOwnershipBridgeSender, OAppSender, Pausable {
     function _dispatch(
         address safe,
         OwnershipBridgeMessageLib.OpKind kind,
+        uint256 sourceNonce,
         bytes memory opData
     ) internal returns (bytes32[] memory guids, uint32[] memory destEids) {
         OwnershipBridgeSenderStorage storage $ = _getOwnershipBridgeSenderStorage();
@@ -451,7 +466,13 @@ contract OwnershipBridgeSender is IOwnershipBridgeSender, OAppSender, Pausable {
         uint256 destCount = liveEids.length;
 
         bytes memory message = OwnershipBridgeMessageLib.encodeEnvelope(
-            OwnershipBridgeMessageLib.Envelope({ kind: kind, safe: safe, opData: opData })
+            OwnershipBridgeMessageLib.Envelope({
+                version: OwnershipBridgeMessageLib.ENVELOPE_VERSION,
+                kind: kind,
+                safe: safe,
+                sourceNonce: sourceNonce,
+                opData: opData
+            })
         );
 
         guids = new bytes32[](destCount);
@@ -499,7 +520,13 @@ contract OwnershipBridgeSender is IOwnershipBridgeSender, OAppSender, Pausable {
         if (destCount == 0) return 0;
 
         bytes memory message = OwnershipBridgeMessageLib.encodeEnvelope(
-            OwnershipBridgeMessageLib.Envelope({ kind: kind, safe: safe, opData: opData })
+            OwnershipBridgeMessageLib.Envelope({
+                version: OwnershipBridgeMessageLib.ENVELOPE_VERSION,
+                kind: kind,
+                safe: safe,
+                sourceNonce: 0,
+                opData: opData
+            })
         );
 
         for (uint256 i = 0; i < destCount;) {

--- a/src/safe/EtherFiSafe.sol
+++ b/src/safe/EtherFiSafe.sol
@@ -21,20 +21,34 @@ contract EtherFiSafe is EtherFiSafeCore, OwnerBridgePublisher {
     ///      `EtherFiSafeBase`. Each override resolves the multi-inheritance ambiguity and
     ///      delegates to `OwnerBridgePublisher`'s concrete implementation.
 
-    function _publishConfigureOwners(address[] calldata owners, bool[] calldata shouldAdd, uint8 threshold) internal override(EtherFiSafeBase, OwnerBridgePublisher) {
-        OwnerBridgePublisher._publishConfigureOwners(owners, shouldAdd, threshold);
+    function _publishConfigureOwners(
+        address[] calldata owners,
+        bool[] calldata shouldAdd,
+        uint8 threshold,
+        uint256 sourceNonce
+    ) internal override(EtherFiSafeBase, OwnerBridgePublisher) {
+        OwnerBridgePublisher._publishConfigureOwners(owners, shouldAdd, threshold, sourceNonce);
     }
 
-    function _publishSetThreshold(uint8 threshold) internal override(EtherFiSafeBase, OwnerBridgePublisher) {
-        OwnerBridgePublisher._publishSetThreshold(threshold);
+    function _publishSetThreshold(
+        uint8 threshold,
+        uint256 sourceNonce
+    ) internal override(EtherFiSafeBase, OwnerBridgePublisher) {
+        OwnerBridgePublisher._publishSetThreshold(threshold, sourceNonce);
     }
 
-    function _publishRecover(address newOwner, uint256 incomingOwnerEffectiveAt) internal override(EtherFiSafeBase, OwnerBridgePublisher) {
-        OwnerBridgePublisher._publishRecover(newOwner, incomingOwnerEffectiveAt);
+    function _publishRecover(
+        address newOwner,
+        uint256 incomingOwnerEffectiveAt,
+        uint256 sourceNonce
+    ) internal override(EtherFiSafeBase, OwnerBridgePublisher) {
+        OwnerBridgePublisher._publishRecover(newOwner, incomingOwnerEffectiveAt, sourceNonce);
     }
 
-    function _publishCancelRecovery() internal override(EtherFiSafeBase, OwnerBridgePublisher) {
-        OwnerBridgePublisher._publishCancelRecovery();
+    function _publishCancelRecovery(
+        uint256 sourceNonce
+    ) internal override(EtherFiSafeBase, OwnerBridgePublisher) {
+        OwnerBridgePublisher._publishCancelRecovery(sourceNonce);
     }
 
     /// @inheritdoc OwnerBridgePublisher

--- a/src/safe/EtherFiSafeBase.sol
+++ b/src/safe/EtherFiSafeBase.sol
@@ -226,8 +226,8 @@ abstract contract EtherFiSafeBase is EtherFiSafeErrors, EIP712Upgradeable {
     // leave them as no-ops, which keeps the publisher's bytecode out of those builds.
     // ------------------------------------------------------------------
 
-    function _publishConfigureOwners(address[] calldata, bool[] calldata, uint8) internal virtual {}
-    function _publishSetThreshold(uint8) internal virtual {}
-    function _publishRecover(address, uint256) internal virtual {}
-    function _publishCancelRecovery() internal virtual {}
+    function _publishConfigureOwners(address[] calldata, bool[] calldata, uint8, uint256) internal virtual {}
+    function _publishSetThreshold(uint8, uint256) internal virtual {}
+    function _publishRecover(address, uint256, uint256) internal virtual {}
+    function _publishCancelRecovery(uint256) internal virtual {}
 }

--- a/src/safe/MultiSig.sol
+++ b/src/safe/MultiSig.sol
@@ -112,12 +112,13 @@ abstract contract MultiSig is EtherFiSafeBase {
      */
     function setThreshold(uint8 threshold, address[] calldata signers, bytes[] calldata signatures) external payable {
         _currentOwner();
-        bytes32 structHash = keccak256(abi.encode(SET_THRESHOLD_TYPEHASH, threshold, _useNonce()));
+        uint256 sourceNonce = _useNonce();
+        bytes32 structHash = keccak256(abi.encode(SET_THRESHOLD_TYPEHASH, threshold, sourceNonce));
 
         bytes32 digestHash = _hashTypedDataV4(structHash);
         if (!checkSignatures(digestHash, signers, signatures)) revert InvalidSignatures();
         _setThreshold(threshold);
-        _publishSetThreshold(threshold);
+        _publishSetThreshold(threshold, sourceNonce);
     }
 
     /**
@@ -137,13 +138,14 @@ abstract contract MultiSig is EtherFiSafeBase {
      */
     function configureOwners(address[] calldata owners, bool[] calldata shouldAdd, uint8 threshold, address[] calldata signers, bytes[] calldata signatures) external payable {
         _currentOwner();
-        bytes32 structHash = keccak256(abi.encode(CONFIGURE_OWNERS_TYPEHASH, keccak256(abi.encodePacked(owners)), keccak256(abi.encodePacked(shouldAdd)), threshold, _useNonce()));
+        uint256 sourceNonce = _useNonce();
+        bytes32 structHash = keccak256(abi.encode(CONFIGURE_OWNERS_TYPEHASH, keccak256(abi.encodePacked(owners)), keccak256(abi.encodePacked(shouldAdd)), threshold, sourceNonce));
 
         bytes32 digestHash = _hashTypedDataV4(structHash);
         if (!checkSignatures(digestHash, signers, signatures)) revert InvalidSignatures();
         _configureOwners(owners, shouldAdd, threshold);
         _configureAdmin(owners, shouldAdd);
-        _publishConfigureOwners(owners, shouldAdd, threshold);
+        _publishConfigureOwners(owners, shouldAdd, threshold, sourceNonce);
     }
 
     /**

--- a/src/safe/OwnerBridgePublisher.sol
+++ b/src/safe/OwnerBridgePublisher.sol
@@ -38,43 +38,52 @@ abstract contract OwnerBridgePublisher {
      *      any leftover (the sender may return unused fee if a per-destination quote
      *      shifted between our quote and dispatch).
      */
-    function _publishConfigureOwners(address[] calldata owners, bool[] calldata shouldAdd, uint8 threshold) internal virtual {
+    function _publishConfigureOwners(
+        address[] calldata owners,
+        bool[] calldata shouldAdd,
+        uint8 threshold,
+        uint256 sourceNonce
+    ) internal virtual {
         IOwnershipBridgeSender sender = _resolveLiveBridgeSender();
         if (address(sender) == address(0)) return;
         uint256 fee = sender.quoteConfigureOwners(address(this), owners, shouldAdd, threshold);
         uint256 preCallBalance = _validateFeeAndSnapshot(fee);
-        sender.publishConfigureOwners{ value: fee }(address(this), owners, shouldAdd, threshold);
+        sender.publishConfigureOwners{ value: fee }(address(this), owners, shouldAdd, threshold, sourceNonce);
         _refundLeftover(preCallBalance);
     }
 
     /// @dev See `_publishConfigureOwners`. Refund semantics are identical.
-    function _publishSetThreshold(uint8 threshold) internal virtual {
+    function _publishSetThreshold(uint8 threshold, uint256 sourceNonce) internal virtual {
         IOwnershipBridgeSender sender = _resolveLiveBridgeSender();
         if (address(sender) == address(0)) return;
         uint256 fee = sender.quoteSetThreshold(address(this), threshold);
         uint256 preCallBalance = _validateFeeAndSnapshot(fee);
-        sender.publishSetThreshold{ value: fee }(address(this), threshold);
+        sender.publishSetThreshold{ value: fee }(address(this), threshold, sourceNonce);
         _refundLeftover(preCallBalance);
     }
 
     /// @dev Publishes a `recover`. The local timelock target is passed through so the
     ///      destination mirrors the same wall-clock activation moment.
-    function _publishRecover(address newOwner, uint256 incomingOwnerEffectiveAt) internal virtual {
+    function _publishRecover(
+        address newOwner,
+        uint256 incomingOwnerEffectiveAt,
+        uint256 sourceNonce
+    ) internal virtual {
         IOwnershipBridgeSender sender = _resolveLiveBridgeSender();
         if (address(sender) == address(0)) return;
         uint256 fee = sender.quoteRecover(address(this), newOwner, incomingOwnerEffectiveAt);
         uint256 preCallBalance = _validateFeeAndSnapshot(fee);
-        sender.publishRecover{ value: fee }(address(this), newOwner, incomingOwnerEffectiveAt);
+        sender.publishRecover{ value: fee }(address(this), newOwner, incomingOwnerEffectiveAt, sourceNonce);
         _refundLeftover(preCallBalance);
     }
 
     /// @dev See `_publishConfigureOwners`. Refund semantics are identical.
-    function _publishCancelRecovery() internal virtual {
+    function _publishCancelRecovery(uint256 sourceNonce) internal virtual {
         IOwnershipBridgeSender sender = _resolveLiveBridgeSender();
         if (address(sender) == address(0)) return;
         uint256 fee = sender.quoteCancelRecovery(address(this));
         uint256 preCallBalance = _validateFeeAndSnapshot(fee);
-        sender.publishCancelRecovery{ value: fee }(address(this));
+        sender.publishCancelRecovery{ value: fee }(address(this), sourceNonce);
         _refundLeftover(preCallBalance);
     }
 

--- a/src/safe/RecoveryManager.sol
+++ b/src/safe/RecoveryManager.sol
@@ -218,7 +218,8 @@ abstract contract RecoveryManager is EtherFiSafeBase {
 
         recoverySigners.checkDuplicates();
 
-        bytes32 structHash = keccak256(abi.encode(RECOVER_SAFE_TYPEHASH, newOwner, _useNonce()));
+        uint256 sourceNonce = _useNonce();
+        bytes32 structHash = keccak256(abi.encode(RECOVER_SAFE_TYPEHASH, newOwner, sourceNonce));
         bytes32 digestHash = _hashTypedDataV4(structHash);
         uint256 validSignatures = 0;
 
@@ -238,7 +239,7 @@ abstract contract RecoveryManager is EtherFiSafeBase {
         _setIncomingOwner(newOwner, incomingOwnerStartTime);
 
         emit Recovery(newOwner, incomingOwnerStartTime);
-        _publishRecover(newOwner, incomingOwnerStartTime);
+        _publishRecover(newOwner, incomingOwnerStartTime, sourceNonce);
     }
 
     /**
@@ -270,14 +271,15 @@ abstract contract RecoveryManager is EtherFiSafeBase {
      */
     function cancelRecovery(address[] calldata signers, bytes[] calldata signatures) external payable {
         _currentOwner();
-        bytes32 structHash = keccak256(abi.encode(CANCEL_RECOVERY_TYPEHASH, _useNonce()));
+        uint256 sourceNonce = _useNonce();
+        bytes32 structHash = keccak256(abi.encode(CANCEL_RECOVERY_TYPEHASH, sourceNonce));
         bytes32 digestHash = _hashTypedDataV4(structHash);
         if (!checkSignatures(digestHash, signers, signatures)) revert InvalidSignatures();
 
         _removeIncomingOwner();
 
         emit RecoveryCancelled();
-        _publishCancelRecovery();
+        _publishCancelRecovery(sourceNonce);
     }
 
     /**

--- a/test/ownership-bridge/OwnershipBridgeMessageLib.t.sol
+++ b/test/ownership-bridge/OwnershipBridgeMessageLib.t.sol
@@ -33,8 +33,10 @@ contract OwnershipBridgeMessageLibTest is Test {
         bytes memory opData = OwnershipBridgeMessageLib.encodeConfigureOwners(owners, shouldAdd, threshold);
         bytes memory encoded = OwnershipBridgeMessageLib.encodeEnvelope(
             OwnershipBridgeMessageLib.Envelope({
+                version: OwnershipBridgeMessageLib.ENVELOPE_VERSION,
                 kind: OwnershipBridgeMessageLib.OpKind.ConfigureOwners,
                 safe: safe,
+                sourceNonce: 7,
                 opData: opData
             })
         );
@@ -42,6 +44,7 @@ contract OwnershipBridgeMessageLibTest is Test {
         OwnershipBridgeMessageLib.Envelope memory env = harness.decodeEnvelope(encoded);
         assertEq(uint8(env.kind), uint8(OwnershipBridgeMessageLib.OpKind.ConfigureOwners));
         assertEq(env.safe, safe);
+        assertEq(env.sourceNonce, 7);
 
         OwnershipBridgeMessageLib.ConfigureOwnersData memory d = OwnershipBridgeMessageLib.decodeConfigureOwners(env.opData);
         assertEq(d.owners.length, 2);
@@ -57,8 +60,10 @@ contract OwnershipBridgeMessageLibTest is Test {
         bytes memory opData = OwnershipBridgeMessageLib.encodeSetThreshold(3);
         bytes memory encoded = OwnershipBridgeMessageLib.encodeEnvelope(
             OwnershipBridgeMessageLib.Envelope({
+                version: OwnershipBridgeMessageLib.ENVELOPE_VERSION,
                 kind: OwnershipBridgeMessageLib.OpKind.SetThreshold,
                 safe: address(0x1234),
+                sourceNonce: 8,
                 opData: opData
             })
         );
@@ -76,8 +81,10 @@ contract OwnershipBridgeMessageLibTest is Test {
         bytes memory opData = OwnershipBridgeMessageLib.encodeRecover(newOwner, effectiveAt);
         bytes memory encoded = OwnershipBridgeMessageLib.encodeEnvelope(
             OwnershipBridgeMessageLib.Envelope({
+                version: OwnershipBridgeMessageLib.ENVELOPE_VERSION,
                 kind: OwnershipBridgeMessageLib.OpKind.Recover,
                 safe: address(0xBEEF),
+                sourceNonce: 9,
                 opData: opData
             })
         );
@@ -95,8 +102,10 @@ contract OwnershipBridgeMessageLibTest is Test {
         bytes memory opData = OwnershipBridgeMessageLib.encodeCancelRecovery();
         bytes memory encoded = OwnershipBridgeMessageLib.encodeEnvelope(
             OwnershipBridgeMessageLib.Envelope({
+                version: OwnershipBridgeMessageLib.ENVELOPE_VERSION,
                 kind: OwnershipBridgeMessageLib.OpKind.CancelRecovery,
                 safe: address(0xC0DE),
+                sourceNonce: 10,
                 opData: opData
             })
         );

--- a/test/ownership-bridge/OwnershipBridgeReceiver.t.sol
+++ b/test/ownership-bridge/OwnershipBridgeReceiver.t.sol
@@ -83,6 +83,29 @@ contract OwnershipBridgeReceiverTest is TradingSafeTestBase {
         receiver.lzReceive(origin, GUID, message, address(0), "");
     }
 
+    function _envelope(
+        OwnershipBridgeMessageLib.OpKind kind,
+        uint256 sourceNonce,
+        bytes memory opData
+    ) internal view returns (bytes memory) {
+        return _envelopeFor(sourceSafe, kind, sourceNonce, opData);
+    }
+
+    function _envelopeFor(
+        address safe,
+        OwnershipBridgeMessageLib.OpKind kind,
+        uint256 sourceNonce,
+        bytes memory opData
+    ) internal pure returns (bytes memory) {
+        return OwnershipBridgeMessageLib.encodeEnvelope(OwnershipBridgeMessageLib.Envelope({
+            version: OwnershipBridgeMessageLib.ENVELOPE_VERSION,
+            kind: kind,
+            safe: safe,
+            sourceNonce: sourceNonce,
+            opData: opData
+        }));
+    }
+
     // ---- Each op kind: applied to the real TradingSafe ----
 
     function test_lzReceive_configureOwners_appliesToTradingSafe() public {
@@ -92,11 +115,11 @@ contract OwnershipBridgeReceiverTest is TradingSafeTestBase {
         bool[] memory shouldAdd = new bool[](1);
         shouldAdd[0] = true;
 
-        bytes memory message = OwnershipBridgeMessageLib.encodeEnvelope(OwnershipBridgeMessageLib.Envelope({
-            kind: OwnershipBridgeMessageLib.OpKind.ConfigureOwners,
-            safe: sourceSafe,
-            opData: OwnershipBridgeMessageLib.encodeConfigureOwners(owners, shouldAdd, 2)
-        }));
+        bytes memory message = _envelope(
+            OwnershipBridgeMessageLib.OpKind.ConfigureOwners,
+            0,
+            OwnershipBridgeMessageLib.encodeConfigureOwners(owners, shouldAdd, 2)
+        );
 
         _send(_origin(), message);
 
@@ -113,18 +136,18 @@ contract OwnershipBridgeReceiverTest is TradingSafeTestBase {
         addOwners[0] = secondOwner;
         bool[] memory addFlags = new bool[](1);
         addFlags[0] = true;
-        bytes memory addMsg = OwnershipBridgeMessageLib.encodeEnvelope(OwnershipBridgeMessageLib.Envelope({
-            kind: OwnershipBridgeMessageLib.OpKind.ConfigureOwners,
-            safe: sourceSafe,
-            opData: OwnershipBridgeMessageLib.encodeConfigureOwners(addOwners, addFlags, 1)
-        }));
+        bytes memory addMsg = _envelope(
+            OwnershipBridgeMessageLib.OpKind.ConfigureOwners,
+            0,
+            OwnershipBridgeMessageLib.encodeConfigureOwners(addOwners, addFlags, 1)
+        );
         _send(_origin(), addMsg);
 
-        bytes memory message = OwnershipBridgeMessageLib.encodeEnvelope(OwnershipBridgeMessageLib.Envelope({
-            kind: OwnershipBridgeMessageLib.OpKind.SetThreshold,
-            safe: sourceSafe,
-            opData: OwnershipBridgeMessageLib.encodeSetThreshold(2)
-        }));
+        bytes memory message = _envelope(
+            OwnershipBridgeMessageLib.OpKind.SetThreshold,
+            1,
+            OwnershipBridgeMessageLib.encodeSetThreshold(2)
+        );
         _send(_origin(), message);
 
         assertEq(tradingSafe.getThreshold(), 2);
@@ -133,11 +156,11 @@ contract OwnershipBridgeReceiverTest is TradingSafeTestBase {
     function test_lzReceive_recover_appliesToTradingSafe() public {
         address newOwner = makeAddr("recoveryOwner");
         uint256 effectiveAt = block.timestamp + 7 days;
-        bytes memory message = OwnershipBridgeMessageLib.encodeEnvelope(OwnershipBridgeMessageLib.Envelope({
-            kind: OwnershipBridgeMessageLib.OpKind.Recover,
-            safe: sourceSafe,
-            opData: OwnershipBridgeMessageLib.encodeRecover(newOwner, effectiveAt)
-        }));
+        bytes memory message = _envelope(
+            OwnershipBridgeMessageLib.OpKind.Recover,
+            0,
+            OwnershipBridgeMessageLib.encodeRecover(newOwner, effectiveAt)
+        );
 
         _send(_origin(), message);
 
@@ -148,23 +171,88 @@ contract OwnershipBridgeReceiverTest is TradingSafeTestBase {
     function test_lzReceive_cancelRecovery_appliesToTradingSafe() public {
         // Seed an incoming owner first.
         address newOwner = makeAddr("recoveryOwner");
-        bytes memory recoverMsg = OwnershipBridgeMessageLib.encodeEnvelope(OwnershipBridgeMessageLib.Envelope({
-            kind: OwnershipBridgeMessageLib.OpKind.Recover,
-            safe: sourceSafe,
-            opData: OwnershipBridgeMessageLib.encodeRecover(newOwner, block.timestamp + 7 days)
-        }));
+        bytes memory recoverMsg = _envelope(
+            OwnershipBridgeMessageLib.OpKind.Recover,
+            0,
+            OwnershipBridgeMessageLib.encodeRecover(newOwner, block.timestamp + 7 days)
+        );
         _send(_origin(), recoverMsg);
         assertEq(tradingSafe.getIncomingOwner(), newOwner);
 
-        bytes memory message = OwnershipBridgeMessageLib.encodeEnvelope(OwnershipBridgeMessageLib.Envelope({
-            kind: OwnershipBridgeMessageLib.OpKind.CancelRecovery,
-            safe: sourceSafe,
-            opData: OwnershipBridgeMessageLib.encodeCancelRecovery()
-        }));
+        bytes memory message = _envelope(
+            OwnershipBridgeMessageLib.OpKind.CancelRecovery,
+            1,
+            OwnershipBridgeMessageLib.encodeCancelRecovery()
+        );
         _send(_origin(), message);
 
         assertEq(tradingSafe.getIncomingOwner(), address(0));
         assertEq(tradingSafe.getIncomingOwnerStartTime(), 0);
+    }
+
+    function test_lzReceive_cancelBeforeDelayedRecover_doesNotResurrectRecovery() public {
+        bytes memory cancelMessage = _envelope(
+            OwnershipBridgeMessageLib.OpKind.CancelRecovery,
+            6,
+            OwnershipBridgeMessageLib.encodeCancelRecovery()
+        );
+        _send(_origin(), cancelMessage);
+
+        address staleOwner = makeAddr("staleRecoveryOwner");
+        bytes memory staleRecover = _envelope(
+            OwnershipBridgeMessageLib.OpKind.Recover,
+            5,
+            OwnershipBridgeMessageLib.encodeRecover(staleOwner, block.timestamp + 7 days)
+        );
+
+        vm.expectEmit(true, true, true, true);
+        emit IOwnershipBridgeReceiver.StaleOwnershipMessageSkipped(
+            sourceSafe,
+            address(tradingSafe),
+            GUID,
+            uint8(OwnershipBridgeMessageLib.OpKind.Recover),
+            5,
+            6
+        );
+        _send(_origin(), staleRecover);
+
+        assertEq(tradingSafe.getIncomingOwner(), address(0));
+        assertEq(tradingSafe.getIncomingOwnerStartTime(), 0);
+    }
+
+    function test_lzReceive_staleOwnerMutation_isSkipped() public {
+        address secondOwner = makeAddr("secondOwner");
+        address[] memory owners = new address[](1);
+        owners[0] = secondOwner;
+        bool[] memory shouldAdd = new bool[](1);
+        shouldAdd[0] = true;
+        _send(
+            _origin(),
+            _envelope(
+                OwnershipBridgeMessageLib.OpKind.ConfigureOwners,
+                3,
+                OwnershipBridgeMessageLib.encodeConfigureOwners(owners, shouldAdd, 1)
+            )
+        );
+        _send(
+            _origin(),
+            _envelope(
+                OwnershipBridgeMessageLib.OpKind.SetThreshold,
+                5,
+                OwnershipBridgeMessageLib.encodeSetThreshold(2)
+            )
+        );
+
+        _send(
+            _origin(),
+            _envelope(
+                OwnershipBridgeMessageLib.OpKind.SetThreshold,
+                4,
+                OwnershipBridgeMessageLib.encodeSetThreshold(1)
+            )
+        );
+
+        assertEq(tradingSafe.getThreshold(), 2);
     }
 
     // ---- Deferred when TradingSafe not deployed ----
@@ -176,11 +264,12 @@ contract OwnershipBridgeReceiverTest is TradingSafeTestBase {
         address predicted = factory.getDeterministicAddress(undeployedSource);
         assertEq(predicted.code.length, 0, "predicted address should be empty");
 
-        bytes memory message = OwnershipBridgeMessageLib.encodeEnvelope(OwnershipBridgeMessageLib.Envelope({
-            kind: OwnershipBridgeMessageLib.OpKind.SetThreshold,
-            safe: undeployedSource,
-            opData: OwnershipBridgeMessageLib.encodeSetThreshold(5)
-        }));
+        bytes memory message = _envelopeFor(
+            undeployedSource,
+            OwnershipBridgeMessageLib.OpKind.SetThreshold,
+            0,
+            OwnershipBridgeMessageLib.encodeSetThreshold(5)
+        );
 
         vm.expectEmit(true, true, true, true);
         emit IOwnershipBridgeReceiver.OwnershipApplyDeferred(undeployedSource, predicted, GUID, uint8(OwnershipBridgeMessageLib.OpKind.SetThreshold));
@@ -189,16 +278,38 @@ contract OwnershipBridgeReceiverTest is TradingSafeTestBase {
 
         // Deployed TradingSafe (for `sourceSafe`) is untouched — threshold still 1.
         assertEq(tradingSafe.getThreshold(), 1);
+        (, bool initialized) = receiver.lastAppliedSourceNonce(undeployedSource);
+        assertFalse(initialized, "deferred message must not advance nonce");
     }
 
     // ---- Source EID validation ----
 
+    function test_lzReceive_revertsWhen_envelopeVersionUnsupported() public {
+        bytes memory message = OwnershipBridgeMessageLib.encodeEnvelope(
+            OwnershipBridgeMessageLib.Envelope({
+                version: OwnershipBridgeMessageLib.ENVELOPE_VERSION + 1,
+                kind: OwnershipBridgeMessageLib.OpKind.SetThreshold,
+                safe: sourceSafe,
+                sourceNonce: 0,
+                opData: OwnershipBridgeMessageLib.encodeSetThreshold(1)
+            })
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IOwnershipBridgeReceiver.UnsupportedEnvelopeVersion.selector,
+                OwnershipBridgeMessageLib.ENVELOPE_VERSION + 1
+            )
+        );
+        _send(_origin(), message);
+    }
+
     function test_lzReceive_revertsWhen_wrongSrcEid() public {
-        bytes memory message = OwnershipBridgeMessageLib.encodeEnvelope(OwnershipBridgeMessageLib.Envelope({
-            kind: OwnershipBridgeMessageLib.OpKind.SetThreshold,
-            safe: sourceSafe,
-            opData: OwnershipBridgeMessageLib.encodeSetThreshold(2)
-        }));
+        bytes memory message = _envelope(
+            OwnershipBridgeMessageLib.OpKind.SetThreshold,
+            0,
+            OwnershipBridgeMessageLib.encodeSetThreshold(2)
+        );
 
         // Peer for src 9999 isn't set; OAppReceiver's peer check fails first with OnlyPeer.
         vm.expectRevert();
@@ -220,11 +331,11 @@ contract OwnershipBridgeReceiverTest is TradingSafeTestBase {
         vm.prank(pauser);
         receiver.pause();
 
-        bytes memory message = OwnershipBridgeMessageLib.encodeEnvelope(OwnershipBridgeMessageLib.Envelope({
-            kind: OwnershipBridgeMessageLib.OpKind.SetThreshold,
-            safe: sourceSafe,
-            opData: OwnershipBridgeMessageLib.encodeSetThreshold(2)
-        }));
+        bytes memory message = _envelope(
+            OwnershipBridgeMessageLib.OpKind.SetThreshold,
+            0,
+            OwnershipBridgeMessageLib.encodeSetThreshold(2)
+        );
 
         vm.expectRevert();
         vm.prank(address(endpoint));

--- a/test/ownership-bridge/OwnershipBridgeSender.t.sol
+++ b/test/ownership-bridge/OwnershipBridgeSender.t.sol
@@ -37,19 +37,20 @@ contract RoleRegistryStub {
 /// @dev Helper to call the sender as if we were a safe. The sender requires `msg.sender == safe`.
 contract SafeCaller {
     OwnershipBridgeSender public immutable sender;
+    uint256 public nextNonce;
     constructor(OwnershipBridgeSender _sender) { sender = _sender; }
 
     function publishConfigureOwners(address[] calldata owners, bool[] calldata shouldAdd, uint8 threshold) external payable {
-        sender.publishConfigureOwners{value: msg.value}(address(this), owners, shouldAdd, threshold);
+        sender.publishConfigureOwners{value: msg.value}(address(this), owners, shouldAdd, threshold, nextNonce++);
     }
     function publishSetThreshold(uint8 threshold) external payable {
-        sender.publishSetThreshold{value: msg.value}(address(this), threshold);
+        sender.publishSetThreshold{value: msg.value}(address(this), threshold, nextNonce++);
     }
     function publishRecover(address newOwner, uint256 incomingOwnerEffectiveAt) external payable {
-        sender.publishRecover{value: msg.value}(address(this), newOwner, incomingOwnerEffectiveAt);
+        sender.publishRecover{value: msg.value}(address(this), newOwner, incomingOwnerEffectiveAt, nextNonce++);
     }
     function publishCancelRecovery() external payable {
-        sender.publishCancelRecovery{value: msg.value}(address(this));
+        sender.publishCancelRecovery{value: msg.value}(address(this), nextNonce++);
     }
 
     receive() external payable {}
@@ -110,16 +111,19 @@ contract OwnershipBridgeSenderTest is Test {
         (uint32 dstEid, bytes memory message) = endpoint.lastSendArgs();
         assertEq(uint256(dstEid), uint256(MAINNET_EID));
 
-        (uint8 kind, address envSafe, ) = abi.decode(message, (uint8, address, bytes));
+        (uint8 version, uint8 kind, address envSafe, uint256 sourceNonce,) =
+            abi.decode(message, (uint8, uint8, address, uint256, bytes));
+        assertEq(version, OwnershipBridgeMessageLib.ENVELOPE_VERSION);
         assertEq(kind, uint8(OwnershipBridgeMessageLib.OpKind.ConfigureOwners));
         assertEq(envSafe, address(safeCaller));
+        assertEq(sourceNonce, 0);
     }
 
     function test_publishSetThreshold_happyPath() public {
         safeCaller.publishSetThreshold(3);
         (uint32 dstEid, bytes memory message) = endpoint.lastSendArgs();
         assertEq(uint256(dstEid), uint256(MAINNET_EID));
-        (uint8 kind, , ) = abi.decode(message, (uint8, address, bytes));
+        (, uint8 kind,,, ) = abi.decode(message, (uint8, uint8, address, uint256, bytes));
         assertEq(kind, uint8(OwnershipBridgeMessageLib.OpKind.SetThreshold));
     }
 
@@ -127,7 +131,8 @@ contract OwnershipBridgeSenderTest is Test {
         address newOwner = makeAddr("newOwner");
         uint256 effectiveAt = block.timestamp + 7 days;
         safeCaller.publishRecover(newOwner, effectiveAt);
-        (uint8 kind, , bytes memory opData) = abi.decode(endpoint.lastMessage(), (uint8, address, bytes));
+        (, uint8 kind,,, bytes memory opData) =
+            abi.decode(endpoint.lastMessage(), (uint8, uint8, address, uint256, bytes));
         assertEq(kind, uint8(OwnershipBridgeMessageLib.OpKind.Recover));
         (address decodedOwner, uint256 decodedEffectiveAt) = abi.decode(opData, (address, uint256));
         assertEq(decodedOwner, newOwner);
@@ -136,7 +141,8 @@ contract OwnershipBridgeSenderTest is Test {
 
     function test_publishCancelRecovery_happyPath() public {
         safeCaller.publishCancelRecovery();
-        (uint8 kind, , ) = abi.decode(endpoint.lastMessage(), (uint8, address, bytes));
+        (, uint8 kind,,, ) =
+            abi.decode(endpoint.lastMessage(), (uint8, uint8, address, uint256, bytes));
         assertEq(kind, uint8(OwnershipBridgeMessageLib.OpKind.CancelRecovery));
     }
 
@@ -147,7 +153,7 @@ contract OwnershipBridgeSenderTest is Test {
         (address[] memory owners, bool[] memory shouldAdd) = _owners();
         vm.expectRevert(IOwnershipBridgeSender.CallerNotSafe.selector);
         vm.prank(notSafe);
-        sender.publishConfigureOwners(address(safeCaller), owners, shouldAdd, 2);
+        sender.publishConfigureOwners(address(safeCaller), owners, shouldAdd, 2, 0);
     }
 
     function test_publish_revertsWhen_safeNotRegistered() public {

--- a/test/safe/OwnershipBridge.t.sol
+++ b/test/safe/OwnershipBridge.t.sol
@@ -68,9 +68,11 @@ contract OwnershipBridgeTest is SafeTestSetup {
         assertEq(safe.getThreshold(), newThreshold, "local threshold updated");
         (uint32 dstEid, bytes memory message) = lzEndpoint.lastSendArgs();
         assertEq(uint256(dstEid), uint256(MAINNET_EID));
-        (uint8 kind, address envSafe, ) = abi.decode(message, (uint8, address, bytes));
+        (, uint8 kind, address envSafe, uint256 publishedNonce,) =
+            abi.decode(message, (uint8, uint8, address, uint256, bytes));
         assertEq(kind, uint8(OwnershipBridgeMessageLib.OpKind.SetThreshold));
         assertEq(envSafe, address(safe));
+        assertEq(publishedNonce + 1, safe.nonce());
     }
 
     function test_configureOwners_publishesToLZ_whenSenderWired() public {
@@ -81,7 +83,8 @@ contract OwnershipBridgeTest is SafeTestSetup {
         assertTrue(safe.isOwner(newOwner), "local owner added");
         (uint32 dstEid, bytes memory message) = lzEndpoint.lastSendArgs();
         assertEq(uint256(dstEid), uint256(MAINNET_EID));
-        (uint8 kind, address envSafe, ) = abi.decode(message, (uint8, address, bytes));
+        (, uint8 kind, address envSafe,,) =
+            abi.decode(message, (uint8, uint8, address, uint256, bytes));
         assertEq(kind, uint8(OwnershipBridgeMessageLib.OpKind.ConfigureOwners));
         assertEq(envSafe, address(safe));
     }
@@ -129,15 +132,18 @@ contract OwnershipBridgeTest is SafeTestSetup {
         recoverySigners[0] = etherFiRecoverySigner;
         recoverySigners[1] = thirdPartyRecoverySigner;
 
+        uint256 sourceNonce = safe.nonce();
         _recoverSafeWithSigners(newOwner, recoverySigners);
 
         uint256 expectedEffectiveAt = block.timestamp + dataProvider.getRecoveryDelayPeriod();
         assertEq(safe.getIncomingOwner(), newOwner, "local incoming owner");
         assertEq(safe.getIncomingOwnerStartTime(), expectedEffectiveAt, "local start time");
 
-        (uint8 kind, address envSafe, bytes memory opData) = abi.decode(lzEndpoint.lastMessage(), (uint8, address, bytes));
+        (, uint8 kind, address envSafe, uint256 publishedNonce, bytes memory opData) =
+            abi.decode(lzEndpoint.lastMessage(), (uint8, uint8, address, uint256, bytes));
         assertEq(kind, uint8(OwnershipBridgeMessageLib.OpKind.Recover));
         assertEq(envSafe, address(safe));
+        assertEq(publishedNonce, sourceNonce);
         (address publishedOwner, uint256 publishedEffectiveAt) = abi.decode(opData, (address, uint256));
         assertEq(publishedOwner, newOwner);
         assertEq(publishedEffectiveAt, expectedEffectiveAt, "destination timelock target matches source");
@@ -153,12 +159,15 @@ contract OwnershipBridgeTest is SafeTestSetup {
         recoverySigners[1] = thirdPartyRecoverySigner;
         _recoverSafeWithSigners(newOwner, recoverySigners);
 
+        uint256 sourceNonce = safe.nonce();
         _cancelRecovery();
 
         assertEq(safe.getIncomingOwner(), address(0), "local cancellation applied");
-        (uint8 kind, address envSafe, ) = abi.decode(lzEndpoint.lastMessage(), (uint8, address, bytes));
+        (, uint8 kind, address envSafe, uint256 publishedNonce,) =
+            abi.decode(lzEndpoint.lastMessage(), (uint8, uint8, address, uint256, bytes));
         assertEq(kind, uint8(OwnershipBridgeMessageLib.OpKind.CancelRecovery));
         assertEq(envSafe, address(safe));
+        assertEq(publishedNonce, sourceNonce);
     }
 
     // ---- Insufficient fee revert ----


### PR DESCRIPTION
## Summary
- add a versioned ownership envelope carrying the nonce consumed by the source Safe
- thread the signed source nonce through all four owner-mutation publish paths
- track the last applied nonce per source Safe in an ERC-7201 receiver storage namespace
- consume but skip stale or duplicate messages instead of applying superseded owner state
- leave deferred messages unrecorded until a TradingSafe exists and the operation can apply

## Security impact
This resolves both Certora M-02 and M-04. If CancelRecovery nonce 6 arrives before delayed Recover nonce 5, the cancel is applied and the later recover is skipped, so a cancelled recovery cannot be resurrected. The same rule prevents stale configureOwners and setThreshold messages from overwriting newer state.

## Compatibility
The envelope is explicitly versioned as v1. Sender and receiver must be deployed/upgraded together; unsupported envelope versions are rejected rather than interpreted under the wrong schema.