### PR TITLE
fix: respect recovery toggle for bridged recovery

### DIFF
--- a/src/interfaces/IOwnershipBridgeReceiver.sol
+++ b/src/interfaces/IOwnershipBridgeReceiver.sol
@@ -58,6 +58,18 @@ interface IOwnershipBridgeReceiver {
     );
 
     /**
+     * @notice Emitted when a bridged recovery is consumed but not applied because recovery
+     *         is disabled on the destination TradingSafe.
+     */
+    event RecoveryApplySkipped(
+        address indexed sourceSafe,
+        address indexed tradingSafe,
+        bytes32 indexed guid,
+        address newOwner,
+        uint256 incomingOwnerEffectiveAt
+    );
+
+    /**
      * @notice Emitted when a `cancelRecovery` operation is applied.
      * @param sourceSafe Source-chain safe.
      * @param tradingSafe Destination TradingSafe.

--- a/src/interfaces/ITradingSafeBridgeReceiver.sol
+++ b/src/interfaces/ITradingSafeBridgeReceiver.sol
@@ -31,8 +31,9 @@ interface ITradingSafeBridgeReceiver {
      * @param incomingOwnerEffectiveAt Source-chain UNIX timestamp at which `newOwner` should activate.
      *        The TradingSafe MUST adopt this exact activation time rather than computing a local one,
      *        so the source and destination timelocks stay synchronized.
+     * @return applied True when recovery was enabled and the incoming owner was staged.
      */
-    function applyBridgeRecover(address newOwner, uint256 incomingOwnerEffectiveAt) external;
+    function applyBridgeRecover(address newOwner, uint256 incomingOwnerEffectiveAt) external returns (bool applied);
 
     /// @notice Apply a bridged `cancelRecovery` on the TradingSafe (clears pending incoming-owner state).
     function applyBridgeCancelRecovery() external;

--- a/src/ownership-bridge/OwnershipBridgeReceiver.sol
+++ b/src/ownership-bridge/OwnershipBridgeReceiver.sol
@@ -130,8 +130,12 @@ contract OwnershipBridgeReceiver is IOwnershipBridgeReceiver, OAppReceiverUpgrad
      */
     function _applyRecover(address sourceSafe, address tradingSafe, bytes32 guid, bytes memory opData) internal {
         OwnershipBridgeMessageLib.RecoverData memory d = OwnershipBridgeMessageLib.decodeRecover(opData);
-        ITradingSafeBridgeReceiver(tradingSafe).applyBridgeRecover(d.newOwner, d.incomingOwnerEffectiveAt);
-        emit RecoverApplied(sourceSafe, tradingSafe, guid, d.newOwner, d.incomingOwnerEffectiveAt);
+        bool applied = ITradingSafeBridgeReceiver(tradingSafe).applyBridgeRecover(d.newOwner, d.incomingOwnerEffectiveAt);
+        if (applied) {
+            emit RecoverApplied(sourceSafe, tradingSafe, guid, d.newOwner, d.incomingOwnerEffectiveAt);
+        } else {
+            emit RecoveryApplySkipped(sourceSafe, tradingSafe, guid, d.newOwner, d.incomingOwnerEffectiveAt);
+        }
     }
 
     /**

--- a/src/trading-safe/TradingOwnerBridgeReceiver.sol
+++ b/src/trading-safe/TradingOwnerBridgeReceiver.sol
@@ -71,8 +71,10 @@ abstract contract TradingOwnerBridgeReceiver is EtherFiSafeCore, ITradingSafeBri
      * @param incomingOwnerEffectiveAt Timestamp (matching the source-chain timelock) at
      *        which `newOwner` becomes the active owner.
      */
-    function applyBridgeRecover(address newOwner, uint256 incomingOwnerEffectiveAt) external override onlyBridgeReceiver {
+    function applyBridgeRecover(address newOwner, uint256 incomingOwnerEffectiveAt) external override onlyBridgeReceiver returns (bool applied) {
+        if (!isRecoveryEnabled()) return false;
         _setIncomingOwner(newOwner, incomingOwnerEffectiveAt);
+        return true;
     }
 
     /**

--- a/test/ownership-bridge/OwnershipBridgeReceiver.t.sol
+++ b/test/ownership-bridge/OwnershipBridgeReceiver.t.sol
@@ -28,7 +28,8 @@ contract OwnershipBridgeReceiverTest is TradingSafeTestBase {
 
     address public senderPeer = makeAddr("senderPeer");
     address public sourceSafe = makeAddr("sourceSafe");
-    address public tradingSafeOwner = makeAddr("tradingSafeOwner");
+    uint256 public tradingSafeOwnerPk = 0xA11CE;
+    address public tradingSafeOwner;
     address public pauser = makeAddr("pauser");
     address public unpauser = makeAddr("unpauser");
 
@@ -38,6 +39,7 @@ contract OwnershipBridgeReceiverTest is TradingSafeTestBase {
 
     function setUp() public {
         _setupCore();
+        tradingSafeOwner = vm.addr(tradingSafeOwnerPk);
         endpoint = new LZEndpointMock();
 
         address predictedReceiver = CREATE3.predictDeterministicAddress(RECEIVER_PROXY_SALT);
@@ -81,6 +83,18 @@ contract OwnershipBridgeReceiverTest is TradingSafeTestBase {
     function _send(Origin memory origin, bytes memory message) internal {
         vm.prank(address(endpoint));
         receiver.lzReceive(origin, GUID, message, address(0), "");
+    }
+
+    function _toggleRecovery(bool shouldEnable) internal {
+        bytes32 structHash = keccak256(abi.encode(tradingSafe.TOGGLE_RECOVERY_ENABLED_TYPEHASH(), shouldEnable, tradingSafe.nonce()));
+        bytes32 digestHash = keccak256(abi.encodePacked("\x19\x01", tradingSafe.getDomainSeparator(), structHash));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(tradingSafeOwnerPk, digestHash);
+
+        address[] memory signers = new address[](1);
+        signers[0] = tradingSafeOwner;
+        bytes[] memory signatures = new bytes[](1);
+        signatures[0] = abi.encodePacked(r, s, v);
+        tradingSafe.toggleRecoveryEnabled(shouldEnable, signers, signatures);
     }
 
     // ---- Each op kind: applied to the real TradingSafe ----
@@ -143,6 +157,25 @@ contract OwnershipBridgeReceiverTest is TradingSafeTestBase {
 
         assertEq(tradingSafe.getIncomingOwner(), newOwner);
         assertEq(tradingSafe.getIncomingOwnerStartTime(), effectiveAt);
+    }
+
+    function test_lzReceive_recover_skipsWhenRecoveryDisabled() public {
+        _toggleRecovery(false);
+
+        address newOwner = makeAddr("recoveryOwner");
+        uint256 effectiveAt = block.timestamp + 7 days;
+        bytes memory message = OwnershipBridgeMessageLib.encodeEnvelope(OwnershipBridgeMessageLib.Envelope({
+            kind: OwnershipBridgeMessageLib.OpKind.Recover,
+            safe: sourceSafe,
+            opData: OwnershipBridgeMessageLib.encodeRecover(newOwner, effectiveAt)
+        }));
+
+        vm.expectEmit(true, true, true, true);
+        emit IOwnershipBridgeReceiver.RecoveryApplySkipped(sourceSafe, address(tradingSafe), GUID, newOwner, effectiveAt);
+        _send(_origin(), message);
+
+        assertEq(tradingSafe.getIncomingOwner(), address(0));
+        assertEq(tradingSafe.getIncomingOwnerStartTime(), 0);
     }
 
     function test_lzReceive_cancelRecovery_appliesToTradingSafe() public {

--- a/test/trading-safe/TradingSafe.t.sol
+++ b/test/trading-safe/TradingSafe.t.sol
@@ -10,12 +10,14 @@ contract TradingSafeTest is TradingSafeTestBase {
     TradingSafeFactory public factory;
     TradingSafe public safe;
     address public bridgeReceiver = makeAddr("bridgeReceiver");
-    address public ownerA = makeAddr("ownerA");
+    uint256 public ownerAPk = 0xA11CE;
+    address public ownerA;
     address public ownerB = makeAddr("ownerB");
     address public stranger = makeAddr("stranger");
 
     function setUp() public {
         _setupCore();
+        ownerA = vm.addr(ownerAPk);
 
         vm.startPrank(owner);
         factory = _deployFactory(bridgeReceiver);
@@ -116,10 +118,22 @@ contract TradingSafeTest is TradingSafeTestBase {
         uint256 effectiveAt = block.timestamp + 7 days;
 
         vm.prank(bridgeReceiver);
-        safe.applyBridgeRecover(newOwner, effectiveAt);
+        bool applied = safe.applyBridgeRecover(newOwner, effectiveAt);
 
+        assertTrue(applied);
         assertEq(safe.getIncomingOwner(), newOwner);
         assertEq(safe.getIncomingOwnerStartTime(), effectiveAt);
+    }
+
+    function test_applyBridgeRecover_skipsWhenRecoveryDisabled() public {
+        _toggleRecovery(false);
+
+        vm.prank(bridgeReceiver);
+        bool applied = safe.applyBridgeRecover(makeAddr("newOwner"), block.timestamp + 7 days);
+
+        assertFalse(applied);
+        assertEq(safe.getIncomingOwner(), address(0));
+        assertEq(safe.getIncomingOwnerStartTime(), 0);
     }
 
     function test_applyBridgeRecover_revertsWhen_notBridgeReceiver() public {
@@ -148,5 +162,17 @@ contract TradingSafeTest is TradingSafeTestBase {
         vm.expectRevert(TradingOwnerBridgeReceiver.OnlyBridgeReceiver.selector);
         vm.prank(stranger);
         safe.applyBridgeCancelRecovery();
+    }
+
+    function _toggleRecovery(bool shouldEnable) internal {
+        bytes32 structHash = keccak256(abi.encode(safe.TOGGLE_RECOVERY_ENABLED_TYPEHASH(), shouldEnable, safe.nonce()));
+        bytes32 digestHash = keccak256(abi.encodePacked("\x19\x01", safe.getDomainSeparator(), structHash));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerAPk, digestHash);
+
+        address[] memory signers = new address[](1);
+        signers[0] = ownerA;
+        bytes[] memory signatures = new bytes[](1);
+        signatures[0] = abi.encodePacked(r, s, v);
+        safe.toggleRecoveryEnabled(shouldEnable, signers, signatures);
     }
 }


### PR DESCRIPTION
## Summary
- prevent bridged recovery messages from staging an incoming owner when recovery is disabled on the TradingSafe
- consume disabled recovery messages without reverting so LayerZero delivery does not remain retryable
- emit `RecoveryApplySkipped` instead of `RecoverApplied` when the destination toggle blocks recovery
- add direct TradingSafe and end-to-end ownership bridge regression coverage

## Security finding
Addresses Certora **M-03: `applyBridgeRecover` bypasses `isRecoveryEnabled`**.
