### PR TITLE
fix: bind swap targets to signed requests

### DIFF
--- a/src/across/AcrossSwapModule.sol
+++ b/src/across/AcrossSwapModule.sol
@@ -70,6 +70,8 @@ contract AcrossSwapModule is ModuleBase, UpgradeableProxy {
         bytes message;
         bytes32 swapId;
         bytes swapData;
+        address target;
+        address multicallHandler;
     }
 
     /// @custom:storage-location erc7201:etherfi.storage.AcrossSwapModule
@@ -290,13 +292,16 @@ contract AcrossSwapModule is ModuleBase, UpgradeableProxy {
         uint256 nonce
     ) internal {
         AcrossSwapModuleStorage storage $ = _getAcrossSwapModuleStorage();
+        (address target, address multicallHandler) = _requestConfig(swapData);
         bytes32 swapId = keccak256(abi.encode(block.chainid, address(this), safe, nonce, order));
         $.swaps[safe] = StoredSwap({
             order: order,
             depositArgs: depositArgs,
             message: message,
             swapId: swapId,
-            swapData: swapData
+            swapData: swapData,
+            target: target,
+            multicallHandler: multicallHandler
         });
 
         _emitSwapRequested(safe, swapId, order);
@@ -337,7 +342,8 @@ contract AcrossSwapModule is ModuleBase, UpgradeableProxy {
         StoredSwap memory swap = $.swaps[safe];
         if (swap.order.srcToken == address(0)) revert NoActiveOrder();
         if (block.timestamp > swap.order.deadline) revert OrderExpired();
-        if ($.spokePool == address(0) || $.multicallHandler == address(0)) revert MissingConfig();
+        if (swap.target == address(0)) revert MissingConfig();
+        if (swap.swapData.length == 0 && swap.multicallHandler == address(0)) revert MissingConfig();
 
         if (address(cashModule) != address(0)) {
             if (block.timestamp < cashModule.getData(safe).pendingWithdrawalRequest.finalizeTime) {
@@ -349,27 +355,22 @@ contract AcrossSwapModule is ModuleBase, UpgradeableProxy {
         if (address(cashModule) != address(0)) cashModule.cancelWithdrawalByModule(safe);
 
         if (swap.swapData.length != 0) _dispatchOriginSwap(safe, swap);
-        else _dispatchDeposit(safe, swap.order, swap.depositArgs, swap.message);
+        else _dispatchDeposit(safe, swap);
 
         emit SwapExecuted(safe, swap.swapId, swap.order.dstChainId, swap.order.dstToken, swap.depositArgs.outputAmount);
     }
 
-    function _dispatchDeposit(
-        address safe,
-        Order memory order,
-        DepositArgs memory depositArgs,
-        bytes memory message
-    ) internal {
-        AcrossSwapModuleStorage storage $ = _getAcrossSwapModuleStorage();
-        bytes memory depositData = _encodeDepositV3(safe, $.multicallHandler, order, depositArgs, message);
-        address spokePool = $.spokePool;
+    function _dispatchDeposit(address safe, StoredSwap memory swap) internal {
+        bytes memory depositData =
+            _encodeDepositV3(safe, swap.multicallHandler, swap.order, swap.depositArgs, swap.message);
+        address spokePool = swap.target;
 
         address[] memory to = new address[](2);
         uint256[] memory values = new uint256[](2);
         bytes[] memory data = new bytes[](2);
 
-        to[0] = order.srcToken;
-        data[0] = abi.encodeCall(IERC20.approve, (spokePool, order.srcAmount));
+        to[0] = swap.order.srcToken;
+        data[0] = abi.encodeCall(IERC20.approve, (spokePool, swap.order.srcAmount));
         to[1] = spokePool;
         data[1] = depositData;
 
@@ -382,7 +383,7 @@ contract AcrossSwapModule is ModuleBase, UpgradeableProxy {
     ///      the BE-built `swapData`: depositor = safe, recipient = destination safe) swaps on origin
     ///      and bridges to the destination.
     function _dispatchOriginSwap(address safe, StoredSwap memory swap) internal {
-        address periphery = _getAcrossSwapModuleStorage().peripheryAddress;
+        address periphery = swap.target;
 
         address[] memory to = new address[](3);
         uint256[] memory values = new uint256[](3);
@@ -517,8 +518,8 @@ contract AcrossSwapModule is ModuleBase, UpgradeableProxy {
     }
 
     /// @dev Digest the safe owners sign over the FULL request (order + depositArgs + message +
-    ///      swapData), bound to the safe nonce. Split from signature verification to keep both
-    ///      under the legacy stack limit.
+    ///      swapData + route config), bound to the safe nonce. Split from signature verification
+    ///      to keep both under the legacy stack limit.
     function _requestDigest(
         address safe,
         Order calldata order,
@@ -527,6 +528,7 @@ contract AcrossSwapModule is ModuleBase, UpgradeableProxy {
         bytes calldata swapData,
         uint256 nonce
     ) internal view returns (bytes32) {
+        (address target, address multicallHandler) = _requestConfig(swapData);
         return keccak256(
             abi.encodePacked(
                 REQUEST_SWAP_SIG,
@@ -537,9 +539,20 @@ contract AcrossSwapModule is ModuleBase, UpgradeableProxy {
                 abi.encode(order),
                 keccak256(abi.encode(depositArgs)),
                 keccak256(message),
-                keccak256(swapData)
+                keccak256(swapData),
+                target,
+                multicallHandler
             )
         ).toEthSignedMessageHash();
+    }
+
+    /// @dev Snapshots the live contracts that affect the selected route. The classic deposit
+    ///      route binds both the SpokePool target and destination MulticallHandler; the origin
+    ///      swap route binds only its periphery target.
+    function _requestConfig(bytes calldata swapData) internal view returns (address target, address multicallHandler) {
+        AcrossSwapModuleStorage storage $ = _getAcrossSwapModuleStorage();
+        if (swapData.length == 0) return ($.spokePool, $.multicallHandler);
+        return ($.peripheryAddress, address(0));
     }
 
     function _onlyAdmin() internal view {

--- a/src/enso/EnsoSwapModule.sol
+++ b/src/enso/EnsoSwapModule.sol
@@ -67,6 +67,7 @@ contract EnsoSwapModule is ModuleBase, UpgradeableProxy, IBridgeModule {
         Order order;
         bytes swapData;
         bytes32 swapId;
+        address target;
     }
 
     /// @custom:storage-location erc7201:etherfi.storage.EnsoSwapModule
@@ -219,7 +220,12 @@ contract EnsoSwapModule is ModuleBase, UpgradeableProxy, IBridgeModule {
     function _storeAndDispatch(address safe, Order calldata order, bytes calldata swapData, uint256 nonce) internal {
         EnsoSwapModuleStorage storage $ = _getEnsoSwapModuleStorage();
         bytes32 swapId = keccak256(abi.encode(block.chainid, address(this), safe, nonce, order));
-        $.swaps[safe] = StoredSwap({ order: order, swapData: swapData, swapId: swapId });
+        $.swaps[safe] = StoredSwap({
+            order: order,
+            swapData: swapData,
+            swapId: swapId,
+            target: $.ensoRouter
+        });
 
         _emitSwapRequested(safe, swapId, order);
 
@@ -258,7 +264,7 @@ contract EnsoSwapModule is ModuleBase, UpgradeableProxy, IBridgeModule {
         StoredSwap memory swap = $.swaps[safe];
         if (swap.order.srcToken == address(0)) revert NoActiveOrder();
         if (block.timestamp > swap.order.deadline) revert OrderExpired();
-        if ($.ensoRouter == address(0)) revert MissingConfig();
+        if (swap.target == address(0)) revert MissingConfig();
 
         if (address(cashModule) != address(0)) {
             if (block.timestamp < cashModule.getData(safe).pendingWithdrawalRequest.finalizeTime) {
@@ -274,12 +280,12 @@ contract EnsoSwapModule is ModuleBase, UpgradeableProxy, IBridgeModule {
         emit SwapExecuted(safe, swap.swapId, swap.order.dstChainId, swap.order.dstToken, swap.order.minOut);
     }
 
-    /// @dev Approve the pinned Enso Router for the input token, forward the signed Enso calldata
+    /// @dev Approve the signed and snapshotted Enso Router for the input token, forward the signed Enso calldata
     ///      verbatim, then reset the approval to zero. The safe is the router's caller, so it
     ///      pulls the input token from the safe and (per the BE-built `swapData`) swaps and/or
     ///      bridges to the recipient encoded in the calldata.
     function _dispatchSwap(address safe, StoredSwap memory swap) internal {
-        address ensoRouter = _getEnsoSwapModuleStorage().ensoRouter;
+        address ensoRouter = swap.target;
 
         address[] memory to = new address[](3);
         uint256[] memory values = new uint256[](3);
@@ -379,8 +385,9 @@ contract EnsoSwapModule is ModuleBase, UpgradeableProxy, IBridgeModule {
         if (!IEtherFiSafe(safe).checkSignatures(digest, signers, signatures)) revert InvalidSignatures();
     }
 
-    /// @dev Digest the safe owners sign over the FULL request (order + swapData), bound to the safe nonce.
+    /// @dev Digest the safe owners sign over the FULL request (order + swapData + target), bound to the safe nonce.
     function _requestDigest(address safe, Order calldata order, bytes calldata swapData, uint256 nonce) internal view returns (bytes32) {
+        address target = _getEnsoSwapModuleStorage().ensoRouter;
         return keccak256(
             abi.encodePacked(
                 REQUEST_SWAP_SIG,
@@ -389,7 +396,8 @@ contract EnsoSwapModule is ModuleBase, UpgradeableProxy, IBridgeModule {
                 nonce,
                 safe,
                 abi.encode(order),
-                keccak256(swapData)
+                keccak256(swapData),
+                target
             )
         ).toEthSignedMessageHash();
     }

--- a/test/across/AcrossSwapModule.t.sol
+++ b/test/across/AcrossSwapModule.t.sol
@@ -140,6 +140,8 @@ contract AcrossSwapModuleTest is SafeTestSetup {
         // The deposit args + message are captured at request for executeSwap to replay.
         assertEq(module.getSwap(address(safe)).depositArgs.outputAmount, MIN_OUT);
         assertEq(module.getSwap(address(safe)).message, FAKE_MESSAGE);
+        assertEq(module.getSwap(address(safe)).target, address(spokePool));
+        assertEq(module.getSwap(address(safe)).multicallHandler, multicallHandler);
         assertEq(cashModule.getData(address(safe)).pendingWithdrawalRequest.recipient, address(module));
     }
 
@@ -200,6 +202,36 @@ contract AcrossSwapModuleTest is SafeTestSetup {
         assertEq(cashModule.getData(address(safe)).pendingWithdrawalRequest.recipient, address(0));
         assertEq(usdc.allowance(address(safe), address(spokePool)), SRC_AMOUNT);
         _checkDepositV3Args(order);
+    }
+
+    function test_executeSwap_usesSpokePoolAndHandlerSnapshottedAtRequest() public {
+        AcrossSwapModule.Order memory order = _baseOrder();
+        _request(order);
+
+        SpokePoolStub newSpokePool = new SpokePoolStub();
+        vm.startPrank(moduleAdmin);
+        module.setSpokePool(address(newSpokePool));
+        module.setMulticallHandler(makeAddr("newMulticallHandler"));
+        vm.stopPrank();
+        _warpPastDelay();
+
+        _executeAsKeeper();
+
+        assertEq(spokePool.callCount(), 1);
+        assertEq(newSpokePool.callCount(), 0);
+        _checkDepositV3Args(order);
+    }
+
+    function test_requestSwap_revertsWhenRouteConfigChangesAfterSigning() public {
+        AcrossSwapModule.Order memory order = _baseOrder();
+        (address[] memory signers, bytes[] memory sigs) = _signRequest(order);
+
+        SpokePoolStub newSpokePool = new SpokePoolStub();
+        vm.prank(moduleAdmin);
+        module.setSpokePool(address(newSpokePool));
+
+        vm.expectRevert(AcrossSwapModule.InvalidSignatures.selector);
+        module.requestSwap(address(safe), order, _baseDepositArgs(MIN_OUT), FAKE_MESSAGE, "", signers, sigs);
     }
 
     function test_executeSwap_permissionless_anyCallerCanExecute() public {
@@ -432,7 +464,9 @@ contract AcrossSwapModuleTest is SafeTestSetup {
             abi.encode(order),
             keccak256(abi.encode(_baseDepositArgs(MIN_OUT))),
             keccak256(FAKE_MESSAGE),
-            keccak256("")
+            keccak256(""),
+            module.getSpokePool(),
+            module.getMulticallHandler()
         )).toEthSignedMessageHash();
         return _twoSig(digest);
     }
@@ -485,6 +519,26 @@ contract AcrossSwapModuleTest is SafeTestSetup {
         assertEq(IERC20(address(usdc)).allowance(address(safe), address(periphery)), 0);
     }
 
+    function test_originSwap_usesPeripherySnapshottedAtRequest() public {
+        PeripheryStub periphery = new PeripheryStub();
+        vm.prank(moduleAdmin);
+        module.setPeriphery(address(periphery));
+
+        AcrossSwapModule.Order memory order = _baseOrder();
+        bytes memory swapData = _originSwapData(SRC_AMOUNT);
+        (address[] memory signers, bytes[] memory sigs) = _signOriginRequest(order, swapData);
+        module.requestSwap(address(safe), order, _baseDepositArgs(MIN_OUT), FAKE_MESSAGE, swapData, signers, sigs);
+
+        PeripheryStub newPeriphery = new PeripheryStub();
+        vm.prank(moduleAdmin);
+        module.setPeriphery(address(newPeriphery));
+        _warpPastDelay();
+        _executeAsKeeper();
+
+        assertEq(periphery.pulled(), SRC_AMOUNT);
+        assertEq(newPeriphery.pulled(), 0);
+    }
+
     /// @dev Origin path swapData the mock periphery understands: pull `amount` of usdc from the safe.
     function _originSwapData(uint256 amount) internal view returns (bytes memory) {
         return abi.encodeWithSelector(PeripheryStub.swapAndBridge.selector, address(usdc), amount);
@@ -502,7 +556,9 @@ contract AcrossSwapModuleTest is SafeTestSetup {
             abi.encode(order),
             keccak256(abi.encode(_baseDepositArgs(MIN_OUT))),
             keccak256(FAKE_MESSAGE),
-            keccak256(swapData)
+            keccak256(swapData),
+            module.getPeriphery(),
+            address(0)
         )).toEthSignedMessageHash();
         return _twoSig(digest);
     }

--- a/test/enso/EnsoSwapModule.t.sol
+++ b/test/enso/EnsoSwapModule.t.sol
@@ -114,6 +114,7 @@ contract EnsoSwapModuleTest is SafeTestSetup {
         assertEq(module.getOrder(address(safe)).srcAmount, SRC_AMOUNT);
         // The Enso calldata is captured at request for executeSwap to replay verbatim.
         assertEq(module.getSwap(address(safe)).swapData, swapData);
+        assertEq(module.getSwap(address(safe)).target, address(ensoRouter));
         assertEq(cashModule.getData(address(safe)).pendingWithdrawalRequest.recipient, address(module));
     }
 
@@ -178,6 +179,33 @@ contract EnsoSwapModuleTest is SafeTestSetup {
         assertEq(cashModule.getData(address(safe)).pendingWithdrawalRequest.recipient, address(0));
         // Approval is reset to zero after forwarding the swap.
         assertEq(usdc.allowance(address(safe), address(ensoRouter)), 0);
+    }
+
+    function test_executeSwap_usesRouterSnapshottedAtRequest() public {
+        _request(_baseOrder());
+
+        EnsoRouterStub newRouter = new EnsoRouterStub();
+        vm.prank(moduleAdmin);
+        module.setEnsoRouter(address(newRouter));
+        _warpPastDelay();
+
+        _executeAsKeeper();
+
+        assertEq(ensoRouter.callCount(), 1);
+        assertEq(newRouter.callCount(), 0);
+    }
+
+    function test_requestSwap_revertsWhenRouterChangesAfterSigning() public {
+        EnsoSwapModule.Order memory order = _baseOrder();
+        bytes memory swapData = _swapData(SRC_AMOUNT);
+        (address[] memory signers, bytes[] memory sigs) = _signRequest(order, swapData);
+
+        EnsoRouterStub newRouter = new EnsoRouterStub();
+        vm.prank(moduleAdmin);
+        module.setEnsoRouter(address(newRouter));
+
+        vm.expectRevert(EnsoSwapModule.InvalidSignatures.selector);
+        module.requestSwap(address(safe), order, swapData, signers, sigs);
     }
 
     function test_executeSwap_permissionless_anyCallerCanExecute() public {
@@ -403,7 +431,8 @@ contract EnsoSwapModuleTest is SafeTestSetup {
             safe.nonce(),
             address(safe),
             abi.encode(order),
-            keccak256(swapData)
+            keccak256(swapData),
+            module.getEnsoRouter()
         )).toEthSignedMessageHash();
         return _twoSig(digest);
     }


### PR DESCRIPTION
## Summary
- include the active execution target in Enso and Across request digests
- snapshot the signed target in each stored swap and dispatch against that snapshot instead of live admin configuration
- bind and snapshot the Across MulticallHandler for classic deposit routes because it controls the destination recipient
- safely reject pre-upgrade in-flight swaps that do not have a snapshotted target
- add regressions covering config changes before request and between request and execution

## Security finding
Addresses Certora **M-08: Swap target is not bound to the signed digest**.

## Tests
- `TEST_CHAIN=10 TEST_RPC=<private OP RPC> ENV=mainnet forge test --match-path test/enso/EnsoSwapModule.t.sol` (30 passed)
- `TEST_CHAIN=10 TEST_RPC=<private OP RPC> ENV=mainnet forge test --match-path test/across/AcrossSwapModule.t.sol` (37 passed)

## Deployment note
The backend digest builders must be deployed with the corresponding target fields before these module implementations are activated.
