### PR TITLE
fix: make Lend reserve registration immutable

### DIFF
--- a/src/modules/lend-gateway/LendGateway.sol
+++ b/src/modules/lend-gateway/LendGateway.sol
@@ -71,7 +71,7 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
     struct LendGatewayStorage {
         /// @notice asset -> Aave reserveId (membership is tracked by `assets`, since reserveId 0 is valid)
         mapping(address asset => uint256 reserveId) reserveId;
-        /// @notice The registered assets; membership doubles as the "is registered" check
+        /// @notice The append-only registered assets; membership doubles as the "is registered" check
         EnumerableSetLib.AddressSet assets;
         /// @notice Extra authorized drivers beyond the CashModule (auto-supply / migration paths)
         mapping(address driver => bool authorized) isDriver;
@@ -85,10 +85,8 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
     // keccak256(abi.encode(uint256(keccak256("etherfi.storage.LendGateway")) - 1)) & ~bytes32(uint256(0xff))
     bytes32 private constant LendGatewayStorageLocation = 0x08cdfbb611f2a1b86b361fad47cf7e3d848e6642121a10c5da4ae64fe25c9800;
 
-    /// @notice Emitted when an asset's reserveId is registered or updated
+    /// @notice Emitted when an asset's reserveId is first registered
     event ReserveRegistered(address indexed asset, uint256 indexed reserveId);
-    /// @notice Emitted when an asset is de-registered
-    event ReserveDeregistered(address indexed asset);
     /// @notice Emitted when a driver is authorized or de-authorized
     event DriverSet(address indexed driver, bool authorized);
     /// @notice Emitted when an asset is added to or removed from the debit-spend set
@@ -120,8 +118,8 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
     error ZeroAmount();
     /// @notice Thrown when a lend op is attempted for a safe that has opted out of lend
     error LendOptedOut();
-    /// @notice Thrown when changing or removing a reserve that still has outstanding debt or supplied balance
-    error ReserveStillInUse();
+    /// @notice Thrown when changing the reserveId of an already registered asset
+    error ReserveAlreadyRegistered(address asset, uint256 reserveId);
     /// @notice Thrown when an operation would leave the safe's health factor below the configured floor
     error HealthFactorBelowMinimum();
     /// @notice Thrown when setting a health-factor floor outside [1e18, 2e18] (0 disables)
@@ -171,53 +169,27 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
     // ---------------------------------------------------------------------
 
     /**
-     * @notice Registers or updates the reserveId for an asset, validated against the Spoke
-     * @dev Re-registering the same reserve is a no-op. Moving to another reserve requires the old reserve to
-     *      have zero aggregate supply and debt so existing positions cannot disappear from gateway accounting.
+     * @notice Registers the reserveId for an asset, validated against the Spoke
+     * @dev Reserve registrations are append-only. Re-registering the same reserve is a no-op, while changing
+     *      an existing mapping reverts so positions can never disappear from gateway accounting.
      * @param asset The underlying asset
      * @param reserveId The Aave reserveId for the asset
      */
     function setReserveId(address asset, uint256 reserveId) external onlyRole(LEND_GATEWAY_ADMIN_ROLE) {
         if (asset == address(0)) revert ZeroAddress();
-        if (spoke.getReserve(reserveId).underlying != asset) revert ReserveAssetMismatch();
 
         LendGatewayStorage storage $ = _getLendGatewayStorage();
         if ($.assets.contains(asset)) {
             uint256 currentReserveId = $.reserveId[asset];
             if (currentReserveId == reserveId) return;
-            if (spoke.getReserveTotalDebt(currentReserveId) != 0 || spoke.getReserveSuppliedAssets(currentReserveId) != 0) {
-                revert ReserveStillInUse();
-            }
+            revert ReserveAlreadyRegistered(asset, currentReserveId);
         }
+        if (spoke.getReserve(reserveId).underlying != asset) revert ReserveAssetMismatch();
 
         $.assets.add(asset);
         $.reserveId[asset] = reserveId;
 
         emit ReserveRegistered(asset, reserveId);
-    }
-
-    /**
-     * @notice De-registers an asset
-     * @dev Reverts while the reserve still has outstanding debt or supplied balance. Removing a
-     * held asset would drop it from the USD views (debt reads 0, understating debt and inflating
-     * borrow headroom) and strand supplied funds behind AssetNotRegistered on the withdraw paths.
-     * Our whitelabel Spoke serves only our safes, so the reserve aggregates gate on our positions.
-     * @param asset The asset to remove from the registry
-     */
-    function removeReserve(address asset) external onlyRole(LEND_GATEWAY_ADMIN_ROLE) {
-        LendGatewayStorage storage $ = _getLendGatewayStorage();
-        if (!$.assets.contains(asset)) revert AssetNotRegistered(asset);
-
-        uint256 reserveId = $.reserveId[asset];
-        if (spoke.getReserveTotalDebt(reserveId) != 0 || spoke.getReserveSuppliedAssets(reserveId) != 0) {
-            revert ReserveStillInUse();
-        }
-
-        $.assets.remove(asset);
-        $.spendAssets.remove(asset);
-        delete $.reserveId[asset];
-
-        emit ReserveDeregistered(asset);
     }
 
     /**

--- a/test/safe/modules/cash/lend/LendGatewayAaveV4.t.sol
+++ b/test/safe/modules/cash/lend/LendGatewayAaveV4.t.sol
@@ -62,25 +62,26 @@ contract LendGatewayAaveV4Test is CashGatewayTestSetup {
         assertTrue(gw.isRegistered(address(usdc)));
         assertEq(gw.reserveIdOf(address(usdc)), usdcReserveId);
 
-        // A reserveId whose underlying != the asset is rejected
+        // A reserveId whose underlying != an unregistered asset is rejected
         vm.prank(owner);
         vm.expectRevert(LendGateway.ReserveAssetMismatch.selector);
-        gw.setReserveId(address(weETH), usdcReserveId);
+        gw.setReserveId(address(usdt), usdcReserveId);
     }
 
-    /// An asset can move to another matching reserve while its current reserve is empty.
-    function test_setReserveId_repointsEmptyReserve() public {
+    /// A registered asset keeps its original reserve even while that reserve is empty.
+    function test_setReserveId_rejectsRepointingEmptyReserve() public {
         IAaveV4Spoke.Reserve memory replacement = IAaveV4Spoke(address(spoke)).getReserve(usdcReserveId);
         replacement.underlying = address(weETH);
         vm.mockCall(address(spoke), abi.encodeWithSelector(IAaveV4Spoke.getReserve.selector, usdcReserveId), abi.encode(replacement));
 
         vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(LendGateway.ReserveAlreadyRegistered.selector, address(weETH), weethReserveId));
         gw.setReserveId(address(weETH), usdcReserveId);
-        assertEq(gw.reserveIdOf(address(weETH)), usdcReserveId);
+        assertEq(gw.reserveIdOf(address(weETH)), weethReserveId);
     }
 
-    /// Re-registering the same reserve is harmless, but a live position prevents moving the asset to another reserve.
-    function test_setReserveId_repointRequiresOldReserveEmpty() public {
+    /// Re-registering the same reserve is harmless, but a live reserve cannot be replaced.
+    function test_setReserveId_rejectsRepointingLiveReserve() public {
         deal(address(weETH), address(safe), 1 ether);
         vm.prank(driver);
         gw.supply(address(safe), address(weETH), 1 ether);
@@ -95,7 +96,7 @@ contract LendGatewayAaveV4Test is CashGatewayTestSetup {
         vm.mockCall(address(spoke), abi.encodeWithSelector(IAaveV4Spoke.getReserve.selector, usdcReserveId), abi.encode(replacement));
 
         vm.prank(owner);
-        vm.expectRevert(LendGateway.ReserveStillInUse.selector);
+        vm.expectRevert(abi.encodeWithSelector(LendGateway.ReserveAlreadyRegistered.selector, address(weETH), weethReserveId));
         gw.setReserveId(address(weETH), usdcReserveId);
     }
 
@@ -206,8 +207,8 @@ contract LendGatewayAaveV4Test is CashGatewayTestSetup {
         assertTrue(gw.isSpendAsset(address(usdc)), "still a debit-spend asset");
     }
 
-    /// setSpendAsset is admin-gated, requires a registered reserve, and removeReserve drops spend membership.
-    function test_setSpendAsset_guardsAndRemovalDropsMembership() public {
+    /// setSpendAsset is admin-gated, requires a registered reserve, and can disable a reserve with outside LP supply.
+    function test_setSpendAsset_guardsAndDisablesSuppliedReserve() public {
         vm.prank(owner);
         vm.expectRevert(abi.encodeWithSelector(LendGateway.AssetNotRegistered.selector, address(0xdead)));
         gw.setSpendAsset(address(0xdead), true);
@@ -215,16 +216,13 @@ contract LendGatewayAaveV4Test is CashGatewayTestSetup {
         vm.expectRevert(); // caller lacks LEND_GATEWAY_ADMIN_ROLE
         gw.setSpendAsset(address(usdc), false);
 
-        // _addAaveReserve manages its own aaveAdmin prank, so list the idle USDT reserve before pranking owner
-        uint256 usdtReserveId = _addAaveReserve(address(usdt), usdcUsdOracle, _usdcCollateralFactorBps(), true);
+        assertGt(spoke.getReserveSuppliedAssets(usdcReserveId), 0, "outside LP liquidity exists");
+        vm.prank(owner);
+        gw.setSpendAsset(address(usdc), false);
 
-        vm.startPrank(owner);
-        gw.setReserveId(address(usdt), usdtReserveId);
-        gw.setSpendAsset(address(usdt), true);
-        assertTrue(gw.isSpendAsset(address(usdt)));
-        gw.removeReserve(address(usdt)); // idle reserve: no debt, no supplied balance
-        vm.stopPrank();
-        assertFalse(gw.isSpendAsset(address(usdt)), "removeReserve drops spend membership");
+        assertFalse(gw.isSpendAsset(address(usdc)), "admin disabled debit spending");
+        assertTrue(gw.isRegistered(address(usdc)), "reserve stays registered for accounting and exits");
+        assertEq(gw.reserveIdOf(address(usdc)), usdcReserveId, "original reserve mapping is retained");
     }
 
     function test_getAccountData_freshSafeIsEmptyAndHealthy() public view {
@@ -333,59 +331,6 @@ contract LendGatewayAaveV4Test is CashGatewayTestSetup {
         vm.prank(owner);
         vm.expectRevert(LendGateway.ZeroAddress.selector);
         gw.setReserveId(address(0), 0);
-    }
-
-    /// An empty reserve (no supply, no debt) removes cleanly and its reads zero out. weETH is used because the
-    /// USDC reserve carries seeded liquidity, which the in-use guard (below) blocks.
-    function test_removeReserve_unregistersAndZeroesReads() public {
-        assertEq(spoke.getReserveSuppliedAssets(weethReserveId), 0, "weETH reserve empty at setup");
-
-        vm.prank(owner);
-        gw.removeReserve(address(weETH));
-
-        assertFalse(gw.isRegistered(address(weETH)));
-        assertEq(gw.ltv(address(weETH)), 0);
-        assertEq(gw.withdrawalLiquidity(address(weETH)), 0);
-        assertEq(gw.suppliedOf(address(safe), address(weETH)), 0);
-        assertEq(gw.debtOf(address(safe), address(weETH)), 0);
-
-        vm.expectRevert(abi.encodeWithSelector(LendGateway.AssetNotRegistered.selector, address(weETH)));
-        gw.reserveIdOf(address(weETH));
-    }
-
-    function test_removeReserve_guards() public {
-        address never = makeAddr("neverRegistered");
-        vm.prank(owner);
-        vm.expectRevert(abi.encodeWithSelector(LendGateway.AssetNotRegistered.selector, never));
-        gw.removeReserve(never);
-
-        vm.prank(makeAddr("notAdmin"));
-        vm.expectRevert(UpgradeableProxy.Unauthorized.selector);
-        gw.removeReserve(address(weETH));
-    }
-
-    /// removeReserve refuses while the reserve still has supply or debt, so a delisting cannot strand positions
-    /// or corrupt the USD views (mirrors the legacy DebtManager unsupportBorrowToken guard).
-    function test_removeReserve_revertsWhileReserveInUse() public {
-        // USDC carries seeded LP liquidity (supplied != 0), so it cannot be pulled
-        vm.prank(owner);
-        vm.expectRevert(LendGateway.ReserveStillInUse.selector);
-        gw.removeReserve(address(usdc));
-
-        // Supplying weETH puts its reserve in use too; a safe borrow then adds USDC debt on top
-        deal(address(weETH), address(safe), 5 ether);
-        vm.startPrank(driver);
-        gw.supply(address(safe), address(weETH), 5 ether);
-        gw.setUsingAsCollateral(address(safe), address(weETH), true);
-        gw.borrow(address(safe), address(usdc), 1000e6, recipient);
-        vm.stopPrank();
-
-        vm.startPrank(owner);
-        vm.expectRevert(LendGateway.ReserveStillInUse.selector);
-        gw.removeReserve(address(weETH));
-        vm.expectRevert(LendGateway.ReserveStillInUse.selector);
-        gw.removeReserve(address(usdc));
-        vm.stopPrank();
     }
 
     // ----------------------------------------------------------------- driver management


### PR DESCRIPTION
## Summary
- make LendGateway reserve registration append-only and reject reserve ID changes
- remove reserve deregistration so permissionless LP dust cannot block wind-down administration
- retain reserves for accounting and exits while setSpendAsset(false) disables debit spending

## Test plan
- [x] forge fmt --check on the changed files
- [x] 39 LendGatewayAaveV4 tests
- [x] broader Lend suite: 292 passed; 2 unrelated OpenOcean FFI tests require OPENOCEAN_API_KEY
- forge lint compiled successfully but Solar cannot resolve imports inside the unchanged lib/aave-v4 submodule

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes governance-only reserve lifecycle on a core lending gateway; misconfiguration can no longer be undone by deregistration, though spend can still be turned off.
> 
> **Overview**
> **Reserve registry is now append-only** in `LendGateway`. Governance can still add assets via `setReserveId`, but **changing an asset’s `reserveId` always reverts** with `ReserveAlreadyRegistered` (re-registering the same id remains a no-op). **`removeReserve` is removed**, along with `ReserveStillInUse`, `ReserveDeregistered`, and the spoke aggregate checks that gated repointing or removal.
> 
> **Operational wind-down** no longer depends on empty reserves: admins **disable card debit spending** with `setSpendAsset(asset, false)` while the reserve **stays registered** so USD views, withdrawals, and repay paths keep working—even when outside LP leaves `getReserveSuppliedAssets` non-zero.
> 
> Tests were updated to expect repoint failures and to cover spend disable on a supplied USDC reserve; `removeReserve` coverage was dropped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7f4936ac0a982ca2e2cb4fe5d479c5653a5440d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->