### PR TITLE
feat: add CashRiskSteward for bounded, rate-limited Aave v4 drawCap tuning

### DIFF
--- a/src/aave-v4/CashRiskSteward.sol
+++ b/src/aave-v4/CashRiskSteward.sol
@@ -42,6 +42,9 @@ interface IAaveV4HubConfigurator {
  * @author ether.fi
  */
 contract CashRiskSteward is Ownable2Step {
+    /// @notice Basis-points denominator (100%).
+    uint256 public constant MAX_BPS = 10_000;
+
     /// @notice The Aave v4 HubConfigurator the steward calls (holds the AccessManager drawCap role)
     IAaveV4HubConfigurator public immutable hubConfigurator;
     /// @notice The Hub whose per-spoke cap is being tuned
@@ -58,8 +61,11 @@ contract CashRiskSteward is Ownable2Step {
     uint256 public maxDrawCapCeiling;
     /// @notice Hard lower bound on `drawCap` (whole tokens). A value > 0 prevents a borrow-freeze grief.
     uint256 public minDrawCapFloor;
-    /// @notice Max change in `drawCap` a single keeper update may make (whole tokens).
-    uint256 public maxStep;
+    /// @notice Max change per keeper update, as a percentage (in BPS) of the CURRENT cap. Scales with
+    ///         volume: e.g. 500 = the keeper may move drawCap by at most ±5% of its current value per
+    ///         update. Bounded to <= MAX_BPS (100%), so one update can at most double the cap upward or
+    ///         move it to zero downward (the floor still binds the result).
+    uint256 public maxStepBps;
     /// @notice Minimum seconds between keeper updates.
     uint256 public cooldown;
 
@@ -71,7 +77,7 @@ contract CashRiskSteward is Ownable2Step {
     bool public paused;
 
     event DrawCapAdjusted(uint256 oldCap, uint256 newCap, address indexed by);
-    event BoundsUpdated(uint256 floor, uint256 ceiling, uint256 maxStep, uint256 cooldown);
+    event BoundsUpdated(uint256 floor, uint256 ceiling, uint256 maxStepBps, uint256 cooldown);
     event KeeperUpdated(address indexed oldKeeper, address indexed newKeeper);
     event PausedSet(bool paused);
 
@@ -81,7 +87,7 @@ contract CashRiskSteward is Ownable2Step {
     error CooldownActive(uint256 readyAt);
     error BelowFloor(uint256 floor);
     error AboveCeiling(uint256 ceiling);
-    error StepTooLarge(uint256 maxStep, uint256 requested);
+    error StepTooLarge(uint256 maxDelta, uint256 requestedDelta);
     error InvalidBounds();
 
     modifier onlyKeeper() {
@@ -89,7 +95,7 @@ contract CashRiskSteward is Ownable2Step {
         _;
     }
 
-    constructor(address hubConfigurator_, address hub_, uint256 assetId_, address spoke_, address governance_, address keeper_, uint256 floor_, uint256 ceiling_, uint256 maxStep_, uint256 cooldown_) Ownable(governance_) {
+    constructor(address hubConfigurator_, address hub_, uint256 assetId_, address spoke_, address governance_, address keeper_, uint256 floor_, uint256 ceiling_, uint256 maxStepBps_, uint256 cooldown_) Ownable(governance_) {
         if (hubConfigurator_ == address(0) || hub_ == address(0) || spoke_ == address(0) || keeper_ == address(0)) {
             revert ZeroAddress();
         }
@@ -101,7 +107,7 @@ contract CashRiskSteward is Ownable2Step {
         maxAllowedSpokeCap = IAaveV4Hub(hub_).MAX_ALLOWED_SPOKE_CAP();
 
         keeper = keeper_;
-        _setBounds(floor_, ceiling_, maxStep_, cooldown_);
+        _setBounds(floor_, ceiling_, maxStepBps_, cooldown_);
     }
 
     /// @notice Move the spoke's `drawCap` to `newDrawCap`, subject to all bounds. The keeper's only
@@ -120,9 +126,12 @@ contract CashRiskSteward is Ownable2Step {
         if (newDrawCap < minDrawCapFloor) revert BelowFloor(minDrawCapFloor);
         if (newDrawCap > maxDrawCapCeiling) revert AboveCeiling(maxDrawCapCeiling);
 
-        // Per-update step bounds the blast radius of a single rogue or buggy keeper call.
+        // Per-update step, as a percentage of the CURRENT cap: bounds the blast radius of a single
+        // rogue or buggy keeper call, and scales with volume as the cap grows. Large or emergency
+        // corrections are governance's job via governanceSetDrawCap (which skips this throttle).
         uint256 delta = newDrawCap > currentCap ? newDrawCap - currentCap : currentCap - newDrawCap;
-        if (delta > maxStep) revert StepTooLarge(maxStep, delta);
+        uint256 maxDelta = currentCap * maxStepBps / MAX_BPS;
+        if (delta > maxDelta) revert StepTooLarge(maxDelta, delta);
 
         lastUpdateTime = block.timestamp;
         hubConfigurator.updateSpokeDrawCap(hub, assetId, spoke, newDrawCap);
@@ -142,8 +151,8 @@ contract CashRiskSteward is Ownable2Step {
     }
 
     /// @notice Governance: update the bounds the keeper operates within.
-    function setBounds(uint256 floor_, uint256 ceiling_, uint256 maxStep_, uint256 cooldown_) external onlyOwner {
-        _setBounds(floor_, ceiling_, maxStep_, cooldown_);
+    function setBounds(uint256 floor_, uint256 ceiling_, uint256 maxStepBps_, uint256 cooldown_) external onlyOwner {
+        _setBounds(floor_, ceiling_, maxStepBps_, cooldown_);
     }
 
     /// @notice Governance: rotate the keeper key.
@@ -172,17 +181,18 @@ contract CashRiskSteward is Ownable2Step {
     }
 
     /// @dev floor <= ceiling, ceiling strictly below Aave's uncapped sentinel (so the steward can never
-    ///      widen the spoke to unlimited), and maxStep > 0 (else the keeper is bricked).
-    function _setBounds(uint256 floor_, uint256 ceiling_, uint256 maxStep_, uint256 cooldown_) internal {
+    ///      widen the spoke to unlimited), and maxStepBps in (0, MAX_BPS] (0 would brick the keeper;
+    ///      capping at 100% stops a single update doubling the cap in one step).
+    function _setBounds(uint256 floor_, uint256 ceiling_, uint256 maxStepBps_, uint256 cooldown_) internal {
         if (floor_ > ceiling_) revert InvalidBounds();
         if (ceiling_ >= uint256(maxAllowedSpokeCap)) revert InvalidBounds();
-        if (maxStep_ == 0) revert InvalidBounds();
+        if (maxStepBps_ == 0 || maxStepBps_ > MAX_BPS) revert InvalidBounds();
 
         minDrawCapFloor = floor_;
         maxDrawCapCeiling = ceiling_;
-        maxStep = maxStep_;
+        maxStepBps = maxStepBps_;
         cooldown = cooldown_;
 
-        emit BoundsUpdated(floor_, ceiling_, maxStep_, cooldown_);
+        emit BoundsUpdated(floor_, ceiling_, maxStepBps_, cooldown_);
     }
 }

--- a/src/aave-v4/CashRiskSteward.sol
+++ b/src/aave-v4/CashRiskSteward.sol
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { Ownable, Ownable2Step } from "@openzeppelin/contracts/access/Ownable2Step.sol";
+
+import { IAaveV4Hub } from "../interfaces/IAaveV4Hub.sol";
+
+/// @dev The single Aave v4 HubConfigurator call the steward drives. `updateSpokeDrawCap` reads the
+///      spoke's current SpokeConfig, overwrites only `drawCap`, and writes it back through the Hub;
+///      it is `restricted` on the real HubConfigurator, so the steward must hold the AccessManager
+///      role scoped to this selector. Verified against aave-v4 (submodule commit cdacec50):
+///      src/hub/HubConfigurator.sol:222, src/hub/interfaces/IHubConfigurator.sol:169.
+interface IAaveV4HubConfigurator {
+    function updateSpokeDrawCap(address hub, uint256 assetId, address spoke, uint256 drawCap) external;
+}
+
+/**
+ * @title CashRiskSteward
+ * @notice Bounds-enforcing wrapper for the ether.fi whitelabel instance's per-spoke borrow cap
+ *         (`drawCap`). It lets a low-trust keeper (an EOA or 1-of-N) tune the Cash spoke's borrow
+ *         cap to track live supply — keeping utilization stable and deposits withdrawable — while
+ *         governance keeps the cap boxed inside an on-chain band the keeper can never leave.
+ * @dev WHY THIS EXISTS. Aave v4's AccessManager gates WHO may call `updateSpokeDrawCap` and with what
+ *      delay, but places NO bound on the drawCap VALUE: `Hub._updateSpokeConfig` does a raw
+ *      `spokeData.drawCap = config.drawCap` with no ceiling/floor check (aave-v4 @ cdacec50,
+ *      Hub.sol:710). So a key granted that selector directly could set drawCap to 0 (freeze all Cash
+ *      borrows) or to `MAX_ALLOWED_SPOKE_CAP` (uncap the spoke -> utilization to 100% -> borrow rate
+ *      spikes and LP withdrawals block). Granting the AccessManager role to THIS contract instead of
+ *      the keeper closes that gap: every keeper move is checked against a governance ceiling, floor,
+ *      per-update step, and cooldown, so a full keeper-key compromise is confined to an availability-
+ *      neutral band [floor, ceiling] and can never uncap the spoke.
+ *
+ *      TRUST MODEL.
+ *      - Governance = the `Ownable2Step` owner (a multisig, ideally behind a timelock). Sets the
+ *        bounds, rotates the keeper, pauses, and has an incident-response setter that skips the
+ *        cooldown/step throttle but is STILL boxed by [floor, ceiling].
+ *      - Keeper = a hot EOA / 1-of-N. May only move drawCap within the live bounds, throttled by the
+ *        cooldown and per-update step. Safe to run hot precisely because the lever is availability-
+ *        only: the steward cannot touch collateral factors, liquidation params, or user funds.
+ *
+ *      The steward drives exactly ONE lever (`drawCap`) on ONE (hub, assetId, spoke), fixed at deploy.
+ * @author ether.fi
+ */
+contract CashRiskSteward is Ownable2Step {
+    /// @notice The Aave v4 HubConfigurator the steward calls (holds the AccessManager drawCap role)
+    IAaveV4HubConfigurator public immutable hubConfigurator;
+    /// @notice The Hub whose per-spoke cap is being tuned
+    address public immutable hub;
+    /// @notice The asset (e.g. USDC) whose borrow cap is being tuned
+    uint256 public immutable assetId;
+    /// @notice The Cash spoke whose `drawCap` is being tuned
+    address public immutable spoke;
+    /// @notice Aave's "uncapped" sentinel; the steward must never let a cap reach it
+    uint40 public immutable maxAllowedSpokeCap;
+
+    /// @notice Hard upper bound on `drawCap` (whole tokens). Kept strictly below `maxAllowedSpokeCap`
+    ///         so the spoke can never be widened to uncapped.
+    uint256 public maxDrawCapCeiling;
+    /// @notice Hard lower bound on `drawCap` (whole tokens). A value > 0 prevents a borrow-freeze grief.
+    uint256 public minDrawCapFloor;
+    /// @notice Max change in `drawCap` a single keeper update may make (whole tokens).
+    uint256 public maxStep;
+    /// @notice Minimum seconds between keeper updates.
+    uint256 public cooldown;
+
+    /// @notice The hot key allowed to tune the cap within bounds.
+    address public keeper;
+    /// @notice Timestamp of the last cap update (keeper or governance path).
+    uint256 public lastUpdateTime;
+    /// @notice When true, keeper updates are blocked (governance path still works).
+    bool public paused;
+
+    event DrawCapAdjusted(uint256 oldCap, uint256 newCap, address indexed by);
+    event BoundsUpdated(uint256 floor, uint256 ceiling, uint256 maxStep, uint256 cooldown);
+    event KeeperUpdated(address indexed oldKeeper, address indexed newKeeper);
+    event PausedSet(bool paused);
+
+    error NotKeeper();
+    error ZeroAddress();
+    error Paused();
+    error CooldownActive(uint256 readyAt);
+    error BelowFloor(uint256 floor);
+    error AboveCeiling(uint256 ceiling);
+    error StepTooLarge(uint256 maxStep, uint256 requested);
+    error InvalidBounds();
+
+    modifier onlyKeeper() {
+        if (msg.sender != keeper) revert NotKeeper();
+        _;
+    }
+
+    constructor(address hubConfigurator_, address hub_, uint256 assetId_, address spoke_, address governance_, address keeper_, uint256 floor_, uint256 ceiling_, uint256 maxStep_, uint256 cooldown_) Ownable(governance_) {
+        if (hubConfigurator_ == address(0) || hub_ == address(0) || spoke_ == address(0) || keeper_ == address(0)) {
+            revert ZeroAddress();
+        }
+
+        hubConfigurator = IAaveV4HubConfigurator(hubConfigurator_);
+        hub = hub_;
+        assetId = assetId_;
+        spoke = spoke_;
+        maxAllowedSpokeCap = IAaveV4Hub(hub_).MAX_ALLOWED_SPOKE_CAP();
+
+        keeper = keeper_;
+        _setBounds(floor_, ceiling_, maxStep_, cooldown_);
+    }
+
+    /// @notice Move the spoke's `drawCap` to `newDrawCap`, subject to all bounds. The keeper's only
+    ///         mutating entrypoint. Reads the current cap live from the Hub as the single source of
+    ///         truth; a revert leaves on-chain state untouched.
+    function adjustDrawCap(uint256 newDrawCap) external onlyKeeper {
+        if (paused) revert Paused();
+
+        uint256 readyAt = lastUpdateTime + cooldown;
+        if (block.timestamp < readyAt) revert CooldownActive(readyAt);
+
+        uint256 currentCap = currentDrawCap();
+
+        // Band: ceiling < maxAllowedSpokeCap guarantees the spoke can never be uncapped; floor > 0
+        // guarantees borrows can never be frozen to zero.
+        if (newDrawCap < minDrawCapFloor) revert BelowFloor(minDrawCapFloor);
+        if (newDrawCap > maxDrawCapCeiling) revert AboveCeiling(maxDrawCapCeiling);
+
+        // Per-update step bounds the blast radius of a single rogue or buggy keeper call.
+        uint256 delta = newDrawCap > currentCap ? newDrawCap - currentCap : currentCap - newDrawCap;
+        if (delta > maxStep) revert StepTooLarge(maxStep, delta);
+
+        lastUpdateTime = block.timestamp;
+        hubConfigurator.updateSpokeDrawCap(hub, assetId, spoke, newDrawCap);
+
+        emit DrawCapAdjusted(currentCap, newDrawCap, msg.sender);
+    }
+
+    /// @notice The live `drawCap` for this spoke as stored on the Hub.
+    function currentDrawCap() public view returns (uint256) {
+        return uint256(IAaveV4Hub(hub).getSpokeConfig(assetId, spoke).drawCap);
+    }
+
+    /// @notice Seconds until the keeper may next update (0 if ready now).
+    function timeUntilReady() external view returns (uint256) {
+        uint256 readyAt = lastUpdateTime + cooldown;
+        return block.timestamp >= readyAt ? 0 : readyAt - block.timestamp;
+    }
+
+    /// @notice Governance: update the bounds the keeper operates within.
+    function setBounds(uint256 floor_, uint256 ceiling_, uint256 maxStep_, uint256 cooldown_) external onlyOwner {
+        _setBounds(floor_, ceiling_, maxStep_, cooldown_);
+    }
+
+    /// @notice Governance: rotate the keeper key.
+    function setKeeper(address newKeeper) external onlyOwner {
+        if (newKeeper == address(0)) revert ZeroAddress();
+        emit KeeperUpdated(keeper, newKeeper);
+        keeper = newKeeper;
+    }
+
+    /// @notice Governance: pause/unpause keeper updates.
+    function setPaused(bool paused_) external onlyOwner {
+        paused = paused_;
+        emit PausedSet(paused_);
+    }
+
+    /// @notice Governance incident-response setter: snap the cap immediately, skipping the cooldown and
+    ///         per-update step throttle. Still boxed by [floor, ceiling] — governance cannot uncap
+    ///         either, so the band remains a hard invariant across every entrypoint.
+    function governanceSetDrawCap(uint256 newDrawCap) external onlyOwner {
+        if (newDrawCap < minDrawCapFloor) revert BelowFloor(minDrawCapFloor);
+        if (newDrawCap > maxDrawCapCeiling) revert AboveCeiling(maxDrawCapCeiling);
+        uint256 currentCap = currentDrawCap();
+        lastUpdateTime = block.timestamp;
+        hubConfigurator.updateSpokeDrawCap(hub, assetId, spoke, newDrawCap);
+        emit DrawCapAdjusted(currentCap, newDrawCap, msg.sender);
+    }
+
+    /// @dev floor <= ceiling, ceiling strictly below Aave's uncapped sentinel (so the steward can never
+    ///      widen the spoke to unlimited), and maxStep > 0 (else the keeper is bricked).
+    function _setBounds(uint256 floor_, uint256 ceiling_, uint256 maxStep_, uint256 cooldown_) internal {
+        if (floor_ > ceiling_) revert InvalidBounds();
+        if (ceiling_ >= uint256(maxAllowedSpokeCap)) revert InvalidBounds();
+        if (maxStep_ == 0) revert InvalidBounds();
+
+        minDrawCapFloor = floor_;
+        maxDrawCapCeiling = ceiling_;
+        maxStep = maxStep_;
+        cooldown = cooldown_;
+
+        emit BoundsUpdated(floor_, ceiling_, maxStep_, cooldown_);
+    }
+}

--- a/test/safe/modules/cash/lend/CashRiskSteward.invariant.t.sol
+++ b/test/safe/modules/cash/lend/CashRiskSteward.invariant.t.sol
@@ -25,7 +25,8 @@ contract CashRiskStewardHandler is Test {
 
     uint256 internal constant FLOOR = 1_000_000;
     uint256 internal constant CEILING = 90_000_000;
-    uint256 internal constant MAX_STEP = 10_000_000;
+    uint256 internal constant MAX_STEP_BPS = 2000; // 20% of current cap per update
+    uint256 internal constant MAX_BPS = 10_000;
 
     constructor(CashRiskSteward steward_, MockAaveV4Hub hub_, MockAaveV4HubConfigurator configurator_, uint256 assetId_, address spoke_, address keeper_, address attacker_) {
         steward = steward_;
@@ -42,10 +43,13 @@ contract CashRiskStewardHandler is Test {
     ///      asserted per-call, which is what makes the campaign non-vacuous.
     function keeperAdjustInBand(uint256 seed) external {
         uint256 cur = steward.currentDrawCap();
-        uint256 lo = cur > MAX_STEP ? cur - MAX_STEP : 0;
+        uint256 maxDelta = cur * MAX_STEP_BPS / MAX_BPS; // step is now % of current cap
+        uint256 lo = cur > maxDelta ? cur - maxDelta : 0;
         if (lo < FLOOR) lo = FLOOR;
-        uint256 hi = cur + MAX_STEP;
+        uint256 hi = cur + maxDelta;
         if (hi > CEILING) hi = CEILING;
+        // When cur sits at the floor, maxDelta may round the window below FLOOR; clamp so lo <= hi.
+        if (lo > hi) lo = hi;
         uint256 target = bound(seed, lo, hi);
 
         vm.warp(block.timestamp + 1 hours + 1);
@@ -64,10 +68,12 @@ contract CashRiskStewardHandler is Test {
     }
 
     /// @dev Adversarial ratchet: a compromised keeper's real play — push the cap UP by the max step
-    ///      every cooldown, climbing toward the ceiling. Each step is individually step-valid, so only
-    ///      the CEILING check can stop the climb. This is what makes the ceiling invariant bite.
+    ///      (% of current) every cooldown, climbing toward the ceiling. Each step is individually
+    ///      step-valid, so only the CEILING check can stop the climb. This makes the ceiling invariant
+    ///      bite: percentage compounding still climbs, just geometrically instead of linearly.
     function keeperRatchetUp() external {
-        uint256 target = steward.currentDrawCap() + MAX_STEP;
+        uint256 cur = steward.currentDrawCap();
+        uint256 target = cur + (cur * MAX_STEP_BPS / MAX_BPS);
         vm.warp(block.timestamp + 1 hours + 1);
         vm.prank(keeper);
         try steward.adjustDrawCap(target) { } catch { }
@@ -106,7 +112,7 @@ contract CashRiskStewardInvariant is Test {
 
     uint256 internal constant FLOOR = 1_000_000;
     uint256 internal constant CEILING = 90_000_000;
-    uint256 internal constant MAX_STEP = 10_000_000;
+    uint256 internal constant MAX_STEP_BPS = 2000;
     uint256 internal constant COOLDOWN = 1 hours;
     uint256 internal constant INIT_CAP = 50_000_000;
 
@@ -117,7 +123,7 @@ contract CashRiskStewardInvariant is Test {
         configurator = new MockAaveV4HubConfigurator(hub);
         hub.setConfigurator(address(configurator));
         hub.seedConfig(ASSET_ID, spoke, IAaveV4Hub.SpokeConfig({ addCap: type(uint40).max, drawCap: uint40(INIT_CAP), riskPremiumThreshold: 0, active: true, halted: false }));
-        steward = new CashRiskSteward(address(configurator), address(hub), ASSET_ID, spoke, governance, keeper, FLOOR, CEILING, MAX_STEP, COOLDOWN);
+        steward = new CashRiskSteward(address(configurator), address(hub), ASSET_ID, spoke, governance, keeper, FLOOR, CEILING, MAX_STEP_BPS, COOLDOWN);
         configurator.grantDrawCapRole(address(steward)); // only the steward holds the role
 
         handler = new CashRiskStewardHandler(steward, hub, configurator, ASSET_ID, spoke, keeper, attacker);

--- a/test/safe/modules/cash/lend/CashRiskSteward.invariant.t.sol
+++ b/test/safe/modules/cash/lend/CashRiskSteward.invariant.t.sol
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { Test } from "forge-std/Test.sol";
+
+import { CashRiskSteward } from "../../../../../../src/aave-v4/CashRiskSteward.sol";
+import { IAaveV4Hub } from "../../../../../../src/interfaces/IAaveV4Hub.sol";
+import { MockAaveV4Hub, MockAaveV4HubConfigurator } from "./mocks/MockAaveV4Hub.sol";
+
+/**
+ * @title CashRiskStewardHandler
+ * @notice Drives the steward through random keeper sequences, adversary bypass attempts, an adversarial
+ *         cap ratchet, and time warps. The fuzzer picks the actions; the invariant contract checks the
+ *         band holds. `keeperAdjustInBand` asserts per-call that a valid move actually lands, so the
+ *         campaign is structurally non-vacuous (the fuzzer cannot "pass" by only ever reverting).
+ */
+contract CashRiskStewardHandler is Test {
+    CashRiskSteward public steward;
+    MockAaveV4Hub public hub;
+    MockAaveV4HubConfigurator public configurator;
+    uint256 public immutable assetId;
+    address public immutable spoke;
+    address public immutable keeper;
+    address public immutable attacker;
+
+    uint256 internal constant FLOOR = 1_000_000;
+    uint256 internal constant CEILING = 90_000_000;
+    uint256 internal constant MAX_STEP = 10_000_000;
+
+    constructor(CashRiskSteward steward_, MockAaveV4Hub hub_, MockAaveV4HubConfigurator configurator_, uint256 assetId_, address spoke_, address keeper_, address attacker_) {
+        steward = steward_;
+        hub = hub_;
+        configurator = configurator_;
+        assetId = assetId_;
+        spoke = spoke_;
+        keeper = keeper_;
+        attacker = attacker_;
+    }
+
+    /// @dev Guaranteed-success keeper path: reads the live cap, picks a target provably inside both the
+    ///      band and the step window, warps past cooldown, adjusts. MUST succeed and land exactly —
+    ///      asserted per-call, which is what makes the campaign non-vacuous.
+    function keeperAdjustInBand(uint256 seed) external {
+        uint256 cur = steward.currentDrawCap();
+        uint256 lo = cur > MAX_STEP ? cur - MAX_STEP : 0;
+        if (lo < FLOOR) lo = FLOOR;
+        uint256 hi = cur + MAX_STEP;
+        if (hi > CEILING) hi = CEILING;
+        uint256 target = bound(seed, lo, hi);
+
+        vm.warp(block.timestamp + 1 hours + 1);
+        vm.prank(keeper);
+        steward.adjustDrawCap(target);
+
+        assertEq(steward.currentDrawCap(), target, "in-band move did not land on target");
+    }
+
+    /// @dev Unconstrained target (straddles the band) to exercise the rejection paths.
+    function keeperAdjust(uint256 target) external {
+        target = bound(target, 0, 120_000_000);
+        vm.warp(block.timestamp + 1 hours + 1);
+        vm.prank(keeper);
+        try steward.adjustDrawCap(target) { } catch { }
+    }
+
+    /// @dev Adversarial ratchet: a compromised keeper's real play — push the cap UP by the max step
+    ///      every cooldown, climbing toward the ceiling. Each step is individually step-valid, so only
+    ///      the CEILING check can stop the climb. This is what makes the ceiling invariant bite.
+    function keeperRatchetUp() external {
+        uint256 target = steward.currentDrawCap() + MAX_STEP;
+        vm.warp(block.timestamp + 1 hours + 1);
+        vm.prank(keeper);
+        try steward.adjustDrawCap(target) { } catch { }
+    }
+
+    /// @dev Attacker calls the configurator directly (must always revert: no AccessManager role).
+    function attackerBypass(uint256 target) external {
+        vm.prank(attacker);
+        try configurator.updateSpokeDrawCap(address(hub), assetId, spoke, target) { } catch { }
+    }
+
+    /// @dev Advance time so cooldown can clear across the sequence.
+    function warp(uint256 dt) external {
+        dt = bound(dt, 0, 3 hours);
+        vm.warp(block.timestamp + dt);
+    }
+}
+
+/**
+ * @title CashRiskStewardInvariant
+ * @notice No reachable sequence of keeper actions, adversary bypass attempts, cap ratchets, or time
+ *         warps can push the live drawCap outside [FLOOR, CEILING] or up to the uncapped sentinel.
+ */
+contract CashRiskStewardInvariant is Test {
+    MockAaveV4Hub internal hub;
+    MockAaveV4HubConfigurator internal configurator;
+    CashRiskSteward internal steward;
+    CashRiskStewardHandler internal handler;
+
+    address internal governance = makeAddr("governance");
+    address internal keeper = makeAddr("keeper");
+    address internal attacker = makeAddr("attacker");
+
+    uint256 internal constant ASSET_ID = 3;
+    address internal spoke = makeAddr("cashSpoke");
+
+    uint256 internal constant FLOOR = 1_000_000;
+    uint256 internal constant CEILING = 90_000_000;
+    uint256 internal constant MAX_STEP = 10_000_000;
+    uint256 internal constant COOLDOWN = 1 hours;
+    uint256 internal constant INIT_CAP = 50_000_000;
+
+    function setUp() public {
+        vm.warp(1_700_000_000);
+
+        hub = new MockAaveV4Hub();
+        configurator = new MockAaveV4HubConfigurator(hub);
+        hub.setConfigurator(address(configurator));
+        hub.seedConfig(ASSET_ID, spoke, IAaveV4Hub.SpokeConfig({ addCap: type(uint40).max, drawCap: uint40(INIT_CAP), riskPremiumThreshold: 0, active: true, halted: false }));
+        steward = new CashRiskSteward(address(configurator), address(hub), ASSET_ID, spoke, governance, keeper, FLOOR, CEILING, MAX_STEP, COOLDOWN);
+        configurator.grantDrawCapRole(address(steward)); // only the steward holds the role
+
+        handler = new CashRiskStewardHandler(steward, hub, configurator, ASSET_ID, spoke, keeper, attacker);
+        targetContract(address(handler));
+    }
+
+    /// @notice Core invariant: the live drawCap always stays inside [FLOOR, CEILING] and never reaches
+    ///         the uncapped sentinel, no matter the action sequence.
+    function invariant_DrawCapStaysInBand() public view {
+        uint256 cap = steward.currentDrawCap();
+        assertGe(cap, FLOOR, "cap fell below floor");
+        assertLe(cap, CEILING, "cap rose above ceiling");
+        assertLt(cap, uint256(type(uint40).max), "cap reached the uncapped sentinel");
+    }
+
+    /// @notice The spoke must never be uncapped.
+    function invariant_NeverUncapped() public view {
+        assertTrue(steward.currentDrawCap() != uint256(type(uint40).max), "spoke got uncapped");
+    }
+}

--- a/test/safe/modules/cash/lend/CashRiskSteward.t.sol
+++ b/test/safe/modules/cash/lend/CashRiskSteward.t.sol
@@ -27,9 +27,9 @@ contract CashRiskStewardBase is Test {
     // whole-token bounds (USDC), matching Aave's whole-asset cap units
     uint256 internal constant FLOOR = 1_000_000; //  1M USDC minimum borrow cap (no freeze)
     uint256 internal constant CEILING = 90_000_000; // 90M USDC hard ceiling (no uncap)
-    uint256 internal constant MAX_STEP = 10_000_000; // 10M per update
+    uint256 internal constant MAX_STEP_BPS = 2000; // 20% of current cap per update
     uint256 internal constant COOLDOWN = 1 hours;
-    uint256 internal constant INIT_CAP = 50_000_000; // 50M starting cap
+    uint256 internal constant INIT_CAP = 50_000_000; // 50M starting cap (20% => 10M max delta)
 
     function setUp() public virtual {
         vm.warp(1_700_000_000); // realistic epoch: block.timestamp >> cooldown, so the first call is ready
@@ -40,7 +40,7 @@ contract CashRiskStewardBase is Test {
 
         hub.seedConfig(ASSET_ID, spoke, IAaveV4Hub.SpokeConfig({ addCap: type(uint40).max, drawCap: uint40(INIT_CAP), riskPremiumThreshold: 0, active: true, halted: false }));
 
-        steward = new CashRiskSteward(address(configurator), address(hub), ASSET_ID, spoke, governance, keeper, FLOOR, CEILING, MAX_STEP, COOLDOWN);
+        steward = new CashRiskSteward(address(configurator), address(hub), ASSET_ID, spoke, governance, keeper, FLOOR, CEILING, MAX_STEP_BPS, COOLDOWN);
 
         // AccessManager: the drawCap role goes to the STEWARD, never the keeper.
         configurator.grantDrawCapRole(address(steward));
@@ -110,10 +110,32 @@ contract CashRiskStewardTest is CashRiskStewardBase {
     }
 
     function test_Keeper_StepLimited() public {
-        // current = 50M, step limit 10M -> 65M is a 15M jump -> revert
+        // current = 50M, step limit 20% => 10M max delta -> 65M is a 15M jump -> revert
         vm.prank(keeper);
-        vm.expectRevert(abi.encodeWithSelector(CashRiskSteward.StepTooLarge.selector, MAX_STEP, 15_000_000));
+        vm.expectRevert(abi.encodeWithSelector(CashRiskSteward.StepTooLarge.selector, 10_000_000, 15_000_000));
         steward.adjustDrawCap(65_000_000);
+    }
+
+    /// @notice The step limit is a PERCENTAGE of the current cap, so the allowed absolute move scales
+    ///         with volume: the same 20% bps permits a 10M move at a 50M cap but only a ~2M move at a
+    ///         10M cap. This is the whole point of the bps form over a fixed absolute step.
+    function test_Keeper_StepScalesWithCap() public {
+        // At the seeded 50M cap, +10M (exactly 20%) is allowed; +10M + 1 is not.
+        vm.prank(keeper);
+        steward.adjustDrawCap(60_000_000);
+        assertEq(steward.currentDrawCap(), 60_000_000);
+
+        // Reseed to a small 10M cap: now 20% is only 2M, so a +5M move (fine at 50M) reverts here.
+        _reseed(10_000_000);
+        vm.warp(block.timestamp + COOLDOWN + 1);
+        vm.prank(keeper);
+        vm.expectRevert(abi.encodeWithSelector(CashRiskSteward.StepTooLarge.selector, 2_000_000, 5_000_000));
+        steward.adjustDrawCap(15_000_000);
+
+        // A +2M move (exactly 20% of 10M) is allowed.
+        vm.prank(keeper);
+        steward.adjustDrawCap(12_000_000);
+        assertEq(steward.currentDrawCap(), 12_000_000);
     }
 
     function test_Cooldown_Enforced() public {
@@ -139,13 +161,13 @@ contract CashRiskStewardTest is CashRiskStewardBase {
     function test_OnlyGovernance_SetBounds() public {
         vm.prank(attacker);
         vm.expectRevert();
-        steward.setBounds(FLOOR, CEILING, MAX_STEP, COOLDOWN);
+        steward.setBounds(FLOOR, CEILING, MAX_STEP_BPS, COOLDOWN);
     }
 
     function test_Governance_RejectsCeilingAtOrAboveMax() public {
         vm.prank(governance);
         vm.expectRevert(CashRiskSteward.InvalidBounds.selector);
-        steward.setBounds(FLOOR, uint256(type(uint40).max), MAX_STEP, COOLDOWN);
+        steward.setBounds(FLOOR, uint256(type(uint40).max), MAX_STEP_BPS, COOLDOWN);
     }
 
     function test_Governance_EmergencyBypassesCooldownButNotBounds() public {

--- a/test/safe/modules/cash/lend/CashRiskSteward.t.sol
+++ b/test/safe/modules/cash/lend/CashRiskSteward.t.sol
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { Test } from "forge-std/Test.sol";
+
+import { CashRiskSteward } from "../../../../../../src/aave-v4/CashRiskSteward.sol";
+import { IAaveV4Hub } from "../../../../../../src/interfaces/IAaveV4Hub.sol";
+import { MockAaveV4Hub, MockAaveV4HubConfigurator } from "./mocks/MockAaveV4Hub.sol";
+
+/**
+ * @title CashRiskStewardBase
+ * @notice Shared setup: a mocked Aave v4 Hub + HubConfigurator, a seeded Cash spoke drawCap, and a
+ *         steward that (as in production) is the SOLE holder of the AccessManager drawCap role.
+ */
+contract CashRiskStewardBase is Test {
+    MockAaveV4Hub internal hub;
+    MockAaveV4HubConfigurator internal configurator;
+    CashRiskSteward internal steward;
+
+    address internal governance = makeAddr("governance");
+    address internal keeper = makeAddr("keeper");
+    address internal attacker = makeAddr("attacker");
+
+    uint256 internal constant ASSET_ID = 3;
+    address internal spoke = makeAddr("cashSpoke");
+
+    // whole-token bounds (USDC), matching Aave's whole-asset cap units
+    uint256 internal constant FLOOR = 1_000_000; //  1M USDC minimum borrow cap (no freeze)
+    uint256 internal constant CEILING = 90_000_000; // 90M USDC hard ceiling (no uncap)
+    uint256 internal constant MAX_STEP = 10_000_000; // 10M per update
+    uint256 internal constant COOLDOWN = 1 hours;
+    uint256 internal constant INIT_CAP = 50_000_000; // 50M starting cap
+
+    function setUp() public virtual {
+        vm.warp(1_700_000_000); // realistic epoch: block.timestamp >> cooldown, so the first call is ready
+
+        hub = new MockAaveV4Hub();
+        configurator = new MockAaveV4HubConfigurator(hub);
+        hub.setConfigurator(address(configurator));
+
+        hub.seedConfig(ASSET_ID, spoke, IAaveV4Hub.SpokeConfig({ addCap: type(uint40).max, drawCap: uint40(INIT_CAP), riskPremiumThreshold: 0, active: true, halted: false }));
+
+        steward = new CashRiskSteward(address(configurator), address(hub), ASSET_ID, spoke, governance, keeper, FLOOR, CEILING, MAX_STEP, COOLDOWN);
+
+        // AccessManager: the drawCap role goes to the STEWARD, never the keeper.
+        configurator.grantDrawCapRole(address(steward));
+    }
+
+    function _reseed(uint40 cap) internal {
+        hub.seedConfig(ASSET_ID, spoke, IAaveV4Hub.SpokeConfig({ addCap: type(uint40).max, drawCap: cap, riskPremiumThreshold: 0, active: true, halted: false }));
+    }
+}
+
+contract CashRiskStewardTest is CashRiskStewardBase {
+    // --- the Aave v4 gap this contract closes ---
+
+    /// @notice Proves the gap: a raw role-holder can uncap the spoke to unlimited (the attack the
+    ///         steward exists to prevent).
+    function test_RawRoleHolder_CanUncapToUnlimited() public {
+        configurator.grantDrawCapRole(attacker);
+        vm.prank(attacker);
+        configurator.updateSpokeDrawCap(address(hub), ASSET_ID, spoke, type(uint40).max);
+        assertEq(steward.currentDrawCap(), uint256(type(uint40).max));
+    }
+
+    /// @notice Proves the grief: a raw role-holder can zero the cap and freeze all borrows.
+    function test_RawRoleHolder_CanFreezeBorrows() public {
+        configurator.grantDrawCapRole(attacker);
+        vm.prank(attacker);
+        configurator.updateSpokeDrawCap(address(hub), ASSET_ID, spoke, 0);
+        assertEq(steward.currentDrawCap(), 0);
+    }
+
+    // --- the fix: the steward is the only role-holder; the keeper is boxed ---
+
+    function test_KeeperCannotCallConfiguratorDirectly() public {
+        vm.prank(keeper);
+        vm.expectRevert(MockAaveV4HubConfigurator.Restricted.selector);
+        configurator.updateSpokeDrawCap(address(hub), ASSET_ID, spoke, 80_000_000);
+    }
+
+    function test_Keeper_CanAdjustWithinBounds() public {
+        vm.prank(keeper);
+        steward.adjustDrawCap(45_000_000);
+        assertEq(steward.currentDrawCap(), 45_000_000);
+    }
+
+    function test_Keeper_CannotExceedCeiling() public {
+        vm.prank(keeper);
+        vm.expectRevert(abi.encodeWithSelector(CashRiskSteward.AboveCeiling.selector, CEILING));
+        steward.adjustDrawCap(CEILING + 1);
+    }
+
+    function test_Keeper_CannotUncap() public {
+        vm.prank(keeper);
+        vm.expectRevert(abi.encodeWithSelector(CashRiskSteward.AboveCeiling.selector, CEILING));
+        steward.adjustDrawCap(type(uint40).max);
+    }
+
+    function test_Keeper_CannotGoBelowFloor() public {
+        vm.prank(keeper);
+        vm.expectRevert(abi.encodeWithSelector(CashRiskSteward.BelowFloor.selector, FLOOR));
+        steward.adjustDrawCap(FLOOR - 1);
+    }
+
+    function test_Keeper_CannotZeroFreeze() public {
+        vm.prank(keeper);
+        vm.expectRevert(abi.encodeWithSelector(CashRiskSteward.BelowFloor.selector, FLOOR));
+        steward.adjustDrawCap(0);
+    }
+
+    function test_Keeper_StepLimited() public {
+        // current = 50M, step limit 10M -> 65M is a 15M jump -> revert
+        vm.prank(keeper);
+        vm.expectRevert(abi.encodeWithSelector(CashRiskSteward.StepTooLarge.selector, MAX_STEP, 15_000_000));
+        steward.adjustDrawCap(65_000_000);
+    }
+
+    function test_Cooldown_Enforced() public {
+        vm.prank(keeper);
+        steward.adjustDrawCap(55_000_000);
+
+        vm.prank(keeper);
+        vm.expectRevert(abi.encodeWithSelector(CashRiskSteward.CooldownActive.selector, block.timestamp + COOLDOWN));
+        steward.adjustDrawCap(52_000_000);
+
+        vm.warp(block.timestamp + COOLDOWN);
+        vm.prank(keeper);
+        steward.adjustDrawCap(52_000_000);
+        assertEq(steward.currentDrawCap(), 52_000_000);
+    }
+
+    function test_OnlyKeeper() public {
+        vm.prank(attacker);
+        vm.expectRevert(CashRiskSteward.NotKeeper.selector);
+        steward.adjustDrawCap(45_000_000);
+    }
+
+    function test_OnlyGovernance_SetBounds() public {
+        vm.prank(attacker);
+        vm.expectRevert();
+        steward.setBounds(FLOOR, CEILING, MAX_STEP, COOLDOWN);
+    }
+
+    function test_Governance_RejectsCeilingAtOrAboveMax() public {
+        vm.prank(governance);
+        vm.expectRevert(CashRiskSteward.InvalidBounds.selector);
+        steward.setBounds(FLOOR, uint256(type(uint40).max), MAX_STEP, COOLDOWN);
+    }
+
+    function test_Governance_EmergencyBypassesCooldownButNotBounds() public {
+        vm.prank(keeper);
+        steward.adjustDrawCap(55_000_000); // arms cooldown
+
+        // governance snaps the cap to the floor immediately (incident response), skipping cooldown/step
+        vm.prank(governance);
+        steward.governanceSetDrawCap(FLOOR);
+        assertEq(steward.currentDrawCap(), FLOOR);
+
+        // but governance still cannot uncap
+        vm.prank(governance);
+        vm.expectRevert(abi.encodeWithSelector(CashRiskSteward.AboveCeiling.selector, CEILING));
+        steward.governanceSetDrawCap(CEILING + 1);
+    }
+
+    function test_Pause_BlocksKeeper() public {
+        vm.prank(governance);
+        steward.setPaused(true);
+        vm.prank(keeper);
+        vm.expectRevert(CashRiskSteward.Paused.selector);
+        steward.adjustDrawCap(45_000_000);
+    }
+
+    function test_TwoStepGovernanceTransfer() public {
+        address newGov = makeAddr("newGov");
+        vm.prank(governance);
+        steward.transferOwnership(newGov);
+        assertEq(steward.owner(), governance, "not transferred until accepted");
+        vm.prank(newGov);
+        steward.acceptOwnership();
+        assertEq(steward.owner(), newGov, "transferred after accept");
+    }
+
+    function test_SetKeeper_RotatesHotKey() public {
+        address newKeeper = makeAddr("newKeeper");
+        vm.prank(governance);
+        steward.setKeeper(newKeeper);
+
+        vm.prank(keeper);
+        vm.expectRevert(CashRiskSteward.NotKeeper.selector);
+        steward.adjustDrawCap(45_000_000);
+
+        vm.prank(newKeeper);
+        steward.adjustDrawCap(45_000_000);
+        assertEq(steward.currentDrawCap(), 45_000_000);
+    }
+
+    // --- fuzz: any target, any starting cap, always ends in-band ---
+
+    /// @notice For ANY fuzzed target and ANY fuzzed starting cap, the resulting on-chain cap is either
+    ///         unchanged (the call reverted) or inside [FLOOR, CEILING] and never the uncapped sentinel.
+    function testFuzz_KeeperAdjust_AlwaysInBand(uint256 target, uint40 startCap) public {
+        startCap = uint40(bound(startCap, FLOOR, CEILING));
+        _reseed(startCap);
+
+        vm.warp(block.timestamp + COOLDOWN + 1);
+        vm.prank(keeper);
+        try steward.adjustDrawCap(target) {
+            uint256 cap = steward.currentDrawCap();
+            assertGe(cap, FLOOR, "below floor after success");
+            assertLe(cap, CEILING, "above ceiling after success");
+            assertLt(cap, uint256(type(uint40).max), "reached uncapped sentinel after success");
+            assertEq(cap, target, "success but cap != target");
+        } catch {
+            assertEq(steward.currentDrawCap(), startCap, "revert must not change state");
+        }
+    }
+}

--- a/test/safe/modules/cash/lend/mocks/MockAaveV4Hub.sol
+++ b/test/safe/modules/cash/lend/mocks/MockAaveV4Hub.sol
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { IAaveV4Hub } from "../../../../../../src/interfaces/IAaveV4Hub.sol";
+
+/// @dev Faithful mock of the drawCap slice of the Aave v4 Hub. Reproduces the behaviour the steward
+///      defends against: the cap write path applies NO ceiling/floor validation (aave-v4 @ cdacec50,
+///      Hub.sol:710). The write is gated to `hubConfigurator` only, mirroring the real AccessManager
+///      `restricted` gate on HubConfigurator. Read-only lens methods are stubbed (unused by the steward).
+contract MockAaveV4Hub is IAaveV4Hub {
+    uint40 public constant MAX_CAP = type(uint40).max;
+
+    address public hubConfigurator;
+    mapping(uint256 => mapping(address => SpokeConfig)) internal _cfg;
+
+    error OnlyConfigurator();
+
+    function setConfigurator(address configurator) external {
+        hubConfigurator = configurator;
+    }
+
+    function MAX_ALLOWED_SPOKE_CAP() external pure returns (uint40) {
+        return MAX_CAP;
+    }
+
+    function getSpokeConfig(uint256 assetId, address spoke) external view returns (SpokeConfig memory) {
+        return _cfg[assetId][spoke];
+    }
+
+    /// @dev Seed initial config for tests (bypasses the gate, as protocol deployment would).
+    function seedConfig(uint256 assetId, address spoke, SpokeConfig calldata config) external {
+        _cfg[assetId][spoke] = config;
+    }
+
+    /// @dev The ONLY drawCap write path. NO ceiling/floor validation — exactly like Aave v4. Callable
+    ///      only by the configurator, which is itself role-gated to the steward.
+    function writeDrawCap(uint256 assetId, address spoke, uint40 drawCap) external {
+        if (msg.sender != hubConfigurator) revert OnlyConfigurator();
+        _cfg[assetId][spoke].drawCap = drawCap;
+    }
+
+    // --- unused lens surface (present to satisfy IAaveV4Hub) ---
+    function getAssetDrawnRate(uint256) external pure returns (uint256) {
+        return 0;
+    }
+
+    function getAssetDrawnIndex(uint256) external pure returns (uint256) {
+        return 0;
+    }
+
+    function previewRemoveByShares(uint256, uint256) external pure returns (uint256) {
+        return 0;
+    }
+
+    function previewRemoveByAssets(uint256, uint256) external pure returns (uint256) {
+        return 0;
+    }
+
+    function previewDrawByShares(uint256, uint256) external pure returns (uint256) {
+        return 0;
+    }
+
+    function getAssetConfig(uint256) external pure returns (AssetConfig memory) {
+        return AssetConfig(address(0), 0, address(0), address(0));
+    }
+
+    function getAssetLiquidity(uint256) external pure returns (uint256) {
+        return 0;
+    }
+
+    function getSpokeTotalOwed(uint256, address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function getSpokeDeficitRay(uint256, address) external pure returns (uint256) {
+        return 0;
+    }
+}
+
+/// @dev Faithful mock of Aave v4's HubConfigurator.updateSpokeDrawCap: read current SpokeConfig,
+///      overwrite ONLY drawCap, write back (aave-v4 @ cdacec50, HubConfigurator.sol:222) — with NO
+///      value bound. The `restricted` modifier is modelled by an explicit AccessManager-style role
+///      check: only addresses granted the drawCap role (the steward) may call it.
+contract MockAaveV4HubConfigurator {
+    MockAaveV4Hub public immutable hub;
+    mapping(address => bool) public hasDrawCapRole;
+
+    error Restricted();
+
+    constructor(MockAaveV4Hub hub_) {
+        hub = hub_;
+    }
+
+    /// @dev Mirrors AccessManager granting the updateSpokeDrawCap selector to an address.
+    function grantDrawCapRole(address account) external {
+        hasDrawCapRole[account] = true;
+    }
+
+    function updateSpokeDrawCap(address, uint256 assetId, address spoke, uint256 drawCap) external {
+        if (!hasDrawCapRole[msg.sender]) revert Restricted();
+        // No bound check here or downstream — the honest reproduction of the Aave gap.
+        hub.writeDrawCap(assetId, spoke, uint40(drawCap));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `src/aave-v4/CashRiskSteward.sol` — a bounds-enforcing wrapper around Aave v4's `HubConfigurator.updateSpokeDrawCap`, so a low-trust keeper (EOA / 1-of-N) can tune the ether.fi Cash spoke's borrow cap to track live supply (keeping utilization stable and deposits withdrawable) while governance keeps the cap inside an on-chain band the keeper can never leave.
- Closes the Aave v4 gap: the `drawCap` **value** is unbounded on-chain (`Hub._updateSpokeConfig` does a raw write with no ceiling/floor check, aave-v4 @ `cdacec50` Hub.sol:710). A key granted that selector directly could set drawCap to `0` (freeze all Cash borrows) or `MAX_ALLOWED_SPOKE_CAP` (uncap → 100% utilization → rate spike + LP withdrawals block). Granting the AccessManager drawCap role to **this contract instead of the keeper** confines every keeper move to `[floor, ceiling]` throttled by a cooldown and a per-update step.

## Protections
Governance sets the band; the keeper can only move within it, throttled:
- **(min, max) cap** — `minDrawCapFloor` / `maxDrawCapCeiling`, enforced on every path. The bounds setter forces `ceiling < MAX_ALLOWED_SPOKE_CAP`, so the spoke can **never** be uncapped — even by governance.
- **Rate limit** — a `cooldown` (min seconds between updates) plus `maxStepBps`, a **percentage of the current cap** (e.g. `500` = ±5% per cooldown). Expressing the step in BPS makes it scale with volume as the book grows (no governance retune) and matches Aave's RiskSteward convention.
- **Role split** — `onlyKeeper` tunes within bounds; `onlyOwner` (governance) sets bounds, rotates the keeper, pauses, and has an incident-response setter that skips the cooldown/step throttle but is **still** boxed by `[floor, ceiling]`.
- **Ownable2Step** governance transfer; single lever (`drawCap`) on a single `(hub, assetId, spoke)` fixed at deploy; every check reads the live cap from the Hub as the source of truth.

## Design notes
- Sits alongside the whitelabel instance plumbing in #209 (`EtherFiSpokeInstance`, `AaveV4RevenueSplitter`); mirrors the splitter's shape (peripheral `src/aave-v4/` contract, immutable config, inline minimal-interface slice, OZ access).
- Complement to AccessManager, not a replacement: AccessManager gates *who / which selector / with what delay*; it does **not** bound the argument value — that's this contract's job.
- Part of the ether.fi Lend project (COR-954); branches from and targets `feat/lend` per the base-branch workflow in #153.

## Test plan
- [x] `FOUNDRY_PROFILE=lend forge test --match-contract CashRiskSteward` — **21 passing** (19 unit/fuzz + 2 stateful invariant)
- [x] Fuzz (10k runs): any target from any starting cap ends unchanged or inside `[floor, ceiling]`, never the uncapped sentinel
- [x] `test_Keeper_StepScalesWithCap`: the same bps permits a 10M move at a 50M cap but only 2M at a 10M cap — proves the step scales with volume
- [x] Stateful invariant (keeper sequences + adversary bypass + adversarial ratchet + time warps): live `drawCap` never leaves the band
- [x] Mutation-verified: removing the ceiling check fails `invariant_DrawCapStaysInBand` (the geometric ratchet breaches `> 90M`) — proves the suite isn't vacuous
- [x] Gap reproduced: `test_RawRoleHolder_CanUncapToUnlimited` / `CanFreezeBorrows` demonstrate the raw-selector danger this wrapper removes
- [ ] Deploy script + AccessManager role wiring (`setTargetFunctionRole` + `grantRole`) — follow-up
- [ ] Fork test against the dev instance (`deployments/dev/10/aave-v4-test.json`) — follow-up

> Note: the bound values in tests (1M floor / 90M ceiling / 20% step / 1h cooldown) are illustrative, not proposed production settings.
