### PR TITLE
feat: add lend errors for cash lends

### DIFF
--- a/src/libraries/LendSourcingLib.sol
+++ b/src/libraries/LendSourcingLib.sol
@@ -24,9 +24,20 @@ library LendSourcingLib {
      *      which Aave lets go freely.
      */
     function withdrawableSupplied(ILendGateway gateway, address safe, address token, uint256 headroom, bool hasDebt) public view returns (uint256) {
-        uint256 supplied = hasDebt ? gateway.collateralForHeadroom(safe, token, headroom) : gateway.suppliedOf(safe, token);
+        (, uint256 withdrawable) = suppliedParts(gateway, safe, token, headroom, hasDebt);
+        return withdrawable;
+    }
+
+    /**
+     * @notice The two legs of withdrawableSupplied: the safe-side supplied amount (headroom-capped when the
+     *         safe carries debt) and the amount actually withdrawable once reserve cash is applied
+     * @dev Callers that decline a spend use the pair to attribute the shortfall: supplied covering the need
+     *      while withdrawable does not means the Hub's cash, not the user's balance, is the binding constraint.
+     */
+    function suppliedParts(ILendGateway gateway, address safe, address token, uint256 headroom, bool hasDebt) public view returns (uint256 supplied, uint256 withdrawable) {
+        supplied = hasDebt ? gateway.collateralForHeadroom(safe, token, headroom) : gateway.suppliedOf(safe, token);
         uint256 cash = gateway.withdrawalLiquidity(token);
-        return supplied < cash ? supplied : cash;
+        withdrawable = supplied < cash ? supplied : cash;
     }
 
     /**
@@ -71,7 +82,13 @@ library LendSourcingLib {
 
         uint256 borrowAmount = fromUsdUp(priceProvider, token, totalSpendingInUsd);
         if (gateway.borrowLiquidity(token) < borrowAmount) {
-            return (false, "Insufficient liquidity to cover the loan");
+            // borrowLiquidity folds Hub cash and the spoke's draw cap into one bound; withdrawalLiquidity is
+            // the cash alone (zero under the same pause/halt gates), so cash covering the loan means the draw
+            // cap (or reported deficit) is what blocks the borrow.
+            if (gateway.withdrawalLiquidity(token) >= borrowAmount) {
+                return (false, "Lend borrow cap reached, please try again later");
+            }
+            return (false, "Insufficient Lend liquidity to cover the loan");
         }
 
         if (gateway.borrowCapacity(safe, token) < borrowAmount) {

--- a/src/libraries/LendSourcingLib.sol
+++ b/src/libraries/LendSourcingLib.sol
@@ -44,23 +44,25 @@ library LendSourcingLib {
      * @notice Sourcing gate for one debit token: loose balance plus the withdrawable supplied amount must
      *         cover `needed`, before and after reserving the `pending` withdrawal against the loose balance
      * @dev The supplied leg is headroom-capped when the safe carries debt; withdrawable further caps it by
-     *      reserve cash. A shortfall the supplied leg would have covered is the Hub's liquidity failing the
-     *      user, not the user's balance — the decline says so. On success `raw` is the loose balance net of
-     *      its pending-withdrawal reservation, for the caller's headroom accounting.
+     *      reserve cash. A shortfall is the Hub's liquidity failing the user only if the spend would clear
+     *      all gates with the cash cap lifted — i.e. the pending-net loose balance plus the full supplied leg
+     *      covers the need; both branches attribute against that same predicate, so a spend also blocked by
+     *      its pending reservation keeps a user-side reason. On success `raw` is the loose balance net of its
+     *      pending-withdrawal reservation, for the caller's headroom accounting.
      */
     function debitTokenCheck(ILendGateway gateway, address safe, address token, uint256 needed, uint256 pending, uint256 headroom, bool hasDebt) public view returns (bool ok, string memory reason, uint256 raw) {
         raw = IERC20Metadata(token).balanceOf(safe);
         (uint256 supplied, uint256 withdrawable) = suppliedParts(gateway, safe, token, headroom, hasDebt);
+        uint256 rawNet = raw > pending ? raw - pending : 0;
         if (raw + withdrawable < needed) {
-            if (raw + supplied >= needed) return (false, "Insufficient Lend withdrawal liquidity, please try again later", 0);
+            if (rawNet + supplied >= needed) return (false, "Insufficient Lend withdrawal liquidity, please try again later", 0);
             return (false, "Insufficient token balance for debit mode spending", 0);
         }
-        raw = raw > pending ? raw - pending : 0;
-        if (raw + withdrawable < needed) {
-            if (raw + supplied >= needed) return (false, "Insufficient Lend withdrawal liquidity, please try again later", 0);
+        if (rawNet + withdrawable < needed) {
+            if (rawNet + supplied >= needed) return (false, "Insufficient Lend withdrawal liquidity, please try again later", 0);
             return (false, "Insufficient effective balance after withdrawal to spend with debit mode", 0);
         }
-        return (true, "", raw);
+        return (true, "", rawNet);
     }
 
     /**

--- a/src/libraries/LendSourcingLib.sol
+++ b/src/libraries/LendSourcingLib.sol
@@ -41,6 +41,29 @@ library LendSourcingLib {
     }
 
     /**
+     * @notice Sourcing gate for one debit token: loose balance plus the withdrawable supplied amount must
+     *         cover `needed`, before and after reserving the `pending` withdrawal against the loose balance
+     * @dev The supplied leg is headroom-capped when the safe carries debt; withdrawable further caps it by
+     *      reserve cash. A shortfall the supplied leg would have covered is the Hub's liquidity failing the
+     *      user, not the user's balance — the decline says so. On success `raw` is the loose balance net of
+     *      its pending-withdrawal reservation, for the caller's headroom accounting.
+     */
+    function debitTokenCheck(ILendGateway gateway, address safe, address token, uint256 needed, uint256 pending, uint256 headroom, bool hasDebt) public view returns (bool ok, string memory reason, uint256 raw) {
+        raw = IERC20Metadata(token).balanceOf(safe);
+        (uint256 supplied, uint256 withdrawable) = suppliedParts(gateway, safe, token, headroom, hasDebt);
+        if (raw + withdrawable < needed) {
+            if (raw + supplied >= needed) return (false, "Insufficient Lend withdrawal liquidity, please try again later", 0);
+            return (false, "Insufficient token balance for debit mode spending", 0);
+        }
+        raw = raw > pending ? raw - pending : 0;
+        if (raw + withdrawable < needed) {
+            if (raw + supplied >= needed) return (false, "Insufficient Lend withdrawal liquidity, please try again later", 0);
+            return (false, "Insufficient effective balance after withdrawal to spend with debit mode", 0);
+        }
+        return (true, "", raw);
+    }
+
+    /**
      * @notice Max credit-mode spend in 6-decimal payment USD
      * @dev For each settlement token, converts min(Aave-priced user capacity, Hub liquidity) through
      *      PriceProvider, rounding payment USD down; returns the largest executable candidate.

--- a/src/modules/cash/CashLens.sol
+++ b/src/modules/cash/CashLens.sol
@@ -62,6 +62,18 @@ contract CashLens is UpgradeableProxy, Constants {
     /// @notice Error thrown when trying to use a token that is not on the borrow whitelist
     error NotABorrowToken();
 
+    /// @dev Working variables of _debitCheck's per-token loop, held in memory to keep the stack flat
+    struct DebitCheckVars {
+        bool hasDebt;
+        uint256 withdrawHeadroom;
+        uint256 needed;
+        uint256 raw;
+        uint256 supplied;
+        uint256 withdrawableSupplied;
+        uint256 pending;
+        uint256 used;
+    }
+
     /**
      * @notice Initializes the CashLens contract with its dependencies
      * @param _cashModule Address of the deployed CashModule contract
@@ -204,10 +216,11 @@ contract CashLens is UpgradeableProxy, Constants {
     /// @notice Debit mode check: each token's spendable amount must cover its share of the spend, threading the borrowing headroom across tokens
     function _debitCheck(address safe, address[] memory tokens, uint256[] memory amountsInUsd, SafeData memory safeData) internal view returns (bool, string memory) {
         ILendGateway lendGateway = gateway();
-        bool hasDebt = lendGateway.hasDebt(safe);
+        DebitCheckVars memory v;
+        v.hasDebt = lendGateway.hasDebt(safe);
         // Aave-priced and buffered by the health-factor floor: quotes size collateral withdrawals so the
         // position stays above the floor; debit execution keeps the raw bound (spends always settle)
-        uint256 withdrawHeadroom = hasDebt ? lendGateway.withdrawHeadroom(safe) : 0;
+        v.withdrawHeadroom = v.hasDebt ? lendGateway.withdrawHeadroom(safe) : 0;
 
         for (uint256 i = 0; i < tokens.length; i++) {
             address token = tokens[i];
@@ -215,25 +228,27 @@ contract CashLens is UpgradeableProxy, Constants {
                 return (false, "Not a supported spend token");
             }
 
-            uint256 needed = LendSourcingLib.fromUsd(IPriceProvider(dataProvider.getPriceProvider()), token, amountsInUsd[i]);
-            uint256 raw = IERC20(token).balanceOf(safe);
-            {
-                uint256 withdrawableSupplied = _withdrawableSupplied(safe, token, withdrawHeadroom, hasDebt);
-                if (raw + withdrawableSupplied < needed) {
-                    return (false, "Insufficient token balance for debit mode spending");
-                }
-                uint256 pending = _getPendingWithdrawalAmount(safeData, token);
-                raw = raw > pending ? raw - pending : 0;
-                if (raw + withdrawableSupplied < needed) {
-                    return (false, "Insufficient effective balance after withdrawal to spend with debit mode");
-                }
+            v.needed = LendSourcingLib.fromUsd(IPriceProvider(dataProvider.getPriceProvider()), token, amountsInUsd[i]);
+            v.raw = IERC20(token).balanceOf(safe);
+            // supplied is the safe-side leg (headroom-capped when in debt); withdrawableSupplied further caps
+            // it by reserve cash. A shortfall the supplied leg would have covered is the Hub's liquidity
+            // failing the user, not the user's balance — the decline says so.
+            (v.supplied, v.withdrawableSupplied) = LendSourcingLib.suppliedParts(lendGateway, safe, token, v.withdrawHeadroom, v.hasDebt);
+            if (v.raw + v.withdrawableSupplied < v.needed) {
+                if (v.raw + v.supplied >= v.needed) return (false, "Insufficient Lend withdrawal liquidity, please try again later");
+                return (false, "Insufficient token balance for debit mode spending");
+            }
+            v.pending = _getPendingWithdrawalAmount(safeData, token);
+            v.raw = v.raw > v.pending ? v.raw - v.pending : 0;
+            if (v.raw + v.withdrawableSupplied < v.needed) {
+                if (v.raw + v.supplied >= v.needed) return (false, "Insufficient Lend withdrawal liquidity, please try again later");
+                return (false, "Insufficient effective balance after withdrawal to spend with debit mode");
             }
 
             // Only the supplied portion (effective raw is spent first) consumes the borrowing headroom for later tokens
-            if (hasDebt) {
-                uint256 usedSupplied = needed > raw ? needed - raw : 0;
-                uint256 used = _headroomRemoved(safe, token, usedSupplied);
-                withdrawHeadroom = withdrawHeadroom > used ? withdrawHeadroom - used : 0;
+            if (v.hasDebt) {
+                v.used = _headroomRemoved(safe, token, v.needed > v.raw ? v.needed - v.raw : 0);
+                v.withdrawHeadroom = v.withdrawHeadroom > v.used ? v.withdrawHeadroom - v.used : 0;
             }
         }
 

--- a/src/modules/cash/CashLens.sol
+++ b/src/modules/cash/CashLens.sol
@@ -67,10 +67,8 @@ contract CashLens is UpgradeableProxy, Constants {
         bool hasDebt;
         uint256 withdrawHeadroom;
         uint256 needed;
-        uint256 raw;
-        uint256 supplied;
-        uint256 withdrawableSupplied;
         uint256 pending;
+        uint256 raw;
         uint256 used;
     }
 
@@ -229,21 +227,13 @@ contract CashLens is UpgradeableProxy, Constants {
             }
 
             v.needed = LendSourcingLib.fromUsd(IPriceProvider(dataProvider.getPriceProvider()), token, amountsInUsd[i]);
-            v.raw = IERC20(token).balanceOf(safe);
-            // supplied is the safe-side leg (headroom-capped when in debt); withdrawableSupplied further caps
-            // it by reserve cash. A shortfall the supplied leg would have covered is the Hub's liquidity
-            // failing the user, not the user's balance — the decline says so.
-            (v.supplied, v.withdrawableSupplied) = LendSourcingLib.suppliedParts(lendGateway, safe, token, v.withdrawHeadroom, v.hasDebt);
-            if (v.raw + v.withdrawableSupplied < v.needed) {
-                if (v.raw + v.supplied >= v.needed) return (false, "Insufficient Lend withdrawal liquidity, please try again later");
-                return (false, "Insufficient token balance for debit mode spending");
-            }
+            // The sourcing gate and its decline reasons (including the Lend-liquidity attribution) live in the
+            // linked LendSourcingLib (code size); on success it returns the loose balance net of the pending
+            // reservation for the headroom accounting below.
             v.pending = _getPendingWithdrawalAmount(safeData, token);
-            v.raw = v.raw > v.pending ? v.raw - v.pending : 0;
-            if (v.raw + v.withdrawableSupplied < v.needed) {
-                if (v.raw + v.supplied >= v.needed) return (false, "Insufficient Lend withdrawal liquidity, please try again later");
-                return (false, "Insufficient effective balance after withdrawal to spend with debit mode");
-            }
+            (bool ok, string memory reason, uint256 rawNet) = LendSourcingLib.debitTokenCheck(lendGateway, safe, token, v.needed, v.pending, v.withdrawHeadroom, v.hasDebt);
+            if (!ok) return (false, reason);
+            v.raw = rawNet;
 
             // Only the supplied portion (effective raw is spent first) consumes the borrowing headroom for later tokens
             if (v.hasDebt) {

--- a/test/safe/modules/cash/lend/BorrowCapacityDryRun.t.sol
+++ b/test/safe/modules/cash/lend/BorrowCapacityDryRun.t.sol
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { console2 } from "forge-std/console2.sol";
+
+import { IAaveV4Hub } from "../../../../../src/interfaces/IAaveV4Hub.sol";
+import { IAaveV4Oracle } from "../../../../../src/interfaces/IAaveV4Oracle.sol";
+import { IAaveV4Spoke } from "../../../../../src/interfaces/IAaveV4Spoke.sol";
+import { CashGatewayTestSetup } from "./CashGatewayTestSetup.t.sol";
+import { ISpoke } from "aave-v4/spoke/interfaces/ISpoke.sol";
+
+/**
+ * @title BorrowCapacityDryRun
+ * @notice Not a regression test: a step-by-step re-derivation of LendGateway._borrowCapacity with every
+ *         intermediate logged, asserted equal to the gateway's own answer, then proven against real Aave by
+ *         borrowing the exact raw quote (succeeds) and one more base unit (reverts).
+ */
+contract BorrowCapacityDryRunTest is CashGatewayTestSetup {
+    uint256 internal constant WEIGHTED_COLLATERAL_TO_DEBT_RAY = 1e41;
+
+    struct Acc {
+        uint256 weightedCollateralValueBps;
+        uint256 totalDebtValueRay;
+        uint256 targetPrice;
+        uint256 targetDrawnIndex;
+        uint256 targetDrawnShares;
+    }
+
+    function test_dryRun_borrowCapacity() public {
+        // ------------------------------------------------------------ scenario
+        // 1 weETH collateral, 400 USDC debt, 20 days of interest accrual, 1.05 HF floor
+        _buildGatewayPosition(address(safe), address(weETH), 1 ether, address(usdc), 400e6);
+        vm.warp(block.timestamp + 20 days);
+        vm.prank(owner);
+        gw.setMinHealthFactor(1.05e18);
+
+        IAaveV4Spoke sp = IAaveV4Spoke(address(spoke));
+        uint256 len = sp.getReserveCount();
+        console2.log("=== position: 1 weETH supplied, 400 USDC borrowed, +20 days, floor 1.05e18 ===");
+        console2.log("reserveCount", len);
+
+        // ------------------------------------------------------------ step 2: accumulate over all reserves
+        uint256[] memory reserveIds = new uint256[](len);
+        for (uint256 i = 0; i < len; i++) reserveIds[i] = i;
+        uint256[] memory prices = IAaveV4Oracle(sp.ORACLE()).getReservesPrices(reserveIds);
+
+        uint256 targetReserveId = gw.reserveIdOf(address(usdc));
+        Acc memory acc;
+        for (uint256 i = 0; i < len; i++) {
+            acc = _addReserve(acc, sp, i, prices[i], i == targetReserveId);
+        }
+
+        console2.log("=== accumulators ===");
+        console2.log("weightedCollateralValueBps", acc.weightedCollateralValueBps);
+        console2.log("  (~USD: /1e26/1e4)", acc.weightedCollateralValueBps / 1e26 / 1e4);
+        console2.log("totalDebtValueRay", acc.totalDebtValueRay);
+        console2.log("  (~USD: /1e26/1e27)", acc.totalDebtValueRay / 1e26 / 1e27);
+
+        // ------------------------------------------------------------ steps 3-5 for both floors
+        IAaveV4Spoke.Reserve memory target = sp.getReserve(targetReserveId);
+        uint256 valuePerDrawnShareRay = acc.targetDrawnIndex * acc.targetPrice * (10 ** (18 - target.decimals));
+        console2.log("valuePerDrawnShareRay", valuePerDrawnShareRay);
+
+        uint256 buffered = _tail(acc, valuePerDrawnShareRay, target, 1.05e18, "floor=1.05");
+        uint256 raw = _tail(acc, valuePerDrawnShareRay, target, 1e18, "floor=1.00");
+
+        assertEq(gw.borrowCapacity(address(safe), address(usdc)), buffered, "manual buffered == gateway borrowCapacity");
+        assertEq(gw.rawBorrowCapacity(address(safe), address(usdc)), raw, "manual raw == gateway rawBorrowCapacity");
+        console2.log("=== gateway agrees: borrowCapacity / rawBorrowCapacity ===", buffered, raw);
+
+        // ------------------------------------------------------------ prove the bound on real Aave
+        IAaveV4Spoke.UserAccountData memory before = sp.getUserAccountData(address(safe));
+        console2.log("Aave healthFactor before (WAD)", before.healthFactor);
+        console2.log("Aave totalDebtValueRay before  ", before.totalDebtValueRay);
+        assertEq(before.totalDebtValueRay, acc.totalDebtValueRay, "debt accumulator matches Aave's view");
+
+        _borrowOnGateway(address(safe), address(usdc), raw, recipient);
+        IAaveV4Spoke.UserAccountData memory afterData = sp.getUserAccountData(address(safe));
+        console2.log("borrowed exact raw quote:", raw);
+        console2.log("Aave healthFactor after (WAD)", afterData.healthFactor);
+        assertGe(afterData.healthFactor, 1e18, "exact raw quote lands at/above 1.00");
+
+        vm.expectRevert();
+        _borrowOnGateway(address(safe), address(usdc), 1, recipient);
+        console2.log("borrowing 1 more base unit: reverted (HF would drop below 1.00)");
+    }
+
+    /// Same walk as above, but with a 20% collateralRisk on weETH so the safe carries non-zero premium debt:
+    /// the scenario of test_borrowCapacity_countsAccruedPremiumDebt, with every intermediate logged.
+    function test_dryRun_borrowCapacity_withPremium() public {
+        vm.prank(aaveAdmin);
+        spoke.updateReserveConfig(weethReserveId, ISpoke.ReserveConfig({ paused: false, frozen: false, borrowable: false, receiveSharesEnabled: true, collateralRisk: 2000 }));
+
+        _buildGatewayPosition(address(safe), address(weETH), 1 ether, address(usdc), 400e6);
+        vm.warp(block.timestamp + 20 days);
+
+        IAaveV4Spoke sp = IAaveV4Spoke(address(spoke));
+        console2.log("=== premium scenario: weETH collateralRisk=2000 BPS, 1 weETH / 400 USDC, +20 days, no floor ===");
+
+        uint256 len = sp.getReserveCount();
+        uint256[] memory reserveIds = new uint256[](len);
+        for (uint256 i = 0; i < len; i++) reserveIds[i] = i;
+        uint256[] memory prices = IAaveV4Oracle(sp.ORACLE()).getReservesPrices(reserveIds);
+
+        uint256 targetReserveId = gw.reserveIdOf(address(usdc));
+        Acc memory acc;
+        for (uint256 i = 0; i < len; i++) {
+            acc = _addReserve(acc, sp, i, prices[i], i == targetReserveId);
+        }
+
+        console2.log("=== accumulators ===");
+        console2.log("weightedCollateralValueBps", acc.weightedCollateralValueBps);
+        console2.log("totalDebtValueRay", acc.totalDebtValueRay);
+
+        IAaveV4Spoke.Reserve memory target = sp.getReserve(targetReserveId);
+        uint256 valuePerDrawnShareRay = acc.targetDrawnIndex * acc.targetPrice * (10 ** (18 - target.decimals));
+        console2.log("valuePerDrawnShareRay", valuePerDrawnShareRay);
+
+        uint256 quote = _tail(acc, valuePerDrawnShareRay, target, 1e18, "floor=1.00");
+        assertEq(gw.rawBorrowCapacity(address(safe), address(usdc)), quote, "manual == gateway rawBorrowCapacity");
+        assertEq(gw.borrowCapacity(address(safe), address(usdc)), quote, "no floor set: buffered == raw");
+        console2.log("=== gateway agrees: capacity ===", quote);
+
+        // Counterfactual: the quote the gateway would give if it ignored premium debt
+        uint256 premiumValueRay = sp.getUserPremiumDebtRay(targetReserveId, address(safe)) * (acc.targetPrice * (10 ** (18 - target.decimals)));
+        Acc memory noPremium = acc;
+        noPremium.totalDebtValueRay -= premiumValueRay;
+        uint256 wrongQuote = _tail(noPremium, valuePerDrawnShareRay, target, 1e18, "counterfactual: premium ignored");
+        console2.log("overquote if premium were ignored (USDC units)", wrongQuote - quote);
+
+        _borrowOnGateway(address(safe), address(usdc), quote, recipient);
+        console2.log("borrowed exact quote:", quote);
+        console2.log("Aave healthFactor after (WAD)", sp.getUserAccountData(address(safe)).healthFactor);
+
+        vm.expectRevert();
+        _borrowOnGateway(address(safe), address(usdc), 1, recipient);
+        console2.log("borrowing 1 more base unit: reverted");
+    }
+
+    /// @dev Mirrors LendGateway._addReserveCapacity, logging each piece.
+    function _addReserve(Acc memory acc, IAaveV4Spoke sp, uint256 reserveId, uint256 price, bool isTarget) internal view returns (Acc memory) {
+        IAaveV4Spoke.Reserve memory reserve = sp.getReserve(reserveId);
+        IAaveV4Spoke.UserPosition memory position = sp.getUserPosition(reserveId, address(safe));
+        (bool isCollateral, bool borrowed) = sp.getUserReserveStatus(reserveId, address(safe));
+        uint256 valueFactor = price * (10 ** (18 - reserve.decimals));
+
+        console2.log("---- reserve", reserveId, reserve.underlying);
+        console2.log("  oraclePrice (8dec) / valueFactor", price, valueFactor);
+        console2.log("  suppliedShares / drawnShares", position.suppliedShares, position.drawnShares);
+        console2.log("  isCollateral / borrowed", isCollateral, borrowed);
+
+        if (isCollateral && position.suppliedShares != 0) {
+            uint256 collateralFactor = sp.getDynamicReserveConfig(reserveId, reserve.dynamicConfigKey).collateralFactor;
+            if (collateralFactor != 0) {
+                uint256 suppliedAssets = IAaveV4Hub(reserve.hub).previewRemoveByShares(reserve.assetId, position.suppliedShares);
+                console2.log("  collateralFactor (BPS)", collateralFactor);
+                console2.log("  suppliedAssets (previewRemoveByShares, down)", suppliedAssets);
+                console2.log("  collateralValue (Value, 1e26=$1)", suppliedAssets * valueFactor);
+                acc.weightedCollateralValueBps += suppliedAssets * valueFactor * collateralFactor;
+                console2.log("  += weightedCollateralValueBps ->", acc.weightedCollateralValueBps);
+            }
+        }
+
+        uint256 drawnIndex;
+        if (borrowed || isTarget) {
+            drawnIndex = IAaveV4Hub(reserve.hub).getAssetDrawnIndex(reserve.assetId);
+            console2.log("  drawnIndex (RAY)", drawnIndex);
+        }
+        if (borrowed) {
+            uint256 premiumDebtRay = sp.getUserPremiumDebtRay(reserveId, address(safe));
+            uint256 debtRay = uint256(position.drawnShares) * drawnIndex + premiumDebtRay;
+            console2.log("  premiumDebtRay", premiumDebtRay);
+            console2.log("  debtRay = drawnShares*index + premium =", debtRay);
+            acc.totalDebtValueRay += debtRay * valueFactor;
+            console2.log("  += totalDebtValueRay ->", acc.totalDebtValueRay);
+        }
+        if (isTarget) {
+            acc.targetPrice = price;
+            acc.targetDrawnIndex = drawnIndex;
+            acc.targetDrawnShares = position.drawnShares;
+        }
+        return acc;
+    }
+
+    /// @dev Mirrors _borrowCapacity's tail: debt ceiling, share budget, uint120 clamp, shares -> assets.
+    function _tail(Acc memory acc, uint256 valuePerDrawnShareRay, IAaveV4Spoke.Reserve memory target, uint256 floor, string memory label) internal view returns (uint256) {
+        console2.log("=== tail:", label, "===");
+        uint256 maxDebtValueRay = (acc.weightedCollateralValueBps * WEIGHTED_COLLATERAL_TO_DEBT_RAY) / floor;
+        console2.log("  maxDebtValueRay", maxDebtValueRay);
+        console2.log("    (~USD)", maxDebtValueRay / 1e26 / 1e27);
+        if (acc.totalDebtValueRay >= maxDebtValueRay) return 0;
+        uint256 room = maxDebtValueRay - acc.totalDebtValueRay;
+        console2.log("  room (Value*RAY)", room);
+        uint256 maxNewDrawnShares = room / valuePerDrawnShareRay;
+        console2.log("  maxNewDrawnShares", maxNewDrawnShares);
+        uint256 shareRoom = type(uint120).max - acc.targetDrawnShares;
+        if (maxNewDrawnShares > shareRoom) maxNewDrawnShares = shareRoom;
+        uint256 amount = IAaveV4Hub(target.hub).previewDrawByShares(target.assetId, maxNewDrawnShares);
+        console2.log("  previewDrawByShares -> capacity (asset units)", amount);
+        return amount;
+    }
+}

--- a/test/safe/modules/cash/lend/CanSpend.t.sol
+++ b/test/safe/modules/cash/lend/CanSpend.t.sol
@@ -45,6 +45,63 @@ contract CashLensCanSpendAaveTest is CashGatewayTestSetup {
         assertEq(reason, "");
     }
 
+    /// Debit spend is declined with an Aave-specific reason when the safe's supplied balance covers the spend
+    /// but the Hub's withdrawal liquidity cannot pay it out (utilization spike / drained reserve).
+    function test_canSpend_fails_inDebitMode_whenAaveWithdrawalLiquidityDrained() public {
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 100e6;
+
+        _supplyToGateway(address(safe), address(usdc), 1000e6); // plenty supplied, nothing loose
+
+        // Draining real Aave takes an unrelated whale borrow, so the reserve-cash read is mocked to isolate
+        // the attribution branch: the safe has the funds, the Hub cannot pay them out.
+        vm.mockCall(address(gw), abi.encodeWithSelector(ILendGateway.withdrawalLiquidity.selector, address(usdc)), abi.encode(uint256(50e6)));
+
+        (bool canSpend, string memory reason) = cashLens.canSpend(address(safe), txId, tokens, amounts);
+        assertEq(canSpend, false);
+        assertEq(reason, "Insufficient Lend withdrawal liquidity, please try again later");
+    }
+
+    /// The user-side decline is unchanged: when the supplied balance itself cannot cover the spend, the
+    /// reason stays the balance message even while reserve liquidity is also short.
+    function test_canSpend_fails_inDebitMode_userShortfallKeepsBalanceMessage() public {
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 100e6;
+
+        _supplyToGateway(address(safe), address(usdc), 50e6); // not enough even if the Hub had cash
+
+        vm.mockCall(address(gw), abi.encodeWithSelector(ILendGateway.withdrawalLiquidity.selector, address(usdc)), abi.encode(uint256(10e6)));
+
+        (bool canSpend, string memory reason) = cashLens.canSpend(address(safe), txId, tokens, amounts);
+        assertEq(canSpend, false);
+        assertEq(reason, "Insufficient token balance for debit mode spending");
+    }
+
+    /// Pending-withdrawal variant: the loose balance is reserved by a withdrawal request and the supplied
+    /// balance could cover the spend, but the Hub cash cannot — attributed to Aave, not the user.
+    function test_canSpend_fails_inDebitMode_withPendingWithdrawal_whenAaveWithdrawalLiquidityDrained() public {
+        _supplyToGateway(address(safe), address(usdc), 1000e6);
+        deal(address(usdc), address(safe), 200e6);
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 200e6;
+        _requestWithdrawal(tokens, amounts, withdrawRecipient);
+
+        vm.mockCall(address(gw), abi.encodeWithSelector(ILendGateway.withdrawalLiquidity.selector, address(usdc)), abi.encode(uint256(50e6)));
+
+        // Loose 200 is fully reserved; supplied 1000 covers the 100 spend but the Hub can only pay 50.
+        amounts[0] = 100e6;
+        (bool canSpend, string memory reason) = cashLens.canSpend(address(safe), txId, tokens, amounts);
+        assertEq(canSpend, false);
+        assertEq(reason, "Insufficient Lend withdrawal liquidity, please try again later");
+    }
+
     /// Credit spend succeeds when the supplied collateral gives enough borrowing power to cover the amount.
     function test_canSpend_succeeds_inCreditMode_whenCollateralAvailable() public {
         _setMode(Mode.Credit);
@@ -93,14 +150,16 @@ contract CashLensCanSpendAaveTest is CashGatewayTestSetup {
         amounts[0] = 100e6;
 
         // Ample borrowing power, but the reserve holds less cash than the loan needs. Reaching a genuinely
-        // drained reserve on real Aave takes an unrelated whale borrow, so the borrowable read is mocked here
-        // to isolate CashLens's liquidity gate (the branch under test).
+        // drained reserve on real Aave takes an unrelated whale borrow, so both liquidity reads are mocked
+        // here to isolate CashLens's liquidity gate (the branch under test): cash itself is short, so the
+        // decline names Aave liquidity rather than the draw cap.
         _supplyToGateway(address(safe), address(weETH), 1 ether);
         vm.mockCall(address(gw), abi.encodeWithSelector(ILendGateway.borrowLiquidity.selector, address(usdc)), abi.encode(amounts[0] - 1));
+        vm.mockCall(address(gw), abi.encodeWithSelector(ILendGateway.withdrawalLiquidity.selector, address(usdc)), abi.encode(amounts[0] - 1));
 
         (bool canSpend, string memory reason) = cashLens.canSpend(address(safe), txId, tokens, amounts);
         assertEq(canSpend, false);
-        assertEq(reason, "Insufficient liquidity to cover the loan");
+        assertEq(reason, "Insufficient Lend liquidity to cover the loan");
     }
 
     /// Credit spend is declined when borrowing power is ample and the pool holds cash, but the loan exceeds
@@ -117,12 +176,13 @@ contract CashLensCanSpendAaveTest is CashGatewayTestSetup {
 
         _supplyToGateway(address(safe), address(weETH), 1 ether); // ample borrowing power
 
-        // drawCap of 50 whole USDC ($50), well under the $100 spend, though the pool holds ~1M cash
+        // drawCap of 50 whole USDC ($50), well under the $100 spend, though the pool holds ~1M cash.
+        // The pool could fund the loan, so the decline names the cap, not liquidity.
         _setAaveSpokeCaps(usdcReserveId, type(uint40).max, 50);
 
         (bool canSpend, string memory reason) = cashLens.canSpend(address(safe), txId, tokens, amounts);
         assertEq(canSpend, false);
-        assertEq(reason, "Insufficient liquidity to cover the loan");
+        assertEq(reason, "Lend borrow cap reached, please try again later");
     }
 
     /// Credit spend succeeds when a pending withdrawal sits against loose funds and the borrow stays within the supplied position's power.

--- a/test/safe/modules/cash/lend/CanSpend.t.sol
+++ b/test/safe/modules/cash/lend/CanSpend.t.sol
@@ -102,6 +102,28 @@ contract CashLensCanSpendAaveTest is CashGatewayTestSetup {
         assertEq(reason, "Insufficient Lend withdrawal liquidity, please try again later");
     }
 
+    /// A drained Hub must not mask a pending-withdrawal shortfall: when the spend could not clear even with
+    /// full withdrawal liquidity (the reserved loose balance is the real blocker), the decline stays the
+    /// user-side balance message rather than promising a retry that can never succeed.
+    function test_canSpend_fails_inDebitMode_pendingShortfallNotAttributedToLendLiquidity() public {
+        _supplyToGateway(address(safe), address(usdc), 100e6);
+        deal(address(usdc), address(safe), 200e6);
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 200e6;
+        _requestWithdrawal(tokens, amounts, withdrawRecipient);
+
+        vm.mockCall(address(gw), abi.encodeWithSelector(ILendGateway.withdrawalLiquidity.selector, address(usdc)), abi.encode(uint256(10e6)));
+
+        // Loose 200 is fully reserved; even with full Hub liquidity only supplied 100 backs the 250 spend.
+        amounts[0] = 250e6;
+        (bool canSpend, string memory reason) = cashLens.canSpend(address(safe), txId, tokens, amounts);
+        assertEq(canSpend, false);
+        assertEq(reason, "Insufficient token balance for debit mode spending");
+    }
+
     /// Credit spend succeeds when the supplied collateral gives enough borrowing power to cover the amount.
     function test_canSpend_succeeds_inCreditMode_whenCollateralAvailable() public {
         _setMode(Mode.Credit);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes only read-path decline strings and shared pre-check logic in CashLens/LendSourcingLib; behavior for genuine user shortfalls is preserved but Hub-liquidity attribution is new and must stay aligned with execution.
> 
> **Overview**
> **Cash `canSpend` now returns clearer Lend-specific decline strings** instead of generic balance or liquidity messages when the real blocker is Hub withdrawal cash, borrow caps, or pool liquidity.
> 
> Debit mode logic moves into **`LendSourcingLib.debitTokenCheck`**: when the safe’s supplied balance would cover the spend but reserve cash cannot pay it out, users see *"Insufficient Lend withdrawal liquidity, please try again later"*; true user shortfalls (including pending-withdrawal cases) still get the existing balance messages. Credit **`creditCheck`** splits *"Lend borrow cap reached, please try again later"* from *"Insufficient Lend liquidity to cover the loan"* by comparing `borrowLiquidity` with `withdrawalLiquidity`. **`CashLens._debitCheck`** calls the library and uses a small struct for stack depth.
> 
> Tests cover the new attribution paths; **`BorrowCapacityDryRun`** is an optional logged walkthrough of borrow capacity math (not a regression suite).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2060279f35eafe4533baad9d94b213b3c373b86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->