### PR TITLE
refactor: address paladin audit info findings in the price feeds

### DIFF
--- a/src/interfaces/IVedaAccountant.sol
+++ b/src/interfaces/IVedaAccountant.sol
@@ -3,8 +3,8 @@ pragma solidity ^0.8.28;
 
 /**
  * @title IVedaAccountant
- * @notice The part of a Veda accountant the feed reads. getRateSafe returns the vault rate and
- *         reverts when the accountant is paused.
+ * @notice The part of a Veda accountant the feed reads. accountantState carries the vault exchange
+ *         rate, the pause flag, and the last update timestamp.
  * @dev MIT mirror of Veda's AccountantWithRateProviders (Se7en-Seas/boring-vault), only what we call.
  * @author ether.fi
  */
@@ -24,10 +24,7 @@ interface IVedaAccountant {
         uint16 performanceFee;
     }
 
-    /// @notice The exchange rate in the base asset; reverts if the accountant is paused
-    function getRateSafe() external view returns (uint256);
-
-    /// @notice The accountant state, including the last exchange-rate update timestamp
+    /// @notice The accountant state, including the exchange rate, pause flag, and last update timestamp
     function accountantState() external view returns (AccountantState memory);
 
     /// @notice The decimals of the exchange rate

--- a/src/oracle/BaseAaveV4PriceFeed.sol
+++ b/src/oracle/BaseAaveV4PriceFeed.sol
@@ -12,9 +12,9 @@ import { StablePriceLib } from "./StablePriceLib.sol";
  * @notice Shared state and math for the Aave v4 receipt-token price feeds. Every feed reports a
  *         feedDecimals-scaled USD price in one of two modes: a USD-quoted source scaled straight to feed
  *         decimals, or a rate in an underlying asset multiplied by that underlying's USD price (any
- *         IAaveV4PriceFeed, which enforces its own staleness). A derived feed supplies only the raw rate
- *         and its decimals from its own source; this base owns the two-mode compose, the stable snap,
- *         decimals(), description(), and the shared errors.
+ *         IAaveV4PriceFeed, which enforces its own staleness). A derived feed supplies its rate decimals
+ *         at construction and the raw rate per read; this base owns the two-mode compose, the stable
+ *         snap, decimals(), description(), and the shared errors.
  * @author ether.fi
  */
 abstract contract BaseAaveV4PriceFeed is IAaveV4PriceFeed {
@@ -32,8 +32,17 @@ abstract contract BaseAaveV4PriceFeed is IAaveV4PriceFeed {
     uint8 public immutable underlyingDecimals;
     /// @notice The decimals of the price this feed reports
     uint8 public immutable feedDecimals;
+    /// @notice The decimals of the raw rate the derived feed reads from its source
+    uint8 public immutable rateDecimals;
     /// @notice Whether the price snaps to exactly 1 USD when within 1% of it (USD stables only)
     bool public immutable isStableToken;
+
+    /// @dev 10 ** feedDecimals; also exactly 1 USD in feed units
+    uint256 private immutable feedScale;
+    /// @dev 10 ** rateDecimals
+    uint256 private immutable rateScale;
+    /// @dev 10 ** (rateDecimals + underlyingDecimals)
+    uint256 private immutable composeScale;
 
     string private _description;
 
@@ -44,12 +53,18 @@ abstract contract BaseAaveV4PriceFeed is IAaveV4PriceFeed {
     /// @notice Thrown when the staleness bound is zero
     error InvalidMaxStaleness();
 
-    constructor(IAaveV4PriceFeed _underlyingUsdFeed, uint8 _feedDecimals, bool _isStableToken, string memory feedDescription) {
+    constructor(IAaveV4PriceFeed _underlyingUsdFeed, uint8 _feedDecimals, uint8 _rateDecimals, bool _isStableToken, string memory feedDescription) {
         underlyingUsdFeed = _underlyingUsdFeed;
+        uint8 _underlyingDecimals;
         if (address(_underlyingUsdFeed) != address(0)) {
-            underlyingDecimals = _underlyingUsdFeed.decimals();
+            _underlyingDecimals = _underlyingUsdFeed.decimals();
         }
+        underlyingDecimals = _underlyingDecimals;
         feedDecimals = _feedDecimals;
+        rateDecimals = _rateDecimals;
+        feedScale = 10 ** _feedDecimals;
+        rateScale = 10 ** _rateDecimals;
+        composeScale = 10 ** (uint256(_rateDecimals) + _underlyingDecimals);
         isStableToken = _isStableToken;
         _description = feedDescription;
     }
@@ -71,17 +86,17 @@ abstract contract BaseAaveV4PriceFeed is IAaveV4PriceFeed {
      *      the underlying leg is non-positive, or when the scaled price floors to zero (a tiny rate lost
      *      to integer division), so the feed never reports a zero collateral price.
      */
-    function _composeUsd(uint256 rate, uint8 rateDecimals) internal view returns (int256) {
+    function _composeUsd(uint256 rate) internal view returns (int256) {
         uint256 price;
         if (address(underlyingUsdFeed) == address(0)) {
-            price = rate.mulDiv(10 ** feedDecimals, 10 ** rateDecimals);
+            price = rate.mulDiv(feedScale, rateScale);
         } else {
             int256 underlyingAnswer = underlyingUsdFeed.latestAnswer();
             if (underlyingAnswer <= 0) revert InvalidPrice();
-            price = rate.mulDiv(underlyingAnswer.toUint256() * 10 ** feedDecimals, 10 ** (rateDecimals + underlyingDecimals));
+            price = rate.mulDiv(underlyingAnswer.toUint256() * feedScale, composeScale);
         }
 
-        price = StablePriceLib.snap(price, isStableToken, feedDecimals);
+        price = StablePriceLib.snap(price, isStableToken, feedScale);
         if (price == 0) revert InvalidPrice();
         return price.toInt256();
     }

--- a/src/oracle/ChainlinkPriceFeed.sol
+++ b/src/oracle/ChainlinkPriceFeed.sol
@@ -26,15 +26,12 @@ contract ChainlinkPriceFeed is BaseAaveV4PriceFeed {
 
     /// @notice The Chainlink feed: a USD price (no underlying) or a rate in the underlying asset
     IAggregatorV3 public immutable rateFeed;
-    /// @notice The decimals of the rate feed
-    uint8 public immutable rateDecimals;
     /// @notice The maximum age in seconds for the rate feed before it is rejected
     uint256 public immutable rateMaxStaleness;
 
-    constructor(IAggregatorV3 _rateFeed, IAaveV4PriceFeed _underlyingUsdFeed, uint8 _feedDecimals, uint256 _rateMaxStaleness, bool _isStableToken, string memory feedDescription) BaseAaveV4PriceFeed(_underlyingUsdFeed, _feedDecimals, _isStableToken, feedDescription) {
+    constructor(IAggregatorV3 _rateFeed, IAaveV4PriceFeed _underlyingUsdFeed, uint8 _feedDecimals, uint256 _rateMaxStaleness, bool _isStableToken, string memory feedDescription) BaseAaveV4PriceFeed(_underlyingUsdFeed, _feedDecimals, _rateFeed.decimals(), _isStableToken, feedDescription) {
         require(_rateMaxStaleness > 0, InvalidMaxStaleness());
         rateFeed = _rateFeed;
-        rateDecimals = _rateFeed.decimals();
         rateMaxStaleness = _rateMaxStaleness;
     }
 
@@ -44,7 +41,7 @@ contract ChainlinkPriceFeed is BaseAaveV4PriceFeed {
      *      underlying leg enforces its own staleness.
      */
     function latestAnswer() external view returns (int256) {
-        return _composeUsd(_readFeed(rateFeed, rateMaxStaleness), rateDecimals);
+        return _composeUsd(_readFeed(rateFeed, rateMaxStaleness));
     }
 
     /// @dev Reads a Chainlink feed, reverting if the price is non-positive or older than maxStaleness

--- a/src/oracle/OracleSinkPriceFeed.sol
+++ b/src/oracle/OracleSinkPriceFeed.sol
@@ -34,20 +34,17 @@ contract OracleSinkPriceFeed is BaseAaveV4PriceFeed {
     IOracleSink public immutable sink;
     /// @notice The token this feed prices, baked in because the sink is token-keyed
     address public immutable token;
-    /// @notice The decimals of the sink's prices
-    uint8 public immutable rateDecimals;
     /// @notice The maximum age in seconds of the relay's source-chain read before the price is rejected
     uint256 public immutable rateMaxStaleness;
 
     /// @notice Thrown when the priced token is the zero address
     error InvalidToken();
 
-    constructor(IOracleSink _sink, address _token, IAaveV4PriceFeed _underlyingUsdFeed, uint8 _feedDecimals, uint256 _rateMaxStaleness, bool _isStableToken, string memory feedDescription) BaseAaveV4PriceFeed(_underlyingUsdFeed, _feedDecimals, _isStableToken, feedDescription) {
+    constructor(IOracleSink _sink, address _token, IAaveV4PriceFeed _underlyingUsdFeed, uint8 _feedDecimals, uint256 _rateMaxStaleness, bool _isStableToken, string memory feedDescription) BaseAaveV4PriceFeed(_underlyingUsdFeed, _feedDecimals, _sink.decimals(), _isStableToken, feedDescription) {
         require(_rateMaxStaleness > 0, InvalidMaxStaleness());
         require(_token != address(0), InvalidToken());
         sink = _sink;
         token = _token;
-        rateDecimals = _sink.decimals();
         rateMaxStaleness = _rateMaxStaleness;
     }
 
@@ -60,6 +57,6 @@ contract OracleSinkPriceFeed is BaseAaveV4PriceFeed {
         (, int256 answer,, uint256 updatedAt,) = sink.latestRoundData(token);
         if (answer <= 0) revert InvalidPrice();
         if (block.timestamp > updatedAt + rateMaxStaleness) revert StalePrice();
-        return _composeUsd(answer.toUint256(), rateDecimals);
+        return _composeUsd(answer.toUint256());
     }
 }

--- a/src/oracle/PythPriceFeed.sol
+++ b/src/oracle/PythPriceFeed.sol
@@ -51,50 +51,49 @@ contract PythPriceFeed is BaseAaveV4PriceFeed {
     /// @notice The Pyth core contract, discovered from the adapter
     IPyth public immutable pyth;
     /// @notice The Pyth feed ids the adapter prices with (zero = unused slot), discovered from the adapter
-    bytes32 public immutable feedId1;
-    bytes32 public immutable feedId2;
-    bytes32 public immutable feedId3;
-    bytes32 public immutable feedId4;
+    bytes32 public immutable baseFeedId1;
+    bytes32 public immutable baseFeedId2;
+    bytes32 public immutable quoteFeedId1;
+    bytes32 public immutable quoteFeedId2;
     /// @notice The maximum age in seconds for every Pyth publish time before the price is rejected
     uint256 public immutable maxStaleness;
-    /// @notice The decimals of the oracle's price
-    uint8 public immutable oracleDecimals;
 
     /// @notice Thrown when a USD-quoted oracle's decimals are lower than the feed decimals
     error UnsupportedDecimals();
 
-    constructor(IPythPairOracle _oracle, uint8 _oracleDecimals, uint8 _feedDecimals, IAaveV4PriceFeed _underlyingUsdFeed, uint256 _maxStaleness, bool _isStableToken, string memory feedDescription) BaseAaveV4PriceFeed(_underlyingUsdFeed, _feedDecimals, _isStableToken, feedDescription) {
+    constructor(IPythPairOracle _oracle, uint8 _rateDecimals, uint8 _feedDecimals, IAaveV4PriceFeed _underlyingUsdFeed, uint256 _maxStaleness, bool _isStableToken, string memory feedDescription) BaseAaveV4PriceFeed(_underlyingUsdFeed, _feedDecimals, _rateDecimals, _isStableToken, feedDescription) {
         // USD-quoted pair: the oracle must be at least as precise as the reported feed decimals
-        if (address(_underlyingUsdFeed) == address(0)) require(_oracleDecimals >= _feedDecimals, UnsupportedDecimals());
+        if (address(_underlyingUsdFeed) == address(0)) {
+            require(_rateDecimals >= _feedDecimals, UnsupportedDecimals());
+        }
         require(_maxStaleness > 0, InvalidMaxStaleness());
 
         oracle = _oracle;
         pyth = IPyth(_oracle.pyth());
-        feedId1 = _oracle.BASE_FEED_1();
-        feedId2 = _oracle.BASE_FEED_2();
-        feedId3 = _oracle.QUOTE_FEED_1();
-        feedId4 = _oracle.QUOTE_FEED_2();
+        baseFeedId1 = _oracle.BASE_FEED_1();
+        baseFeedId2 = _oracle.BASE_FEED_2();
+        quoteFeedId1 = _oracle.QUOTE_FEED_1();
+        quoteFeedId2 = _oracle.QUOTE_FEED_2();
         maxStaleness = _maxStaleness;
-        oracleDecimals = _oracleDecimals;
     }
 
     /// @notice The latest USD price: the pair price, times the underlying USD price when configured
     function latestAnswer() external view returns (int256) {
-        _requireFresh(feedId1);
-        _requireFresh(feedId2);
-        _requireFresh(feedId3);
-        _requireFresh(feedId4);
+        _requireFresh(baseFeedId1);
+        _requireFresh(baseFeedId2);
+        _requireFresh(quoteFeedId1);
+        _requireFresh(quoteFeedId2);
 
         uint256 price = oracle.price();
-        require(price > 0, InvalidPrice());
+        if (price == 0) revert InvalidPrice();
 
-        return _composeUsd(price, oracleDecimals);
+        return _composeUsd(price);
     }
 
     /// @dev Enforces the feed's own staleness bound against the Pyth publish time; zero ids are unused slots
     function _requireFresh(bytes32 feedId) private view {
         if (feedId == bytes32(0)) return;
         uint256 publishTime = pyth.getPriceUnsafe(feedId).publishTime;
-        require(block.timestamp <= publishTime + maxStaleness, StalePrice());
+        if (block.timestamp > publishTime + maxStaleness) revert StalePrice();
     }
 }

--- a/src/oracle/StablePriceLib.sol
+++ b/src/oracle/StablePriceLib.sol
@@ -3,12 +3,12 @@ pragma solidity ^0.8.28;
 
 /// @notice Stable-price handling shared by the Aave v4 price feeds, mirroring PriceProviderV2.
 library StablePriceLib {
-    /// @dev Snaps a USD-stable price to exactly 1 USD when it is within 1% of it; non-stables pass through.
-    function snap(uint256 price, bool isStableToken, uint8 feedDecimals) internal pure returns (uint256) {
+    /// @dev Snaps a USD-stable price to exactly 1 USD (`oneUsd`, 10 ** feed decimals) when it is within
+    ///      1% of it; non-stables pass through.
+    function snap(uint256 price, bool isStableToken, uint256 oneUsd) internal pure returns (uint256) {
         if (!isStableToken) return price;
-        uint256 stablePrice = 10 ** feedDecimals;
-        uint256 maxDeviation = stablePrice / 100;
-        if (price > stablePrice - maxDeviation && price < stablePrice + maxDeviation) return stablePrice;
+        uint256 maxDeviation = oneUsd / 100;
+        if (price > oneUsd - maxDeviation && price < oneUsd + maxDeviation) return oneUsd;
         return price;
     }
 }

--- a/src/oracle/VedaAccountantPriceFeed.sol
+++ b/src/oracle/VedaAccountantPriceFeed.sol
@@ -14,15 +14,15 @@ import { BaseAaveV4PriceFeed } from "./BaseAaveV4PriceFeed.sol";
 contract VedaAccountantPriceFeed is BaseAaveV4PriceFeed {
     /// @notice The Veda accountant that provides the vault exchange rate
     IVedaAccountant public immutable accountant;
-    /// @notice The decimals of the exchange rate from the accountant
-    uint8 public immutable rateDecimals;
     /// @notice The maximum age in seconds for the Veda rate before it is rejected
     uint256 public immutable rateMaxStaleness;
 
-    constructor(IVedaAccountant _accountant, IAaveV4PriceFeed _underlyingUsdFeed, uint8 _feedDecimals, uint256 _rateMaxStaleness, bool _isStableToken, string memory feedDescription) BaseAaveV4PriceFeed(_underlyingUsdFeed, _feedDecimals, _isStableToken, feedDescription) {
+    /// @notice Thrown when the accountant has paused itself
+    error AccountantPaused();
+
+    constructor(IVedaAccountant _accountant, IAaveV4PriceFeed _underlyingUsdFeed, uint8 _feedDecimals, uint256 _rateMaxStaleness, bool _isStableToken, string memory feedDescription) BaseAaveV4PriceFeed(_underlyingUsdFeed, _feedDecimals, _accountant.decimals(), _isStableToken, feedDescription) {
         require(_rateMaxStaleness > 0, InvalidMaxStaleness());
         accountant = _accountant;
-        rateDecimals = _accountant.decimals();
         rateMaxStaleness = _rateMaxStaleness;
     }
 
@@ -33,12 +33,12 @@ contract VedaAccountantPriceFeed is BaseAaveV4PriceFeed {
      */
     function latestAnswer() external view returns (int256) {
         IVedaAccountant.AccountantState memory state = accountant.accountantState();
+        if (state.isPaused) revert AccountantPaused();
         if (block.timestamp > state.lastUpdateTimestamp + rateMaxStaleness) revert StalePrice();
 
-        // Vault rate; reverts if the accountant paused itself.
-        uint256 rate = accountant.getRateSafe();
+        uint256 rate = state.exchangeRate;
         if (rate == 0) revert InvalidPrice();
 
-        return _composeUsd(rate, rateDecimals);
+        return _composeUsd(rate);
     }
 }

--- a/test/price-provider/PythPriceFeed.t.sol
+++ b/test/price-provider/PythPriceFeed.t.sol
@@ -79,7 +79,7 @@ contract PythPriceFeedTest is Test {
 
     /// @notice A positive price that floors to zero after scaling to feed decimals is rejected, not returned as 0.
     function test_latestAnswer_revertsWhenScaledPriceFloorsToZero() public {
-        mockOracle.setPrice(1e7); // positive at 16 decimals, but < 10**(oracleDecimals-feedDecimals), so floors to 0
+        mockOracle.setPrice(1e7); // positive at 16 decimals, but < 10**(rateDecimals-feedDecimals), so floors to 0
         vm.expectRevert(BaseAaveV4PriceFeed.InvalidPrice.selector);
         feed.latestAnswer();
     }
@@ -102,8 +102,8 @@ contract PythPriceFeedTest is Test {
 
     function test_constructor_readsPythWiringFromAdapter() public view {
         assertEq(address(feed.pyth()), address(mockPyth));
-        assertEq(feed.feedId1(), FEED_ID);
-        assertEq(feed.feedId2(), bytes32(0));
+        assertEq(feed.baseFeedId1(), FEED_ID);
+        assertEq(feed.baseFeedId2(), bytes32(0));
         assertEq(feed.maxStaleness(), MAX_STALENESS);
     }
 
@@ -154,7 +154,7 @@ contract PythPriceFeedTest is Test {
         PythPriceFeed liveFeed = new PythPriceFeed(IPythPairOracle(ETHFI_USD_ORACLE), ORACLE_DECIMALS, FEED_DECIMALS, IAaveV4PriceFeed(address(0)), 1 days, false, "ETHFI / USD");
 
         assertEq(address(liveFeed.pyth()), IPythPairOracle(ETHFI_USD_ORACLE).pyth());
-        assertEq(liveFeed.feedId1(), IPythPairOracle(ETHFI_USD_ORACLE).BASE_FEED_1());
+        assertEq(liveFeed.baseFeedId1(), IPythPairOracle(ETHFI_USD_ORACLE).BASE_FEED_1());
 
         uint256 raw = IPythPairOracle(ETHFI_USD_ORACLE).price();
         uint256 price = liveFeed.latestAnswer().toUint256();

--- a/test/price-provider/VedaAccountantPriceFeed.t.sol
+++ b/test/price-provider/VedaAccountantPriceFeed.t.sol
@@ -35,7 +35,7 @@ contract VedaAccountantPriceFeedTest is Test {
 
     /// @notice The reported price equals rate x underlying, and lands in a sane USD range.
     function test_latestAnswer_matchesRateTimesUnderlying() public view {
-        uint256 rate = accountant.getRateSafe();
+        uint256 rate = accountant.accountantState().exchangeRate;
         (, int256 ethUsd,,,) = IAggregatorV3(ethUsdOracle).latestRoundData();
 
         uint256 expected = rate * ethUsd.toUint256() * (10 ** FEED_DECIMALS) / (10 ** (feed.rateDecimals() + feed.underlyingDecimals()));
@@ -76,16 +76,20 @@ contract VedaAccountantPriceFeedTest is Test {
         new VedaAccountantPriceFeed(accountant, IAaveV4PriceFeed(ethUsdOracle), FEED_DECIMALS, 0, false, "liquidETH / USD");
     }
 
-    /// @notice Reverts when the accountant has paused itself (getRateSafe reverts).
+    /// @notice Reverts when the accountant has paused itself.
     function test_reverts_whenAccountantPaused() public {
-        vm.mockCallRevert(address(accountant), abi.encodeWithSelector(IVedaAccountant.getRateSafe.selector), "paused");
-        vm.expectRevert();
+        IVedaAccountant.AccountantState memory state = accountant.accountantState();
+        state.isPaused = true;
+        vm.mockCall(address(accountant), abi.encodeWithSelector(IVedaAccountant.accountantState.selector), abi.encode(state));
+        vm.expectRevert(VedaAccountantPriceFeed.AccountantPaused.selector);
         feed.latestAnswer();
     }
 
     /// @notice Reverts when the rate is zero.
     function test_reverts_whenRateZero() public {
-        vm.mockCall(address(accountant), abi.encodeWithSelector(IVedaAccountant.getRateSafe.selector), abi.encode(uint256(0)));
+        IVedaAccountant.AccountantState memory state = accountant.accountantState();
+        state.exchangeRate = 0;
+        vm.mockCall(address(accountant), abi.encodeWithSelector(IVedaAccountant.accountantState.selector), abi.encode(state));
         vm.expectRevert(BaseAaveV4PriceFeed.InvalidPrice.selector);
         feed.latestAnswer();
     }
@@ -93,7 +97,7 @@ contract VedaAccountantPriceFeedTest is Test {
     /// @notice Without an underlying feed, the price is the accountant rate scaled to feed decimals.
     function test_noUnderlying_latestAnswer_isScaledRate() public {
         VedaAccountantPriceFeed usdFeed = new VedaAccountantPriceFeed(accountant, IAaveV4PriceFeed(address(0)), FEED_DECIMALS, RATE_MAX_STALENESS, false, "liquidETH / ETH");
-        uint256 rate = accountant.getRateSafe();
+        uint256 rate = accountant.accountantState().exchangeRate;
         uint256 expected = rate * (10 ** FEED_DECIMALS) / (10 ** usdFeed.rateDecimals());
         assertEq(usdFeed.latestAnswer().toUint256(), expected);
     }
@@ -101,9 +105,12 @@ contract VedaAccountantPriceFeedTest is Test {
     /// @notice A stable feed snaps to exactly 1 USD inside the 1% band and passes the raw price outside it.
     function test_stable_snapsWithinOnePercent() public {
         VedaAccountantPriceFeed stableFeed = new VedaAccountantPriceFeed(accountant, IAaveV4PriceFeed(address(0)), FEED_DECIMALS, RATE_MAX_STALENESS, true, "STABLE / USD");
-        vm.mockCall(address(accountant), abi.encodeWithSelector(IVedaAccountant.getRateSafe.selector), abi.encode(uint256(0.995e18)));
+        IVedaAccountant.AccountantState memory state = accountant.accountantState();
+        state.exchangeRate = 0.995e18;
+        vm.mockCall(address(accountant), abi.encodeWithSelector(IVedaAccountant.accountantState.selector), abi.encode(state));
         assertEq(stableFeed.latestAnswer(), 1e8);
-        vm.mockCall(address(accountant), abi.encodeWithSelector(IVedaAccountant.getRateSafe.selector), abi.encode(uint256(1.02e18)));
+        state.exchangeRate = 1.02e18;
+        vm.mockCall(address(accountant), abi.encodeWithSelector(IVedaAccountant.accountantState.selector), abi.encode(state));
         assertEq(stableFeed.latestAnswer(), 1.02e8);
     }
 


### PR DESCRIPTION
Fixes for the resolved findings from Paladin's preliminary audit report (2026-07-23) of the Aave v4 price feeds. Targets `feat/lend-price-feeds` (#199) so the resolution lands on the audited PR.

- **01.1** (Base, gas): `rateDecimals` moves into `BaseAaveV4PriceFeed` and the three `10 ** x` scale factors are precomputed as immutables; `_composeUsd` drops its per-call decimals param and `StablePriceLib.snap` takes the precomputed one-USD scale. Deletes the four per-feed `rateDecimals`/`oracleDecimals` copies; external constructor signatures are unchanged, so deploy scripts are unaffected.
- **03** (Pyth, naming/style): `feedId1-4` renamed to `baseFeedId1/2`, `quoteFeedId1/2`; source decimals now named `rateDecimals` like the siblings (via the base move); runtime `require(cond, Error())` converted to `if (!cond) revert Error()`; the braceless constructor `if` is braced.
- **04** (Veda): `latestAnswer` reads `isPaused` and `exchangeRate` from the already-fetched `AccountantState` instead of a second `getRateSafe()` call, with a new `AccountantPaused` error; `getRateSafe` is dropped from `IVedaAccountant`. Verified against boring-vault source that `getRateSafe` is exactly the pause check plus the struct's `exchangeRate`.

Not changed (acknowledged to Paladin): the redundant `SafeCast.toUint256()` after sign guards (01.2/02/05) is kept deliberately for forge-lint `unsafe-typecast` conformity and defense in depth.

Decisions made under uncertainty, for a second pair of eyes:
- Constructor `require(cond, Error())` style is kept in all four feeds (Paladin only flagged Pyth's runtime paths); the repo split is now "require in constructors, if/revert in read paths".
- A paused accountant now reverts with our `AccountantPaused` selector instead of bubbling Veda's error.

Tested with `forge test --match-path "test/price-provider/*"` (99 passed, includes OP fork tests), full `forge test` (remaining failures are missing env vars / public-RPC 429s, unrelated), `forge fmt --check` and `forge lint` on changed files (only the accepted block-timestamp warnings).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live oracle price composition and Veda pause/revert behavior on collateral pricing paths; intended to be equivalent aside from the explicit AccountantPaused error selector.
> 
> **Overview**
> Addresses Paladin audit findings on the Aave v4 price feeds by centralizing rate scaling in **`BaseAaveV4PriceFeed`**, tightening Veda reads, and aligning Pyth naming/style.
> 
> **Base / gas:** `rateDecimals` now lives on the base contract (each child passes source decimals at deploy). **`feedScale`**, **`rateScale`**, and **`composeScale`** are precomputed immutables so **`_composeUsd`** no longer recomputes `10 ** x` or takes a per-call decimals argument. **`StablePriceLib.snap`** takes the precomputed one-USD scale instead of `feedDecimals`. Per-feed duplicate `rateDecimals` / `oracleDecimals` fields are removed; Chainlink, OracleSink, and Veda still expose **`rateDecimals()`** via the base.
> 
> **Veda:** **`latestAnswer`** uses a single **`accountantState()`** call for pause, staleness timestamp, and **`exchangeRate`** instead of **`getRateSafe()`**; pause reverts with **`AccountantPaused`**. **`getRateSafe`** is removed from **`IVedaAccountant`**.
> 
> **Pyth:** Feed id immutables are renamed to **`baseFeedId1/2`** and **`quoteFeedId1/2`**; constructor decimals arg is **`rateDecimals`**. Read-path checks use **`if (…) revert`** instead of **`require(…, Error())`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac7092621579e5bbe630104dbd22e1d9d9f78470. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->