### PR TITLE
docs: record the lend position-manager exit invariant

### DIFF
--- a/src/modules/lend-gateway/LendGateway.sol
+++ b/src/modules/lend-gateway/LendGateway.sol
@@ -32,6 +32,13 @@ import { LendCapacityLib } from "./LendCapacityLib.sol";
  *         live from the data provider); further drivers are added by a LEND_GATEWAY_ADMIN_ROLE holder. A position
  *         manager can move user funds, so who may drive it is the most security-critical surface in this contract.
  *
+ *      Invariant: assets only leave a safe's position through this gateway, so every exit lands in the safe
+ *      (behind the Cash withdrawal delay) or card settlement (behind spend checks); liquidation at HF < 1 is
+ *      the only exception. Two conditions keep it: no position manager other than this gateway is ever
+ *      activated on the Spoke (spoke admin controlled), and EtherFiSafe never implements ERC-1271
+ *      isValidSignature. Breaking either arms the Spoke's setUserPositionManagersWithSig, letting safe owners
+ *      hand the position to another manager by signature alone and withdraw collateral with no delay.
+ *
  *      Aave v4 addresses reserves by a uint256 reserveId, not by asset address. The gateway keeps its own
  *      asset -> reserveId registry, each entry validated against the Spoke's getReserve at registration time.
  *

--- a/src/safe/MultiSig.sol
+++ b/src/safe/MultiSig.sol
@@ -12,6 +12,8 @@ import { EtherFiSafeBase } from "./EtherFiSafeBase.sol";
  * @title MultiSig
  * @author ether.fi
  * @notice Implements multi-sig functionality with configurable owners and threshold
+ * @dev Deliberately does not expose ERC-1271 isValidSignature. Adding it would arm Aave's
+ *      setUserPositionManagersWithSig against safes; see the invariant in LendGateway before changing this.
  */
 abstract contract MultiSig is EtherFiSafeBase {
     using SignatureUtils for bytes32;


### PR DESCRIPTION
## Summary
- Responds to the auditor flag on Aave v4's setUserPositionManagersWithSig: a signature-only path for a user to approve any position manager on the Spoke.
- It is dead today only because EtherFiSafe does not implement ERC-1271 isValidSignature; adding that later would let safe owners approve another manager by signature alone and withdraw Aave collateral with no Cash withdrawal delay.
- Records the invariant in the LendGateway header: assets only leave a safe's position through the gateway, so every exit lands in the safe or card settlement (liquidation excepted), held by two conditions: gateway is the only activated position manager, and safes never gain ERC-1271.
- Adds a one-line warning on MultiSig, since that is where a future ERC-1271 implementation would land and its author would have no reason to open the gateway file.
- Comments only, no logic change. Monitoring tripwires (UpdatePositionManager and SetUserPositionManager alerts) are tracked separately under COR-1108.

## Test plan
- [x] forge build passes (comment-only diff, 2 files, +9 lines)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/etherfi-protocol/codesmith/cash-v3/pr/239"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787910096&installation_model_id=18424&pr_number=239&repository=etherfi-protocol%2Fcash-v3&return_to=https%3A%2F%2Fgithub.com%2Fetherfi-protocol%2Fcash-v3%2Fpull%2F239&signature=64f373b6e3cc48012751ba1304157f0985d7902049f77c13c148f9287a4b22fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only changes with no executable logic; they document an existing security assumption for future reviewers.
> 
> **Overview**
> **Documents** the security invariant that Aave collateral should only exit via `LendGateway` (into the Cash safe delay or card settlement, aside from liquidation). The `LendGateway` header now states that invariant explicitly and names the two assumptions that preserve it: Spoke governance keeps this gateway as the only activated position manager, and `EtherFiSafe` must not implement ERC-1271 `isValidSignature`.
> 
> **Adds** a matching `@dev` warning on `MultiSig` that ERC-1271 is intentionally omitted, because implementing it would enable Aave’s `setUserPositionManagersWithSig` path and let owners approve another manager by signature to pull collateral without the Cash withdrawal delay.
> 
> No runtime or access-control behavior changes—comments only, in response to auditor concern on the signature-based position-manager approval surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57d372cb4ea71767334effef7375b37edade6416. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->