### PR TITLE
fix: skip unsuppliable reserves in credit-spend resupply sizing

### DIFF
--- a/src/debt-manager/DebtManagerCore.sol
+++ b/src/debt-manager/DebtManagerCore.sol
@@ -744,6 +744,9 @@ contract DebtManagerCore is DebtManagerStorageContract {
             for (uint256 i = 0; i < cLen;) {
                 uint256 bal = _suppliableBalance(cashModule, safe, collateralTokens[i]);
                 if (bal != 0) {
+                    // Typed pre-check mirroring the borrow side, so a reserve that cannot take the
+                    // supply surfaces as a routable error for the runner, not a raw Aave revert
+                    if (_gateway.supplyHeadroom(collateralTokens[i]) < bal) revert LendGatewayCannotAcceptSupply(collateralTokens[i]);
                     _gateway.supply(safe, collateralTokens[i], bal);
                 }
                 unchecked {

--- a/src/debt-manager/DebtManagerStorageContract.sol
+++ b/src/debt-manager/DebtManagerStorageContract.sol
@@ -399,6 +399,9 @@ contract DebtManagerStorageContract is UpgradeableProxy {
     /// @notice Thrown when the Aave reserve lacks the liquidity to fund the migration borrow
     error InsufficientLendGatewayLiquidity(address token);
 
+    /// @notice Thrown when an Aave reserve cannot take the migration supply (paused, frozen, halted, or past its cap)
+    error LendGatewayCannotAcceptSupply(address token);
+
     /// @notice Thrown when, after supplying its collateral, the Safe's debt does not fit Aave's LTVs
     error PositionExceedsLendGatewayLtv();
 

--- a/src/interfaces/IAaveV4Hub.sol
+++ b/src/interfaces/IAaveV4Hub.sol
@@ -35,6 +35,9 @@ interface IAaveV4Hub {
     /// @notice Returns the current drawn index of the asset, in RAY.
     function getAssetDrawnIndex(uint256 assetId) external view returns (uint256);
 
+    /// @notice Converts supplied shares to added assets, rounding up: the Hub's addCap usage figure.
+    function previewAddByShares(uint256 assetId, uint256 shares) external view returns (uint256);
+
     /// @notice Converts supplied shares to removable assets, rounding down.
     function previewRemoveByShares(uint256 assetId, uint256 shares) external view returns (uint256);
 

--- a/src/interfaces/IAaveV4Spoke.sol
+++ b/src/interfaces/IAaveV4Spoke.sol
@@ -139,6 +139,9 @@ interface IAaveV4Spoke {
     /// @notice Total underlying supplied to the reserve, in asset units.
     function getReserveSuppliedAssets(uint256 reserveId) external view returns (uint256);
 
+    /// @notice Total supplied shares of the reserve.
+    function getReserveSuppliedShares(uint256 reserveId) external view returns (uint256);
+
     /// @notice Total debt (drawn + premium) of the reserve, in asset units.
     function getReserveTotalDebt(uint256 reserveId) external view returns (uint256);
 

--- a/src/interfaces/ILendGateway.sol
+++ b/src/interfaces/ILendGateway.sol
@@ -138,6 +138,15 @@ interface ILendGateway {
     function borrowLiquidity(address asset) external view returns (uint256);
 
     /**
+     * @notice Returns the amount of `asset` the Spoke can currently accept as new supply
+     * @dev Zero while the reserve is paused or frozen or its Hub Spoke is inactive or halted;
+     *      type(uint256).max when the addCap is the uncapped sentinel, otherwise the remaining cap room.
+     * @param asset The reserve asset
+     * @return The suppliable amount in asset units, or 0 if the asset is not registered
+     */
+    function supplyHeadroom(address asset) external view returns (uint256);
+
+    /**
      * @notice Returns `safe`'s buffered Aave-priced borrowing capacity in units of `asset`
      * @dev The auth quote: capacity holding the post-borrow health factor at or above the configured floor
      *      (Aave's 1.00 bound while no floor is set). Uses Aave's current oracle, collateral factors, debt

--- a/src/mocks/MockLendGateway.sol
+++ b/src/mocks/MockLendGateway.sol
@@ -145,6 +145,11 @@ contract MockLendGateway is ILendGateway {
         return _withdrawalLiquidity[asset];
     }
 
+    /// @dev The mock models no supply cap or reserve flags, so the headroom is unlimited
+    function supplyHeadroom(address) external pure returns (uint256) {
+        return type(uint256).max;
+    }
+
     /// @dev Defaults to unlimited so existing tests can configure only their relevant gate.
     function borrowCapacity(address safe, address asset) external view returns (uint256) {
         return _borrowCapacitySet[safe][asset] ? _borrowCapacity[safe][asset] : type(uint256).max;

--- a/src/modules/cash/CashLendLib.sol
+++ b/src/modules/cash/CashLendLib.sol
@@ -686,8 +686,9 @@ library CashLendLib {
      * @dev Supplies loose collateral to cover the pre-measured shortfall. The first sizing pass uses only
      *      balance not reserved by the pending withdrawal request; the reserved remainder is taken only when
      *      the spend cannot be funded otherwise, and then the request is cancelled before any supply executes
-     *      (the debit path's rule). If loose collateral cannot fully cover, it supplies what fits and the
-     *      caller's borrow reverts the whole spend. CashLens never counts this capacity, so canSpend does not
+     *      (the debit path's rule). Reserves Aave would reject the supply into are skipped at sizing (see
+     *      _sizeResupply). If loose collateral cannot fully cover, it supplies what fits and the caller's
+     *      borrow reverts the whole spend. CashLens never counts this capacity, so canSpend does not
      *      advertise it as headroom.
      * @param $ The CashModule storage pointer
      * @param dataProvider The EtherFiDataProvider
@@ -728,6 +729,14 @@ library CashLendLib {
             // A zero-LTV asset adds no borrowing headroom, so supplying it cannot help
             if (gateway.ltv(tokens[i]) == 0) continue;
 
+            // A reserve Aave will not accept (paused, frozen, halted, or at its supply cap) would revert
+            // the whole spend at supply time; bound this token by its headroom so the next token carries
+            // the rest. The first pass's earmark is not supplied yet, so it still counts against the
+            // fresh headroom.
+            uint256 headroom = gateway.supplyHeadroom(tokens[i]);
+            if (headroom <= supplyAmounts[i]) continue;
+            headroom -= supplyAmounts[i];
+
             // Loose balance still available for this token, net of what an earlier pass already claimed
             uint256 capacity = IERC20(tokens[i]).balanceOf(safe) - supplyAmounts[i];
             if (!useReserved) {
@@ -735,6 +744,7 @@ library CashLendLib {
                 uint256 pending = _pendingWithdrawalAmount($, safe, tokens[i]);
                 capacity = capacity > pending ? capacity - pending : 0;
             }
+            if (capacity > headroom) capacity = headroom;
             if (capacity == 0) continue;
 
             // Full cover fits in this token: take it and stop

--- a/src/modules/lend-gateway/LendGateway.sol
+++ b/src/modules/lend-gateway/LendGateway.sol
@@ -603,6 +603,34 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
     }
 
     /**
+     * @notice Returns the amount of `asset` the Spoke can currently accept as new supply
+     * @dev Zero while the reserve is paused or frozen or its Hub Spoke is inactive or halted (the states
+     *      where Aave rejects a supply outright); type(uint256).max when the addCap is the uncapped
+     *      sentinel. Finite cap usage counts the spoke's added shares rounded up exactly as Hub execution
+     *      does, so filling to this headroom never trips AddCapExceeded.
+     * @param asset The reserve asset
+     * @return The suppliable amount in asset units, or 0 if the asset is not registered
+     */
+    function supplyHeadroom(address asset) external view returns (uint256) {
+        LendGatewayStorage storage $ = _getLendGatewayStorage();
+        if (!$.assets.contains(asset)) return 0;
+
+        uint256 reserveId = $.reserveId[asset];
+        IAaveV4Spoke.ReserveConfig memory reserveConfig = spoke.getReserveConfig(reserveId);
+        if (reserveConfig.paused || reserveConfig.frozen) return 0;
+
+        IAaveV4Spoke.Reserve memory reserve = spoke.getReserve(reserveId);
+        IAaveV4Hub hub = IAaveV4Hub(reserve.hub);
+        IAaveV4Hub.SpokeConfig memory config = hub.getSpokeConfig(reserve.assetId, address(spoke));
+        if (!config.active || config.halted) return 0;
+        if (config.addCap == hub.MAX_ALLOWED_SPOKE_CAP()) return type(uint256).max;
+
+        uint256 capLimit = uint256(config.addCap) * (10 ** reserve.decimals);
+        uint256 supplied = hub.previewAddByShares(reserve.assetId, spoke.getReserveSuppliedShares(reserveId));
+        return supplied >= capLimit ? 0 : capLimit - supplied;
+    }
+
+    /**
      * @notice Returns `safe`'s buffered Aave-priced borrowing capacity in units of `asset`
      * @dev The auth quote: capacity that keeps the post-borrow health factor at or above the configured floor
      *      (Aave's 1.00 bound while no floor is set). New auth decisions and getMaxSpendCredit read this so an

--- a/test/safe/modules/cash/lend/DebtManagerMigration.t.sol
+++ b/test/safe/modules/cash/lend/DebtManagerMigration.t.sol
@@ -51,6 +51,7 @@ contract DebtManagerMigrationTest is CashGatewayTestSetup {
 
     // ----------------------------------------------------------------- happy path
 
+    /// @dev The happy path: legacy debt clears, collateral and debt re-home to Aave atomically, nothing strands.
     function test_migrateToLendGateway_atomic_noFlashLoan() public {
         _seedAaveLiquidity(usdcReserveId, address(usdc), 5_000_000e6);
 
@@ -84,6 +85,7 @@ contract DebtManagerMigrationTest is CashGatewayTestSetup {
 
     // ----------------------------------------------------------------- reverts
 
+    /// @dev A position that fits DebtManager's LTV but not Aave's reverts with the typed LTV-fit error.
     function test_migrateToLendGateway_revertsWhenExceedsAaveLtv() public {
         _seedAaveLiquidity(usdcReserveId, address(usdc), 5_000_000e6);
 
@@ -98,6 +100,7 @@ contract DebtManagerMigrationTest is CashGatewayTestSetup {
         dm.migrateToLendGateway(address(safe));
     }
 
+    /// @dev An Aave reserve that cannot fund the re-borrow reverts with the typed liquidity error.
     function test_migrateToLendGateway_revertsWhenInsufficientLendGatewayLiquidity() public {
         // No Aave liquidity seeded → the reserve cannot fund the borrow
         deal(address(weETH), address(safe), 10 ether);
@@ -110,6 +113,18 @@ contract DebtManagerMigrationTest is CashGatewayTestSetup {
         dm.migrateToLendGateway(address(safe));
     }
 
+    /// @dev An Aave reserve that cannot take the collateral supply (here: at its addCap) reverts with the
+    ///      typed error instead of Aave's raw AddCapExceeded, so a batch runner can route the Safe.
+    function test_migrateToLendGateway_revertsWhenReserveCannotAcceptSupply() public {
+        deal(address(weETH), address(safe), 10 ether);
+        _setAaveSpokeCaps(weethReserveId, 1, type(uint40).max);
+
+        vm.prank(migrator);
+        vm.expectRevert(abi.encodeWithSelector(DebtManagerStorageContract.LendGatewayCannotAcceptSupply.selector, address(weETH)));
+        dm.migrateToLendGateway(address(safe));
+    }
+
+    /// @dev A debt-free safe still migrates: its collateral moves to Aave so post-migration credit spends work.
     function test_migrateToLendGateway_noDebt_suppliesCollateralAndMarksMigrated() public {
         deal(address(weETH), address(safe), 10 ether); // collateral but no debt
         assertFalse(dm.hasMigratedToLendGateway(address(safe)));
@@ -190,12 +205,14 @@ contract DebtManagerMigrationTest is CashGatewayTestSetup {
         assertEq(weETH.balanceOf(address(safe)), 0, "safe holds nothing loose afterwards");
     }
 
+    /// @dev Only the DebtManager may flip the CashModule's engine routing flag.
     function test_markUsesLendGateway_onlyDebtManager() public {
         vm.prank(makeAddr("rando"));
         vm.expectRevert(ICashModule.OnlyDebtManager.selector);
         cashModule.markUsesLendGateway(address(safe));
     }
 
+    /// @dev Migration is gated to the EtherFi wallet role; anyone else is rejected.
     function test_migrateToLendGateway_onlyEtherFiWallet() public {
         _seedAaveLiquidity(usdcReserveId, address(usdc), 5_000_000e6);
         deal(address(weETH), address(safe), 10 ether);
@@ -208,6 +225,7 @@ contract DebtManagerMigrationTest is CashGatewayTestSetup {
         dm.migrateToLendGateway(address(safe));
     }
 
+    /// @dev After migration the legacy engine is frozen: DebtManager borrow and repay both reject the safe.
     function test_migratedSafe_cannotBorrowOrRepayOnDebtManager() public {
         _seedAaveLiquidity(usdcReserveId, address(usdc), 5_000_000e6);
         deal(address(weETH), address(safe), 10 ether);

--- a/test/safe/modules/cash/lend/LendGatewayAaveV4.t.sol
+++ b/test/safe/modules/cash/lend/LendGatewayAaveV4.t.sol
@@ -150,6 +150,35 @@ contract LendGatewayAaveV4Test is CashGatewayTestSetup {
         assertEq(gw.borrowLiquidity(address(usdc)), 0, "halted spoke cannot borrow");
     }
 
+    /// supplyHeadroom is the resupply gate: uncapped it is unlimited, a finite addCap leaves the remaining
+    /// room counted with the Hub's round-up (so filling exactly to it is accepted), and a paused or frozen
+    /// reserve or a halted Hub Spoke drives it to zero.
+    function test_reads_supplyHeadroom_boundedByAddCap() public {
+        // Uncapped (fixture default)
+        assertEq(gw.supplyHeadroom(address(usdc)), type(uint256).max);
+        assertEq(gw.supplyHeadroom(address(0xdead)), 0, "unregistered asset has no headroom");
+
+        // 1M tokens seeded at setup: a 1.2M addCap leaves 200k of room
+        _setAaveSpokeCaps(usdcReserveId, 1_200_000, type(uint40).max);
+        assertEq(gw.supplyHeadroom(address(usdc)), 200_000e6, "remaining addCap room");
+
+        // Filling exactly to the reported headroom passes the Hub's cap check and lands at zero room
+        _supplyToGateway(address(safe), address(usdc), 200_000e6);
+        assertEq(gw.supplyHeadroom(address(usdc)), 0, "at cap");
+
+        _setAaveSpokeCaps(usdcReserveId, type(uint40).max, type(uint40).max);
+        _setAaveReserveFrozen(usdcReserveId, true);
+        assertEq(gw.supplyHeadroom(address(usdc)), 0, "frozen reserve accepts no supply");
+        _setAaveReserveFrozen(usdcReserveId, false);
+
+        _setAaveReservePaused(usdcReserveId, true);
+        assertEq(gw.supplyHeadroom(address(usdc)), 0, "paused reserve accepts no supply");
+        _setAaveReservePaused(usdcReserveId, false);
+
+        _setAaveSpokeHalted(usdcReserveId, true);
+        assertEq(gw.supplyHeadroom(address(usdc)), 0, "halted Hub Spoke accepts no supply");
+    }
+
     /// isBorrowable/borrowableAssets read the reserve's borrowable flag on the Spoke: USDC's reserve allows
     /// borrowing, weETH's is collateral-only, and unregistered assets are never borrowable.
     function test_reads_borrowable() public view {

--- a/test/safe/modules/cash/lend/Spend.t.sol
+++ b/test/safe/modules/cash/lend/Spend.t.sol
@@ -479,6 +479,77 @@ contract CashModuleSpendAaveTest is CashGatewayTestSetup {
         assertEq(gw.suppliedOf(address(safe), address(usdc)), expectedUsdc, "USDC covers the proportional remainder");
     }
 
+    /// A frozen reserve would revert the whole spend at supply time: sizing skips it (headroom zero) and the
+    /// next registered token covers the shortfall, even though the frozen one is first and could fully cover.
+    function test_spend_creditResupply_skipsFrozenReserve_nextTokenCovers() public {
+        deal(address(weETH), address(safe), 1 ether);
+        deal(address(usdc), address(safe), 100e6);
+        _enterCreditMode();
+        _setAaveReserveFrozen(weethReserveId, true);
+
+        _creditSpendUsdc(10e6);
+
+        assertEq(gw.suppliedOf(address(safe), address(weETH)), 0, "frozen weETH skipped");
+        assertEq(gw.suppliedOf(address(safe), address(usdc)), _resupplyAmount(address(usdc), 10e6), "USDC covers the whole shortfall");
+        assertApproxEqAbs(gw.debtOf(address(safe), address(usdc)), 10e6, 2, "borrow lands");
+    }
+
+    /// The paused sibling: a paused reserve is skipped the same way.
+    function test_spend_creditResupply_skipsPausedReserve_nextTokenCovers() public {
+        deal(address(weETH), address(safe), 1 ether);
+        deal(address(usdc), address(safe), 100e6);
+        _enterCreditMode();
+        _setAaveReservePaused(weethReserveId, true);
+
+        _creditSpendUsdc(10e6);
+
+        assertEq(gw.suppliedOf(address(safe), address(weETH)), 0, "paused weETH skipped");
+        assertEq(gw.suppliedOf(address(safe), address(usdc)), _resupplyAmount(address(usdc), 10e6), "USDC covers the whole shortfall");
+        assertApproxEqAbs(gw.debtOf(address(safe), address(usdc)), 10e6, 2, "borrow lands");
+    }
+
+    /// A reserve near its addCap contributes exactly its remaining cap room (not skipped outright, not
+    /// oversized into an AddCapExceeded revert) and the next token covers the proportional remainder.
+    function test_spend_creditResupply_atCapUsesPartialHeadroom_thenNextToken() public {
+        // Someone else's supply fills most of a 1-token weETH addCap without giving the safe any capacity
+        _seedAaveLiquidity(weethReserveId, address(weETH), 0.999 ether);
+        _setAaveSpokeCaps(weethReserveId, 1, type(uint40).max);
+        deal(address(weETH), address(safe), 1 ether);
+        deal(address(usdc), address(safe), 100e6);
+        _enterCreditMode();
+
+        uint256 headroom = gw.supplyHeadroom(address(weETH));
+        uint256 shortfallValue = _bufferedShortfallValue(10e6);
+        uint256 neededWeeth = gw.collateralForValue(address(weETH), shortfallValue);
+        assertLt(headroom, neededWeeth, "cap room must be the binding limit for this test to bite");
+        uint256 expectedUsdc = gw.collateralForValue(address(usdc), _residualValue(shortfallValue, headroom, neededWeeth));
+
+        _creditSpendUsdc(10e6);
+
+        assertEq(gw.suppliedOf(address(safe), address(weETH)), headroom, "weETH fills exactly its remaining cap room");
+        assertEq(gw.suppliedOf(address(safe), address(usdc)), expectedUsdc, "USDC covers the proportional remainder");
+        assertApproxEqAbs(gw.debtOf(address(safe), address(usdc)), 10e6, 2, "borrow lands");
+    }
+
+    /// Every candidate unsuppliable (weETH frozen, USDC at its addCap): nothing is supplied and the failing
+    /// borrow reverts the whole spend, same terminal error as the no-eligible-collateral case.
+    function test_spend_creditResupply_allUnsuppliable_borrowReverts() public {
+        deal(address(weETH), address(safe), 1 ether);
+        deal(address(usdc), address(safe), 100e6);
+        _enterCreditMode();
+        _setAaveReserveFrozen(weethReserveId, true);
+        // The seeded 1M USDC liquidity fills a 1M-token addCap exactly; USDC stays borrowable and spendable
+        _setAaveSpokeCaps(usdcReserveId, 1_000_000, type(uint40).max);
+        assertEq(gw.supplyHeadroom(address(usdc)), 0, "USDC reserve at its cap");
+
+        vm.prank(etherFiWallet);
+        vm.expectRevert(ISpoke.HealthFactorBelowThreshold.selector);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, _tokens(address(usdc)), _amounts(10e6), _noCashback());
+
+        assertEq(gw.suppliedOf(address(safe), address(weETH)), 0, "nothing supplied on the reverted spend");
+        assertEq(gw.suppliedOf(address(safe), address(usdc)), 0, "nothing supplied on the reverted spend");
+    }
+
     // ================ helpers ================
 
     function _enterCreditMode() internal {


### PR DESCRIPTION
## What

An audit finding: the credit-spend resupply flow sizes collateral top-ups over the gateway's registered assets checking only `ltv != 0` and loose balance, then calls `gateway.supply` bare. Aave v4 rejects supplies into a paused, frozen, halted, or at-cap reserve, so one such reserve early in the list hard-reverts the whole card spend even when a later token could cover the shortfall.

Fix: a new `LendGateway.supplyHeadroom(asset)` view reports how much of an asset the Spoke currently accepts (0 while paused/frozen/inactive/halted, `type(uint256).max` when uncapped, remaining addCap room otherwise), and `_sizeResupply` clamps each token's capacity with it. Dead reserves are skipped; a partially-capped reserve contributes exactly its remaining room; the existing partial-cover math redistributes the rest to the next token unchanged.

## Decisions worth a second pair of eyes

- A boolean "is suppliable" skip (the reported recommendation) is not enough: the addCap case is not binary, and sizing more than the remaining room into a passing reserve still reverts with `AddCapExceeded`. Hence a headroom amount, mirroring `borrowLiquidity` on the draw side.
- Cap usage is measured with `hub.previewAddByShares` (round-up), not `getReserveSuppliedAssets` (round-down), because the Hub's cap check rounds the supplied side up; the down-rounded getter could overstate headroom by 1 wei and filling to it would still revert.
- Residual risk accepted: `setUsingAsCollateral` can still revert with `MaximumUserReservesExceeded` when enabling a new collateral reserve at Aave's per-user reserve limit. That is user-specific, not reserve-level, and with our handful of registered assets a limit below that count would be an Aave misconfiguration.
- `MockLendGateway.supplyHeadroom` returns unlimited, so legacy-engine tests are unaffected.

## Testing

- New fork tests in `Spend.t.sol`: frozen reserve skipped, paused reserve skipped, at-cap reserve contributes exactly its partial headroom, all-unsuppliable reverts the spend with `HealthFactorBelowThreshold` (unchanged terminal behavior).
- New gateway unit test `test_reads_supplyHeadroom_boundedByAddCap`, including filling exactly to the reported headroom passing the Hub's cap check.
- Full lend suite: 316 passed; the only 2 failures are the pre-existing `OpenOceanSwapGateway` FFI tests, which need `OPENOCEAN_API_KEY` locally and are unrelated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches credit spend execution and migration collateral supply paths; behavior change is intentional (skip/route vs revert) but incorrect headroom math could still mis-size resupply or migration batches.
> 
> **Overview**
> Adds **`LendGateway.supplyHeadroom`** so callers know how much of an asset Aave will accept (0 when paused/frozen/halted/inactive; unlimited when uncapped; otherwise remaining **addCap** room using Hub **`previewAddByShares`** round-up).
> 
> **Credit spend resupply** (`CashLendLib._sizeResupply`) clamps each collateral token by that headroom so paused/frozen/capped reserves are skipped or partially used and a later token can cover the shortfall instead of reverting the whole card spend.
> 
> **DebtManager migration** pre-checks supply headroom before supplying collateral and reverts with **`LendGatewayCannotAcceptSupply`** for batch routing, mirroring the borrow-side liquidity error.
> 
> Interface/mock updates and fork tests cover headroom math, migration at cap, and resupply skip/partial/fail paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2f6dd4f3ad68a77bcc618e62d3f40138daa9a69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/etherfi-protocol/codesmith/cash-v3/pr/241"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788001399&installation_model_id=18424&pr_number=241&repository=etherfi-protocol%2Fcash-v3&return_to=https%3A%2F%2Fgithub.com%2Fetherfi-protocol%2Fcash-v3%2Fpull%2F241&signature=a818ea20377389a10038125b3367c518744cbff064705106a4cef916e0e5e8a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->