### PR TITLE
fix: typed supply-side pre-check in the lend gateway migration

### DIFF
--- a/src/debt-manager/DebtManagerCore.sol
+++ b/src/debt-manager/DebtManagerCore.sol
@@ -744,6 +744,9 @@ contract DebtManagerCore is DebtManagerStorageContract {
             for (uint256 i = 0; i < cLen;) {
                 uint256 bal = _suppliableBalance(cashModule, safe, collateralTokens[i]);
                 if (bal != 0) {
+                    // Typed pre-check mirroring the borrow side, so a reserve that cannot take the
+                    // supply surfaces as a routable error for the runner, not a raw Aave revert
+                    if (_gateway.supplyHeadroom(collateralTokens[i]) < bal) revert LendGatewayCannotAcceptSupply(collateralTokens[i]);
                     _gateway.supply(safe, collateralTokens[i], bal);
                 }
                 unchecked {

--- a/src/debt-manager/DebtManagerStorageContract.sol
+++ b/src/debt-manager/DebtManagerStorageContract.sol
@@ -399,6 +399,9 @@ contract DebtManagerStorageContract is UpgradeableProxy {
     /// @notice Thrown when the Aave reserve lacks the liquidity to fund the migration borrow
     error InsufficientLendGatewayLiquidity(address token);
 
+    /// @notice Thrown when an Aave reserve cannot take the migration supply (paused, frozen, halted, or past its cap)
+    error LendGatewayCannotAcceptSupply(address token);
+
     /// @notice Thrown when, after supplying its collateral, the Safe's debt does not fit Aave's LTVs
     error PositionExceedsLendGatewayLtv();
 

--- a/test/safe/modules/cash/lend/DebtManagerMigration.t.sol
+++ b/test/safe/modules/cash/lend/DebtManagerMigration.t.sol
@@ -51,6 +51,7 @@ contract DebtManagerMigrationTest is CashGatewayTestSetup {
 
     // ----------------------------------------------------------------- happy path
 
+    /// @dev The happy path: legacy debt clears, collateral and debt re-home to Aave atomically, nothing strands.
     function test_migrateToLendGateway_atomic_noFlashLoan() public {
         _seedAaveLiquidity(usdcReserveId, address(usdc), 5_000_000e6);
 
@@ -84,6 +85,7 @@ contract DebtManagerMigrationTest is CashGatewayTestSetup {
 
     // ----------------------------------------------------------------- reverts
 
+    /// @dev A position that fits DebtManager's LTV but not Aave's reverts with the typed LTV-fit error.
     function test_migrateToLendGateway_revertsWhenExceedsAaveLtv() public {
         _seedAaveLiquidity(usdcReserveId, address(usdc), 5_000_000e6);
 
@@ -98,6 +100,7 @@ contract DebtManagerMigrationTest is CashGatewayTestSetup {
         dm.migrateToLendGateway(address(safe));
     }
 
+    /// @dev An Aave reserve that cannot fund the re-borrow reverts with the typed liquidity error.
     function test_migrateToLendGateway_revertsWhenInsufficientLendGatewayLiquidity() public {
         // No Aave liquidity seeded → the reserve cannot fund the borrow
         deal(address(weETH), address(safe), 10 ether);
@@ -110,6 +113,18 @@ contract DebtManagerMigrationTest is CashGatewayTestSetup {
         dm.migrateToLendGateway(address(safe));
     }
 
+    /// @dev An Aave reserve that cannot take the collateral supply (here: at its addCap) reverts with the
+    ///      typed error instead of Aave's raw AddCapExceeded, so a batch runner can route the Safe.
+    function test_migrateToLendGateway_revertsWhenReserveCannotAcceptSupply() public {
+        deal(address(weETH), address(safe), 10 ether);
+        _setAaveSpokeCaps(weethReserveId, 1, type(uint40).max);
+
+        vm.prank(migrator);
+        vm.expectRevert(abi.encodeWithSelector(DebtManagerStorageContract.LendGatewayCannotAcceptSupply.selector, address(weETH)));
+        dm.migrateToLendGateway(address(safe));
+    }
+
+    /// @dev A debt-free safe still migrates: its collateral moves to Aave so post-migration credit spends work.
     function test_migrateToLendGateway_noDebt_suppliesCollateralAndMarksMigrated() public {
         deal(address(weETH), address(safe), 10 ether); // collateral but no debt
         assertFalse(dm.hasMigratedToLendGateway(address(safe)));
@@ -190,12 +205,14 @@ contract DebtManagerMigrationTest is CashGatewayTestSetup {
         assertEq(weETH.balanceOf(address(safe)), 0, "safe holds nothing loose afterwards");
     }
 
+    /// @dev Only the DebtManager may flip the CashModule's engine routing flag.
     function test_markUsesLendGateway_onlyDebtManager() public {
         vm.prank(makeAddr("rando"));
         vm.expectRevert(ICashModule.OnlyDebtManager.selector);
         cashModule.markUsesLendGateway(address(safe));
     }
 
+    /// @dev Migration is gated to the EtherFi wallet role; anyone else is rejected.
     function test_migrateToLendGateway_onlyEtherFiWallet() public {
         _seedAaveLiquidity(usdcReserveId, address(usdc), 5_000_000e6);
         deal(address(weETH), address(safe), 10 ether);
@@ -208,6 +225,7 @@ contract DebtManagerMigrationTest is CashGatewayTestSetup {
         dm.migrateToLendGateway(address(safe));
     }
 
+    /// @dev After migration the legacy engine is frozen: DebtManager borrow and repay both reject the safe.
     function test_migratedSafe_cannotBorrowOrRepayOnDebtManager() public {
         _seedAaveLiquidity(usdcReserveId, address(usdc), 5_000_000e6);
         deal(address(weETH), address(safe), 10 ether);


### PR DESCRIPTION
Stacked on #241 (uses its `supplyHeadroom` view). Merge that first, then retarget or merge this.

## What

`migrateToLendGateway` pre-checks the borrow side with typed errors (`InsufficientLendGatewayLiquidity`, `PositionExceedsLendGatewayLtv`) so the batch runner can route failing safes, but the collateral supply loop had no equivalent: a reserve that cannot take the supply (paused, frozen, halted, or past its addCap) surfaced as a raw Aave revert. This adds the matching typed pre-check, `LendGatewayCannotAcceptSupply(token)`, using the `supplyHeadroom` view from #241.

No behavior change beyond the error: migration stays atomic and still reverts in this case, just with an error the runner can act on. The realistic trigger is a batch of migrations eating addCap headroom mid-run.

Also gives every test in `DebtManagerMigration.t.sol` a `/// @dev` one-liner, matching the documented ones.

## Testing

- New fork test: a 1-token weETH addCap rejects a 10 weETH migration with the typed error.
- Full `DebtManagerMigration.t.sol` suite: 19 passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/etherfi-protocol/codesmith/cash-v3/pr/242"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788002702&installation_model_id=18424&pr_number=242&repository=etherfi-protocol%2Fcash-v3&return_to=https%3A%2F%2Fgithub.com%2Fetherfi-protocol%2Fcash-v3%2Fpull%2F242&signature=ab407fa0eaf645ff2e93b271a58cb5f74ac0a1a8231123c92307b883ebbb2b9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to migration error handling before existing supply calls; no new success paths, with coverage for the add-cap revert case.
> 
> **Overview**
> **`migrateToLendGateway`** now mirrors the borrow-side typed guards on the collateral supply loop: before each `_gateway.supply`, it compares `_gateway.supplyHeadroom(token)` to the suppliable balance and reverts with **`LendGatewayCannotAcceptSupply(token)`** when the reserve cannot accept the amount (paused/frozen/halted or past add cap). Migration still fails atomically in those cases; only the error surface changes so batch runners can route safes instead of parsing raw Aave reverts.
> 
> Adds the matching custom error on **`DebtManagerStorageContract`**, a fork test that pins add-cap rejection to the typed error, and **`/// @dev`** one-liners on the migration test suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1051c8f4fd78e486596c9e81f8a55711b5f10a80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->