### PR TITLE
fix: prioritize user borrowing capacity in credit checks

### DIFF
--- a/src/libraries/LendSourcingLib.sol
+++ b/src/libraries/LendSourcingLib.sol
@@ -106,6 +106,13 @@ library LendSourcingLib {
         }
 
         uint256 borrowAmount = fromUsdUp(priceProvider, token, totalSpendingInUsd);
+        // Check the Safe-specific constraint first. A shared-market decline therefore guarantees this Safe
+        // had sufficient borrowing power for the quote, which lets downstream systems distinguish a user
+        // shortfall from a temporary Hub-side availability problem.
+        if (gateway.borrowCapacity(safe, token) < borrowAmount) {
+            return (false, "Insufficient borrowing power");
+        }
+
         if (gateway.borrowLiquidity(token) < borrowAmount) {
             // borrowLiquidity folds Hub cash and the spoke's draw cap into one bound; withdrawalLiquidity is
             // the cash alone (zero under the same pause/halt gates), so cash covering the loan means the draw
@@ -114,10 +121,6 @@ library LendSourcingLib {
                 return (false, "Lend borrow cap reached, please try again later");
             }
             return (false, "Insufficient Lend liquidity to cover the loan");
-        }
-
-        if (gateway.borrowCapacity(safe, token) < borrowAmount) {
-            return (false, "Insufficient borrowing power");
         }
 
         return (true, "");

--- a/test/safe/modules/cash/lend/CanSpend.t.sol
+++ b/test/safe/modules/cash/lend/CanSpend.t.sol
@@ -269,6 +269,25 @@ contract CashLensCanSpendAaveTest is CashGatewayTestSetup {
         assertEq(reason, "Insufficient borrowing power");
     }
 
+    /// A user-level shortfall takes precedence over a shared draw-cap shortfall so market-side declines
+    /// safely prove that the Safe itself had enough borrowing power for the requested spend.
+    function test_canSpend_failsInCreditMode_withInsufficientBorrowingPowerBeforeDrawCap() public {
+        _setMode(Mode.Credit);
+        vm.warp(cashModule.incomingModeStartTime(address(safe)) + 1);
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 100e6;
+
+        // No collateral leaves the Safe with zero borrowing power, while the shared draw cap is also short.
+        _setAaveSpokeCaps(usdcReserveId, type(uint40).max, 50);
+
+        (bool canSpend, string memory reason) = cashLens.canSpend(address(safe), txId, tokens, amounts);
+        assertEq(canSpend, false);
+        assertEq(reason, "Insufficient borrowing power");
+    }
+
     /// canSpendSingleToken picks credit mode and USDC when supplied collateral covers the amount.
     function test_canSpendSingleToken_creditMode_works() public {
         _setMode(Mode.Credit);


### PR DESCRIPTION
Requested By: syko

## What was the issue

`creditCheck` evaluated shared Hub liquidity and the Spoke draw cap before the Safe's own borrowing capacity. If both were insufficient, `canSpend` returned a market-side error even though the user would not have been eligible to borrow if market liquidity were available.

## How the changes fix it

Evaluate `borrowCapacity(safe, token)` before shared `borrowLiquidity`. A market-side decline now guarantees that the Safe passed the user-level borrowing-power quote for the requested amount.

## Expected behavior after the change

- Insufficient Safe borrowing power takes precedence over Hub liquidity or draw-cap failures.
- A Hub liquidity or draw-cap decline can be safely treated as a candidate for a separately bounded off-chain fallback, subject to its own reservation and reconciliation controls.

## Test plan

- `TEST_CHAIN=10 FOUNDRY_PROFILE=lend ~/.foundry/bin/forge test --match-test test_canSpend_failsInCreditMode_withInsufficientBorrowingPowerBeforeDrawCap -vvv`
- `TEST_CHAIN=10 FOUNDRY_PROFILE=lend ~/.foundry/bin/forge test --match-contract CashLensCanSpendAaveTest -vv`
- `~/.foundry/bin/forge fmt --check src/libraries/LendSourcingLib.sol test/safe/modules/cash/lend/CanSpend.t.sol`
- `git diff --check`

Note: repository-wide `forge fmt --check` reports pre-existing formatting drift outside this PR's files.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/etherfi-protocol/codesmith/cash-v3/pr/243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788027181&installation_model_id=18424&pr_number=243&repository=etherfi-protocol%2Fcash-v3&return_to=https%3A%2F%2Fgithub.com%2Fetherfi-protocol%2Fcash-v3%2Fpull%2F243&signature=b026cee36e8f2b21ad061d7cc9976a0381d233c3f7b2ad4aad413ebb982a3ba2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> View-only gate reordering with unchanged success path; only decline reason ordering changes when multiple constraints fail.
> 
> **Overview**
> **`LendSourcingLib.creditCheck`** now evaluates the Safe’s **`borrowCapacity`** immediately after token eligibility and the USD→token quote, **before** shared **`borrowLiquidity`** (and the draw-cap vs cash attribution branches). When both the user and the market would block the spend, **`canSpend`** returns **"Insufficient borrowing power"** instead of a Hub liquidity or draw-cap message.
> 
> That ordering lets off-chain systems treat Hub-side declines as cases where the Safe already passed the user-level quote, so they can consider bounded fallback without misreading a user shortfall as a temporary market issue.
> 
> A lend **`CanSpend`** test covers zero collateral with a tight draw cap and asserts the user-side reason wins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 762fff17cad682726656c296ef81b95ba155523b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->