### PR TITLE
fix: lend audit fixes

### DIFF
--- a/src/across/AcrossSwapModule.sol
+++ b/src/across/AcrossSwapModule.sol
@@ -363,22 +363,23 @@ contract AcrossSwapModule is ModuleBase, ModuleCheckBalance, ModuleLendGatewaySa
         }
 
         delete $.swaps[safe];
+        uint256 healthFactorBefore;
         if (address(cashModule) != address(0)) {
             cashModule.cancelWithdrawalByModule(safe);
             // Front bookend: request-time sourcing normally leaves the input loose through the delay;
             // this re-pulls any shortfall from the safe's Aave position and asserts the full input is
             // present before the safe approves the target. Runs after the cancel so the released
             // reservation no longer masks the loose balance.
-            _pullAndRequire(safe, swap.order.srcToken, swap.order.srcAmount);
+            healthFactorBefore = _pullAndRequire(safe, swap.order.srcToken, swap.order.srcAmount);
         }
 
         if (swap.swapData.length != 0) _dispatchOriginSwap(safe, swap);
         else _dispatchDeposit(safe, swap);
 
-        // The input was collateral pulled out of Aave (at request or just above) and every route
-        // bridges it away from this chain, so the end state must sit at or above the gateway's
-        // health-factor floor. Nothing lands back at the safe here, hence no resupply half.
-        if (address(cashModule) != address(0)) _ensureGatewayFloor(safe);
+        // The input was collateral pulled out of Aave (at request or just above) and every route bridges it
+        // away from this chain, so the end state must hold the gateway's health-factor floor unless it left
+        // the position no worse off. Nothing lands back at the safe here, hence no resupply half.
+        if (address(cashModule) != address(0)) _ensureGatewayFloor(safe, healthFactorBefore);
 
         emit SwapExecuted(safe, swap.swapId, swap.order.dstChainId, swap.order.dstToken, swap.depositArgs.outputAmount);
     }

--- a/src/enso/EnsoSwapModule.sol
+++ b/src/enso/EnsoSwapModule.sol
@@ -291,20 +291,21 @@ contract EnsoSwapModule is ModuleBase, ModuleCheckBalance, ModuleLendGatewaySand
         }
 
         delete $.swaps[safe];
+        uint256 healthFactorBefore;
         if (address(cashModule) != address(0)) {
             cashModule.cancelWithdrawalByModule(safe);
             // Front bookend: request-time sourcing normally leaves the input loose through the delay;
             // this re-pulls any shortfall from the safe's Aave position and asserts the full input is
             // present before the safe approves the router. Runs after the cancel so the released
             // reservation no longer masks the loose balance.
-            _pullAndRequire(safe, swap.order.srcToken, swap.order.srcAmount);
+            healthFactorBefore = _pullAndRequire(safe, swap.order.srcToken, swap.order.srcAmount);
         }
 
         _dispatchSwap(safe, swap);
 
-        // The input was collateral pulled out of Aave (at request or just above), so the end state
-        // must sit at or above the gateway's health-factor floor.
-        if (address(cashModule) != address(0)) _ensureGatewayFloor(safe);
+        // The input was collateral pulled out of Aave (at request or just above), so the end state must hold
+        // the gateway's health-factor floor unless it left the position no worse off than it started.
+        if (address(cashModule) != address(0)) _ensureGatewayFloor(safe, healthFactorBefore);
 
         emit SwapExecuted(safe, swap.swapId, swap.order.dstChainId, swap.order.dstToken, swap.order.minOut);
     }

--- a/src/interfaces/ILendGateway.sol
+++ b/src/interfaces/ILendGateway.sol
@@ -19,6 +19,9 @@ interface ILendGateway {
         uint256 debtUsd;
         // borrowing headroom: collateral weighted by each reserve's LTV, minus debt
         uint256 availableBorrowsUsd;
+        // gross borrowing power: collateral weighted by each reserve's LTV, NOT reduced by debt and never
+        // clamped, so a value below debtUsd both signals and measures an over-LTV position
+        uint256 maxBorrowUsd;
         uint256 healthFactor;
     }
 

--- a/src/interfaces/ILendGateway.sol
+++ b/src/interfaces/ILendGateway.sol
@@ -290,21 +290,21 @@ interface ILendGateway {
     function borrowableAssets() external view returns (address[] memory);
 
     /**
-     * @notice Returns whether `asset` can fund a debit spend
-     * @dev An admin-declared spend asset (via setSpendAsset, always a registered reserve) whose reserve is
-     *      not paused. Membership is declared, not read from Aave's borrowable flag, so a supply-only
-     *      reserve can be spendable. Frozen is tolerated: a debit spend only transfers loose balance and
-     *      withdraws supplied balance, both of which Aave allows while frozen. Paused blocks the withdraw
-     *      leg, so a paused reserve is not spendable.
+     * @notice Returns whether `asset` is an admin-declared card settlement token
+     * @dev Static membership (via setSpendAsset, always a registered reserve), read from neither Aave's
+     *      borrowable flag — so a supply-only reserve can be spendable — nor its execution state. A debit
+     *      spend transfers loose balance and withdraws supplied balance, so one funded entirely from loose
+     *      balance needs nothing from Aave; a freeze is irrelevant and a pause costs only the supplied leg,
+     *      which withdrawalLiquidity already reports as zero (audit I-02). Credit gates on isBorrowable.
      * @param asset The asset to query
-     * @return True if the asset can fund a debit spend
+     * @return True if the asset is a declared card settlement token
      */
     function isSpendAsset(address asset) external view returns (bool);
 
     /**
-     * @notice Returns the spend-set assets that can currently fund a debit spend
-     * @dev See isSpendAsset.
-     * @return The spendable asset addresses
+     * @notice Returns the admin-declared card settlement tokens
+     * @dev See isSpendAsset: membership, not Aave state.
+     * @return The declared spend asset addresses
      */
     function spendAssets() external view returns (address[] memory);
 }

--- a/src/interfaces/ILendGateway.sol
+++ b/src/interfaces/ILendGateway.sol
@@ -186,6 +186,16 @@ interface ILendGateway {
     function rawWithdrawHeadroom(address safe) external view returns (uint256);
 
     /**
+     * @notice Returns the weighted collateral value `safe`'s position is short of Aave's 1.00 bound
+     * @dev The unclamped complement of rawWithdrawHeadroom: non-zero only while a price move holds the
+     *      position under 1.00 pre-liquidation. Sizing paths that must pass Aave's whole-position check
+     *      (credit resupply, the repay-withdraw leg) add this so an existing deficit is covered up front.
+     * @param safe The Safe whose position is measured
+     * @return The deficit in weighted collateral value units, 0 while healthy
+     */
+    function deficitValue(address safe) external view returns (uint256);
+
+    /**
      * @notice Amount of `asset` the safe can withdraw from Aave while consuming at most `headroom`
      * @dev Supply carrying no borrowing power (collateral flag off or zero collateral factor) is fully
      *      withdrawable, matching Aave's own check. Rounds down, so withdrawing the quote never breaches

--- a/src/interfaces/ILendGateway.sol
+++ b/src/interfaces/ILendGateway.sol
@@ -100,6 +100,23 @@ interface ILendGateway {
     function ensureMinHealthFactor(address safe) external view;
 
     /**
+     * @notice Returns `safe`'s current Aave health factor in WAD (1e18), unbounded when it carries no debt
+     * @param safe The safe to query
+     * @return The health factor in WAD
+     */
+    function healthFactor(address safe) external view returns (uint256);
+
+    /**
+     * @notice Enforces the floor as "no worse off": passes when the operation did not degrade `safe`'s health,
+     *         otherwise requires the end state to hold the configured floor
+     * @dev Lets a position already below the floor still run health-neutral or de-risking operations, which a
+     *      plain end-state floor check would block. Callers capture the health factor before the operation.
+     * @param safe The safe to check
+     * @param healthFactorBefore The safe's health factor captured before the operation ran
+     */
+    function ensureMinHealthFactorNotWorsened(address safe, uint256 healthFactorBefore) external view;
+
+    /**
      * @notice Sets the post-op health-factor floor
      * @param value The floor in WAD; 0 disables, otherwise bounded to [1e18, 2e18]
      */

--- a/src/libraries/LendSourcingLib.sol
+++ b/src/libraries/LendSourcingLib.sol
@@ -135,9 +135,18 @@ library LendSourcingLib {
      *      health check at the exact boundary). Raw headroom: a repay de-risks the position, so it is
      *      floor-exempt like spends. Callers only get here with debt remaining after the loose leg, so
      *      the headroom cap always applies.
+     *
+     *      Any existing deficit is netted out first: rawWithdrawHeadroom clamps to zero for an underwater
+     *      position, so adding the freed value to the clamped figure would over-credit the quote by the
+     *      deficit and the sized withdraw would fail Aave's own health check (audit L-08). The loose leg
+     *      must therefore free more than the deficit before anything is withdrawable.
      */
     function repayWithdrawable(ILendGateway gateway, address safe, address token, uint256 fromLoose) public view returns (uint256) {
         uint256 headroom = gateway.rawWithdrawHeadroom(safe) + gateway.repayValue(safe, token, fromLoose);
+        // Saturating, so a healthy position (deficit 0) keeps the unmodified quote and an underwater one
+        // only becomes withdrawable once the repay frees more than the deficit
+        uint256 deficit = gateway.deficitValue(safe);
+        headroom = headroom > deficit ? headroom - deficit : 0;
         return withdrawableSupplied(gateway, safe, token, headroom, true);
     }
 

--- a/src/mocks/MockLendGateway.sol
+++ b/src/mocks/MockLendGateway.sol
@@ -181,6 +181,18 @@ contract MockLendGateway is ILendGateway {
         return _rawWithdrawHeadroom[safe];
     }
 
+    mapping(address safe => uint256) internal _deficitValue;
+
+    /// @notice Sets the deficit a subsequent `deficitValue(safe)` will return
+    function setDeficitValue(address safe, uint256 value) external {
+        _deficitValue[safe] = value;
+    }
+
+    /// @dev Defaults to zero: the mock models a healthy position unless a test sets a deficit
+    function deficitValue(address safe) external view returns (uint256) {
+        return _deficitValue[safe];
+    }
+
     /// @dev The mock models every asset as zero-weight (see ltv), so supply is fully withdrawable under debt
     function collateralForHeadroom(address safe, address asset, uint256) external view returns (uint256) {
         return _suppliedOf[safe][asset];

--- a/src/mocks/MockLendGateway.sol
+++ b/src/mocks/MockLendGateway.sol
@@ -113,6 +113,21 @@ contract MockLendGateway is ILendGateway {
 
     function ensureMinHealthFactor(address safe) external view { }
 
+    mapping(address safe => uint256) internal _healthFactor;
+
+    /// @notice Sets the health factor a subsequent `healthFactor(safe)` will return
+    function setHealthFactor(address safe, uint256 value) external {
+        _healthFactor[safe] = value;
+    }
+
+    /// @dev Defaults to unbounded, matching a safe with no debt
+    function healthFactor(address safe) external view returns (uint256) {
+        return _healthFactor[safe] == 0 ? type(uint256).max : _healthFactor[safe];
+    }
+
+    /// @dev The mock's floor check is inert, so this only models the not-worsened short-circuit
+    function ensureMinHealthFactorNotWorsened(address safe, uint256 healthFactorBefore) external view { }
+
     function repay(address safe, address asset, uint256 amount) external returns (uint256) {
         uint256 debt = _debtOf[safe][asset];
         uint256 repaid = amount < debt ? amount : debt;

--- a/src/modules/ModuleLendGatewaySandwich.sol
+++ b/src/modules/ModuleLendGatewaySandwich.sol
@@ -14,11 +14,12 @@ import { ModuleCheckBalance } from "./ModuleCheckBalance.sol";
  *      end state must sit at or above the gateway's configured health-factor floor (a failed or
  *      unregistered resupply otherwise leaves the health factor between Aave's 1.0 limit and the floor).
  *      Repayment flows (the LiquidUSD liquifier) are deliberately exempt: de-risking must never be
- *      blocked. Gating is asymmetric by design: the WITHDRAW bookend runs for any gateway-engine safe —
+ *      blocked. Gating: the WITHDRAW bookend and the FLOOR check run for any gateway-engine safe —
  *      an opted-out safe (including a matured opt-out whose unwind open borrows still block) can hold
  *      funds supplied on Aave, and pulling them loose is an exit op the repayment/exit paths depend on
- *      (repayUsingLiquidUSD sourcing supplied LiquidUSD). The RESUPPLY bookend and the floor check stay
- *      on _lendActive, so no new supply reaches Aave for a legacy or opted-out safe.
+ *      (repayUsingLiquidUSD sourcing supplied LiquidUSD); the floor must bind those pulls exactly
+ *      because the resupply behind them is off (audit L-03). Only the RESUPPLY bookend stays on
+ *      _lendActive, so no new supply reaches Aave for a legacy or opted-out safe.
  *
  *      Inherits ModuleCheckBalance because the bookends extend its balance model (the front bookend
  *      sources what _getAvailableAmount found missing) and it holds the cashModule reference every
@@ -119,12 +120,16 @@ abstract contract ModuleLendGatewaySandwich is ModuleCheckBalance {
      *      module's signed amount is not bound to the lens quote, and a failed or unregistered resupply
      *      can leave the health factor between Aave's 1.0 limit and the configured floor — this makes the
      *      end state take the floor. Repayment flows are deliberately exempt (de-risking must never be
-     *      blocked). No-op for legacy or opted-out safes (their ops only touch loose, non-collateral
-     *      funds) and while the floor is disabled.
+     *      blocked). Engine-gated like the withdraw bookend, NOT _lendActive: an opted-out safe can still
+     *      hold a live Aave position (a matured opt-out whose unwind open borrows block), and the floor
+     *      must bind its extractions too — otherwise the withdraw bookend could park that position at
+     *      Aave's raw 1.0 boundary with no check. A cleanly opted-out safe has no debt, so
+     *      an unbounded health factor passes and the check stays a no-op for it. No-op for legacy safes
+     *      and while the floor is disabled.
      * @param safe The safe to check
      */
     function _ensureGatewayFloor(address safe) internal view {
-        if (!_lendActive(safe)) return;
+        if (!_onGatewayEngine(safe)) return;
         gateway().ensureMinHealthFactor(safe);
     }
 }

--- a/src/modules/ModuleLendGatewaySandwich.sol
+++ b/src/modules/ModuleLendGatewaySandwich.sol
@@ -87,14 +87,32 @@ abstract contract ModuleLendGatewaySandwich is ModuleCheckBalance {
      * @notice Front bookend: source `amount` of `asset` loose from Aave if short, then require it all present
      * @dev The idiom every gateway consumer runs before acting: _withdrawShortfall to pull the missing part
      *      out of the safe's Aave position, then the ModuleCheckBalance assertion that the full amount is now
-     *      loose.
+     *      loose. Returns the health factor read BEFORE the pull, which is what _ensureGatewayFloor compares
+     *      against — the pull itself lowers health, so a snapshot taken any later would measure the operation
+     *      against its own first step.
      * @param safe The safe whose input is sourced
      * @param asset The input asset the operation needs loose
      * @param amount The full amount the operation needs
+     * @return healthFactorBefore The safe's pre-operation health factor, to pass to _ensureGatewayFloor
      */
-    function _pullAndRequire(address safe, address asset, uint256 amount) internal {
+    function _pullAndRequire(address safe, address asset, uint256 amount) internal returns (uint256 healthFactorBefore) {
+        healthFactorBefore = _gatewayHealthFactor(safe);
         _withdrawShortfall(safe, asset, amount, _getAvailableAmount(safe, asset));
         _checkAmountAvailable(safe, asset, amount);
+    }
+
+    /**
+     * @notice The safe's current health factor, or 0 for a safe with no gateway position to protect
+     * @dev Zero is the inert value: _ensureGatewayFloor no-ops off the gateway engine, and a zero snapshot
+     *      elsewhere can only ever read as "not worsened", never as a tightened bound.
+     * @param safe The safe to read
+     * @return The health factor in WAD, or 0 when the safe is not on the gateway engine
+     */
+    function _gatewayHealthFactor(address safe) internal view returns (uint256) {
+        if (!_onGatewayEngine(safe)) return 0;
+        ILendGateway lendGateway = gateway();
+        if (address(lendGateway) == address(0)) return 0;
+        return lendGateway.healthFactor(safe);
     }
 
     /**
@@ -126,10 +144,16 @@ abstract contract ModuleLendGatewaySandwich is ModuleCheckBalance {
      *      Aave's raw 1.0 boundary with no check. A cleanly opted-out safe has no debt, so
      *      an unbounded health factor passes and the check stays a no-op for it. No-op for legacy safes
      *      and while the floor is disabled.
+     *
+     *      Enforced as "no worse off" against the pre-operation snapshot from _pullAndRequire: a position
+     *      already under the floor may still run operations that hold or improve its health, since the floor
+     *      exists to stop extraction from approaching the liquidation line, not to freeze a safe out of
+     *      de-risking. Anything that degrades health still takes the full floor.
      * @param safe The safe to check
+     * @param healthFactorBefore The health factor _pullAndRequire captured before the operation ran
      */
-    function _ensureGatewayFloor(address safe) internal view {
+    function _ensureGatewayFloor(address safe, uint256 healthFactorBefore) internal view {
         if (!_onGatewayEngine(safe)) return;
-        gateway().ensureMinHealthFactor(safe);
+        gateway().ensureMinHealthFactorNotWorsened(safe, healthFactorBefore);
     }
 }

--- a/src/modules/cash/CashLendLib.sol
+++ b/src/modules/cash/CashLendLib.sol
@@ -667,6 +667,9 @@ library CashLendLib {
      * @dev Resupplies loose collateral for the part of a pending borrow of `amount` that Aave's raw (1.00)
      *      capacity cannot cover. Gating on the raw capacity, not the configured floor, is what lets an
      *      authorized spend execute in the band between the floor and 1.00 without touching the safe's funds.
+     *      Any existing deficit is added on top: rawBorrowCapacity clamps to zero for an underwater
+     *      position, so sizing the new borrow alone would still leave the borrow failing Aave's
+     *      whole-position check (audit L-08).
      * @param $ The CashModule storage pointer
      * @param dataProvider The EtherFiDataProvider
      * @param gateway The LendGateway serving the safe
@@ -676,9 +679,12 @@ library CashLendLib {
      */
     function _resupplyForCreditShortfall(CashModuleStorageContract.CashModuleStorage storage $, IEtherFiDataProvider dataProvider, ILendGateway gateway, address safe, address token, uint256 amount) private {
         uint256 rawCapacity = gateway.rawBorrowCapacity(safe, token);
-        if (rawCapacity >= amount) return;
-        // Aave-priced: the collateral the shortfall's borrow requires at Aave's own 1.00 bound
-        uint256 shortfallValue = gateway.borrowValue(token, amount - rawCapacity);
+        uint256 deficit = gateway.deficitValue(safe);
+        if (rawCapacity >= amount && deficit == 0) return;
+        // Aave-priced: the collateral the shortfall's borrow requires at Aave's own 1.00 bound, plus the
+        // value the position is already short of it
+        uint256 shortfallValue = deficit;
+        if (amount > rawCapacity) shortfallValue += gateway.borrowValue(token, amount - rawCapacity);
         _resupplyCollateral($, dataProvider, gateway, safe, shortfallValue);
     }
 

--- a/src/modules/cash/CashLens.sol
+++ b/src/modules/cash/CashLens.sol
@@ -299,8 +299,11 @@ contract CashLens is UpgradeableProxy, Constants {
             // (PriceProvider-priced, same 6-decimal scale). Idle funds add no borrowing power.
             data.totalCollateral = account.collateralUsd + idleUsd;
             data.totalBorrow = account.debtUsd;
-            // Gross borrowing power (collateral weighted by LTV): the gateway headroom plus current debt
-            data.maxBorrow = account.availableBorrowsUsd + account.debtUsd;
+            // Gross borrowing power (collateral weighted by LTV), read unclamped rather than reconstructed
+            // from the headroom: headroom + debt collapses to exactly the debt once the headroom floors at
+            // zero, so an over-LTV position would read as one sitting precisely at its limit. Taken direct,
+            // this can fall below totalBorrow and measure the breach.
+            data.maxBorrow = account.maxBorrowUsd;
         }
 
         uint256 len = collateralTokens.length;

--- a/src/modules/cash/CashModuleSetters.sol
+++ b/src/modules/cash/CashModuleSetters.sol
@@ -408,12 +408,20 @@ contract CashModuleSetters is CashModuleStorageContract {
      * @param amounts Array of token amounts to withdraw
      * @param recipient Address to receive the withdrawn tokens
      * @custom:throws RecipientCannotBeAddressZero if recipient is the zero address
+     * @custom:throws InvalidInput if tokens is empty
+     * @custom:throws AmountZero if every amount is zero
      */
     function _requestWithdrawal(address safe, address[] memory tokens, uint256[] memory amounts, address recipient) internal {
         CashModuleStorage storage $ = _getCashModuleStorage();
         SafeCashConfig storage $$ = $.safeCashConfig[safe];
 
         if (recipient == address(0)) revert RecipientCannotBeAddressZero();
+        // A request that withdraws nothing still cancels the live request (and its in-flight bridge) and
+        // occupies the slot, while reading as non-existent to every other function — they all key existence
+        // off tokens.length. Individual zero entries stay legal: _processWithdrawal skips and
+        // compacts them by design, so a caller may pass a token list with some legs sized to zero.
+        if (tokens.length == 0) revert InvalidInput();
+        if (!_hasNonZeroAmount(amounts)) revert AmountZero();
         if (tokens.length > 1) tokens.checkDuplicates();
 
         _areAssetsWithdrawable($, tokens);
@@ -434,5 +442,17 @@ contract CashModuleSetters is CashModuleStorageContract {
         if (!_usesLendGateway(safe)) _getDebtManager().ensureHealth(safe);
 
         if ($.withdrawalDelay == 0) _processWithdrawal(safe);
+    }
+
+    /// @dev Whether the request moves anything at all (see _requestWithdrawal's zero-amount rule)
+    function _hasNonZeroAmount(uint256[] memory amounts) private pure returns (bool) {
+        uint256 len = amounts.length;
+        for (uint256 i = 0; i < len;) {
+            if (amounts[i] != 0) return true;
+            unchecked {
+                ++i;
+            }
+        }
+        return false;
     }
 }

--- a/src/modules/etherfi/EtherFiLiquidModule.sol
+++ b/src/modules/etherfi/EtherFiLiquidModule.sol
@@ -230,7 +230,7 @@ contract EtherFiLiquidModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardT
 
         // Pull any shortfall of the deposit asset out of the safe's Aave position (no-op for ETH), then
         // confirm the safe holds the full amount loose (net of any pending-withdrawal reservation).
-        _pullAndRequire(safe, assetToDeposit, amountToDeposit);
+        uint256 healthFactorBefore = _pullAndRequire(safe, assetToDeposit, amountToDeposit);
 
         address[] memory to;
         bytes[] memory data;
@@ -276,7 +276,7 @@ contract EtherFiLiquidModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardT
         // Re-supply the receipt token as collateral when the gateway lists it; an unlisted receipt stays loose.
         _resupplyToGateway(safe, liquidAsset, liquidTokenReceived);
 
-        _ensureGatewayFloor(safe);
+        _ensureGatewayFloor(safe, healthFactorBefore);
 
         emit LiquidDeposit(safe, assetToDeposit, liquidAsset, amountToDeposit, liquidTokenReceived);
     }
@@ -339,7 +339,7 @@ contract EtherFiLiquidModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardT
 
         // Pull any shortfall of the liquid token out of the safe's Aave position. Only this front bookend
         // applies: the queued withdrawal's output arrives later, loose in the safe.
-        _pullAndRequire(safe, liquidAsset, amountToWithdraw);
+        uint256 healthFactorBefore = _pullAndRequire(safe, liquidAsset, amountToWithdraw);
 
         uint128 amountOutFromQueue = boringQueue.previewAssetsOut(assetOut, amountToWithdraw, discount);
         if (amountOutFromQueue < minReturn) revert InsufficientReturnAmount();
@@ -358,7 +358,7 @@ contract EtherFiLiquidModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardT
 
         // Risk-increasing flow with no resupply (the queued output arrives later, loose): the end state
         // takes the gateway's health-factor floor
-        _ensureGatewayFloor(safe);
+        _ensureGatewayFloor(safe, healthFactorBefore);
         
         emit LiquidWithdrawal(safe, liquidAsset, amountToWithdraw, amountOutFromQueue);
     }

--- a/src/modules/etherfi/EtherFiStakeModule.sol
+++ b/src/modules/etherfi/EtherFiStakeModule.sol
@@ -107,7 +107,7 @@ contract EtherFiStakeModule is ModuleBase, ModuleCheckBalance, ModuleLendGateway
 
         // Pull any shortfall of the input out of the safe's Aave position (a no-op for ETH, which is not a
         // reserve), then confirm the safe holds the full amount loose.
-        _pullAndRequire(safe, assetToDeposit, amountToDeposit);
+        uint256 healthFactorBefore = _pullAndRequire(safe, assetToDeposit, amountToDeposit);
 
         address[] memory to;
         bytes[] memory data;
@@ -143,7 +143,7 @@ contract EtherFiStakeModule is ModuleBase, ModuleCheckBalance, ModuleLendGateway
         // Re-supply the weETH output as collateral when the gateway lists it; an unlisted output stays loose.
         _resupplyToGateway(safe, weETH, weETHAmtReceived);
 
-        _ensureGatewayFloor(safe);
+        _ensureGatewayFloor(safe, healthFactorBefore);
 
         emit StakeDeposit(safe, assetToDeposit, weETH, amountToDeposit, weETHAmtReceived);
     }

--- a/src/modules/frax/FraxModule.sol
+++ b/src/modules/frax/FraxModule.sol
@@ -170,7 +170,7 @@ contract FraxModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardTransient,
 
         // Pull any shortfall of the input out of the safe's Aave position, then confirm the safe holds the
         // full amount loose.
-        _pullAndRequire(safe, assetToDeposit, amountToDeposit);
+        uint256 healthFactorBefore = _pullAndRequire(safe, assetToDeposit, amountToDeposit);
 
         // Validate that custodian has sufficient balance for synchronous deposit
         // The custodian needs at least minReturnAmount of fraxusd tokens to fulfill the deposit synchronously
@@ -199,7 +199,7 @@ contract FraxModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardTransient,
         // Re-supply the fraxUSD output as collateral when the gateway lists it; an unlisted output stays loose.
         _resupplyToGateway(safe, fraxusd, fraxUSDTokenReceived);
 
-        _ensureGatewayFloor(safe);
+        _ensureGatewayFloor(safe, healthFactorBefore);
 
         emit Deposit(safe, assetToDeposit, amountToDeposit, fraxUSDTokenReceived);
     }
@@ -249,7 +249,7 @@ contract FraxModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardTransient,
 
         // Pull any shortfall of the fraxUSD input out of the safe's Aave position, then confirm the safe holds
         // the full amount loose.
-        _pullAndRequire(safe, fraxusd, amountToWithdraw);
+        uint256 healthFactorBefore = _pullAndRequire(safe, fraxusd, amountToWithdraw);
 
         address[] memory to = new address[](2);
         bytes[] memory data = new bytes[](2);
@@ -273,7 +273,7 @@ contract FraxModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardTransient,
         _resupplyToGateway(safe, outputAsset, assetReceived);
 
         // Risk-increasing flow: the end state takes the gateway's health-factor floor
-        _ensureGatewayFloor(safe);
+        _ensureGatewayFloor(safe, healthFactorBefore);
 
         emit Withdrawal(safe, outputAsset, amountToWithdraw, assetReceived);
     }

--- a/src/modules/hype/BeHYPEStakeModule.sol
+++ b/src/modules/hype/BeHYPEStakeModule.sol
@@ -140,7 +140,7 @@ contract BeHYPEStakeModule is ModuleBase, ModuleCheckBalance, ModuleLendGatewayS
 
         // Pull any shortfall of the WHYPE input out of the safe's Aave position, then confirm the safe holds
         // the full amount loose.
-        _pullAndRequire(safe, whype, amountToStake);
+        uint256 healthFactorBefore = _pullAndRequire(safe, whype, amountToStake);
 
         uint256 quotedFee = staker.quoteStake(amountToStake, safe);
         if (msg.value < quotedFee) revert InsufficientFee();
@@ -170,7 +170,7 @@ contract BeHYPEStakeModule is ModuleBase, ModuleCheckBalance, ModuleLendGatewayS
 
         // Risk-increasing flow with no resupply (the beHYPE output arrives later, loose): the end state
         // takes the gateway's health-factor floor
-        _ensureGatewayFloor(safe);
+        _ensureGatewayFloor(safe, healthFactorBefore);
 
         emit StakeDeposit(safe, whype, beHYPE, amountToStake);
     }

--- a/src/modules/lend-gateway/LendCapacityLib.sol
+++ b/src/modules/lend-gateway/LendCapacityLib.sol
@@ -82,6 +82,25 @@ library LendCapacityLib {
     }
 
     /**
+     * @notice The weighted collateral value the position is short of Aave's raw 1.00 bound, 0 while healthy
+     * @dev The unclamped complement of withdrawHeadroom at the 1.00 floor (audit L-08): the capacity views
+     *      clamp to zero once a price move parks the position under 1.00, discarding how deep. Sizing paths
+     *      that must pass Aave's whole-position check (credit resupply, the repay-withdraw leg) add this so
+     *      an existing deficit is covered up front instead of resurfacing as an opaque Aave revert. The
+     *      requirement rounds up, mirroring withdrawHeadroom, so covering the returned value always restores
+     *      the position to at least 1.00.
+     * @param spoke The Aave Spoke holding the position
+     * @param safe The Safe whose position is measured
+     * @return The deficit in weighted-collateral value units, 0 when the position holds at or above 1.00
+     */
+    function deficitValue(IAaveV4Spoke spoke, address safe) external view returns (uint256) {
+        BorrowCapacityData memory data = _accountData(spoke, safe);
+        if (data.totalDebtValueRay == 0) return 0;
+        uint256 required = Math.mulDiv(data.totalDebtValueRay, 1e18, WEIGHTED_COLLATERAL_TO_DEBT_RAY, Math.Rounding.Ceil);
+        return required > data.weightedCollateralValueBps ? required - data.weightedCollateralValueBps : 0;
+    }
+
+    /**
      * @notice Amount of `targetReserveId`'s asset the safe can withdraw while consuming at most `headroom`
      *         of weighted collateral value
      * @dev Supply that carries no borrowing power (collateral flag off, or a zero collateral factor) is

--- a/src/modules/lend-gateway/LendGateway.sol
+++ b/src/modules/lend-gateway/LendGateway.sol
@@ -810,37 +810,25 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
     }
 
     /**
-     * @notice Whether `asset` can fund a debit spend: an admin-declared spend asset whose reserve is not paused
-     * @dev Membership is declared via setSpendAsset (always a subset of registered reserves), so "is this a
-     *      card settlement token" no longer keys on Aave's borrowable flag and a supply-only reserve can be
-     *      spendable. A debit spend transfers loose balance and withdraws supplied balance, which Aave allows
-     *      while frozen, so frozen is tolerated; paused blocks the withdraw leg, so a paused reserve is not
-     *      spendable. New debt takes the full isBorrowable gate instead.
+     * @notice Whether `asset` is an admin-declared card settlement token
+     * @dev Static membership only, declared via setSpendAsset (always a subset of registered reserves), so
+     *      "is this a card settlement token" keys on neither Aave's borrowable flag (a supply-only reserve
+     *      can be spendable) nor its execution state. Aave's state is deliberately NOT folded in (audit
+     *      I-02): a debit spend transfers loose balance and withdraws supplied balance, so a spend funded
+     *      entirely from loose balance needs nothing from Aave, and folding a pause in here blocked such
+     *      settlements outright — worst for a lend-opted-out safe, which is forced into Debit and holds
+     *      everything loose. A pause costs only the supplied leg, which withdrawalLiquidity already reports
+     *      as zero, so the sourcing gate declines exactly the spends that truly need the withdraw. New debt
+     *      takes the full isBorrowable gate, which reads the pause itself.
      * @param asset The asset to query
      */
     function isSpendAsset(address asset) external view returns (bool) {
-        LendGatewayStorage storage $ = _getLendGatewayStorage();
-        if (!$.spendAssets.contains(asset)) return false;
-        return !spoke.getReserveConfig($.reserveId[asset]).paused;
+        return _getLendGatewayStorage().spendAssets.contains(asset);
     }
 
-    /// @notice The spend-set assets that can currently fund a debit spend (see isSpendAsset)
+    /// @notice The admin-declared card settlement tokens (see isSpendAsset: membership, not Aave state)
     function spendAssets() external view returns (address[] memory) {
-        LendGatewayStorage storage $ = _getLendGatewayStorage();
-        address[] memory assets = $.spendAssets.values();
-        uint256 count = 0;
-        for (uint256 i = 0; i < assets.length; i++) {
-            if (!spoke.getReserveConfig($.reserveId[assets[i]]).paused) {
-                assets[count] = assets[i];
-                unchecked {
-                    ++count;
-                }
-            }
-        }
-        assembly ("memory-safe") {
-            mstore(assets, count)
-        }
-        return assets;
+        return _getLendGatewayStorage().spendAssets.values();
     }
 
     /// @notice Whether `account` may drive the gateway (CashModule or an authorized driver)

--- a/src/modules/lend-gateway/LendGateway.sol
+++ b/src/modules/lend-gateway/LendGateway.sol
@@ -208,7 +208,12 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
      * @dev Reverts while the reserve still has outstanding debt or supplied balance. Removing a
      * held asset would drop it from the USD views (debt reads 0, understating debt and inflating
      * borrow headroom) and strand supplied funds behind AssetNotRegistered on the withdraw paths.
-     * Our whitelabel Spoke serves only our safes, so the reserve aggregates gate on our positions.
+     * The gate reads spoke-wide aggregates, which any outside address can hold non-zero forever with a
+     * dust self-supply (Spoke.supply is permissionless for self-positions, and a debt-free position can
+     * be neither liquidated nor force-withdrawn). A reserve pinned that way stays registered by design:
+     * freezing it on the Spoke is the deprecation path (no new supply or borrows, exits stay open, every
+     * gateway supply flow skips or tolerates a frozen reserve), so removal is never operationally
+     * required and the pin is harmless. See audit L-01.
      * @param asset The asset to remove from the registry
      */
     function removeReserve(address asset) external onlyRole(LEND_GATEWAY_ADMIN_ROLE) {

--- a/src/modules/lend-gateway/LendGateway.sol
+++ b/src/modules/lend-gateway/LendGateway.sol
@@ -495,6 +495,35 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
     }
 
     /**
+     * @notice `safe`'s current Aave health factor in WAD (1e18), unbounded when it carries no debt
+     * @dev Read straight from the Spoke, like the floor check itself: getAccountData's healthFactor is the
+     *      same number but reached through the PriceProvider-derived USD fields, which revert for a supplied
+     *      asset Cash cannot price.
+     * @param safe The safe to query
+     * @return The health factor in WAD
+     */
+    function healthFactor(address safe) external view returns (uint256) {
+        return spoke.getUserAccountData(safe).healthFactor;
+    }
+
+    /**
+     * @notice Enforces the floor as "no worse off": passes when the position did not degrade, otherwise
+     *         requires the end state to hold the configured floor
+     * @dev The floor exists to stop ether.fi-initiated operations from parking a position near Aave's
+     *      liquidation line, so it has nothing to say about an operation that holds or improves health. A
+     *      plain floor check cannot express that: comparing only the end state traps a safe sitting between
+     *      Aave's 1.00 bound and the floor, blocking even the de-risking operations that would lift it out.
+     *      An operation that degrades health still takes the full floor, so nothing may cross down through it.
+     * @param safe The safe to check
+     * @param healthFactorBefore The safe's health factor captured before the operation ran
+     * @custom:throws HealthFactorBelowMinimum if the operation degraded health and the end state is below the floor
+     */
+    function ensureMinHealthFactorNotWorsened(address safe, uint256 healthFactorBefore) external view {
+        if (spoke.getUserAccountData(safe).healthFactor >= healthFactorBefore) return;
+        ensureMinHealthFactor(safe);
+    }
+
+    /**
      * @notice Returns `safe`'s Cash-priced position summary (collateral, debt, borrow headroom, health factor)
      * @dev Re-derives the USD fields from PriceProvider for display only; capacity and sizing use the
      *      Aave-priced borrowCapacity and withdrawHeadroom families. healthFactor (WAD) comes directly from Aave.

--- a/src/modules/lend-gateway/LendGateway.sol
+++ b/src/modules/lend-gateway/LendGateway.sol
@@ -531,6 +531,10 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
             }
         }
 
+        // Gross power is reported unclamped alongside the clamped headroom: once debt passes gross power the
+        // headroom floors at zero, which cannot distinguish an over-LTV position from one sitting exactly at
+        // its limit, and nothing else here recovers the gap.
+        data.maxBorrowUsd = maxBorrowUsd;
         data.availableBorrowsUsd = maxBorrowUsd > data.debtUsd ? maxBorrowUsd - data.debtUsd : 0;
         // healthFactor is WAD (1e18) on Aave, matching ILendGateway's 1e18 scale.
         data.healthFactor = spoke.getUserAccountData(safe).healthFactor;

--- a/src/modules/lend-gateway/LendGateway.sol
+++ b/src/modules/lend-gateway/LendGateway.sol
@@ -690,6 +690,19 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
     }
 
     /**
+     * @notice The weighted collateral value the safe's position is short of Aave's 1.00 bound, 0 while healthy
+     * @dev The unclamped complement of rawWithdrawHeadroom (audit L-08): the capacity views clamp at zero
+     *      once a price move parks the position under 1.00, hiding how deep. Sizing paths that must pass
+     *      Aave's whole-position check (credit resupply, the repay-withdraw leg) add this so a pre-existing
+     *      deficit is covered up front rather than resurfacing as an opaque Aave revert.
+     * @param safe The Safe whose position is measured
+     * @return The deficit in weighted collateral value units
+     */
+    function deficitValue(address safe) external view returns (uint256) {
+        return LendCapacityLib.deficitValue(spoke, safe);
+    }
+
+    /**
      * @notice Amount of `asset` the safe can withdraw from Aave while consuming at most `headroom`
      * @dev Supply carrying no borrowing power (collateral flag off or zero collateral factor) is fully
      *      withdrawable, matching Aave's own check.

--- a/src/modules/midas/MidasModule.sol
+++ b/src/modules/midas/MidasModule.sol
@@ -173,7 +173,7 @@ contract MidasModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardTransient
 
         // Pull any shortfall of the input out of the safe's Aave position, then confirm the safe holds the
         // full amount loose.
-        _pullAndRequire(safe, asset, amount);
+        uint256 healthFactorBefore = _pullAndRequire(safe, asset, amount);
 
         uint256 midasTokenBefore = ERC20(midasToken).balanceOf(safe);
 
@@ -194,7 +194,7 @@ contract MidasModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardTransient
         // Re-supply the Midas-token output as collateral when the gateway lists it; an unlisted output stays loose.
         _resupplyToGateway(safe, midasToken, midasTokenReceived);
 
-        _ensureGatewayFloor(safe);
+        _ensureGatewayFloor(safe, healthFactorBefore);
 
         emit Deposit(safe, asset, amount, midasToken, midasTokenReceived);
     }
@@ -250,7 +250,7 @@ contract MidasModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardTransient
         // Pull any shortfall of the Midas token out of the safe's Aave position, then confirm the safe holds
         // the full amount loose. No re-supply bookend: the asset output arrives asynchronously via the
         // redemption vault, not in this call.
-        _pullAndRequire(safe, midasToken, amount);
+        uint256 healthFactorBefore = _pullAndRequire(safe, midasToken, amount);
 
         address[] memory to = new address[](2);
         bytes[] memory data = new bytes[](2);
@@ -266,7 +266,7 @@ contract MidasModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardTransient
 
         // Risk-increasing flow with no resupply (the redemption output arrives later, loose): the end
         // state takes the gateway's health-factor floor
-        _ensureGatewayFloor(safe);
+        _ensureGatewayFloor(safe, healthFactorBefore);
 
         emit Withdrawal(safe, amount, asset, midasToken);
     }

--- a/src/modules/openocean-swap/OpenOceanSwapModule.sol
+++ b/src/modules/openocean-swap/OpenOceanSwapModule.sol
@@ -165,7 +165,7 @@ contract OpenOceanSwapModule is ModuleBase, ModuleCheckBalance, ModuleLendGatewa
 
         // Pull any shortfall of the input out of the safe's Aave position, then confirm the safe holds the
         // full amount loose (net of any pending-withdrawal reservation).
-        _pullAndRequire(safe, fromAsset, fromAssetAmount);
+        uint256 healthFactorBefore = _pullAndRequire(safe, fromAsset, fromAssetAmount);
 
         uint256 balBefore;
         if (toAsset == ETH) balBefore = address(safe).balance;
@@ -191,7 +191,7 @@ contract OpenOceanSwapModule is ModuleBase, ModuleCheckBalance, ModuleLendGatewa
         // Re-supply the output as collateral when the gateway lists it; an unlisted output (or ETH) stays loose.
         _resupplyToGateway(safe, toAsset, receivedAmt);
 
-        _ensureGatewayFloor(safe);
+        _ensureGatewayFloor(safe, healthFactorBefore);
 
         emit SwapOnOpenOcean(safe, fromAsset, toAsset, fromAssetAmount, minToAssetAmount, receivedAmt);
     }

--- a/src/modules/recovery/SafeAssetRecoveryModule.sol
+++ b/src/modules/recovery/SafeAssetRecoveryModule.sol
@@ -9,6 +9,7 @@ import { ISafeAssetRecoveryModule } from "../../interfaces/ISafeAssetRecoveryMod
 import { IRoleRegistry } from "../../interfaces/IRoleRegistry.sol";
 import { ICashModule } from "../../interfaces/ICashModule.sol";
 import { IDebtManager } from "../../interfaces/IDebtManager.sol";
+import { ILendGateway } from "../../interfaces/ILendGateway.sol";
 import { ModuleBase } from "../ModuleBase.sol";
 
 /**
@@ -65,16 +66,36 @@ contract SafeAssetRecoveryModule is ISafeAssetRecoveryModule, ModuleBase, Pausab
     ///      supported token:
     ///        - collateral / borrow tokens back the safe's active debt position;
     ///        - whitelisted withdraw assets are timelocked on the normal withdrawal path, and
-    ///          sweeping one here would skip that delay (and could drain a pending withdrawal).
+    ///          sweeping one here would skip that delay (and could drain a pending withdrawal);
+    ///        - LendGateway-registered reserves serve gateway safes' Aave positions:
+    ///          the gateway registry diverges from DebtManager's legacy lists by design, and a
+    ///          registered asset's loose balance may be awaiting auto-supply or reserved by flows
+    ///          the legacy checks know nothing about.
     function _assertRecoverable(address token) internal view {
         ICashModule cashModule = ICashModule(etherFiDataProvider.getCashModule());
         IDebtManager debtManager = cashModule.getDebtManager();
         if (
-            debtManager.isCollateralToken(token) ||
+            _isGatewayRegistered(cashModule, token) ||
+            debtManager.isCollateralToken(token) || 
             debtManager.isBorrowToken(token) ||
             _isWithdrawWhitelisted(cashModule, token)
         ) {
             revert OnlySupportedTokensCannotBeRecovered();
+        }
+    }
+
+    /// @dev True if `token` is a registered reserve on the LendGateway. Borrowable and
+    ///      spend assets are strict subsets of the registry, so this one check covers all three
+    ///      gateway sets. Deliberately not branched per-safe on usesLendGateway: over-blocking is
+    ///      the safe direction for a rescue hatch, and a registered reserve is a live cash asset
+    ///      regardless of which engine this safe runs. False while no gateway is configured — the
+    ///      try/catch keeps recovery working against a CashModule that predates the lend gateway
+    ///      (no getLendGateway selector), so this module can ship ahead of the lend upgrade.
+    function _isGatewayRegistered(ICashModule cashModule, address token) internal view returns (bool) {
+        try cashModule.getLendGateway() returns (ILendGateway gateway) {
+            return address(gateway) != address(0) && gateway.isRegistered(token);
+        } catch {
+            return false;
         }
     }
 

--- a/test/safe/modules/ModuleLendGatewaySandwich.t.sol
+++ b/test/safe/modules/ModuleLendGatewaySandwich.t.sol
@@ -56,6 +56,10 @@ contract SandwichHarness is ModuleLendGatewaySandwich {
     function resupplyToGateway(address safe, address asset, uint256 amount) external {
         _resupplyToGateway(safe, asset, amount);
     }
+
+    function ensureGatewayFloor(address safe) external view {
+        _ensureGatewayFloor(safe);
+    }
 }
 
 contract ModuleLendGatewaySandwichTest is Test {
@@ -163,5 +167,39 @@ contract ModuleLendGatewaySandwichTest is Test {
         assertEq(s, address(0), "no supply call recorded");
         assertEq(amount, 0);
         assertFalse(gateway.usingAsCollateral(safe, asset), "collateral flag untouched");
+    }
+
+    // ----------------------------------------------------------------- floor check gating (audit L-03)
+
+    /// @dev Simulates the gateway judging the safe below the configured floor.
+    function _mockFloorViolated() internal {
+        vm.mockCallRevert(address(gateway), abi.encodeWithSelector(ILendGateway.ensureMinHealthFactor.selector, safe), "below floor");
+    }
+
+    // The floor check runs for a fully active gateway safe: a below-floor end state reverts the operation.
+    function test_floor_revertsForActiveSafeBelowFloor() public {
+        _mockFloorViolated();
+        vm.expectRevert("below floor");
+        harness.ensureGatewayFloor(safe);
+    }
+
+    // Audit L-03: the floor check is ENGINE-gated like the withdraw bookend, not lend-active-gated. An
+    // opted-out safe with a live Aave position (a matured opt-out whose unwind open borrows still block)
+    // can pull collateral through the front bookend with no resupply behind it; the floor must still bind
+    // that extraction, or the position can be parked at Aave's raw 1.0 boundary. Repayment flows never
+    // call this check, so the safe can always still repay its way out of the blocked opt-out.
+    function test_floor_revertsForOptedOutSafeOnEngine() public {
+        harness.setLendActive(false); // opted out, but still on the gateway engine with a live position
+        _mockFloorViolated();
+        vm.expectRevert("below floor");
+        harness.ensureGatewayFloor(safe);
+    }
+
+    // Off the gateway engine (legacy safe) there is no Aave position to protect: the check is a no-op
+    // even when the gateway would judge the safe below floor.
+    function test_floor_noOpOffGatewayEngine() public {
+        harness.setOnGatewayEngine(false);
+        _mockFloorViolated();
+        harness.ensureGatewayFloor(safe); // must not revert
     }
 }

--- a/test/safe/modules/ModuleLendGatewaySandwich.t.sol
+++ b/test/safe/modules/ModuleLendGatewaySandwich.t.sol
@@ -57,8 +57,12 @@ contract SandwichHarness is ModuleLendGatewaySandwich {
         _resupplyToGateway(safe, asset, amount);
     }
 
-    function ensureGatewayFloor(address safe) external view {
-        _ensureGatewayFloor(safe);
+    function ensureGatewayFloor(address safe, uint256 healthFactorBefore) external view {
+        _ensureGatewayFloor(safe, healthFactorBefore);
+    }
+
+    function gatewayHealthFactor(address safe) external view returns (uint256) {
+        return _gatewayHealthFactor(safe);
     }
 }
 
@@ -169,37 +173,49 @@ contract ModuleLendGatewaySandwichTest is Test {
         assertFalse(gateway.usingAsCollateral(safe, asset), "collateral flag untouched");
     }
 
-    // ----------------------------------------------------------------- floor check gating (audit L-03)
+    // ----------------------------------------------------------------- floor check gating
 
-    /// @dev Simulates the gateway judging the safe below the configured floor.
+    uint256 constant HF_BEFORE = 1.02e18;
+
+    /// @dev Simulates the gateway rejecting the end state, whatever rule it applies internally.
     function _mockFloorViolated() internal {
-        vm.mockCallRevert(address(gateway), abi.encodeWithSelector(ILendGateway.ensureMinHealthFactor.selector, safe), "below floor");
+        vm.mockCallRevert(address(gateway), abi.encodeWithSelector(ILendGateway.ensureMinHealthFactorNotWorsened.selector, safe, HF_BEFORE), "below floor");
     }
 
-    // The floor check runs for a fully active gateway safe: a below-floor end state reverts the operation.
+    // The floor check runs for a fully active gateway safe: a rejected end state reverts the operation.
     function test_floor_revertsForActiveSafeBelowFloor() public {
         _mockFloorViolated();
         vm.expectRevert("below floor");
-        harness.ensureGatewayFloor(safe);
+        harness.ensureGatewayFloor(safe, HF_BEFORE);
     }
 
-    // Audit L-03: the floor check is ENGINE-gated like the withdraw bookend, not lend-active-gated. An
-    // opted-out safe with a live Aave position (a matured opt-out whose unwind open borrows still block)
-    // can pull collateral through the front bookend with no resupply behind it; the floor must still bind
-    // that extraction, or the position can be parked at Aave's raw 1.0 boundary. Repayment flows never
-    // call this check, so the safe can always still repay its way out of the blocked opt-out.
+    // The floor check is ENGINE-gated like the withdraw bookend, not lend-active-gated. An opted-out safe
+    // with a live Aave position (a matured opt-out whose unwind open borrows still block) can pull collateral
+    // through the front bookend with no resupply behind it; the floor must still bind that extraction, or the
+    // position can be parked at Aave's raw 1.0 boundary. Repayment flows never call this check, so the safe
+    // can always still repay its way out of the blocked opt-out.
     function test_floor_revertsForOptedOutSafeOnEngine() public {
         harness.setLendActive(false); // opted out, but still on the gateway engine with a live position
         _mockFloorViolated();
         vm.expectRevert("below floor");
-        harness.ensureGatewayFloor(safe);
+        harness.ensureGatewayFloor(safe, HF_BEFORE);
     }
 
     // Off the gateway engine (legacy safe) there is no Aave position to protect: the check is a no-op
-    // even when the gateway would judge the safe below floor.
+    // even when the gateway would reject the end state.
     function test_floor_noOpOffGatewayEngine() public {
         harness.setOnGatewayEngine(false);
         _mockFloorViolated();
-        harness.ensureGatewayFloor(safe); // must not revert
+        harness.ensureGatewayFloor(safe, HF_BEFORE); // must not revert
+    }
+
+    // The pre-operation snapshot the floor check compares against is read for a gateway safe and inert
+    // (zero) off the engine, where a snapshot could only ever tighten a check that does not run.
+    function test_floor_snapshotReadsGatewayHealthOnEngineOnly() public {
+        gateway.setHealthFactor(safe, HF_BEFORE);
+        assertEq(harness.gatewayHealthFactor(safe), HF_BEFORE, "snapshot reads the gateway health factor");
+
+        harness.setOnGatewayEngine(false);
+        assertEq(harness.gatewayHealthFactor(safe), 0, "inert off the gateway engine");
     }
 }

--- a/test/safe/modules/cash/SetLendGateway.t.sol
+++ b/test/safe/modules/cash/SetLendGateway.t.sol
@@ -72,7 +72,7 @@ contract CashModuleSetLendGatewayTest is CashModuleTestSetup {
         newGateway.setBorrowable(address(usdc), true);
         newGateway.setSpendAsset(address(usdc), true);
         newGateway.setBorrowCapacity(address(safe), address(usdc), amountsInUsd[0]);
-        newGateway.setAccountData(address(safe), ILendGateway.AccountData({ collateralUsd: 200e6, debtUsd: 0, availableBorrowsUsd: amountsInUsd[0], healthFactor: type(uint256).max }));
+        newGateway.setAccountData(address(safe), ILendGateway.AccountData({ collateralUsd: 200e6, debtUsd: 0, availableBorrowsUsd: amountsInUsd[0], maxBorrowUsd: amountsInUsd[0], healthFactor: type(uint256).max }));
 
         vm.prank(owner);
         unconfiguredCashModule.setLendGateway(address(newGateway));

--- a/test/safe/modules/cash/Withdrawals.t.sol
+++ b/test/safe/modules/cash/Withdrawals.t.sol
@@ -121,6 +121,60 @@ contract CashModuleWithdrawalTest is CashModuleTestSetup {
         assertEq(cashModule.getPendingWithdrawalAmount(address(safe), address(usdc)), withdrawalAmount);
     }
 
+    /// @dev An empty request withdraws nothing, yet it cancelled any live request (and its
+    ///      in-flight bridge) and stored a request with a finalizeTime that every other function reads as
+    ///      non-existent — cancelWithdrawal and processWithdrawal all key existence off tokens.length.
+    function test_requestWithdrawal_fails_forEmptyTokenList() public {
+        // A live request first, to prove the rejected call cannot destroy it
+        uint256 withdrawalAmount = 50e6;
+        deal(address(usdc), address(safe), withdrawalAmount);
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = withdrawalAmount;
+        _requestWithdrawal(tokens, amounts, withdrawRecipient);
+
+        address[] memory noTokens = new address[](0);
+        uint256[] memory noAmounts = new uint256[](0);
+        (address[] memory signers, bytes[] memory signatures) = _signWithdrawal(noTokens, noAmounts, withdrawRecipient);
+
+        vm.expectRevert(ICashModule.InvalidInput.selector);
+        cashModule.requestWithdrawal(address(safe), noTokens, noAmounts, withdrawRecipient, signers, signatures);
+
+        assertEq(cashModule.getPendingWithdrawalAmount(address(safe), address(usdc)), withdrawalAmount, "live request survived");
+    }
+
+    /// @dev An all-zero request is an empty request wearing a token list — it withdraws nothing
+    ///      while still cancelling the previous one. Partially-zero requests stay legal (see
+    ///      test_processWithdrawals_compactsMixedZeroAmounts): the process path skips those entries by design.
+    function test_requestWithdrawal_fails_whenEveryAmountIsZero() public {
+        address[] memory tokens = new address[](2);
+        tokens[0] = address(usdc);
+        tokens[1] = address(weETH);
+        uint256[] memory amounts = new uint256[](2); // both zero
+
+        (address[] memory signers, bytes[] memory signatures) = _signWithdrawal(tokens, amounts, withdrawRecipient);
+
+        vm.expectRevert(ICashModule.AmountZero.selector);
+        cashModule.requestWithdrawal(address(safe), tokens, amounts, withdrawRecipient, signers, signatures);
+    }
+
+    /// @dev Signs an owner-quorum withdrawal request without submitting it, for the rejection cases above.
+    function _signWithdrawal(address[] memory tokens, uint256[] memory amounts, address recipient) internal view returns (address[] memory signers, bytes[] memory signatures) {
+        bytes32 digestHash = keccak256(abi.encodePacked(CashVerificationLib.REQUEST_WITHDRAWAL_METHOD, block.chainid, address(safe), safe.nonce(), abi.encode(tokens, amounts, recipient))).toEthSignedMessageHash();
+
+        (uint8 v1, bytes32 r1, bytes32 s1) = vm.sign(owner1Pk, digestHash);
+        (uint8 v2, bytes32 r2, bytes32 s2) = vm.sign(owner2Pk, digestHash);
+
+        signers = new address[](2);
+        signers[0] = owner1;
+        signers[1] = owner2;
+
+        signatures = new bytes[](2);
+        signatures[0] = abi.encodePacked(r1, s1, v1);
+        signatures[1] = abi.encodePacked(r2, s2, v2);
+    }
+
     function test_requestWithdrawal_fails_forUnsupportedAsset() public {
         uint256 withdrawalAmount = 50e6;
 
@@ -184,11 +238,18 @@ contract CashModuleWithdrawalTest is CashModuleTestSetup {
         assertEq(cashModule.getPendingWithdrawalAmount(address(safe), address(usdc)), 0);
     }
 
-    /// A zero-amount withdrawal must not issue a zero-value ERC-20 transfer.
+    /// A zero-amount leg must not issue a zero-value ERC-20 transfer, and the request still clears fully.
+    /// @dev A request whose legs are ALL zero is rejected upstream now (audit I-08, see
+    ///      test_requestWithdrawal_fails_whenEveryAmountIsZero), so the zero leg is paired with a real one.
     function test_processWithdrawals_skipsZeroAmount() external {
-        address[] memory tokens = new address[](1);
+        uint256 weETHAmount = 1 ether;
+        deal(address(weETH), address(safe), weETHAmount);
+
+        address[] memory tokens = new address[](2);
         tokens[0] = address(usdc);
-        uint256[] memory amounts = new uint256[](1);
+        tokens[1] = address(weETH);
+        uint256[] memory amounts = new uint256[](2);
+        amounts[1] = weETHAmount;
 
         _requestWithdrawal(tokens, amounts, withdrawRecipient);
 
@@ -198,7 +259,7 @@ contract CashModuleWithdrawalTest is CashModuleTestSetup {
         vm.expectCall(address(usdc), abi.encodeCall(IERC20.transfer, (withdrawRecipient, 0)), 0);
         cashModule.processWithdrawal(address(safe));
 
-        assertEq(cashModule.getData(address(safe)).pendingWithdrawalRequest.tokens.length, 0);
+        assertEq(cashModule.getData(address(safe)).pendingWithdrawalRequest.tokens.length, 0, "request cleared");
     }
 
     /// A mixed withdrawal must compact zero amounts without misaligning the remaining transfers.

--- a/test/safe/modules/cash/lend/CanSpend.t.sol
+++ b/test/safe/modules/cash/lend/CanSpend.t.sol
@@ -45,6 +45,38 @@ contract CashLensCanSpendAaveTest is CashGatewayTestSetup {
         assertEq(reason, "");
     }
 
+    /// Audit I-02: a pause must not decline a debit auth the safe can fund entirely from loose balance — the
+    /// settlement needs no Aave interaction at all. The pause only removes the supplied leg (below).
+    function test_canSpend_succeeds_inDebitMode_fromLooseWhileReservePaused() public {
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 100e6;
+
+        deal(address(usdc), address(safe), 100e6); // fully funded loose, nothing needed from Aave
+        _setAaveReservePaused(usdcReserveId, true);
+
+        (bool canSpend, string memory reason) = cashLens.canSpend(address(safe), txId, tokens, amounts);
+        assertEq(canSpend, true);
+        assertEq(reason, "");
+    }
+
+    /// The pause still blocks the supplied leg: with nothing loose, the auth declines on the Aave-liquidity
+    /// attribution (withdrawalLiquidity reads zero while paused), not on spend-token membership.
+    function test_canSpend_fails_inDebitMode_whenPausedAndNeedsSuppliedLeg() public {
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 100e6;
+
+        _supplyToGateway(address(safe), address(usdc), 1000e6); // supplied only, nothing loose
+        _setAaveReservePaused(usdcReserveId, true);
+
+        (bool canSpend, string memory reason) = cashLens.canSpend(address(safe), txId, tokens, amounts);
+        assertEq(canSpend, false);
+        assertEq(reason, "Insufficient Lend withdrawal liquidity, please try again later");
+    }
+
     /// Debit spend is declined with an Aave-specific reason when the safe's supplied balance covers the spend
     /// but the Hub's withdrawal liquidity cannot pay it out (utilization spike / drained reserve).
     function test_canSpend_fails_inDebitMode_whenAaveWithdrawalLiquidityDrained() public {

--- a/test/safe/modules/cash/lend/CashGatewayTestSetup.t.sol
+++ b/test/safe/modules/cash/lend/CashGatewayTestSetup.t.sol
@@ -10,6 +10,7 @@ import { LendGateway } from "../../../../../src/modules/lend-gateway/LendGateway
 import { ChainlinkPriceFeed } from "../../../../../src/oracle/ChainlinkPriceFeed.sol";
 import { AaveV4Fixture } from "./helpers/AaveV4Fixture.sol";
 import { CashModuleTestSetup } from "../CashModuleTestSetup.t.sol";
+import { IPriceFeed } from "aave-v4/spoke/interfaces/IPriceFeed.sol";
 
 /**
  * @title CashGatewayTestSetup
@@ -133,6 +134,15 @@ abstract contract CashGatewayTestSetup is CashModuleTestSetup, AaveV4Fixture {
     /// @dev Sets a registered asset's Aave collateral factor (BPS), i.e. its LTV, for the whole reserve.
     function _setAaveCollateralFactor(address token, uint16 cfBps) internal {
         _setAaveReserveCollateralFactor(gw.reserveIdOf(token), cfBps);
+    }
+
+    /// @dev Reprices the weETH Aave reserve to `factorBps` of its current value by mocking its price
+    ///      source. Aave's own health check and the gateway's capacity math read the same source, so a
+    ///      crash makes the position genuinely underwater for every consumer at once.
+    function _crashWeethAavePrice(uint256 factorBps) internal {
+        address source = oracle.getReserveSource(weethReserveId);
+        int256 price = IPriceFeed(source).latestAnswer();
+        vm.mockCall(source, abi.encodeWithSelector(IPriceFeed.latestAnswer.selector), abi.encode(int256(uint256(price) * factorBps / 10_000)));
     }
 
     // ----------------------------------------------------------------- module wiring helpers

--- a/test/safe/modules/cash/lend/CashLensMaxSpend.t.sol
+++ b/test/safe/modules/cash/lend/CashLensMaxSpend.t.sol
@@ -7,6 +7,7 @@ import { IERC20Metadata } from "@openzeppelin/contracts/interfaces/IERC20Metadat
 import { DebitModeMaxSpend, Mode, SafeCashData } from "../../../../../src/interfaces/ICashModule.sol";
 import { IDebtManager } from "../../../../../src/interfaces/IDebtManager.sol";
 import { ILendGateway } from "../../../../../src/interfaces/ILendGateway.sol";
+import { IPriceProvider } from "../../../../../src/interfaces/IPriceProvider.sol";
 import { ArrayDeDupLib } from "../../../../../src/libraries/ArrayDeDupLib.sol";
 import { CashLens } from "../../../../../src/modules/cash/CashLens.sol";
 import { IAggregatorV3, PriceProvider } from "../../../../../src/oracle/PriceProvider.sol";
@@ -395,6 +396,28 @@ contract CashLensMaxSpendAaveTest is CashGatewayTestSetup {
         assertEq(data.creditMaxSpend, account.availableBorrowsUsd, "creditMaxSpend is the net headroom (liquidity ample)");
         assertEq(data.maxBorrow, data.totalBorrow + data.creditMaxSpend, "gross == debt + net headroom");
         assertGt(data.maxBorrow, data.creditMaxSpend, "gross exceeds net once there is debt");
+    }
+
+    /// maxBorrow is documented as gross borrowing power, but reconstructing it as headroom + debt collapses
+    /// to exactly the debt once availableBorrowsUsd clamps at zero — an over-LTV position then reads
+    /// identically to a healthy one sitting precisely at its limit, and nothing in SafeCashData recovers the
+    /// gap. Gross power is reported directly, so it can fall below totalBorrow and quantify the breach.
+    function test_safeCashData_maxBorrowGoesBelowTotalBorrowWhenOverLtv() public {
+        // 2000 liquidUSD collateral at 50% backing 800 USDC of debt: gross power $1000 against $800
+        _supplyToGateway(address(safe), address(liquidUsd), 2000e6);
+        _borrowOnGateway(address(safe), address(usdc), 800e6, recipient);
+
+        // Quartering the collateral's Cash price alone drops gross power to ~$250, well under the debt
+        uint256 cashLiquidPrice = priceProvider.price(address(liquidUsd));
+        vm.mockCall(address(priceProvider), abi.encodeWithSelector(IPriceProvider.price.selector, address(liquidUsd)), abi.encode(cashLiquidPrice / 4));
+
+        SafeCashData memory data = cashLens.getSafeCashData(address(safe), new address[](0));
+        ILendGateway.AccountData memory account = gw.getAccountData(address(safe));
+
+        assertEq(account.availableBorrowsUsd, 0, "headroom clamps to zero once debt exceeds gross power");
+        assertApproxEqAbs(data.totalBorrow, 800e6, 2, "debt unchanged");
+        assertLt(data.maxBorrow, data.totalBorrow, "gross power reads below the debt, exposing the breach");
+        assertApproxEqAbs(data.maxBorrow, 250e6, 2e6, "gross power quantifies the shortfall");
     }
 
     /// getSafeCashData honors the token preference order and populates the position fields.

--- a/test/safe/modules/cash/lend/EtherFiLiquidGateway.t.sol
+++ b/test/safe/modules/cash/lend/EtherFiLiquidGateway.t.sol
@@ -174,6 +174,46 @@ contract EtherFiLiquidGatewayTest is CashGatewayTestSetup {
         assertGe(spoke.getUserAccountData(address(safe)).healthFactor, 1.05e18, "end state above the floor");
     }
 
+    // A safe parked between Aave's 1.00 bound and the floor is not frozen out of the sandwiched modules: an
+    // operation that leaves its health no worse off still runs, because the floor is there to stop extraction
+    // approaching the liquidation line, not to block a safe from improving. A deposit funded from loose
+    // balance re-supplies the receipt as collateral, so it lifts health even while staying under the floor.
+    function test_deposit_belowFloor_allowedWhenHealthImproves() public {
+        _supplyToGateway(address(safe), address(liquidVault), 10_000e6);
+        _borrowOnGateway(address(safe), address(usdc), 7800e6, recipient); // HF ~1.026
+        vm.prank(owner);
+        gw.setMinHealthFactor(1.05e18);
+
+        uint256 hfBefore = gw.healthFactor(address(safe));
+        assertLt(hfBefore, 1.05e18, "safe starts below the floor");
+        assertGt(hfBefore, 1e18, "and above Aave's bound");
+
+        // Loose USDC in, receipt back as collateral: strictly more collateral, same debt
+        uint256 amount = 100e6;
+        deal(address(usdc), address(safe), amount);
+        liquidModule.deposit(address(safe), address(usdc), address(liquidVault), amount, amount, owner1, _depositSig(address(usdc), amount, amount));
+
+        uint256 hfAfter = gw.healthFactor(address(safe));
+        assertGt(hfAfter, hfBefore, "the deposit improved health");
+        assertLt(hfAfter, 1.05e18, "while still under the floor, which no longer blocks it");
+        assertEq(gw.suppliedOf(address(safe), address(liquidVault)), 10_100e6, "receipt supplied as collateral");
+    }
+
+    // The other half: from the same below-floor start, an operation that degrades health is still rejected.
+    // Withdrawing escrows the receipt away with no resupply, so it strictly worsens the position.
+    function test_withdraw_belowFloor_stillRejectedWhenHealthWorsens() public {
+        _supplyToGateway(address(safe), address(liquidVault), 10_000e6);
+        _borrowOnGateway(address(safe), address(usdc), 7800e6, recipient);
+        vm.prank(owner);
+        gw.setMinHealthFactor(1.05e18);
+        assertLt(gw.healthFactor(address(safe)), 1.05e18, "safe starts below the floor");
+
+        uint128 amount = 100e6;
+        bytes memory sig = _withdrawSig(amount, amount, 0, 1 days);
+        vm.expectRevert(LendGateway.HealthFactorBelowMinimum.selector);
+        liquidModule.withdraw(address(safe), address(liquidVault), address(usdc), amount, amount, 0, 1 days, owner1, sig);
+    }
+
     function _depositSig(address assetToDeposit, uint256 amount, uint256 minReturn) internal view returns (bytes memory) {
         bytes32 digestHash = keccak256(
             abi.encodePacked(liquidModule.DEPOSIT_SIG(), block.chainid, address(liquidModule), liquidModule.getNonce(address(safe)), address(safe), abi.encode(assetToDeposit, address(liquidVault), amount, minReturn))

--- a/test/safe/modules/cash/lend/LendGatewayAaveV4.t.sol
+++ b/test/safe/modules/cash/lend/LendGatewayAaveV4.t.sol
@@ -179,6 +179,24 @@ contract LendGatewayAaveV4Test is CashGatewayTestSetup {
         assertEq(gw.supplyHeadroom(address(usdc)), 0, "halted Hub Spoke accepts no supply");
     }
 
+    /// deficitValue is the unclamped complement of rawWithdrawHeadroom at Aave's 1.00 bound: zero for a
+    /// debt-free or healthy position, and the weighted-value gap once a price move parks the position
+    /// under 1.00 — the state every clamped capacity view hides (audit L-08).
+    function test_reads_deficitValue_surfacesUnderwaterGap() public {
+        assertEq(gw.deficitValue(address(safe)), 0, "no position: no deficit");
+
+        _buildGatewayPosition(address(safe), address(weETH), 1 ether, address(usdc), 100e6);
+        assertEq(gw.deficitValue(address(safe)), 0, "healthy position: no deficit");
+
+        // Lever to ~98% of raw capacity, then crash weETH 15%: the position lands under 1.00
+        _borrowOnGateway(address(safe), address(usdc), (gw.rawBorrowCapacity(address(safe), address(usdc)) * 98) / 100, recipient);
+        _crashWeethAavePrice(8500);
+
+        assertLt(spoke.getUserAccountData(address(safe)).healthFactor, 1e18, "underwater");
+        assertEq(gw.rawWithdrawHeadroom(address(safe)), 0, "clamped headroom hides the gap");
+        assertGt(gw.deficitValue(address(safe)), 0, "deficitValue surfaces it");
+    }
+
     /// isBorrowable/borrowableAssets read the reserve's borrowable flag on the Spoke: USDC's reserve allows
     /// borrowing, weETH's is collateral-only, and unregistered assets are never borrowable.
     function test_reads_borrowable() public view {

--- a/test/safe/modules/cash/lend/LendGatewayAaveV4.t.sol
+++ b/test/safe/modules/cash/lend/LendGatewayAaveV4.t.sol
@@ -227,10 +227,12 @@ contract LendGatewayAaveV4Test is CashGatewayTestSetup {
         assertTrue(gw.isBorrowable(address(usdc)), "borrowable again after unpause");
     }
 
-    /// isSpendAsset (the debit gate) reads the admin spend set, not Aave's borrowable flag: USDC is a declared
-    /// spend asset, weETH is a registered reserve that was never declared spendable, and the set tolerates a
-    /// freeze (a debit only transfers and withdraws) while a pause blocks it.
-    function test_reads_spendAsset_readsAdminSetToleratesFreezeNotPause() public {
+    /// isSpendAsset (the debit gate) is pure admin-set membership: USDC is a declared spend asset, weETH is a
+    /// registered reserve that was never declared spendable. Aave's execution state is deliberately NOT folded
+    /// in (audit I-02) — a debit spend only transfers loose balance and withdraws supplied balance, so a freeze
+    /// is irrelevant and a pause only costs the supplied leg, which the withdrawalLiquidity cap already
+    /// enforces. Folding a pause in here rejected loose-funded settlements that never touch Aave.
+    function test_reads_spendAsset_readsAdminSetOnly() public {
         assertTrue(gw.isSpendAsset(address(usdc)));
         assertFalse(gw.isSpendAsset(address(weETH)), "registered but not a declared spend asset");
         assertFalse(gw.isSpendAsset(address(0xdead)));
@@ -241,8 +243,9 @@ contract LendGatewayAaveV4Test is CashGatewayTestSetup {
         _setAaveReserveFrozen(usdcReserveId, false);
 
         _setAaveReservePaused(usdcReserveId, true);
-        assertFalse(gw.isSpendAsset(address(usdc)), "paused reserve not spendable");
-        assertEq(gw.spendAssets().length, 0, "dropped from spendAssets while paused");
+        assertTrue(gw.isSpendAsset(address(usdc)), "membership survives a pause: loose balance still settles");
+        assertEq(gw.spendAssets().length, 1, "stays in spendAssets while paused");
+        assertEq(gw.withdrawalLiquidity(address(usdc)), 0, "the pause is enforced on the supplied leg instead");
     }
 
     /// Membership is decoupled from Aave's borrowable flag: turning USDC's borrowable flag off (so it is no

--- a/test/safe/modules/cash/lend/LendGatewayAaveV4.t.sol
+++ b/test/safe/modules/cash/lend/LendGatewayAaveV4.t.sol
@@ -197,6 +197,39 @@ contract LendGatewayAaveV4Test is CashGatewayTestSetup {
         assertGt(gw.deficitValue(address(safe)), 0, "deficitValue surfaces it");
     }
 
+    /// The floor is enforced as "no worse off": a position already under the floor may still run operations
+    /// that hold or improve its health, and only an operation that worsens it must clear the floor. Without
+    /// that, a safe parked between Aave's 1.00 bound and the floor could not even de-risk, because the check
+    /// compared the end state to the floor alone and ignored where the position started.
+    function test_ensureMinHealthFactorNotWorsened_allowsImprovementBelowFloor() public {
+        // Lever to ~98% of raw capacity, then park the safe between 1.00 and a 1.05 floor
+        _buildGatewayPosition(address(safe), address(weETH), 1 ether, address(usdc), 0);
+        _borrowOnGateway(address(safe), address(usdc), (gw.rawBorrowCapacity(address(safe), address(usdc)) * 98) / 100, recipient);
+        vm.prank(owner);
+        gw.setMinHealthFactor(1.05e18);
+
+        uint256 hfBefore = gw.healthFactor(address(safe));
+        assertLt(hfBefore, 1.05e18, "safe sits below the floor");
+        assertGt(hfBefore, 1e18, "but above Aave's own bound");
+
+        // Unchanged position: not worsened, so it passes even though it is still under the floor
+        gw.ensureMinHealthFactorNotWorsened(address(safe), hfBefore);
+        // The plain floor check still rejects the same state, which is what used to block de-risking
+        vm.expectRevert(LendGateway.HealthFactorBelowMinimum.selector);
+        gw.ensureMinHealthFactor(address(safe));
+
+        // Improved but still under the floor: allowed
+        _supplyToGateway(address(safe), address(weETH), 0.02 ether);
+        uint256 hfImproved = gw.healthFactor(address(safe));
+        assertGt(hfImproved, hfBefore, "supply improved health");
+        assertLt(hfImproved, 1.05e18, "still under the floor");
+        gw.ensureMinHealthFactorNotWorsened(address(safe), hfBefore);
+
+        // Worsened while under the floor: rejected
+        vm.expectRevert(LendGateway.HealthFactorBelowMinimum.selector);
+        gw.ensureMinHealthFactorNotWorsened(address(safe), hfImproved + 1);
+    }
+
     /// isBorrowable/borrowableAssets read the reserve's borrowable flag on the Spoke: USDC's reserve allows
     /// borrowing, weETH's is collateral-only, and unregistered assets are never borrowable.
     function test_reads_borrowable() public view {

--- a/test/safe/modules/cash/lend/LendGatewayAaveV4.t.sol
+++ b/test/safe/modules/cash/lend/LendGatewayAaveV4.t.sol
@@ -417,6 +417,45 @@ contract LendGatewayAaveV4Test is CashGatewayTestSetup {
         vm.stopPrank();
     }
 
+    /// Audit L-01, accepted: the in-use gate reads spoke-wide aggregates, which any outsider can pin non-zero
+    /// forever by parking a dust self-supply (Spoke.supply is permissionless when user == onBehalfOf, and a
+    /// debt-free position can be neither liquidated nor withdrawn by anyone else). The reserve then stays
+    /// registered by design — freezing it on the Spoke is the deprecation path, and this asserts the frozen
+    /// state is harmless: the griefer cannot borrow against the dust, safes still exit, and gateway supply
+    /// sizing skips the reserve.
+    function test_removeReserve_outsiderDustPinsGate_freezeIsTheMitigation() public {
+        // A safe holds a real position first, so the exit path below is exercised on genuine state
+        deal(address(weETH), address(safe), 1 ether);
+        vm.startPrank(driver);
+        gw.supply(address(safe), address(weETH), 1 ether);
+        vm.stopPrank();
+
+        address griefer = makeAddr("griefer");
+        deal(address(weETH), griefer, 1e12);
+        vm.startPrank(griefer);
+        weETH.approve(address(spoke), 1e12);
+        spoke.supply(weethReserveId, 1e12, griefer);
+        vm.stopPrank();
+
+        // The dust pins the spoke aggregate: delisting (and setReserveId re-pointing) is blocked for good
+        vm.prank(owner);
+        vm.expectRevert(LendGateway.ReserveStillInUse.selector);
+        gw.removeReserve(address(weETH));
+
+        // Mitigation: freeze the reserve. New supplies and borrows stop, so the pin cannot be leveraged...
+        _setAaveReserveFrozen(weethReserveId, true);
+        assertEq(gw.supplyHeadroom(address(weETH)), 0, "frozen reserve is skipped by every supply sizing path");
+        vm.startPrank(griefer);
+        vm.expectRevert();
+        spoke.borrow(weethReserveId, 1, griefer);
+        vm.stopPrank();
+
+        // ...while exits stay open: the safe withdraws its full position out of the frozen reserve
+        vm.prank(driver);
+        gw.withdraw(address(safe), address(weETH), 1 ether, address(safe));
+        assertEq(gw.suppliedOf(address(safe), address(weETH)), 0, "safe exits a frozen reserve freely");
+    }
+
     // ----------------------------------------------------------------- driver management
 
     function test_setDriver_guardsAndDeauthorization() public {

--- a/test/safe/modules/cash/lend/RepaySourcing.t.sol
+++ b/test/safe/modules/cash/lend/RepaySourcing.t.sol
@@ -120,6 +120,34 @@ contract RepaySourcingTest is CashGatewayTestSetup {
         assertApproxEqAbs(suppliedBefore - gw.suppliedOf(address(safe), address(usdc)), repayAmt - looseUsdc, 3, "only the shortfall left the supplied pot");
     }
 
+    /// Audit L-08: repayWithdrawable credited the repay's freed headroom on top of the CLAMPED raw
+    /// headroom, over-crediting by the deficit while the position sits under 1.00 — the sized withdraw
+    /// then failed Aave's own health check, bricking the de-risking path exactly when it is needed.
+    /// The quote's contract is that it is executable: repay the loose leg, then withdraw the quote, in
+    /// the exact order the repay flow runs them.
+    function test_repayWithdrawable_quoteExecutableWhileUnderwater() public {
+        // weETH collateral plus a supplied USDC pot for the withdraw leg to draw on, levered to ~98% of
+        // raw capacity; a 15% weETH crash then parks the position under Aave's 1.00 bound.
+        _supplyToGateway(address(safe), address(weETH), 0.2 ether);
+        _supplyToGateway(address(safe), address(usdc), 500e6);
+        _borrowOnGateway(address(safe), address(usdc), (gw.rawBorrowCapacity(address(safe), address(usdc)) * 98) / 100, recipient);
+        _crashWeethAavePrice(8500);
+        assertLt(spoke.getUserAccountData(address(safe)).healthFactor, 1e18, "underwater");
+
+        // A loose repay larger than the deficit frees real headroom, so the quote must be non-zero
+        uint256 fromLoose = 200e6;
+        uint256 quote = LendSourcingLib.repayWithdrawable(gw, address(safe), address(usdc), fromLoose);
+        assertGt(quote, 0, "freed headroom beyond the deficit is quotable");
+
+        deal(address(usdc), address(safe), fromLoose);
+        vm.startPrank(driver);
+        gw.repay(address(safe), address(usdc), fromLoose);
+        gw.withdraw(address(safe), address(usdc), quote, address(safe));
+        vm.stopPrank();
+
+        assertGe(spoke.getUserAccountData(address(safe)).healthFactor, 1e18, "executed quote respects Aave's bound");
+    }
+
     /// At max leverage the supplied pot alone cannot fund a repay (Aave's health check caps the withdraw),
     /// but topping up loose unlocks more: the loose leg repays first and frees headroom for the withdraw.
     function test_repay_unloopsAtMaxLeverageWithLooseTopUp() public {

--- a/test/safe/modules/cash/lend/Spend.t.sol
+++ b/test/safe/modules/cash/lend/Spend.t.sol
@@ -531,6 +531,29 @@ contract CashModuleSpendAaveTest is CashGatewayTestSetup {
         assertApproxEqAbs(gw.debtOf(address(safe), address(usdc)), 10e6, 2, "borrow lands");
     }
 
+    /// Audit L-08: a pre-existing deficit (a price crash parked the position under Aave's 1.00 before
+    /// liquidation caught it) is invisible to the clamped rawBorrowCapacity, so resupply used to size
+    /// collateral for the new borrow only and the settlement borrow reverted on Aave's whole-position
+    /// health check — with ample loose collateral sitting in the safe. Sizing now adds deficitValue:
+    /// the spend settles and the resupply incidentally restores the position to at or above 1.00.
+    function test_spend_creditResupply_coversPreexistingDeficit() public {
+        _enterCreditMode();
+        // Lever an existing position to ~98% of raw capacity, then crash weETH 15%
+        _buildGatewayPosition(address(safe), address(weETH), 1 ether, address(usdc), 0);
+        _borrowOnGateway(address(safe), address(usdc), (gw.rawBorrowCapacity(address(safe), address(usdc)) * 98) / 100, recipient);
+        _crashWeethAavePrice(8500);
+        assertLt(spoke.getUserAccountData(address(safe)).healthFactor, 1e18, "underwater before the spend");
+        uint256 debtBefore = gw.debtOf(address(safe), address(usdc));
+
+        // Ample loose collateral: enough for the deficit and the new borrow's cover
+        deal(address(weETH), address(safe), 1 ether);
+
+        _creditSpendUsdc(10e6);
+
+        assertApproxEqAbs(gw.debtOf(address(safe), address(usdc)) - debtBefore, 10e6, 2, "settlement borrow landed");
+        assertGe(spoke.getUserAccountData(address(safe)).healthFactor, 1e18, "resupply covered the deficit too");
+    }
+
     /// Every candidate unsuppliable (weETH frozen, USDC at its addCap): nothing is supplied and the failing
     /// borrow reverts the whole spend, same terminal error as the no-eligible-collateral case.
     function test_spend_creditResupply_allUnsuppliable_borrowReverts() public {

--- a/test/safe/modules/cash/lend/Spend.t.sol
+++ b/test/safe/modules/cash/lend/Spend.t.sol
@@ -184,6 +184,44 @@ contract CashModuleSpendAaveTest is CashGatewayTestSetup {
         assertApproxEqAbs(gw.suppliedOf(address(safe), address(usdc)), 100e6 - 60e6, 2, "shortfall withdrawn from the supply-only reserve");
     }
 
+    /// Audit I-02: a paused reserve must not block a debit spend the safe can fund entirely from loose
+    /// balance — no Aave interaction is needed, and an opted-out safe (forced into Debit, everything loose)
+    /// would otherwise have card settlement blocked by an Aave pause it does not depend on.
+    function test_spend_debit_succeeds_fromLooseWhileReservePaused() public {
+        deal(address(usdc), address(safe), 100e6);
+        _setAaveReservePaused(usdcReserveId, true);
+        uint256 dispatcherBefore = usdc.balanceOf(address(settlementDispatcherReap));
+
+        vm.prank(etherFiWallet);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, _tokens(address(usdc)), _amounts(100e6), _noCashback());
+
+        assertEq(usdc.balanceOf(address(settlementDispatcherReap)), dispatcherBefore + 100e6, "loose balance settled the spend during the pause");
+    }
+
+    /// The pause still binds the part a debit spend cannot fund loose: withdrawalLiquidity reads zero for a
+    /// paused reserve, so the supplied leg is unavailable and the spend declines on balance, not membership.
+    function test_spend_debit_revertsWhenPausedAndNeedsSuppliedLeg() public {
+        _supplyToGateway(address(safe), address(usdc), 100e6);
+        deal(address(usdc), address(safe), 40e6);
+        _setAaveReservePaused(usdcReserveId, true);
+
+        vm.prank(etherFiWallet);
+        vm.expectRevert(ICashModule.InsufficientBalance.selector);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, _tokens(address(usdc)), _amounts(100e6), _noCashback());
+    }
+
+    /// A paused reserve cannot fund a CREDIT spend: the borrow gate (isBorrowable) reads the pause itself, so
+    /// the typed rejection survives making the debit gate pause-agnostic.
+    function test_spend_credit_reverts_whenReservePaused() public {
+        _supplyToGateway(address(safe), address(weETH), 1 ether);
+        _enterCreditMode();
+        _setAaveReservePaused(usdcReserveId, true);
+
+        vm.prank(etherFiWallet);
+        vm.expectRevert(ICashModule.UnsupportedToken.selector);
+        cashModule.spend(address(safe), txId, BinSponsor.Reap, _tokens(address(usdc)), _amounts(10e6), _noCashback());
+    }
+
     /// The auth-vs-freeze race: an auth approved while the reserve was borrowable cannot settle once the
     /// reserve is frozen. The spend reverts on the module's gate — the same predicate the auth now declines
     /// on — instead of deep inside Aave.

--- a/test/safe/modules/recovery/SafeAssetRecoveryModule.t.sol
+++ b/test/safe/modules/recovery/SafeAssetRecoveryModule.t.sol
@@ -131,6 +131,32 @@ contract SafeAssetRecoveryModuleTest is SafeTestSetup {
         module.recover(safeAddr, address(withdrawable), recipient, DEADLINE, signers, sigs);
     }
 
+    /// @dev L-07 regression: a token registered as a LendGateway reserve — but absent from every
+    ///      legacy DebtManager list and the withdraw whitelist — is in active use by gateway safes'
+    ///      Aave positions (loose funds awaiting auto-supply included) and must not be sweepable.
+    ///      The gateway registry and the legacy lists diverge by design as DebtManager is retired.
+    function test_recover_revertsIfGatewayRegisteredToken() public {
+        MockERC20 gatewayAsset = new MockERC20("Gateway Reserve", "GWR", 18);
+        gateway.setRegistered(address(gatewayAsset), true);
+        gatewayAsset.mint(safeAddr, 1_000e18);
+
+        (address[] memory signers, bytes[] memory sigs) = _signRecover(address(module), address(gatewayAsset), recipient);
+        vm.expectRevert(ISafeAssetRecoveryModule.OnlySupportedTokensCannotBeRecovered.selector);
+        module.recover(safeAddr, address(gatewayAsset), recipient, DEADLINE, signers, sigs);
+    }
+
+    /// @dev With no gateway configured the registry check is skipped, not reverted on: a genuinely
+    ///      unsupported token still recovers.
+    function test_recover_worksWhenNoGatewayConfigured() public {
+        vm.mockCall(address(cashModule), abi.encodeWithSignature("getLendGateway()"), abi.encode(address(0)));
+
+        uint256 amount = 1_000e18;
+        token.mint(safeAddr, amount);
+        (address[] memory signers, bytes[] memory sigs) = _signRecover(address(module), address(token), recipient);
+        module.recover(safeAddr, address(token), recipient, DEADLINE, signers, sigs);
+        assertEq(token.balanceOf(recipient), amount, "sweep unaffected by missing gateway");
+    }
+
     function test_recover_revertsIfZeroBalance() public {
         // token unsupported but safe holds none.
         (address[] memory signers, bytes[] memory sigs) = _signRecover(address(module), address(token), recipient);


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/etherfi-protocol/codesmith/cash-v3/pr/246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788105394&installation_model_id=18424&pr_number=246&repository=etherfi-protocol%2Fcash-v3&return_to=https%3A%2F%2Fgithub.com%2Fetherfi-protocol%2Fcash-v3%2Fpull%2F246&signature=1ca6c80331851fe364c63ebdf6bcbd55a585ae6766d2105f96572cae3c18bb63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core lend health enforcement, credit/debit sizing, and spend gating on Aave positions—areas where mistakes can block de-risking or allow unsafe extractions.
> 
> **Overview**
> Addresses lend-gateway audit findings around **health-factor enforcement**, **underwater position sizing**, and **card settlement gating**.
> 
> **Health factor (“no worse off”)** — `_pullAndRequire` now snapshots health **before** the Aave pull and returns it; post-op checks call `ensureMinHealthFactorNotWorsened` instead of a plain end-state floor. Positions already below the configured floor can still run neutral or de-risking module flows; worsening health still requires meeting the floor. The floor check is **engine-gated** (like withdraw), not `_lendActive`, so opted-out safes with live Aave collateral are still bound on extraction.
> 
> **Underwater / deficit (L-08)** — New `deficitValue` (and `maxBorrowUsd` on account data) surfaces how far a position sits under Aave’s 1.00 bound when clamped headroom reads zero. **Credit resupply** and **`repayWithdrawable`** subtract that deficit so quotes and spends don’t over-credit and fail Aave’s whole-position check. **CashLens** uses unclamped `maxBorrowUsd` so over-LTV positions don’t look “at limit.”
> 
> **Debit spend (I-02)** — `isSpendAsset` / `spendAssets` are **admin membership only**; paused reserves no longer drop spend tokens. Loose-funded debits can settle while paused; the supplied leg remains gated via `withdrawalLiquidity` / sourcing.
> 
> **Other** — Withdrawal requests reject empty token lists and all-zero amounts. **Safe asset recovery** blocks LendGateway-registered reserves. Docs/tests for reserve delist pinning (L-01), recovery (L-07), and related cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bef47d7ca91e37459ec3c8589df217e77ee5e4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->