### PR TITLE
fix: enforce the lend health-factor floor as "no worse off"

### DIFF
--- a/src/across/AcrossSwapModule.sol
+++ b/src/across/AcrossSwapModule.sol
@@ -363,22 +363,23 @@ contract AcrossSwapModule is ModuleBase, ModuleCheckBalance, ModuleLendGatewaySa
         }
 
         delete $.swaps[safe];
+        uint256 healthFactorBefore;
         if (address(cashModule) != address(0)) {
             cashModule.cancelWithdrawalByModule(safe);
             // Front bookend: request-time sourcing normally leaves the input loose through the delay;
             // this re-pulls any shortfall from the safe's Aave position and asserts the full input is
             // present before the safe approves the target. Runs after the cancel so the released
             // reservation no longer masks the loose balance.
-            _pullAndRequire(safe, swap.order.srcToken, swap.order.srcAmount);
+            healthFactorBefore = _pullAndRequire(safe, swap.order.srcToken, swap.order.srcAmount);
         }
 
         if (swap.swapData.length != 0) _dispatchOriginSwap(safe, swap);
         else _dispatchDeposit(safe, swap);
 
-        // The input was collateral pulled out of Aave (at request or just above) and every route
-        // bridges it away from this chain, so the end state must sit at or above the gateway's
-        // health-factor floor. Nothing lands back at the safe here, hence no resupply half.
-        if (address(cashModule) != address(0)) _ensureGatewayFloor(safe);
+        // The input was collateral pulled out of Aave (at request or just above) and every route bridges it
+        // away from this chain, so the end state must hold the gateway's health-factor floor unless it left
+        // the position no worse off. Nothing lands back at the safe here, hence no resupply half.
+        if (address(cashModule) != address(0)) _ensureGatewayFloor(safe, healthFactorBefore);
 
         emit SwapExecuted(safe, swap.swapId, swap.order.dstChainId, swap.order.dstToken, swap.depositArgs.outputAmount);
     }

--- a/src/enso/EnsoSwapModule.sol
+++ b/src/enso/EnsoSwapModule.sol
@@ -291,20 +291,21 @@ contract EnsoSwapModule is ModuleBase, ModuleCheckBalance, ModuleLendGatewaySand
         }
 
         delete $.swaps[safe];
+        uint256 healthFactorBefore;
         if (address(cashModule) != address(0)) {
             cashModule.cancelWithdrawalByModule(safe);
             // Front bookend: request-time sourcing normally leaves the input loose through the delay;
             // this re-pulls any shortfall from the safe's Aave position and asserts the full input is
             // present before the safe approves the router. Runs after the cancel so the released
             // reservation no longer masks the loose balance.
-            _pullAndRequire(safe, swap.order.srcToken, swap.order.srcAmount);
+            healthFactorBefore = _pullAndRequire(safe, swap.order.srcToken, swap.order.srcAmount);
         }
 
         _dispatchSwap(safe, swap);
 
-        // The input was collateral pulled out of Aave (at request or just above), so the end state
-        // must sit at or above the gateway's health-factor floor.
-        if (address(cashModule) != address(0)) _ensureGatewayFloor(safe);
+        // The input was collateral pulled out of Aave (at request or just above), so the end state must hold
+        // the gateway's health-factor floor unless it left the position no worse off than it started.
+        if (address(cashModule) != address(0)) _ensureGatewayFloor(safe, healthFactorBefore);
 
         emit SwapExecuted(safe, swap.swapId, swap.order.dstChainId, swap.order.dstToken, swap.order.minOut);
     }

--- a/src/interfaces/ILendGateway.sol
+++ b/src/interfaces/ILendGateway.sol
@@ -100,6 +100,23 @@ interface ILendGateway {
     function ensureMinHealthFactor(address safe) external view;
 
     /**
+     * @notice Returns `safe`'s current Aave health factor in WAD (1e18), unbounded when it carries no debt
+     * @param safe The safe to query
+     * @return The health factor in WAD
+     */
+    function healthFactor(address safe) external view returns (uint256);
+
+    /**
+     * @notice Enforces the floor as "no worse off": passes when the operation did not degrade `safe`'s health,
+     *         otherwise requires the end state to hold the configured floor
+     * @dev Lets a position already below the floor still run health-neutral or de-risking operations, which a
+     *      plain end-state floor check would block. Callers capture the health factor before the operation.
+     * @param safe The safe to check
+     * @param healthFactorBefore The safe's health factor captured before the operation ran
+     */
+    function ensureMinHealthFactorNotWorsened(address safe, uint256 healthFactorBefore) external view;
+
+    /**
      * @notice Sets the post-op health-factor floor
      * @param value The floor in WAD; 0 disables, otherwise bounded to [1e18, 2e18]
      */

--- a/src/mocks/MockLendGateway.sol
+++ b/src/mocks/MockLendGateway.sol
@@ -113,6 +113,21 @@ contract MockLendGateway is ILendGateway {
 
     function ensureMinHealthFactor(address safe) external view { }
 
+    mapping(address safe => uint256) internal _healthFactor;
+
+    /// @notice Sets the health factor a subsequent `healthFactor(safe)` will return
+    function setHealthFactor(address safe, uint256 value) external {
+        _healthFactor[safe] = value;
+    }
+
+    /// @dev Defaults to unbounded, matching a safe with no debt
+    function healthFactor(address safe) external view returns (uint256) {
+        return _healthFactor[safe] == 0 ? type(uint256).max : _healthFactor[safe];
+    }
+
+    /// @dev The mock's floor check is inert, so this only models the not-worsened short-circuit
+    function ensureMinHealthFactorNotWorsened(address safe, uint256 healthFactorBefore) external view { }
+
     function repay(address safe, address asset, uint256 amount) external returns (uint256) {
         uint256 debt = _debtOf[safe][asset];
         uint256 repaid = amount < debt ? amount : debt;

--- a/src/modules/ModuleLendGatewaySandwich.sol
+++ b/src/modules/ModuleLendGatewaySandwich.sol
@@ -87,14 +87,32 @@ abstract contract ModuleLendGatewaySandwich is ModuleCheckBalance {
      * @notice Front bookend: source `amount` of `asset` loose from Aave if short, then require it all present
      * @dev The idiom every gateway consumer runs before acting: _withdrawShortfall to pull the missing part
      *      out of the safe's Aave position, then the ModuleCheckBalance assertion that the full amount is now
-     *      loose.
+     *      loose. Returns the health factor read BEFORE the pull, which is what _ensureGatewayFloor compares
+     *      against — the pull itself lowers health, so a snapshot taken any later would measure the operation
+     *      against its own first step.
      * @param safe The safe whose input is sourced
      * @param asset The input asset the operation needs loose
      * @param amount The full amount the operation needs
+     * @return healthFactorBefore The safe's pre-operation health factor, to pass to _ensureGatewayFloor
      */
-    function _pullAndRequire(address safe, address asset, uint256 amount) internal {
+    function _pullAndRequire(address safe, address asset, uint256 amount) internal returns (uint256 healthFactorBefore) {
+        healthFactorBefore = _gatewayHealthFactor(safe);
         _withdrawShortfall(safe, asset, amount, _getAvailableAmount(safe, asset));
         _checkAmountAvailable(safe, asset, amount);
+    }
+
+    /**
+     * @notice The safe's current health factor, or 0 for a safe with no gateway position to protect
+     * @dev Zero is the inert value: _ensureGatewayFloor no-ops off the gateway engine, and a zero snapshot
+     *      elsewhere can only ever read as "not worsened", never as a tightened bound.
+     * @param safe The safe to read
+     * @return The health factor in WAD, or 0 when the safe is not on the gateway engine
+     */
+    function _gatewayHealthFactor(address safe) internal view returns (uint256) {
+        if (!_onGatewayEngine(safe)) return 0;
+        ILendGateway lendGateway = gateway();
+        if (address(lendGateway) == address(0)) return 0;
+        return lendGateway.healthFactor(safe);
     }
 
     /**
@@ -126,10 +144,16 @@ abstract contract ModuleLendGatewaySandwich is ModuleCheckBalance {
      *      Aave's raw 1.0 boundary with no check. A cleanly opted-out safe has no debt, so
      *      an unbounded health factor passes and the check stays a no-op for it. No-op for legacy safes
      *      and while the floor is disabled.
+     *
+     *      Enforced as "no worse off" against the pre-operation snapshot from _pullAndRequire: a position
+     *      already under the floor may still run operations that hold or improve its health, since the floor
+     *      exists to stop extraction from approaching the liquidation line, not to freeze a safe out of
+     *      de-risking. Anything that degrades health still takes the full floor.
      * @param safe The safe to check
+     * @param healthFactorBefore The health factor _pullAndRequire captured before the operation ran
      */
-    function _ensureGatewayFloor(address safe) internal view {
+    function _ensureGatewayFloor(address safe, uint256 healthFactorBefore) internal view {
         if (!_onGatewayEngine(safe)) return;
-        gateway().ensureMinHealthFactor(safe);
+        gateway().ensureMinHealthFactorNotWorsened(safe, healthFactorBefore);
     }
 }

--- a/src/modules/etherfi/EtherFiLiquidModule.sol
+++ b/src/modules/etherfi/EtherFiLiquidModule.sol
@@ -230,7 +230,7 @@ contract EtherFiLiquidModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardT
 
         // Pull any shortfall of the deposit asset out of the safe's Aave position (no-op for ETH), then
         // confirm the safe holds the full amount loose (net of any pending-withdrawal reservation).
-        _pullAndRequire(safe, assetToDeposit, amountToDeposit);
+        uint256 healthFactorBefore = _pullAndRequire(safe, assetToDeposit, amountToDeposit);
 
         address[] memory to;
         bytes[] memory data;
@@ -276,7 +276,7 @@ contract EtherFiLiquidModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardT
         // Re-supply the receipt token as collateral when the gateway lists it; an unlisted receipt stays loose.
         _resupplyToGateway(safe, liquidAsset, liquidTokenReceived);
 
-        _ensureGatewayFloor(safe);
+        _ensureGatewayFloor(safe, healthFactorBefore);
 
         emit LiquidDeposit(safe, assetToDeposit, liquidAsset, amountToDeposit, liquidTokenReceived);
     }
@@ -339,7 +339,7 @@ contract EtherFiLiquidModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardT
 
         // Pull any shortfall of the liquid token out of the safe's Aave position. Only this front bookend
         // applies: the queued withdrawal's output arrives later, loose in the safe.
-        _pullAndRequire(safe, liquidAsset, amountToWithdraw);
+        uint256 healthFactorBefore = _pullAndRequire(safe, liquidAsset, amountToWithdraw);
 
         uint128 amountOutFromQueue = boringQueue.previewAssetsOut(assetOut, amountToWithdraw, discount);
         if (amountOutFromQueue < minReturn) revert InsufficientReturnAmount();
@@ -358,7 +358,7 @@ contract EtherFiLiquidModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardT
 
         // Risk-increasing flow with no resupply (the queued output arrives later, loose): the end state
         // takes the gateway's health-factor floor
-        _ensureGatewayFloor(safe);
+        _ensureGatewayFloor(safe, healthFactorBefore);
         
         emit LiquidWithdrawal(safe, liquidAsset, amountToWithdraw, amountOutFromQueue);
     }

--- a/src/modules/etherfi/EtherFiStakeModule.sol
+++ b/src/modules/etherfi/EtherFiStakeModule.sol
@@ -107,7 +107,7 @@ contract EtherFiStakeModule is ModuleBase, ModuleCheckBalance, ModuleLendGateway
 
         // Pull any shortfall of the input out of the safe's Aave position (a no-op for ETH, which is not a
         // reserve), then confirm the safe holds the full amount loose.
-        _pullAndRequire(safe, assetToDeposit, amountToDeposit);
+        uint256 healthFactorBefore = _pullAndRequire(safe, assetToDeposit, amountToDeposit);
 
         address[] memory to;
         bytes[] memory data;
@@ -143,7 +143,7 @@ contract EtherFiStakeModule is ModuleBase, ModuleCheckBalance, ModuleLendGateway
         // Re-supply the weETH output as collateral when the gateway lists it; an unlisted output stays loose.
         _resupplyToGateway(safe, weETH, weETHAmtReceived);
 
-        _ensureGatewayFloor(safe);
+        _ensureGatewayFloor(safe, healthFactorBefore);
 
         emit StakeDeposit(safe, assetToDeposit, weETH, amountToDeposit, weETHAmtReceived);
     }

--- a/src/modules/frax/FraxModule.sol
+++ b/src/modules/frax/FraxModule.sol
@@ -170,7 +170,7 @@ contract FraxModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardTransient,
 
         // Pull any shortfall of the input out of the safe's Aave position, then confirm the safe holds the
         // full amount loose.
-        _pullAndRequire(safe, assetToDeposit, amountToDeposit);
+        uint256 healthFactorBefore = _pullAndRequire(safe, assetToDeposit, amountToDeposit);
 
         // Validate that custodian has sufficient balance for synchronous deposit
         // The custodian needs at least minReturnAmount of fraxusd tokens to fulfill the deposit synchronously
@@ -199,7 +199,7 @@ contract FraxModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardTransient,
         // Re-supply the fraxUSD output as collateral when the gateway lists it; an unlisted output stays loose.
         _resupplyToGateway(safe, fraxusd, fraxUSDTokenReceived);
 
-        _ensureGatewayFloor(safe);
+        _ensureGatewayFloor(safe, healthFactorBefore);
 
         emit Deposit(safe, assetToDeposit, amountToDeposit, fraxUSDTokenReceived);
     }
@@ -249,7 +249,7 @@ contract FraxModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardTransient,
 
         // Pull any shortfall of the fraxUSD input out of the safe's Aave position, then confirm the safe holds
         // the full amount loose.
-        _pullAndRequire(safe, fraxusd, amountToWithdraw);
+        uint256 healthFactorBefore = _pullAndRequire(safe, fraxusd, amountToWithdraw);
 
         address[] memory to = new address[](2);
         bytes[] memory data = new bytes[](2);
@@ -273,7 +273,7 @@ contract FraxModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardTransient,
         _resupplyToGateway(safe, outputAsset, assetReceived);
 
         // Risk-increasing flow: the end state takes the gateway's health-factor floor
-        _ensureGatewayFloor(safe);
+        _ensureGatewayFloor(safe, healthFactorBefore);
 
         emit Withdrawal(safe, outputAsset, amountToWithdraw, assetReceived);
     }

--- a/src/modules/hype/BeHYPEStakeModule.sol
+++ b/src/modules/hype/BeHYPEStakeModule.sol
@@ -140,7 +140,7 @@ contract BeHYPEStakeModule is ModuleBase, ModuleCheckBalance, ModuleLendGatewayS
 
         // Pull any shortfall of the WHYPE input out of the safe's Aave position, then confirm the safe holds
         // the full amount loose.
-        _pullAndRequire(safe, whype, amountToStake);
+        uint256 healthFactorBefore = _pullAndRequire(safe, whype, amountToStake);
 
         uint256 quotedFee = staker.quoteStake(amountToStake, safe);
         if (msg.value < quotedFee) revert InsufficientFee();
@@ -170,7 +170,7 @@ contract BeHYPEStakeModule is ModuleBase, ModuleCheckBalance, ModuleLendGatewayS
 
         // Risk-increasing flow with no resupply (the beHYPE output arrives later, loose): the end state
         // takes the gateway's health-factor floor
-        _ensureGatewayFloor(safe);
+        _ensureGatewayFloor(safe, healthFactorBefore);
 
         emit StakeDeposit(safe, whype, beHYPE, amountToStake);
     }

--- a/src/modules/lend-gateway/LendGateway.sol
+++ b/src/modules/lend-gateway/LendGateway.sol
@@ -495,6 +495,35 @@ contract LendGateway is ILendGateway, UpgradeableProxy, ModuleBase {
     }
 
     /**
+     * @notice `safe`'s current Aave health factor in WAD (1e18), unbounded when it carries no debt
+     * @dev Read straight from the Spoke, like the floor check itself: getAccountData's healthFactor is the
+     *      same number but reached through the PriceProvider-derived USD fields, which revert for a supplied
+     *      asset Cash cannot price.
+     * @param safe The safe to query
+     * @return The health factor in WAD
+     */
+    function healthFactor(address safe) external view returns (uint256) {
+        return spoke.getUserAccountData(safe).healthFactor;
+    }
+
+    /**
+     * @notice Enforces the floor as "no worse off": passes when the position did not degrade, otherwise
+     *         requires the end state to hold the configured floor
+     * @dev The floor exists to stop ether.fi-initiated operations from parking a position near Aave's
+     *      liquidation line, so it has nothing to say about an operation that holds or improves health. A
+     *      plain floor check cannot express that: comparing only the end state traps a safe sitting between
+     *      Aave's 1.00 bound and the floor, blocking even the de-risking operations that would lift it out.
+     *      An operation that degrades health still takes the full floor, so nothing may cross down through it.
+     * @param safe The safe to check
+     * @param healthFactorBefore The safe's health factor captured before the operation ran
+     * @custom:throws HealthFactorBelowMinimum if the operation degraded health and the end state is below the floor
+     */
+    function ensureMinHealthFactorNotWorsened(address safe, uint256 healthFactorBefore) external view {
+        if (spoke.getUserAccountData(safe).healthFactor >= healthFactorBefore) return;
+        ensureMinHealthFactor(safe);
+    }
+
+    /**
      * @notice Returns `safe`'s Cash-priced position summary (collateral, debt, borrow headroom, health factor)
      * @dev Re-derives the USD fields from PriceProvider for display only; capacity and sizing use the
      *      Aave-priced borrowCapacity and withdrawHeadroom families. healthFactor (WAD) comes directly from Aave.

--- a/src/modules/midas/MidasModule.sol
+++ b/src/modules/midas/MidasModule.sol
@@ -173,7 +173,7 @@ contract MidasModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardTransient
 
         // Pull any shortfall of the input out of the safe's Aave position, then confirm the safe holds the
         // full amount loose.
-        _pullAndRequire(safe, asset, amount);
+        uint256 healthFactorBefore = _pullAndRequire(safe, asset, amount);
 
         uint256 midasTokenBefore = ERC20(midasToken).balanceOf(safe);
 
@@ -194,7 +194,7 @@ contract MidasModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardTransient
         // Re-supply the Midas-token output as collateral when the gateway lists it; an unlisted output stays loose.
         _resupplyToGateway(safe, midasToken, midasTokenReceived);
 
-        _ensureGatewayFloor(safe);
+        _ensureGatewayFloor(safe, healthFactorBefore);
 
         emit Deposit(safe, asset, amount, midasToken, midasTokenReceived);
     }
@@ -250,7 +250,7 @@ contract MidasModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardTransient
         // Pull any shortfall of the Midas token out of the safe's Aave position, then confirm the safe holds
         // the full amount loose. No re-supply bookend: the asset output arrives asynchronously via the
         // redemption vault, not in this call.
-        _pullAndRequire(safe, midasToken, amount);
+        uint256 healthFactorBefore = _pullAndRequire(safe, midasToken, amount);
 
         address[] memory to = new address[](2);
         bytes[] memory data = new bytes[](2);
@@ -266,7 +266,7 @@ contract MidasModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardTransient
 
         // Risk-increasing flow with no resupply (the redemption output arrives later, loose): the end
         // state takes the gateway's health-factor floor
-        _ensureGatewayFloor(safe);
+        _ensureGatewayFloor(safe, healthFactorBefore);
 
         emit Withdrawal(safe, amount, asset, midasToken);
     }

--- a/src/modules/openocean-swap/OpenOceanSwapModule.sol
+++ b/src/modules/openocean-swap/OpenOceanSwapModule.sol
@@ -165,7 +165,7 @@ contract OpenOceanSwapModule is ModuleBase, ModuleCheckBalance, ModuleLendGatewa
 
         // Pull any shortfall of the input out of the safe's Aave position, then confirm the safe holds the
         // full amount loose (net of any pending-withdrawal reservation).
-        _pullAndRequire(safe, fromAsset, fromAssetAmount);
+        uint256 healthFactorBefore = _pullAndRequire(safe, fromAsset, fromAssetAmount);
 
         uint256 balBefore;
         if (toAsset == ETH) balBefore = address(safe).balance;
@@ -191,7 +191,7 @@ contract OpenOceanSwapModule is ModuleBase, ModuleCheckBalance, ModuleLendGatewa
         // Re-supply the output as collateral when the gateway lists it; an unlisted output (or ETH) stays loose.
         _resupplyToGateway(safe, toAsset, receivedAmt);
 
-        _ensureGatewayFloor(safe);
+        _ensureGatewayFloor(safe, healthFactorBefore);
 
         emit SwapOnOpenOcean(safe, fromAsset, toAsset, fromAssetAmount, minToAssetAmount, receivedAmt);
     }

--- a/test/safe/modules/ModuleLendGatewaySandwich.t.sol
+++ b/test/safe/modules/ModuleLendGatewaySandwich.t.sol
@@ -57,8 +57,12 @@ contract SandwichHarness is ModuleLendGatewaySandwich {
         _resupplyToGateway(safe, asset, amount);
     }
 
-    function ensureGatewayFloor(address safe) external view {
-        _ensureGatewayFloor(safe);
+    function ensureGatewayFloor(address safe, uint256 healthFactorBefore) external view {
+        _ensureGatewayFloor(safe, healthFactorBefore);
+    }
+
+    function gatewayHealthFactor(address safe) external view returns (uint256) {
+        return _gatewayHealthFactor(safe);
     }
 }
 
@@ -169,37 +173,49 @@ contract ModuleLendGatewaySandwichTest is Test {
         assertFalse(gateway.usingAsCollateral(safe, asset), "collateral flag untouched");
     }
 
-    // ----------------------------------------------------------------- floor check gating (audit L-03)
+    // ----------------------------------------------------------------- floor check gating
 
-    /// @dev Simulates the gateway judging the safe below the configured floor.
+    uint256 constant HF_BEFORE = 1.02e18;
+
+    /// @dev Simulates the gateway rejecting the end state, whatever rule it applies internally.
     function _mockFloorViolated() internal {
-        vm.mockCallRevert(address(gateway), abi.encodeWithSelector(ILendGateway.ensureMinHealthFactor.selector, safe), "below floor");
+        vm.mockCallRevert(address(gateway), abi.encodeWithSelector(ILendGateway.ensureMinHealthFactorNotWorsened.selector, safe, HF_BEFORE), "below floor");
     }
 
-    // The floor check runs for a fully active gateway safe: a below-floor end state reverts the operation.
+    // The floor check runs for a fully active gateway safe: a rejected end state reverts the operation.
     function test_floor_revertsForActiveSafeBelowFloor() public {
         _mockFloorViolated();
         vm.expectRevert("below floor");
-        harness.ensureGatewayFloor(safe);
+        harness.ensureGatewayFloor(safe, HF_BEFORE);
     }
 
-    // Audit L-03: the floor check is ENGINE-gated like the withdraw bookend, not lend-active-gated. An
-    // opted-out safe with a live Aave position (a matured opt-out whose unwind open borrows still block)
-    // can pull collateral through the front bookend with no resupply behind it; the floor must still bind
-    // that extraction, or the position can be parked at Aave's raw 1.0 boundary. Repayment flows never
-    // call this check, so the safe can always still repay its way out of the blocked opt-out.
+    // The floor check is ENGINE-gated like the withdraw bookend, not lend-active-gated. An opted-out safe
+    // with a live Aave position (a matured opt-out whose unwind open borrows still block) can pull collateral
+    // through the front bookend with no resupply behind it; the floor must still bind that extraction, or the
+    // position can be parked at Aave's raw 1.0 boundary. Repayment flows never call this check, so the safe
+    // can always still repay its way out of the blocked opt-out.
     function test_floor_revertsForOptedOutSafeOnEngine() public {
         harness.setLendActive(false); // opted out, but still on the gateway engine with a live position
         _mockFloorViolated();
         vm.expectRevert("below floor");
-        harness.ensureGatewayFloor(safe);
+        harness.ensureGatewayFloor(safe, HF_BEFORE);
     }
 
     // Off the gateway engine (legacy safe) there is no Aave position to protect: the check is a no-op
-    // even when the gateway would judge the safe below floor.
+    // even when the gateway would reject the end state.
     function test_floor_noOpOffGatewayEngine() public {
         harness.setOnGatewayEngine(false);
         _mockFloorViolated();
-        harness.ensureGatewayFloor(safe); // must not revert
+        harness.ensureGatewayFloor(safe, HF_BEFORE); // must not revert
+    }
+
+    // The pre-operation snapshot the floor check compares against is read for a gateway safe and inert
+    // (zero) off the engine, where a snapshot could only ever tighten a check that does not run.
+    function test_floor_snapshotReadsGatewayHealthOnEngineOnly() public {
+        gateway.setHealthFactor(safe, HF_BEFORE);
+        assertEq(harness.gatewayHealthFactor(safe), HF_BEFORE, "snapshot reads the gateway health factor");
+
+        harness.setOnGatewayEngine(false);
+        assertEq(harness.gatewayHealthFactor(safe), 0, "inert off the gateway engine");
     }
 }

--- a/test/safe/modules/cash/lend/EtherFiLiquidGateway.t.sol
+++ b/test/safe/modules/cash/lend/EtherFiLiquidGateway.t.sol
@@ -174,6 +174,46 @@ contract EtherFiLiquidGatewayTest is CashGatewayTestSetup {
         assertGe(spoke.getUserAccountData(address(safe)).healthFactor, 1.05e18, "end state above the floor");
     }
 
+    // A safe parked between Aave's 1.00 bound and the floor is not frozen out of the sandwiched modules: an
+    // operation that leaves its health no worse off still runs, because the floor is there to stop extraction
+    // approaching the liquidation line, not to block a safe from improving. A deposit funded from loose
+    // balance re-supplies the receipt as collateral, so it lifts health even while staying under the floor.
+    function test_deposit_belowFloor_allowedWhenHealthImproves() public {
+        _supplyToGateway(address(safe), address(liquidVault), 10_000e6);
+        _borrowOnGateway(address(safe), address(usdc), 7800e6, recipient); // HF ~1.026
+        vm.prank(owner);
+        gw.setMinHealthFactor(1.05e18);
+
+        uint256 hfBefore = gw.healthFactor(address(safe));
+        assertLt(hfBefore, 1.05e18, "safe starts below the floor");
+        assertGt(hfBefore, 1e18, "and above Aave's bound");
+
+        // Loose USDC in, receipt back as collateral: strictly more collateral, same debt
+        uint256 amount = 100e6;
+        deal(address(usdc), address(safe), amount);
+        liquidModule.deposit(address(safe), address(usdc), address(liquidVault), amount, amount, owner1, _depositSig(address(usdc), amount, amount));
+
+        uint256 hfAfter = gw.healthFactor(address(safe));
+        assertGt(hfAfter, hfBefore, "the deposit improved health");
+        assertLt(hfAfter, 1.05e18, "while still under the floor, which no longer blocks it");
+        assertEq(gw.suppliedOf(address(safe), address(liquidVault)), 10_100e6, "receipt supplied as collateral");
+    }
+
+    // The other half: from the same below-floor start, an operation that degrades health is still rejected.
+    // Withdrawing escrows the receipt away with no resupply, so it strictly worsens the position.
+    function test_withdraw_belowFloor_stillRejectedWhenHealthWorsens() public {
+        _supplyToGateway(address(safe), address(liquidVault), 10_000e6);
+        _borrowOnGateway(address(safe), address(usdc), 7800e6, recipient);
+        vm.prank(owner);
+        gw.setMinHealthFactor(1.05e18);
+        assertLt(gw.healthFactor(address(safe)), 1.05e18, "safe starts below the floor");
+
+        uint128 amount = 100e6;
+        bytes memory sig = _withdrawSig(amount, amount, 0, 1 days);
+        vm.expectRevert(LendGateway.HealthFactorBelowMinimum.selector);
+        liquidModule.withdraw(address(safe), address(liquidVault), address(usdc), amount, amount, 0, 1 days, owner1, sig);
+    }
+
     function _depositSig(address assetToDeposit, uint256 amount, uint256 minReturn) internal view returns (bytes memory) {
         bytes32 digestHash = keccak256(
             abi.encodePacked(liquidModule.DEPOSIT_SIG(), block.chainid, address(liquidModule), liquidModule.getNonce(address(safe)), address(safe), abi.encode(assetToDeposit, address(liquidVault), amount, minReturn))

--- a/test/safe/modules/cash/lend/LendGatewayAaveV4.t.sol
+++ b/test/safe/modules/cash/lend/LendGatewayAaveV4.t.sol
@@ -197,6 +197,39 @@ contract LendGatewayAaveV4Test is CashGatewayTestSetup {
         assertGt(gw.deficitValue(address(safe)), 0, "deficitValue surfaces it");
     }
 
+    /// The floor is enforced as "no worse off": a position already under the floor may still run operations
+    /// that hold or improve its health, and only an operation that worsens it must clear the floor. Without
+    /// that, a safe parked between Aave's 1.00 bound and the floor could not even de-risk, because the check
+    /// compared the end state to the floor alone and ignored where the position started.
+    function test_ensureMinHealthFactorNotWorsened_allowsImprovementBelowFloor() public {
+        // Lever to ~98% of raw capacity, then park the safe between 1.00 and a 1.05 floor
+        _buildGatewayPosition(address(safe), address(weETH), 1 ether, address(usdc), 0);
+        _borrowOnGateway(address(safe), address(usdc), (gw.rawBorrowCapacity(address(safe), address(usdc)) * 98) / 100, recipient);
+        vm.prank(owner);
+        gw.setMinHealthFactor(1.05e18);
+
+        uint256 hfBefore = gw.healthFactor(address(safe));
+        assertLt(hfBefore, 1.05e18, "safe sits below the floor");
+        assertGt(hfBefore, 1e18, "but above Aave's own bound");
+
+        // Unchanged position: not worsened, so it passes even though it is still under the floor
+        gw.ensureMinHealthFactorNotWorsened(address(safe), hfBefore);
+        // The plain floor check still rejects the same state, which is what used to block de-risking
+        vm.expectRevert(LendGateway.HealthFactorBelowMinimum.selector);
+        gw.ensureMinHealthFactor(address(safe));
+
+        // Improved but still under the floor: allowed
+        _supplyToGateway(address(safe), address(weETH), 0.02 ether);
+        uint256 hfImproved = gw.healthFactor(address(safe));
+        assertGt(hfImproved, hfBefore, "supply improved health");
+        assertLt(hfImproved, 1.05e18, "still under the floor");
+        gw.ensureMinHealthFactorNotWorsened(address(safe), hfBefore);
+
+        // Worsened while under the floor: rejected
+        vm.expectRevert(LendGateway.HealthFactorBelowMinimum.selector);
+        gw.ensureMinHealthFactorNotWorsened(address(safe), hfImproved + 1);
+    }
+
     /// isBorrowable/borrowableAssets read the reserve's borrowable flag on the Spoke: USDC's reserve allows
     /// borrowing, weETH's is collateral-only, and unregistered assets are never borrowable.
     function test_reads_borrowable() public view {


### PR DESCRIPTION
## What

The health-factor floor was an absolute post-op check, so a safe parked between Aave's 1.00 bound and the configured floor could not run **any** sandwiched module operation — not even one that improved its health — unless that single operation lifted it all the way back above the floor. With the floor at 1.05, a safe at 1.02 was locked out of every swap, stake, deposit and redeem, including the collateral swap that is often the most rational way out of that state. Governance raising the floor traps every safe in the newly created band the same way.

The floor exists to stop ether.fi-initiated extraction from parking a position near the liquidation line, so it has nothing to say about an operation that holds or improves health. New `LendGateway.ensureMinHealthFactorNotWorsened(safe, healthFactorBefore)` passes when the end state is no worse than the pre-operation state, and otherwise falls through to the existing floor check — so nothing may cross down through the floor, and anything that degrades health is still fully bound by it.

## Decisions worth a second pair of eyes

- **The snapshot is taken inside `_pullAndRequire`, which now returns it.** The front bookend's own pull lowers health, so a snapshot taken any later would measure the operation against its own first step. All ten sandwiched sites across eight consumers are updated; Enso and Across declare the snapshot outside the conditional that guards their pull. `LiquidUSDLiquifierOP` is unaffected — it is deliberately floor-exempt and simply ignores the new return value.
- **`>=` rather than `>`.** A genuinely health-neutral operation (a like-for-like collateral swap) should not be rejected, and rounding makes exact equality rare anyway.
- **`healthFactor` reads the Spoke directly**, not `getAccountData().healthFactor`: the latter reaches the same number through PriceProvider-derived USD fields, which revert for a supplied asset Cash cannot price.
- **Gas: +26k to +40k per operation (~3%)**, measured on the liquid deposit and withdraw paths — one extra `spoke.getUserAccountData` for the snapshot, scaling with how many reserves the safe holds. The exit check reads account data once and only pays a second read when health actually degraded.

## Testing

- `LendGatewayAaveV4.t.sol`: the rule directly — from a below-floor start, unchanged and improved states pass while a worsened state reverts, and the plain floor check still rejects the same unchanged state.
- `EtherFiLiquidGateway.t.sol`: end-to-end both ways — a deposit funded from loose balance now succeeds below the floor, and a withdraw that worsens health is still rejected.
- Sandwich unit tests updated for the new signature, plus coverage that the snapshot is inert off the gateway engine.
- 337 lend fork tests and 1286 default-profile tests pass.

## Note on the base branch

Based on `feat/lend-audit-fixes` (#246) rather than `feat/lend` directly, because it builds on the L-03 commit there — that commit is what moved this same floor check onto the engine gate. Basing it here keeps the diff to this change alone; GitHub retargets it to `feat/lend` automatically once #246 merges. Say the word if you would rather have it straight against `feat/lend`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/etherfi-protocol/codesmith/cash-v3/pr/247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788107003&installation_model_id=18424&pr_number=247&repository=etherfi-protocol%2Fcash-v3&return_to=https%3A%2F%2Fgithub.com%2Fetherfi-protocol%2Fcash-v3%2Fpull%2F247&signature=549cb62057694c7bfd1a3701e1d72afa9029dccb310811a853ee239e71b77050"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes collateral-extraction gating across many user-facing module paths and introduces a pre-op health snapshot; logic is well-tested but mistakes could allow worsening positions below the floor or block legitimate de-risking.
> 
> **Overview**
> **Post-op lend health checks** no longer require the safe to sit at or above the configured floor after every sandwiched module action. They compare end health to a snapshot taken **before** `_pullAndRequire` withdraws collateral, so safes already between Aave’s 1.0 bound and the governance floor can still run **neutral or de-risking** flows (e.g. collateral deposits) without being frozen until a single op lifts them above the floor.
> 
> `LendGateway` adds `healthFactor` (Spoke read) and `ensureMinHealthFactorNotWorsened`: pass if `HF_end >= HF_before`, otherwise fall back to `ensureMinHealthFactor`. `ModuleLendGatewaySandwich` returns that snapshot from `_pullAndRequire`, reads it via `_gatewayHealthFactor`, and routes `_ensureGatewayFloor` through the new rule. **Across, Enso, Liquid, Stake, Frax, BeHYPE, Midas, and OpenOcean** consumers thread `healthFactorBefore` into the floor check; `ILendGateway` and `MockLendGateway` are updated accordingly.
> 
> Tests cover the gateway rule directly, liquid deposit/withdraw below the floor, and sandwich harness behavior for the new signature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b415bbb5a74c5bdac9dd04c2cbd246b699077c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->