### PR TITLE
feat: sync the dev aave v4 instance with the prod whitelabel deployment

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,4 +18,4 @@
 	url = https://github.com/LayerZero-Labs/LayerZero-v2
 [submodule "lib/aave-v4"]
 	path = lib/aave-v4
-	url = https://github.com/aave/aave-v4
+	url = https://github.com/etherfi-protocol/aave-v4

--- a/foundry.toml
+++ b/foundry.toml
@@ -32,18 +32,18 @@ depth = 10
 
 # Profile for scripts/aave-v4/** (real Aave v4 deployments). Forge can't resolve LiquidationLogic's
 # aave-rooted `src/` import to an artifact (same issue as [profile.lend]), so auto-link/auto-deploy fails;
-# instead pin it to its deterministic CREATE2 address (Nick's factory, salt keccak256("ether.fi/aave-v4-test/LiquidationLogic"),
-# current aave-v4 bytecode) and DeployAaveV4TestInstance deploys the library there idempotently before the
-# spoke. The script recomputes this address from the artifact and reverts if the pin is stale.
+# instead link the canonical Aave-deployed LiquidationLogic on OP Mainnet — the same library the prod
+# whitelabel instance links — so dev spoke impls run the exact library code prod runs. The historical
+# self-deployed CREATE2 library (Nick's factory, salt keccak256("ether.fi/aave-v4-test/LiquidationLogic"),
+# 0x49dEE75906621Ea28D7332bb26E0da6f2d15E838) is what the pre-upgrade dev spoke impl links; new deploys
+# use the canonical address below. Scripts must require code at this address before deploying a spoke.
 [profile.aave-deploy]
 skip = ["test/safe/modules/cash/lend/**"]
-libraries = ["src/spoke/libraries/LiquidationLogic.sol:LiquidationLogic:0x49dEE75906621Ea28D7332bb26E0da6f2d15E838"]
+libraries = ["src/spoke/libraries/LiquidationLogic.sol:LiquidationLogic:0x88dF535473C5adf1f57789734A05E555F7Deb8DB"]
 # HubInstance/SpokeInstance exceed EIP-170 (spoke: 25441 bytes runtime) under this repo's default settings
 # (optimizer_runs = 0, no via-ir). Compile the whole profile with aave-v4's spoke settings (via-ir, 750 runs)
 # so the deployed instances fit the size limit — a per-contract compilation_restrictions split doesn't work
 # here because the deploy script `new`s the instances, embedding their creation code in its own unit.
-# NB these settings change LiquidationLogic's bytecode, so the pinned CREATE2 address above is specific to
-# this profile; the deploy script recomputes it from the artifact and reverts if it drifts.
 via_ir = true
 optimizer_runs = 750
 

--- a/remappings.txt
+++ b/remappings.txt
@@ -4,6 +4,7 @@ forge-std/=lib/forge-std/src/
 openzeppelin-contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/
 openzeppelin-contracts/=lib/openzeppelin-contracts/
 solady/=lib/solady/src/
+aave-v4/=lib/aave-v4/src/
 lib/aave-v4/:src/=lib/aave-v4/src/
 @layerzerolabs/oapp-evm/=lib/devtools/packages/oapp-evm/
 @layerzerolabs/oapp-evm-upgradeable/=lib/devtools/packages/oapp-evm-upgradeable/

--- a/scripts/aave-v4/AaveV4DevRoles.sol
+++ b/scripts/aave-v4/AaveV4DevRoles.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/**
+ * @title AaveV4DevRoles
+ * @notice Role ids the dev Aave v4 test instance was deployed with (the aave-v4 v0.5.11 Roles
+ *         library). The launch-branch Roles library renumbered role ids (hub 100s, spoke 300s)
+ *         and the prod whitelabel instance uses that scheme, but the dev AccessManager still maps
+ *         selectors to the original ids, so they are pinned here as deployed facts.
+ */
+library AaveV4DevRoles {
+    uint64 constant HUB_ADMIN_ROLE = 1;
+    uint64 constant SPOKE_ADMIN_ROLE = 2;
+}

--- a/scripts/aave-v4/AaveV4TestActions.s.sol
+++ b/scripts/aave-v4/AaveV4TestActions.s.sol
@@ -6,18 +6,18 @@ import { console } from "forge-std/console.sol";
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-import { IAaveV4Hub } from "../../src/interfaces/IAaveV4Hub.sol";
 import { IAaveV4Spoke } from "../../src/interfaces/IAaveV4Spoke.sol";
-import { Utils } from "../utils/Utils.sol";
+import { ChainConfig, Utils } from "../utils/Utils.sol";
 
 /**
  * @title AaveV4TestActions
- * @notice Exercises the full user lifecycle on the Aave v4 TEST instance deployed by
+ * @notice Exercises the public LP lifecycle on the Aave v4 TEST instance deployed by
  *         DeployAaveV4TestInstance (addresses from deployments/<env>/10/aave-v4-test.json):
- *         supply weETH, enable it as collateral, borrow USDC, repay the debt in full, and
- *         withdraw the whole position. If the USDC reserve lacks the liquidity to cover the
- *         borrow, the wallet supplies the shortfall first and withdraws it again at the end,
- *         so a successful run leaves no residue besides interest dust.
+ *         supply weETH, enable it as collateral, and withdraw the whole position. Reserve ids
+ *         are resolved on-chain by underlying, not from the manifest.
+ * @dev Since the spoke upgrade to EtherFiSpokeInstanceDev, `borrow` reverts unless the position
+ *      owner is an ether.fi Cash Safe, so this script no longer covers borrow/repay — exercise
+ *      those through the LendGateway with a dev safe (see the lend dev-flows fork suite).
  *
  * Usage (simulate by dropping --broadcast):
  *   source .env && ENV=dev FOUNDRY_PROFILE=aave-deploy forge script \
@@ -26,14 +26,11 @@ import { Utils } from "../utils/Utils.sol";
  *
  * Optional env:
  *   SUPPLY_WEETH  weETH amount (18 decimals) to supply as collateral (default 0.002 weETH)
- *   BORROW_USDC   USDC amount (6 decimals) to borrow (default 1 USDC)
  */
 contract AaveV4TestActions is Utils {
     IAaveV4Spoke spoke;
     IERC20 weeth;
-    IERC20 usdc;
     uint256 weethReserveId;
-    uint256 usdcReserveId;
     address user;
 
     function run() public {
@@ -41,16 +38,14 @@ contract AaveV4TestActions is Utils {
 
         string memory json = vm.readFile(string.concat(vm.projectRoot(), "/deployments/", getEnv(), "/", vm.toString(block.chainid), "/aave-v4-test.json"));
         spoke = IAaveV4Spoke(stdJson.readAddress(json, ".spoke"));
-        weethReserveId = stdJson.readUint(json, ".weethReserveId");
-        usdcReserveId = stdJson.readUint(json, ".usdcReserveId");
-        weeth = IERC20(spoke.getReserve(weethReserveId).underlying);
-        usdc = IERC20(spoke.getReserve(usdcReserveId).underlying);
+        ChainConfig memory cfg = getChainConfig(vm.toString(block.chainid));
+        weethReserveId = _reserveIdOf(cfg.weETH);
+        weeth = IERC20(cfg.weETH);
 
         uint256 privateKey = vm.envUint("PRIVATE_KEY");
         user = vm.addr(privateKey);
 
         uint256 supplyWeeth = vm.envOr("SUPPLY_WEETH", uint256(0.002 ether));
-        uint256 borrowUsdc = vm.envOr("BORROW_USDC", uint256(1e6));
 
         console.log("Spoke:", address(spoke));
         console.log("User: ", user);
@@ -67,58 +62,28 @@ contract AaveV4TestActions is Utils {
         console.log("1. supplied weETH:", supplied);
         _logState("after supply");
 
-        // 2. Make sure the USDC reserve can cover the borrow, seeding the shortfall from the wallet.
-        // Actual lendable cash comes from the Hub (supplied minus debt underflows once debt outgrows
-        // this spoke's supply on the shared-liquidity hub).
-        IAaveV4Spoke.Reserve memory usdcReserve = spoke.getReserve(usdcReserveId);
-        uint256 available = IAaveV4Hub(usdcReserve.hub).getAssetLiquidity(usdcReserve.assetId);
-        uint256 seeded = 0;
-        if (available < borrowUsdc) {
-            seeded = borrowUsdc - available;
-            require(usdc.balanceOf(user) >= seeded, "wallet lacks USDC to seed borrow liquidity");
-            usdc.approve(address(spoke), seeded);
-            spoke.supply(usdcReserveId, seeded, user);
-            console.log("2. seeded USDC liquidity:", seeded);
-        }
-
-        // 3. Borrow USDC against the weETH collateral
-        (, uint256 borrowed) = spoke.borrow(usdcReserveId, borrowUsdc, user);
-        console.log("3. borrowed USDC:", borrowed);
-        _logState("after borrow");
-
-        // 4. Repay in full; the approval carries 1% headroom for interest accrued between the
-        //    approve and repay transactions landing, and is cleared afterwards
-        uint256 debt = spoke.getUserTotalDebt(usdcReserveId, user);
-        require(usdc.balanceOf(user) >= debt, "wallet lacks USDC to repay");
-        usdc.approve(address(spoke), (debt * 101) / 100 + 1);
-        (, uint256 repaid) = spoke.repay(usdcReserveId, type(uint256).max, user);
-        usdc.approve(address(spoke), 0);
-        console.log("4. repaid USDC:", repaid);
-        _logState("after repay");
-
-        // 5. Withdraw the full weETH position (max signals a full withdrawal)
+        // 2. Withdraw the full weETH position (max signals a full withdrawal)
         (, uint256 withdrawn) = spoke.withdraw(weethReserveId, type(uint256).max, user);
-        console.log("5. withdrew weETH:", withdrawn);
-
-        // 6. Pull back any liquidity seeded in step 2
-        if (seeded > 0) {
-            (, uint256 unseeded) = spoke.withdraw(usdcReserveId, type(uint256).max, user);
-            console.log("6. withdrew seeded USDC:", unseeded);
-        }
+        console.log("2. withdrew weETH:", withdrawn);
 
         vm.stopBroadcast();
 
         _logState("final");
     }
 
+    function _reserveIdOf(address token) internal view returns (uint256) {
+        uint256 count = spoke.getReserveCount();
+        for (uint256 i; i < count; ++i) {
+            if (spoke.getReserve(i).underlying == token) return i;
+        }
+        revert("reserve not listed on dev");
+    }
+
     function _logState(string memory label) internal view {
         IAaveV4Spoke.UserAccountData memory data = spoke.getUserAccountData(user);
         console.log("--- state:", label);
         console.log("    wallet weETH:  ", weeth.balanceOf(user));
-        console.log("    wallet USDC:   ", usdc.balanceOf(user));
         console.log("    supplied weETH:", spoke.getUserSuppliedAssets(weethReserveId, user));
-        console.log("    supplied USDC: ", spoke.getUserSuppliedAssets(usdcReserveId, user));
-        console.log("    USDC debt:     ", spoke.getUserTotalDebt(usdcReserveId, user));
         if (data.healthFactor == type(uint256).max) console.log("    health factor:  max (no debt)");
         else console.log("    health factor (wad):", data.healthFactor);
     }

--- a/scripts/aave-v4/AddSummerLendCollateral.s.sol
+++ b/scripts/aave-v4/AddSummerLendCollateral.s.sol
@@ -10,7 +10,6 @@ import { IAccessManager } from "aave-v4/dependencies/openzeppelin/IAccessManager
 import { AssetInterestRateStrategy } from "aave-v4/hub/AssetInterestRateStrategy.sol";
 import { IAssetInterestRateStrategy } from "aave-v4/hub/interfaces/IAssetInterestRateStrategy.sol";
 import { IHub } from "aave-v4/hub/interfaces/IHub.sol";
-import { Roles } from "aave-v4/libraries/types/Roles.sol";
 import { ISpoke } from "aave-v4/spoke/interfaces/ISpoke.sol";
 
 import { IAaveV4PriceFeed } from "../../src/interfaces/IAaveV4PriceFeed.sol";
@@ -21,6 +20,7 @@ import { ChainlinkPriceFeed } from "../../src/oracle/ChainlinkPriceFeed.sol";
 import { IPythPairOracle, PythPriceFeed } from "../../src/oracle/PythPriceFeed.sol";
 import { VedaAccountantPriceFeed } from "../../src/oracle/VedaAccountantPriceFeed.sol";
 import { ChainConfig, Utils } from "../utils/Utils.sol";
+import { AaveV4DevRoles } from "./AaveV4DevRoles.sol";
 
 /**
  * @title AddSummerLendCollateral
@@ -128,7 +128,7 @@ contract AddSummerLendCollateral is Utils {
         // updateReservePriceSource is `restricted`; its selector was not mapped at instance deploy.
         bytes4[] memory sourceSelectors = new bytes4[](1);
         sourceSelectors[0] = ISpoke.updateReservePriceSource.selector;
-        accessManager.setTargetFunctionRole(address(spoke), sourceSelectors, Roles.SPOKE_ADMIN_ROLE);
+        accessManager.setTargetFunctionRole(address(spoke), sourceSelectors, AaveV4DevRoles.SPOKE_ADMIN_ROLE);
 
         // One staleness-checked ChainlinkPriceFeed per Chainlink oracle, shared as direct sources
         // and as underlying legs

--- a/scripts/aave-v4/DeployAaveV4TestInstance.s.sol
+++ b/scripts/aave-v4/DeployAaveV4TestInstance.s.sol
@@ -14,7 +14,6 @@ import { AssetInterestRateStrategy } from "aave-v4/hub/AssetInterestRateStrategy
 import { HubInstance } from "aave-v4/hub/instances/HubInstance.sol";
 import { IAssetInterestRateStrategy } from "aave-v4/hub/interfaces/IAssetInterestRateStrategy.sol";
 import { IHub } from "aave-v4/hub/interfaces/IHub.sol";
-import { Roles } from "aave-v4/libraries/types/Roles.sol";
 import { AaveOracle } from "aave-v4/spoke/AaveOracle.sol";
 import { SpokeInstance } from "aave-v4/spoke/instances/SpokeInstance.sol";
 import { TreasurySpokeInstance } from "aave-v4/spoke/instances/TreasurySpokeInstance.sol";
@@ -26,6 +25,7 @@ import { IAaveV4PriceFeed } from "../../src/interfaces/IAaveV4PriceFeed.sol";
 import { IAggregatorV3 } from "../../src/interfaces/IAggregatorV3.sol";
 import { ChainlinkPriceFeed } from "../../src/oracle/ChainlinkPriceFeed.sol";
 import { ChainConfig, Utils } from "../utils/Utils.sol";
+import { AaveV4DevRoles } from "./AaveV4DevRoles.sol";
 
 /// @dev Minimal init interface shared by the hub/spoke/treasury proxy implementations
 interface IProxyInit {
@@ -45,11 +45,10 @@ interface IProxyInit {
  *
  * @dev SpokeInstance links the external LiquidationLogic library via an aave-rooted `src/` import that
  *      forge can't resolve to an artifact, so auto-linking is unavailable (and the lend test profile's
- *      0x...0A01 pin only works under vm.etch). The `aave-deploy` profile therefore pins the library to
- *      its deterministic CREATE2 address (Nick's factory + fixed salt + current aave-v4 bytecode), and
- *      this script deploys the library there (idempotent) before the spoke. If the aave-v4 bytecode or
- *      compiler settings change, the recomputed address won't match the pin and the script reverts —
- *      recompute the address and update foundry.toml. The script refuses to run under any other profile.
+ *      0x...0A01 pin only works under vm.etch). The `aave-deploy` profile therefore links the canonical
+ *      Aave-deployed LiquidationLogic on OP Mainnet — the same library the prod whitelabel instance
+ *      links — and this script requires its code to be present before deploying the spoke. The script
+ *      refuses to run under any other profile.
  *
  * Usage (simulate by dropping --broadcast):
  *   source .env && ENV=dev FOUNDRY_PROFILE=aave-deploy forge script \
@@ -61,11 +60,9 @@ interface IProxyInit {
  *   SEED_USDC         USDC amount (6 decimals) to supply from the deployer as initial borrowable liquidity
  */
 contract DeployAaveV4TestInstance is Utils {
-    // --- LiquidationLogic deterministic deployment (see @dev above) ---
-    address constant NICKS_FACTORY = 0x4e59b44847b379578588920cA78FbF26c0B4956C;
-    bytes32 constant LIQUIDATION_LOGIC_SALT = keccak256("ether.fi/aave-v4-test/LiquidationLogic");
-    /// @dev Must match the pin in foundry.toml [profile.aave-deploy] libraries
-    address constant LIQUIDATION_LOGIC = 0x49dEE75906621Ea28D7332bb26E0da6f2d15E838;
+    /// @dev Canonical Aave-deployed LiquidationLogic on OP Mainnet; must match the pin in
+    ///      foundry.toml [profile.aave-deploy] libraries
+    address constant LIQUIDATION_LOGIC = 0x88dF535473C5adf1f57789734A05E555F7Deb8DB;
 
     // --- reserve policy (mirrors the lend test fixture) ---
     uint16 constant WEETH_COLLATERAL_FACTOR_BPS = 55_00; // 55% LTV
@@ -130,22 +127,11 @@ contract DeployAaveV4TestInstance is Utils {
         _logAndRecord();
     }
 
-    /// @dev Deploys LiquidationLogic to its pinned CREATE2 address (no-op if already there). Reads the
-    ///      creation bytecode straight from the compiled artifact — the same direct-read workaround the
-    ///      lend fixture uses, since forge can't resolve the aave-rooted import — and reverts loudly if
-    ///      the recomputed CREATE2 address no longer matches the foundry.toml pin the spoke was linked to.
-    function _ensureLiquidationLogic() internal {
-        bytes memory initCode = vm.parseJsonBytes(vm.readFile("out/LiquidationLogic.sol/LiquidationLogic.json"), ".bytecode.object");
-        address expected = address(uint160(uint256(keccak256(abi.encodePacked(bytes1(0xff), NICKS_FACTORY, LIQUIDATION_LOGIC_SALT, keccak256(initCode))))));
-        require(expected == LIQUIDATION_LOGIC, "LiquidationLogic bytecode drifted from the foundry.toml pin; recompute the CREATE2 address and update both");
-
-        if (LIQUIDATION_LOGIC.code.length == 0) {
-            (bool success,) = NICKS_FACTORY.call(abi.encodePacked(LIQUIDATION_LOGIC_SALT, initCode));
-            require(success && LIQUIDATION_LOGIC.code.length > 0, "LiquidationLogic CREATE2 deployment failed");
-            console.log("Deployed LiquidationLogic:", LIQUIDATION_LOGIC);
-        } else {
-            console.log("LiquidationLogic already deployed:", LIQUIDATION_LOGIC);
-        }
+    /// @dev The canonical library is deployed by Aave, not this script; the spoke bytecode is linked
+    ///      against it, so refuse to deploy if it is somehow absent.
+    function _ensureLiquidationLogic() internal view {
+        require(LIQUIDATION_LOGIC.code.length > 0, "Canonical LiquidationLogic has no code on this chain");
+        console.log("Linking canonical LiquidationLogic:", LIQUIDATION_LOGIC);
     }
 
     /// @dev Deploys access manager, hub (proxy), IR strategy, oracle, spoke (proxy) and treasury spoke (proxy)
@@ -168,21 +154,21 @@ contract DeployAaveV4TestInstance is Utils {
 
     /// @dev Grants the admin the hub/spoke roles and maps the admin functions we call to those roles
     function _grantRoles() internal {
-        accessManager.grantRole(Roles.HUB_ADMIN_ROLE, admin, 0);
-        accessManager.grantRole(Roles.SPOKE_ADMIN_ROLE, admin, 0);
+        accessManager.grantRole(AaveV4DevRoles.HUB_ADMIN_ROLE, admin, 0);
+        accessManager.grantRole(AaveV4DevRoles.SPOKE_ADMIN_ROLE, admin, 0);
 
         bytes4[] memory spokeSelectors = new bytes4[](4);
         spokeSelectors[0] = ISpoke.addReserve.selector;
         spokeSelectors[1] = ISpoke.updatePositionManager.selector;
         spokeSelectors[2] = ISpoke.updateLiquidationConfig.selector;
         spokeSelectors[3] = ISpoke.updateDynamicReserveConfig.selector;
-        accessManager.setTargetFunctionRole(address(spoke), spokeSelectors, Roles.SPOKE_ADMIN_ROLE);
+        accessManager.setTargetFunctionRole(address(spoke), spokeSelectors, AaveV4DevRoles.SPOKE_ADMIN_ROLE);
 
         bytes4[] memory hubSelectors = new bytes4[](3);
         hubSelectors[0] = IHub.addAsset.selector;
         hubSelectors[1] = IHub.updateAssetConfig.selector;
         hubSelectors[2] = IHub.addSpoke.selector;
-        accessManager.setTargetFunctionRole(address(hub), hubSelectors, Roles.HUB_ADMIN_ROLE);
+        accessManager.setTargetFunctionRole(address(hub), hubSelectors, AaveV4DevRoles.HUB_ADMIN_ROLE);
     }
 
     /// @dev Lists `token` on the hub + spoke with the given price source, LTV and borrowability

--- a/scripts/aave-v4/EtherFiSpokeInstanceDev.sol
+++ b/scripts/aave-v4/EtherFiSpokeInstanceDev.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: LicenseRef-BUSL
+pragma solidity ^0.8.28;
+
+import { SpokeInstance } from "aave-v4/spoke/instances/SpokeInstance.sol";
+
+/// @dev The ether.fi data provider used to recognize Cash Safes (a proxy; address is stable).
+interface IEtherFiDataProvider {
+    function isEtherFiSafe(address account) external view returns (bool);
+}
+
+/**
+ * @title EtherFiSpokeInstanceDev
+ * @notice Dev-instance build of the fork's `src/etherfi/EtherFiSpokeInstance.sol`
+ *         (etherfi-protocol/aave-v4): `borrow` is gated so only ether.fi Cash Safes (per
+ *         EtherFiDataProvider.isEtherFiSafe) can be the position owner. Supply, withdraw, repay,
+ *         and liquidationCall are untouched.
+ * @dev Identical to the prod contract except ETHERFI_DATA_PROVIDER, which is a compile-time
+ *      constant and so cannot be inherited away: prod bakes the prod data provider proxy, this
+ *      build bakes the dev one. Keep everything else in sync with the fork copy.
+ */
+contract EtherFiSpokeInstanceDev is SpokeInstance {
+    /// @notice The ether.fi data provider used to recognize Cash Safes (dev proxy, OP Mainnet).
+    address public constant ETHERFI_DATA_PROVIDER = 0x4a9c44c97BBf6079db37C4769AebE425bBcDD09a;
+
+    error OnlyEtherFiSafe(address account);
+
+    constructor(address oracle_, uint16 maxUserReservesLimit_) SpokeInstance(oracle_, maxUserReservesLimit_) { }
+
+    /// @notice Borrows `amount` of reserve `reserveId` for `onBehalfOf`, which must be an ether.fi
+    ///         Cash Safe.
+    function borrow(uint256 reserveId, uint256 amount, address onBehalfOf) public override returns (uint256, uint256) {
+        require(IEtherFiDataProvider(ETHERFI_DATA_PROVIDER).isEtherFiSafe(onBehalfOf), OnlyEtherFiSafe(onBehalfOf));
+        return super.borrow(reserveId, amount, onBehalfOf);
+    }
+}

--- a/scripts/aave-v4/SyncDevMarketConfigWithProd.s.sol
+++ b/scripts/aave-v4/SyncDevMarketConfigWithProd.s.sol
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { stdJson } from "forge-std/StdJson.sol";
+import { console } from "forge-std/console.sol";
+
+import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+
+import { IAccessManager } from "aave-v4/dependencies/openzeppelin/IAccessManager.sol";
+import { IAssetInterestRateStrategy } from "aave-v4/hub/interfaces/IAssetInterestRateStrategy.sol";
+import { IHub } from "aave-v4/hub/interfaces/IHub.sol";
+import { ISpoke } from "aave-v4/spoke/interfaces/ISpoke.sol";
+
+import { Utils } from "../utils/Utils.sol";
+import { AaveV4DevRoles } from "./AaveV4DevRoles.sol";
+
+/**
+ * @title SyncDevMarketConfigWithProd
+ * @notice Aligns the dev Aave v4 test instance's market config (spoke/hub from
+ *         deployments/<env>/10/aave-v4-test.json) with the live prod whitelabel instance on
+ *         OP Mainnet: per-reserve collateral factor / liquidation bonus / liquidation fee,
+ *         borrowable flags (WETH becomes borrowable next to USDC), hub liquidity fees, interest
+ *         rate curves, spoke add/draw caps and risk premium threshold, and the spoke liquidation
+ *         config. The dev-only reserves (iwSPYx and the legacy liquidRESERVE OFT) are left
+ *         untouched, as are the dev fee receiver, oracle sources, and irStrategy wiring.
+ * @dev Values below were read from the live prod hub/spoke/irStrategy at OP block 154956068
+ *      (2026-07-31) and cross-checked against the fork's scripts/etherfi/LAUNCH_SPEC.md — they
+ *      matched exactly. Caps are whole-token (uint40). Idempotent: every setter writes absolute
+ *      values, so the script can be re-run after a partial broadcast.
+ *
+ * Usage (simulate by dropping --broadcast; the broadcast wallet must hold the instance admin roles):
+ *   source .env && ENV=dev FOUNDRY_PROFILE=aave-deploy forge script \
+ *     scripts/aave-v4/SyncDevMarketConfigWithProd.s.sol:SyncDevMarketConfigWithProd \
+ *     --rpc-url $OPTIMISM_RPC --broadcast -vvvv
+ */
+contract SyncDevMarketConfigWithProd is Utils {
+    struct ProdReserveParams {
+        address underlying;
+        uint16 collateralFactor; // BPS
+        uint32 maxLiquidationBonus; // BPS, 100_00 = no bonus
+        uint16 liquidationFee; // BPS
+        bool borrowable;
+        uint16 liquidityFee; // BPS
+        uint16 optimalUsageRatio; // BPS
+        uint32 baseDrawnRate; // BPS
+        uint32 rateGrowthBeforeOptimal; // BPS
+        uint32 rateGrowthAfterOptimal; // BPS
+        uint40 addCap; // whole tokens
+        uint40 drawCap; // whole tokens
+    }
+
+    // Prod spoke liquidation config
+    uint128 constant TARGET_HEALTH_FACTOR = 1.24e18;
+    uint64 constant HEALTH_FACTOR_FOR_MAX_BONUS = 0.9e18;
+    uint16 constant LIQUIDATION_BONUS_FACTOR = 0;
+    // Prod spoke risk premium threshold (dev was deployed with the no-threshold sentinel)
+    uint24 constant RISK_PREMIUM_THRESHOLD = 0;
+
+    IHub hub;
+    ISpoke spoke;
+    IAccessManager accessManager;
+
+    function run() public {
+        require(block.chainid == 10, "Must run on Optimism (10)");
+        require(isEqualString(vm.envOr("FOUNDRY_PROFILE", string("default")), "aave-deploy"), "Run with FOUNDRY_PROFILE=aave-deploy (library linking)");
+
+        string memory json = vm.readFile(string.concat(vm.projectRoot(), "/deployments/", getEnv(), "/", vm.toString(block.chainid), "/aave-v4-test.json"));
+        hub = IHub(stdJson.readAddress(json, ".hub"));
+        spoke = ISpoke(stdJson.readAddress(json, ".spoke"));
+        accessManager = IAccessManager(stdJson.readAddress(json, ".accessManager"));
+
+        vm.startBroadcast(vm.envUint("PRIVATE_KEY"));
+
+        // Selectors not mapped at instance deploy
+        bytes4[] memory hubSelectors = new bytes4[](2);
+        hubSelectors[0] = IHub.setInterestRateData.selector;
+        hubSelectors[1] = IHub.updateSpokeConfig.selector;
+        accessManager.setTargetFunctionRole(address(hub), hubSelectors, AaveV4DevRoles.HUB_ADMIN_ROLE);
+        bytes4[] memory spokeSelectors = new bytes4[](1);
+        spokeSelectors[0] = ISpoke.updateReserveConfig.selector;
+        accessManager.setTargetFunctionRole(address(spoke), spokeSelectors, AaveV4DevRoles.SPOKE_ADMIN_ROLE);
+
+        spoke.updateLiquidationConfig(ISpoke.LiquidationConfig({ targetHealthFactor: TARGET_HEALTH_FACTOR, healthFactorForMaxBonus: HEALTH_FACTOR_FOR_MAX_BONUS, liquidationBonusFactor: LIQUIDATION_BONUS_FACTOR }));
+
+        ProdReserveParams[19] memory params = _prodParams();
+        for (uint256 i; i < params.length; ++i) {
+            _sync(params[i]);
+        }
+
+        vm.stopBroadcast();
+    }
+
+    function _sync(ProdReserveParams memory p) internal {
+        uint256 reserveId = _reserveIdOf(p.underlying);
+        ISpoke.Reserve memory reserve = spoke.getReserve(reserveId);
+        uint256 assetId = reserve.assetId;
+
+        spoke.updateDynamicReserveConfig(reserveId, reserve.dynamicConfigKey, ISpoke.DynamicReserveConfig({ collateralFactor: p.collateralFactor, maxLiquidationBonus: p.maxLiquidationBonus, liquidationFee: p.liquidationFee }));
+
+        // Patch only borrowable; keep the reserve's live pause/freeze/shares/risk state
+        ISpoke.ReserveConfig memory reserveConfig = spoke.getReserveConfig(reserveId);
+        reserveConfig.borrowable = p.borrowable;
+        spoke.updateReserveConfig(reserveId, reserveConfig);
+
+        // Patch only the liquidity fee; the fee receiver and irStrategy stay the dev ones
+        IHub.AssetConfig memory assetConfig = hub.getAssetConfig(assetId);
+        assetConfig.liquidityFee = p.liquidityFee;
+        hub.updateAssetConfig(assetId, assetConfig, new bytes(0));
+
+        hub.setInterestRateData(assetId, abi.encode(IAssetInterestRateStrategy.InterestRateData({ optimalUsageRatio: p.optimalUsageRatio, baseDrawnRate: p.baseDrawnRate, rateGrowthBeforeOptimal: p.rateGrowthBeforeOptimal, rateGrowthAfterOptimal: p.rateGrowthAfterOptimal })));
+
+        hub.updateSpokeConfig(assetId, address(spoke), IHub.SpokeConfig({ addCap: p.addCap, drawCap: p.drawCap, riskPremiumThreshold: RISK_PREMIUM_THRESHOLD, active: true, halted: false }));
+
+        console.log("synced:", IERC20Metadata(p.underlying).symbol(), reserveId);
+    }
+
+    function _reserveIdOf(address token) internal view returns (uint256) {
+        uint256 count = spoke.getReserveCount();
+        for (uint256 i; i < count; ++i) {
+            if (spoke.getReserve(i).underlying == token) return i;
+        }
+        revert("reserve not listed on dev");
+    }
+
+    /// @dev Live prod values per reserve (prod reserve order); see @dev above for provenance
+    function _prodParams() internal pure returns (ProdReserveParams[19] memory) {
+        return [
+            // USDC
+            ProdReserveParams(0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85, 9500, 10_100, 1000, true, 500, 9200, 0, 400, 1000, 10_000_000, 7_000_000),
+            // WETH
+            ProdReserveParams(0x4200000000000000000000000000000000000006, 7500, 10_350, 1000, true, 700, 9200, 0, 235, 1400, 1000, 100),
+            // USDT
+            ProdReserveParams(0x94b008aA00579c1307B0EF2c499aD98a8ce58e58, 9500, 10_100, 1000, false, 0, 9900, 0, 0, 0, 10_000_000, 0),
+            // EURC
+            ProdReserveParams(0xDCB612005417Dc906fF72c87DF732e5a90D49e11, 9500, 10_100, 1000, false, 0, 9900, 0, 0, 0, 5_000_000, 0),
+            // frxUSD
+            ProdReserveParams(0x80Eede496655FB9047dd39d9f418d5483ED600df, 9500, 10_100, 1000, false, 0, 9900, 0, 0, 0, 5_000_000, 0),
+            // weETH
+            ProdReserveParams(0x5A7fACB970D094B6C7FF1df0eA68D99E6e73CBFF, 7500, 10_350, 1000, false, 0, 9900, 0, 0, 0, 1000, 0),
+            // eBTC
+            ProdReserveParams(0x657e8C867D8B37dCC18fA4Caead9C45EB088C642, 7200, 10_500, 1000, false, 0, 9900, 0, 0, 0, 200, 0),
+            // eUSD
+            ProdReserveParams(0x939778D83b46B456224A33Fb59630B11DEC56663, 9000, 10_200, 1000, false, 0, 9900, 0, 0, 0, 1_000_000, 0),
+            // ETHFI
+            ProdReserveParams(0xe0080d2F853ecDdbd81A643dC10DA075Df26fD3f, 3000, 10_500, 1000, false, 0, 9900, 0, 0, 0, 2_000_000, 0),
+            // sETHFI
+            ProdReserveParams(0x86B5780b606940Eb59A062aA85a07959518c0161, 3000, 10_500, 1000, false, 0, 9900, 0, 0, 0, 2_000_000, 0),
+            // OP
+            ProdReserveParams(0x4200000000000000000000000000000000000042, 3000, 10_500, 1000, false, 0, 9900, 0, 0, 0, 1_000_000, 0),
+            // WHYPE
+            ProdReserveParams(0xd83E3d560bA6F05094d9D8B3EB8aaEA571D1864E, 6500, 10_400, 1000, false, 0, 9900, 0, 0, 0, 100_000, 0),
+            // beHYPE
+            ProdReserveParams(0xA519AfBc91986c0e7501d7e34968FEE51CD901aC, 6000, 10_500, 1000, false, 0, 9900, 0, 0, 0, 100_000, 0),
+            // liquidETH
+            ProdReserveParams(0xf0bb20865277aBd641a307eCe5Ee04E79073416C, 7000, 10_500, 1000, false, 0, 9900, 0, 0, 0, 1000, 0),
+            // liquidBTC
+            ProdReserveParams(0x5f46d540b6eD704C3c8789105F30E075AA900726, 7000, 10_500, 1000, false, 0, 9900, 0, 0, 0, 100, 0),
+            // liquidUSD
+            ProdReserveParams(0x08c6F91e2B681FaF5e17227F2a44C307b3C1364C, 8000, 10_200, 1000, false, 0, 9900, 0, 0, 0, 5_000_000, 0),
+            // liquidRESERVE (Midas)
+            ProdReserveParams(0xca5921DF65E2e1b0B98Ae91c0187BA80D4124898, 8000, 10_200, 1000, false, 0, 9900, 0, 0, 0, 1_000_000, 0),
+            // weEUR
+            ProdReserveParams(0xcC476B1a49bcDf5192561e87b6Fb8ea78aa28C13, 8000, 10_200, 1000, false, 0, 9900, 0, 0, 0, 1_000_000, 0),
+            // liquidRWA
+            ProdReserveParams(0x17bC8Ffd82b8a36e737Ca1141C025089589B915e, 8000, 10_200, 1000, false, 0, 9900, 0, 0, 0, 1_000_000, 0)
+        ];
+    }
+}

--- a/scripts/aave-v4/UpgradeDevSpokeToEtherFi.s.sol
+++ b/scripts/aave-v4/UpgradeDevSpokeToEtherFi.s.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { stdJson } from "forge-std/StdJson.sol";
+import { console } from "forge-std/console.sol";
+
+import { ISpoke } from "aave-v4/spoke/interfaces/ISpoke.sol";
+
+import { Utils } from "../utils/Utils.sol";
+import { EtherFiSpokeInstanceDev } from "./EtherFiSpokeInstanceDev.sol";
+
+/// @dev OZ v5 ProxyAdmin (auto-deployed by the spoke's TransparentUpgradeableProxy).
+interface IProxyAdmin {
+    function owner() external view returns (address);
+    function upgradeAndCall(address proxy, address implementation, bytes calldata data) external payable;
+}
+
+/**
+ * @title UpgradeDevSpokeToEtherFi
+ * @notice Upgrades the dev Aave v4 test instance's spoke proxy (deployments/<env>/10/aave-v4-test.json)
+ *         to EtherFiSpokeInstanceDev, the dev build of the prod whitelabel spoke: same one-line
+ *         borrow gate (only ether.fi Cash Safes as position owner), dev EtherFiDataProvider constant.
+ *         The new implementation re-bakes the immutables: same oracle as the live spoke, and
+ *         MAX_USER_RESERVES_LIMIT = 64 to match prod (dev was uint16.max; dev lists 21 reserves,
+ *         so no existing position can exceed the new limit).
+ * @dev Storage-safe: between the pinned v0.5.11 and the fork launch branch the only core spoke
+ *      change is `borrow` going external -> public virtual, and EtherFiSpokeInstanceDev adds no
+ *      storage. No initializer is called (same SPOKE_REVISION). The new implementation links the
+ *      canonical Aave-deployed LiquidationLogic (foundry.toml [profile.aave-deploy]) — the same
+ *      library the prod instance links; the pre-upgrade dev impl linked a self-deployed copy.
+ *
+ * Usage (simulate by dropping --broadcast; the broadcast wallet must own the spoke's ProxyAdmin):
+ *   source .env && ENV=dev FOUNDRY_PROFILE=aave-deploy forge script \
+ *     scripts/aave-v4/UpgradeDevSpokeToEtherFi.s.sol:UpgradeDevSpokeToEtherFi \
+ *     --rpc-url $OPTIMISM_RPC --broadcast -vvvv
+ */
+contract UpgradeDevSpokeToEtherFi is Utils {
+    /// @dev Canonical Aave-deployed LiquidationLogic on OP Mainnet; must match the pin in
+    ///      foundry.toml [profile.aave-deploy] libraries
+    address constant LIQUIDATION_LOGIC = 0x88dF535473C5adf1f57789734A05E555F7Deb8DB;
+    /// @dev ERC-1967 admin slot (eip1967.proxy.admin)
+    bytes32 constant ADMIN_SLOT = 0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103;
+    uint16 constant MAX_USER_RESERVES_LIMIT = 64; // prod whitelabel spoke value
+
+    function run() public {
+        require(block.chainid == 10, "Must run on Optimism (10)");
+        require(isEqualString(vm.envOr("FOUNDRY_PROFILE", string("default")), "aave-deploy"), "Run with FOUNDRY_PROFILE=aave-deploy (library linking)");
+        require(LIQUIDATION_LOGIC.code.length > 0, "Canonical LiquidationLogic has no code on this chain");
+
+        string memory json = vm.readFile(string.concat(vm.projectRoot(), "/deployments/", getEnv(), "/", vm.toString(block.chainid), "/aave-v4-test.json"));
+        address spoke = stdJson.readAddress(json, ".spoke");
+        address oracle = ISpoke(spoke).ORACLE();
+        require(oracle == stdJson.readAddress(json, ".aaveOracle"), "Live spoke oracle does not match the manifest");
+
+        IProxyAdmin proxyAdmin = IProxyAdmin(address(uint160(uint256(vm.load(spoke, ADMIN_SLOT)))));
+        address admin = vm.addr(vm.envUint("PRIVATE_KEY"));
+        require(proxyAdmin.owner() == admin, "Broadcast wallet does not own the spoke ProxyAdmin");
+
+        vm.startBroadcast(vm.envUint("PRIVATE_KEY"));
+        EtherFiSpokeInstanceDev impl = new EtherFiSpokeInstanceDev(oracle, MAX_USER_RESERVES_LIMIT);
+        proxyAdmin.upgradeAndCall(spoke, address(impl), "");
+        vm.stopBroadcast();
+
+        // Post-upgrade sanity through the proxy: immutables took, borrow gate is the dev one
+        require(ISpoke(spoke).ORACLE() == oracle, "Oracle changed across the upgrade");
+        require(EtherFiSpokeInstanceDev(spoke).ETHERFI_DATA_PROVIDER() == impl.ETHERFI_DATA_PROVIDER(), "Borrow gate data provider mismatch");
+
+        console.log("New spoke implementation (EtherFiSpokeInstanceDev):", address(impl));
+        console.log("Update aave-v4-test.json: spokeImpl + liquidationLogic =", LIQUIDATION_LOGIC);
+    }
+}

--- a/scripts/aave-v4/VerifyDevAaveParity.s.sol
+++ b/scripts/aave-v4/VerifyDevAaveParity.s.sol
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { stdJson } from "forge-std/StdJson.sol";
+import { console } from "forge-std/console.sol";
+
+import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+
+import { IAssetInterestRateStrategy } from "aave-v4/hub/interfaces/IAssetInterestRateStrategy.sol";
+import { IHub } from "aave-v4/hub/interfaces/IHub.sol";
+import { ISpoke } from "aave-v4/spoke/interfaces/ISpoke.sol";
+
+import { Utils } from "../utils/Utils.sol";
+import { EtherFiSpokeInstanceDev } from "./EtherFiSpokeInstanceDev.sol";
+
+/**
+ * @title VerifyDevAaveParity
+ * @notice Read-only parity check between the dev Aave v4 test instance
+ *         (deployments/<env>/10/aave-v4-test.json) and the live prod whitelabel instance on
+ *         OP Mainnet. For every prod reserve (matched to dev by underlying) it compares the
+ *         dynamic reserve config, borrowable flag, hub liquidity fee, interest rate data, and
+ *         spoke caps / risk premium threshold, plus the spoke-level liquidation config and the
+ *         borrow gate (dev data provider baked into the dev spoke impl, non-safe borrow reverts).
+ *         Dev-only reserves (iwSPYx and the legacy liquidRESERVE OFT) are reported and ignored.
+ *         Reverts if any parameter differs, so it doubles as a CI-style gate after config drift.
+ *
+ * Usage:
+ *   source .env && ENV=dev FOUNDRY_PROFILE=aave-deploy forge script \
+ *     scripts/aave-v4/VerifyDevAaveParity.s.sol:VerifyDevAaveParity --rpc-url $OPTIMISM_RPC -vvv
+ */
+contract VerifyDevAaveParity is Utils {
+    // Prod whitelabel instance (etherfi-protocol/aave-v4 deployments/optimism/10.json)
+    ISpoke constant PROD_SPOKE = ISpoke(0xdffcC3536D932eb51Df51a7F5FA407c4270d5308);
+    IHub constant PROD_HUB = IHub(0x66753c4e3fC84f1eD0e3C267C927284E9d90C572);
+    IAssetInterestRateStrategy constant PROD_IR = IAssetInterestRateStrategy(0x51d07C362f9c4716F96EbEB63DB985EF9D2aCd7C);
+    address constant DEV_ETHERFI_DATA_PROVIDER = 0x4a9c44c97BBf6079db37C4769AebE425bBcDD09a;
+
+    IHub devHub;
+    ISpoke devSpoke;
+    IAssetInterestRateStrategy devIr;
+    uint256 mismatches;
+
+    function run() public {
+        require(block.chainid == 10, "Must run on Optimism (10)");
+
+        string memory json = vm.readFile(string.concat(vm.projectRoot(), "/deployments/", getEnv(), "/", vm.toString(block.chainid), "/aave-v4-test.json"));
+        devHub = IHub(stdJson.readAddress(json, ".hub"));
+        devSpoke = ISpoke(stdJson.readAddress(json, ".spoke"));
+        devIr = IAssetInterestRateStrategy(stdJson.readAddress(json, ".irStrategy"));
+
+        _checkBorrowGate();
+        _checkLiquidationConfig();
+
+        uint256 prodCount = PROD_SPOKE.getReserveCount();
+        bool[] memory devMatched = new bool[](devSpoke.getReserveCount());
+        for (uint256 i; i < prodCount; ++i) {
+            address underlying = PROD_SPOKE.getReserve(i).underlying;
+            (bool found, uint256 devId) = _devReserveIdOf(underlying);
+            if (!found) {
+                _flag(string.concat("missing dev reserve for ", IERC20Metadata(underlying).symbol()));
+                continue;
+            }
+            devMatched[devId] = true;
+            _compareReserve(IERC20Metadata(underlying).symbol(), i, devId);
+        }
+
+        for (uint256 i; i < devMatched.length; ++i) {
+            if (!devMatched[i]) {
+                console.log("dev-only reserve (ignored):", IERC20Metadata(devSpoke.getReserve(i).underlying).symbol(), i);
+            }
+        }
+
+        require(mismatches == 0, "dev/prod parity check failed (see logs)");
+        console.log("parity OK: dev matches prod on all shared reserves");
+    }
+
+    function _checkBorrowGate() internal {
+        require(EtherFiSpokeInstanceDev(address(devSpoke)).ETHERFI_DATA_PROVIDER() == DEV_ETHERFI_DATA_PROVIDER, "dev spoke is not the gated EtherFiSpokeInstanceDev build");
+        // This script contract is not a Cash Safe, so the gate must reject it as position owner
+        // before any position-manager or health checks run
+        try EtherFiSpokeInstanceDev(address(devSpoke)).borrow(0, 1, address(this)) {
+            _flag("borrow gate did not revert for a non-safe position owner");
+        } catch (bytes memory reason) {
+            if (bytes4(reason) != EtherFiSpokeInstanceDev.OnlyEtherFiSafe.selector) _flag("borrow reverted, but not with OnlyEtherFiSafe");
+        }
+        console.log("borrow gate: active, dev data provider baked in");
+    }
+
+    function _checkLiquidationConfig() internal {
+        ISpoke.LiquidationConfig memory dev = devSpoke.getLiquidationConfig();
+        ISpoke.LiquidationConfig memory prod = PROD_SPOKE.getLiquidationConfig();
+        if (dev.targetHealthFactor != prod.targetHealthFactor || dev.healthFactorForMaxBonus != prod.healthFactorForMaxBonus || dev.liquidationBonusFactor != prod.liquidationBonusFactor) {
+            _flag("liquidation config differs");
+        }
+    }
+
+    function _compareReserve(string memory symbol, uint256 prodId, uint256 devId) internal {
+        ISpoke.Reserve memory prodReserve = PROD_SPOKE.getReserve(prodId);
+        ISpoke.Reserve memory devReserve = devSpoke.getReserve(devId);
+
+        ISpoke.DynamicReserveConfig memory prodDyn = PROD_SPOKE.getDynamicReserveConfig(prodId, prodReserve.dynamicConfigKey);
+        ISpoke.DynamicReserveConfig memory devDyn = devSpoke.getDynamicReserveConfig(devId, devReserve.dynamicConfigKey);
+        if (devDyn.collateralFactor != prodDyn.collateralFactor) _flag(string.concat(symbol, ": collateralFactor"));
+        if (devDyn.maxLiquidationBonus != prodDyn.maxLiquidationBonus) _flag(string.concat(symbol, ": maxLiquidationBonus"));
+        if (devDyn.liquidationFee != prodDyn.liquidationFee) _flag(string.concat(symbol, ": liquidationFee"));
+
+        if (devSpoke.getReserveConfig(devId).borrowable != PROD_SPOKE.getReserveConfig(prodId).borrowable) _flag(string.concat(symbol, ": borrowable"));
+
+        if (devHub.getAssetConfig(devReserve.assetId).liquidityFee != PROD_HUB.getAssetConfig(prodReserve.assetId).liquidityFee) _flag(string.concat(symbol, ": liquidityFee"));
+
+        IAssetInterestRateStrategy.InterestRateData memory prodRate = PROD_IR.getInterestRateData(prodReserve.assetId);
+        IAssetInterestRateStrategy.InterestRateData memory devRate = devIr.getInterestRateData(devReserve.assetId);
+        if (devRate.optimalUsageRatio != prodRate.optimalUsageRatio || devRate.baseDrawnRate != prodRate.baseDrawnRate || devRate.rateGrowthBeforeOptimal != prodRate.rateGrowthBeforeOptimal || devRate.rateGrowthAfterOptimal != prodRate.rateGrowthAfterOptimal) {
+            _flag(string.concat(symbol, ": interest rate data"));
+        }
+
+        IHub.SpokeConfig memory prodSpokeCfg = PROD_HUB.getSpokeConfig(prodReserve.assetId, address(PROD_SPOKE));
+        IHub.SpokeConfig memory devSpokeCfg = devHub.getSpokeConfig(devReserve.assetId, address(devSpoke));
+        if (devSpokeCfg.addCap != prodSpokeCfg.addCap) _flag(string.concat(symbol, ": addCap"));
+        if (devSpokeCfg.drawCap != prodSpokeCfg.drawCap) _flag(string.concat(symbol, ": drawCap"));
+        if (devSpokeCfg.riskPremiumThreshold != prodSpokeCfg.riskPremiumThreshold) _flag(string.concat(symbol, ": riskPremiumThreshold"));
+        if (devSpokeCfg.active != prodSpokeCfg.active || devSpokeCfg.halted != prodSpokeCfg.halted) _flag(string.concat(symbol, ": active/halted"));
+    }
+
+    function _devReserveIdOf(address token) internal view returns (bool, uint256) {
+        uint256 count = devSpoke.getReserveCount();
+        for (uint256 i; i < count; ++i) {
+            if (devSpoke.getReserve(i).underlying == token) return (true, i);
+        }
+        return (false, 0);
+    }
+
+    function _flag(string memory what) internal {
+        ++mismatches;
+        console.log("MISMATCH:", what);
+    }
+}

--- a/scripts/lend/SetMinHealthFactorDev.s.sol
+++ b/scripts/lend/SetMinHealthFactorDev.s.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { stdJson } from "forge-std/StdJson.sol";
+import { console } from "forge-std/console.sol";
+
+import { LendGateway } from "../../src/modules/lend-gateway/LendGateway.sol";
+import { RoleRegistry } from "../../src/role-registry/RoleRegistry.sol";
+import { Utils } from "../utils/Utils.sol";
+
+/**
+ * @title SetMinHealthFactorDev
+ * @notice Raises the dev LendGateway's minimum health factor from the deploy-time 1.05 to 1.10,
+ *         the day-one value proposed for the prod gateway, so dev rehearses the prod guardrail.
+ * @dev Dev-only. The CLI sender must hold LEND_GATEWAY_ADMIN_ROLE (the dev admin from
+ *      DeployCashLendDev). Idempotent.
+ *
+ * Usage (drop --broadcast for simulation):
+ *   source .env && ENV=dev forge script \
+ *     scripts/lend/SetMinHealthFactorDev.s.sol:SetMinHealthFactorDev \
+ *     --rpc-url $OPTIMISM_RPC --broadcast -vvvv
+ */
+contract SetMinHealthFactorDev is Utils {
+    uint256 constant MIN_HEALTH_FACTOR = 1.1e18;
+
+    function run() public {
+        require(block.chainid == 10, "Optimism only");
+        require(isEqualString(getEnv(), "dev"), "ENV must be dev");
+
+        string memory record = vm.readFile(string.concat(vm.projectRoot(), "/deployments/dev/", vm.toString(block.chainid), "/cash-lend.json"));
+        LendGateway gateway = LendGateway(stdJson.readAddress(record, ".lendGateway"));
+
+        string memory deployments = readDeploymentFile();
+        RoleRegistry registry = RoleRegistry(stdJson.readAddress(deployments, ".addresses.RoleRegistry"));
+        address deployer = vm.addr(vm.envUint("PRIVATE_KEY"));
+        require(registry.hasRole(gateway.LEND_GATEWAY_ADMIN_ROLE(), deployer), "sender missing LendGateway admin role");
+
+        vm.startBroadcast(vm.envUint("PRIVATE_KEY"));
+        gateway.setMinHealthFactor(MIN_HEALTH_FACTOR);
+        vm.stopBroadcast();
+
+        require(gateway.minHealthFactor() == MIN_HEALTH_FACTOR, "minHealthFactor not applied");
+        console.log("dev LendGateway minHealthFactor set to", MIN_HEALTH_FACTOR);
+    }
+}

--- a/test/safe/modules/cash/lend/helpers/AaveV4Fixture.sol
+++ b/test/safe/modules/cash/lend/helpers/AaveV4Fixture.sol
@@ -12,7 +12,6 @@ import { AssetInterestRateStrategy } from "aave-v4/hub/AssetInterestRateStrategy
 import { HubInstance } from "aave-v4/hub/instances/HubInstance.sol";
 import { IAssetInterestRateStrategy } from "aave-v4/hub/interfaces/IAssetInterestRateStrategy.sol";
 import { IHub } from "aave-v4/hub/interfaces/IHub.sol";
-import { Roles } from "aave-v4/libraries/types/Roles.sol";
 import { AaveOracle } from "aave-v4/spoke/AaveOracle.sol";
 import { SpokeInstance } from "aave-v4/spoke/instances/SpokeInstance.sol";
 import { TreasurySpokeInstance } from "aave-v4/spoke/instances/TreasurySpokeInstance.sol";
@@ -48,6 +47,11 @@ abstract contract AaveV4Fixture is Test {
 
     /// @notice Fixed link address for LiquidationLogic (see foundry.toml `[profile.lend]` libraries)
     address internal constant LIQUIDATION_LOGIC = 0x0000000000000000000000000000000000000a01;
+
+    // v0.5.11 role ids, matching the live dev instance; the launch-branch Roles library renumbered
+    // them (hub 100s, spoke 300s) so they are pinned here rather than imported
+    uint64 internal constant HUB_ADMIN_ROLE = 1;
+    uint64 internal constant SPOKE_ADMIN_ROLE = 2;
 
     /// @notice Deploys and wires a full Aave v4 instance (access manager, hub, spoke, oracle, treasury)
     function _deployAaveV4() internal {
@@ -85,8 +89,8 @@ abstract contract AaveV4Fixture is Test {
     function _grantAaveRoles() private {
         vm.startPrank(aaveAdmin);
 
-        accessManager.grantRole(Roles.HUB_ADMIN_ROLE, aaveAdmin, 0);
-        accessManager.grantRole(Roles.SPOKE_ADMIN_ROLE, aaveAdmin, 0);
+        accessManager.grantRole(HUB_ADMIN_ROLE, aaveAdmin, 0);
+        accessManager.grantRole(SPOKE_ADMIN_ROLE, aaveAdmin, 0);
 
         bytes4[] memory spokeSelectors = new bytes4[](5);
         spokeSelectors[0] = ISpoke.addReserve.selector;
@@ -94,14 +98,14 @@ abstract contract AaveV4Fixture is Test {
         spokeSelectors[2] = ISpoke.updateLiquidationConfig.selector;
         spokeSelectors[3] = ISpoke.updateDynamicReserveConfig.selector;
         spokeSelectors[4] = ISpoke.updateReserveConfig.selector;
-        accessManager.setTargetFunctionRole(address(spoke), spokeSelectors, Roles.SPOKE_ADMIN_ROLE);
+        accessManager.setTargetFunctionRole(address(spoke), spokeSelectors, SPOKE_ADMIN_ROLE);
 
         bytes4[] memory hubSelectors = new bytes4[](4);
         hubSelectors[0] = IHub.addAsset.selector;
         hubSelectors[1] = IHub.updateAssetConfig.selector;
         hubSelectors[2] = IHub.addSpoke.selector;
         hubSelectors[3] = IHub.updateSpokeConfig.selector;
-        accessManager.setTargetFunctionRole(address(hub), hubSelectors, Roles.HUB_ADMIN_ROLE);
+        accessManager.setTargetFunctionRole(address(hub), hubSelectors, HUB_ADMIN_ROLE);
 
         // A permissive liquidation config, so borrows/withdrawals are governed by collateral factors alone
         spoke.updateLiquidationConfig(ISpoke.LiquidationConfig({ targetHealthFactor: 1.05e18, healthFactorForMaxBonus: 0.7e18, liquidationBonusFactor: 2000 }));


### PR DESCRIPTION
Brings the dev Aave v4 test instance in line with the live prod whitelabel instance (etherfi-protocol/aave-v4, `deployments/optimism/10.json`), so dev testing rehearses what internal users will hit on prod.

What it does:

- Points the `lib/aave-v4` submodule at the etherfi-protocol fork, pinned to the launch-branch commit prod was deployed from.
- Adds `EtherFiSpokeInstanceDev` (the prod borrow-gated spoke with the dev EtherFiDataProvider constant) and `UpgradeDevSpokeToEtherFi` to upgrade the dev spoke proxy in place. Storage-safe: the only core change since v0.5.11 is `borrow` going external to public virtual.
- Adds `SyncDevMarketConfigWithProd`: sets all 19 shared reserves to the live prod values (CFs, liquidation bonus/fee, WETH borrowable, liquidity fees, IR curves, caps, liquidation config). Values read on-chain at block 154956068 and cross-checked against LAUNCH_SPEC (exact match). iwSPYx and the legacy liquidRESERVE OFT stay dev-only.
- Adds `SetMinHealthFactorDev`: gateway floor 1.05 to 1.20 (the intended prod value). The dev DebtManager already matches prod on every collateral, so no change there.
- Adds `VerifyDevAaveParity`: read-only live-vs-live parity check, including a borrow-gate probe.
- Repairs fallout: explicit `aave-v4/=lib/aave-v4/src/` remapping (the fork's new top-level `scripts/` dir flipped forge's auto-remap), `AaveV4DevRoles` pinning the dev instance's v0.5.11 role ids (the launch branch renumbered the Roles library), and `AaveV4TestActions` fixed (broken manifest read) and trimmed to the public supply/withdraw flow since EOA borrows die on the gated spoke.

Decisions made under uncertainty, for a second pair of eyes:

- The `aave-deploy` profile now links the canonical Aave-deployed LiquidationLogic (`0x88dF5354...`, the library prod links) instead of re-pinning our self-deployed CREATE2 copy, whose address drifted with the submodule bump. The pre-upgrade dev spoke impl still links the old copy at `0x49dEE7...`.
- The new dev spoke impl bakes `MAX_USER_RESERVES_LIMIT = 64` to match prod (dev was uint16.max; dev only has 21 reserves, so no position can exceed it).
- Gateway minHF 1.20 was set per the owner; there is no prod gateway to read it from yet.

Not in this PR: the on-chain broadcasts (need the dev Aave admin `0x7D829d50...`; runbook section has the order) and the post-broadcast `aave-v4-test.json` update.

How it was tested: lend fork suite on the new pin, 318 passed; the 2 failures are OpenOcean FFI quote fetches missing `OPENOCEAN_API_KEY` locally, unrelated. `forge fmt --check` and `forge lint` clean on the changed files. Upgrade script simulation exercises the ProxyAdmin-owner guard correctly (rejected the non-admin local key).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/etherfi-protocol/codesmith/cash-v3/pr/249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788186879&installation_model_id=18424&pr_number=249&repository=etherfi-protocol%2Fcash-v3&return_to=https%3A%2F%2Fgithub.com%2Fetherfi-protocol%2Fcash-v3%2Fpull%2F249&signature=0f4d698731afd99952fdaba29ba9181f01e72751e512ca680436b1b5ed1d3a05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches dev-only OP scripts and spoke upgrade path (borrow gating, market params, library linking); no prod contract deploys in-repo, but mis-run broadcasts or stale parity constants could misalign dev from prod.
> 
> **Overview**
> Aligns the **Optimism dev Aave v4 test instance** with the **live prod whitelabel** deployment so lend dev flows rehearse prod behavior.
> 
> **Submodule & build:** `lib/aave-v4` now tracks **etherfi-protocol/aave-v4**; **`aave-v4/=lib/aave-v4/src/`** fixes forge remapping after the fork layout change. **`[profile.aave-deploy]`** links **canonical OP LiquidationLogic** (`0x88dF…`) instead of self-deployed CREATE2; deploy scripts only **require** that library to exist.
> 
> **Dev spoke & market parity:** Adds **`EtherFiSpokeInstanceDev`** (prod-style **`borrow`** gate via dev **`EtherFiDataProvider`**), **`UpgradeDevSpokeToEtherFi`**, **`SyncDevMarketConfigWithProd`** (19 shared reserves + liquidation config from prod), and read-only **`VerifyDevAaveParity`**. **`AaveV4DevRoles`** pins v0.5.11 **AccessManager** role ids because the fork renumbered **`Roles`**.
> 
> **Script/test fallout:** **`AaveV4TestActions`** is supply/withdraw only (EOA borrow fails after upgrade); reserve ids come from chain config. **`SetMinHealthFactorDev`** sets dev **`LendGateway`** min HF to **1.10**. **`AaveV4Fixture`** uses pinned role constants instead of **`Roles`** import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4014cf7080e705161f52160bafd21323c72e2f53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
