### PR TITLE
feat: re-key iwSPYx lend wiring to canonical wrapper, add iPAXG feed + collateral

### DIFF
--- a/deployments/dev/10/aave-v4-test.json
+++ b/deployments/dev/10/aave-v4-test.json
@@ -4,13 +4,29 @@
   "aaveV4LensImpl": "0x30695edd8e35c2ea0e281b7253d029865d5ae804",
   "accessManager": "0x3E05aBDe0588d56ea9B44579Aa93299971FFF3fe",
   "admin": "0x7D829d50aAF400B8B29B3b311F4aD70aD819DC6E",
-  "hub": "0x03641abDa8BF0d9196CE44EbEd9f85ccCe3c5e1f",
-  "irStrategy": "0xA5B8515C52149E3f8EC9bFD99144E3C9BC00E0f3",
-  "liquidationLogic": "0x88dF535473C5adf1f57789734A05E555F7Deb8DB",
-  "spoke": "0x7e99c7846df8527FFE510a2CA0215874052102ed",
-  "spokeImpl": "0xd5a5efaA08f2DF808f2EA2dBFA82cfC0B0AfaF75",
-  "spokeImplType": "EtherFiSpokeInstanceDev",
-  "treasurySpoke": "0xf316938C33E81b4f02e1B7141399b872671f13Ad",
+  "assetIds": {
+    "ETHFI": 2,
+    "EURC": 5,
+    "OP": 17,
+    "USDC": 1,
+    "USDT": 15,
+    "WETH": 16,
+    "WHYPE": 3,
+    "beHYPE": 4,
+    "eBTC": 10,
+    "eUSD": 11,
+    "frxUSD": 18,
+    "iPAXG": 22,
+    "iwSPYx": 21,
+    "liquidBTC": 8,
+    "liquidETH": 7,
+    "liquidRESERVE": 19,
+    "liquidRWA": 14,
+    "liquidUSD": 9,
+    "sETHFI": 6,
+    "weETH": 0,
+    "weEUR": 13
+  },
   "details": {
     "weETH": {
       "assetId": 0,
@@ -89,9 +105,42 @@
       "oracle": "0x439755986dB80135F7Aa4d300c113Faa88aDe304"
     },
     "iwSPYx": {
-      "oracle": "0xDDC9D65D80F6BF51682F50A5647584465D724094",
-      "spyUsdLeg": "0x3184C90dAFbC13Eff2D402B84d341B2f71720140",
+      "oracle": "0xF81b2D32401fcd8E2d9649F15f809c72a5D574f5",
+      "spyUsdLeg": "0xcA5bB551C8919B500C576d93042aA385E8F8a08A",
       "assetId": 20
+    },
+    "iPAXG": {
+      "oracle": "0x5c7E37b3Ddd7A098A641A9b879Ef3a84f2d52Cd0"
     }
-  }
+  },
+  "hub": "0x03641abDa8BF0d9196CE44EbEd9f85ccCe3c5e1f",
+  "irStrategy": "0xA5B8515C52149E3f8EC9bFD99144E3C9BC00E0f3",
+  "liquidationLogic": "0x88dF535473C5adf1f57789734A05E555F7Deb8DB",
+  "reserveIds": {
+    "ETHFI": 2,
+    "EURC": 5,
+    "OP": 17,
+    "USDC": 1,
+    "USDT": 15,
+    "WETH": 16,
+    "WHYPE": 3,
+    "beHYPE": 4,
+    "eBTC": 10,
+    "eUSD": 11,
+    "frxUSD": 18,
+    "iPAXG": 22,
+    "iwSPYx": 21,
+    "liquidBTC": 8,
+    "liquidETH": 7,
+    "liquidRESERVE": 19,
+    "liquidRWA": 14,
+    "liquidUSD": 9,
+    "sETHFI": 6,
+    "weETH": 0,
+    "weEUR": 13
+  },
+  "spoke": "0x7e99c7846df8527FFE510a2CA0215874052102ed",
+  "spokeImpl": "0xd5a5efaA08f2DF808f2EA2dBFA82cfC0B0AfaF75",
+  "spokeImplType": "EtherFiSpokeInstanceDev",
+  "treasurySpoke": "0xf316938C33E81b4f02e1B7141399b872671f13Ad"
 }

--- a/scripts/DeployPaxgOracleSinkFeed.s.sol
+++ b/scripts/DeployPaxgOracleSinkFeed.s.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { console } from "forge-std/console.sol";
+
+import { IAaveV4PriceFeed } from "../src/interfaces/IAaveV4PriceFeed.sol";
+import { IOracleSink } from "../src/interfaces/IOracleSink.sol";
+import { OracleSinkPriceFeed } from "../src/oracle/OracleSinkPriceFeed.sol";
+import { Utils } from "./utils/Utils.sol";
+
+/**
+ * @title DeployPaxgOracleSinkFeed
+ * @notice Deploys the iPAXG/USD price feed for the Aave v4 TEST instance on Optimism:
+ *           1. iPAXG/USD: an OracleSinkPriceFeed over the dev OracleSink, keyed by the MAINNET
+ *              PAXG address (the relay ships mainnet token addresses), whose relayed value is
+ *              already the full PAXG/USD price (6 decimals) — unlike iwSPYx, no local underlying
+ *              leg is composed on top.
+ *
+ *         Deploy-only: listing iPAXG (the OP ShadowOFT) as a reserve pointing at this feed is a
+ *         separate step with its own collateral-factor decisions.
+ *
+ * Usage (simulate by dropping --broadcast):
+ *   source .env && ENV=dev forge script \
+ *     scripts/DeployPaxgOracleSinkFeed.s.sol:DeployPaxgOracleSinkFeed \
+ *     --rpc-url $OPTIMISM_RPC --broadcast --verify --etherscan-api-key $ETHERSCAN_KEY -vvvv
+ */
+contract DeployPaxgOracleSinkFeed is Utils {
+    /// @dev Dev OracleSink on Optimism (cash-mainnet-asset-listing deployments/dev/10)
+    address constant ORACLE_SINK = 0x83Ba7f354B705C34935437526Cf318c77d9093Aa;
+    /// @dev Mainnet PAXG — the OracleSink price key (the relay ships mainnet token addresses)
+    address constant PAXG_MAINNET = 0x45804880De22913dAFE09f4980848ECE6EcbAf78;
+
+    uint8 constant FEED_DECIMALS = 8;
+    /// @dev Max age of the relay's source-chain read. Driven by the keeper's poke cadence, matches
+    ///      the sink's own PAXG window of 2 days (24h Chainlink heartbeat x margin; tighter than
+    ///      wSPYx's 7d because the relayed value is a live price, not a slow-moving rate)
+    uint256 constant SINK_RATE_MAX_STALENESS = 2 days;
+
+    function run() public {
+        require(block.chainid == 10, "Must run on Optimism (10)");
+        require(isEqualString(getEnv(), "dev"), "dev-only: the OracleSink address is the dev deployment");
+
+        vm.startBroadcast(vm.envUint("PRIVATE_KEY"));
+
+        // No underlying leg: the relayed price is already the full PAXG/USD price
+        OracleSinkPriceFeed ipaxgUsd = new OracleSinkPriceFeed(IOracleSink(ORACLE_SINK), PAXG_MAINNET, IAaveV4PriceFeed(address(0)), FEED_DECIMALS, SINK_RATE_MAX_STALENESS, false, "iPAXG / USD");
+
+        vm.stopBroadcast();
+
+        _requireLivePrice(address(ipaxgUsd), "iPAXG / USD");
+
+        console.log("iPAXG / USD feed:", address(ipaxgUsd));
+    }
+
+    function _requireLivePrice(address feed, string memory desc) internal view {
+        int256 answer = IAaveV4PriceFeed(feed).latestAnswer();
+        require(answer > 0, string.concat("dead feed: ", desc));
+        // 8-decimal USD, printed as dollars.cents for a quick eyeball check
+        uint256 cents = (uint256(answer) % 1e8) / 1e6;
+        console.log(string.concat("  ", desc, ": $", vm.toString(uint256(answer) / 1e8), cents < 10 ? ".0" : ".", vm.toString(cents)));
+    }
+}

--- a/scripts/DeployWspyxOracleSinkFeed.s.sol
+++ b/scripts/DeployWspyxOracleSinkFeed.s.sol
@@ -33,8 +33,8 @@ import { Utils } from "./utils/Utils.sol";
 contract DeployWspyxOracleSinkFeed is Utils {
     /// @dev Dev OracleSink on Optimism (cash-mainnet-asset-listing deployments/dev/10)
     address constant ORACLE_SINK = 0x83Ba7f354B705C34935437526Cf318c77d9093Aa;
-    /// @dev Mainnet wSPYx — the OracleSink price key (the relay ships mainnet token addresses)
-    address constant WSPYX_MAINNET = 0xc88FcD8B874fDb3256E8B55b3decB8c24EAb4c02;
+    /// @dev Mainnet wSPYx (canonical wrapper) — the OracleSink price key (the relay ships mainnet token addresses)
+    address constant WSPYX_MAINNET = 0xE7E553Cd128F0011777323A0b44a7b96EA1CB540;
     /// @dev Chainlink SPY/USD (24/5) aggregator on Optimism, 8 decimals
     address constant SPY_USD_FEED = 0x5F77134CfAA7DB2906649Ca21C50dA54daE9291d;
 

--- a/scripts/aave-v4/RefreshSummerLendOracles.s.sol
+++ b/scripts/aave-v4/RefreshSummerLendOracles.s.sol
@@ -35,15 +35,21 @@ import { AddSummerLendCollateral } from "./AddSummerLendCollateral.s.sol";
 contract RefreshSummerLendOracles is AddSummerLendCollateral {
     /// @dev Dev OracleSink on Optimism (cash-mainnet-asset-listing deployments/dev/10)
     address constant ORACLE_SINK = 0x83Ba7f354B705C34935437526Cf318c77d9093Aa;
-    /// @dev Mainnet wSPYx, the OracleSink price key (the relay ships mainnet token addresses)
-    address constant WSPYX_MAINNET = 0xc88FcD8B874fDb3256E8B55b3decB8c24EAb4c02;
+    /// @dev Mainnet wSPYx (canonical wrapper), the OracleSink price key (the relay ships mainnet token addresses)
+    address constant WSPYX_MAINNET = 0xE7E553Cd128F0011777323A0b44a7b96EA1CB540;
     /// @dev iwSPYx ShadowOFT on Optimism (cash-mainnet-asset-listing deployments/dev/10)
-    address constant IWSPYX = 0xc83305D859EAc5E34B6aa00b4a45bDC13b2F3869;
+    address constant IWSPYX = 0xCb4Ee509849AC1101b16556c658d6c48e5862fFA;
     /// @dev Chainlink SPY/USD (24/5) aggregator on Optimism; staleness spans the weekend close gap
     address constant SPY_USD_FEED = 0x5F77134CfAA7DB2906649Ca21C50dA54daE9291d;
     uint256 constant SPY_USD_MAX_STALENESS = 78 hours;
     /// @dev Max age of the relay's source-chain read; matches the sink's own dev window
     uint256 constant SINK_RATE_MAX_STALENESS = 7 days;
+    /// @dev Mainnet PAXG, the OracleSink price key (the relay ships mainnet token addresses)
+    address constant PAXG_MAINNET = 0x45804880De22913dAFE09f4980848ECE6EcbAf78;
+    /// @dev iPAXG ShadowOFT on Optimism (cash-mainnet-asset-listing deployments/dev/10)
+    address constant IPAXG = 0x56904d70E597e1D2D40853c61B6aA95622c70B0e;
+    /// @dev PAXG sink window: 24h Chainlink heartbeat x margin (a live price, not a slow rate)
+    uint256 constant PAXG_SINK_MAX_STALENESS = 2 days;
 
     function run() public override {
         require(block.chainid == 10, "Must run on Optimism (10)");
@@ -97,6 +103,12 @@ contract RefreshSummerLendOracles is AddSummerLendCollateral {
             _requireLivePrice(address(iwspyxUsd), "iwSPYx / USD");
             _update(IWSPYX, address(iwspyxUsd));
             vm.writeJson(vm.toString(spyUsd), jsonPath, ".details.iwSPYx.spyUsdLeg");
+
+            // iPAXG: relayed full PAXG/USD price from the OracleSink, no composition leg (see
+            // DeployPaxgOracleSinkFeed).
+            OracleSinkPriceFeed ipaxgUsd = new OracleSinkPriceFeed(IOracleSink(ORACLE_SINK), PAXG_MAINNET, IAaveV4PriceFeed(address(0)), FEED_DECIMALS, PAXG_SINK_MAX_STALENESS, false, "iPAXG / USD");
+            _requireLivePrice(address(ipaxgUsd), "iPAXG / USD");
+            _update(IPAXG, address(ipaxgUsd));
         }
 
         // Deploy-time reserves (their ids come from the deployment json, not a token scan)

--- a/scripts/aave-v4/SupportPaxgCollateral.s.sol
+++ b/scripts/aave-v4/SupportPaxgCollateral.s.sol
@@ -10,33 +10,31 @@ import { OracleSinkPriceFeed } from "../../src/oracle/OracleSinkPriceFeed.sol";
 import { AddSummerLendCollateral } from "./AddSummerLendCollateral.s.sol";
 
 /**
- * @title SupportWspyxCollateral
- * @notice Supports iwSPYx (the OP ShadowOFT of mainnet wSPYx) as collateral on both lend backends,
- *         priced by the OracleSinkPriceFeed deployed by DeployWspyxOracleSinkFeed (relayed
- *         wSPYx -> SPYx rate x local SPY/USD 24/5 Chainlink leg):
+ * @title SupportPaxgCollateral
+ * @notice Supports iPAXG (the OP ShadowOFT of mainnet PAXG) as collateral on both lend backends,
+ *         priced by the OracleSinkPriceFeed deployed by DeployPaxgOracleSinkFeed (relayed full
+ *         PAXG/USD price, no composition leg):
  *           1. Aave v4 TEST instance: collateral-only reserve, collateralFactor 73%,
  *              maxLiquidationBonus 7.5% (10_750 bps of collateral per unit of debt repaid);
  *           2. LendGateway: registers the new reserveId so gateway accounting sees the asset;
  *           3. DebtManager: 73% LTV / 78% liquidation threshold / 7.5% liquidation bonus
- *              (100e18 scale). The cash PriceProvider must already price iwSPYx
- *              (ConfigureWspyxOracleOptimism in cash-mainnet-asset-listing did on dev).
+ *              (100e18 scale). The cash PriceProvider must already price iPAXG.
  *
  *         Idempotent via the parent's _list (an already-listed reserve just gets its price source
- *         refreshed); the DebtManager leg falls back to setCollateralTokenConfig when iwSPYx is
+ *         refreshed); the DebtManager leg falls back to setCollateralTokenConfig when iPAXG is
  *         already a collateral token.
  *
  * Usage (simulate by dropping --broadcast; the broadcast wallet must hold the instance admin,
  * LEND_GATEWAY_ADMIN_ROLE and DEBT_MANAGER_ADMIN_ROLE roles):
  *   source .env && ENV=dev FOUNDRY_PROFILE=aave-deploy forge script \
- *     scripts/aave-v4/SupportWspyxCollateral.s.sol:SupportWspyxCollateral \
+ *     scripts/aave-v4/SupportPaxgCollateral.s.sol:SupportPaxgCollateral \
  *     --rpc-url $OPTIMISM_RPC --broadcast -vvvv
  */
-contract SupportWspyxCollateral is AddSummerLendCollateral {
-    /// @dev iwSPYx ShadowOFT on Optimism (cash-mainnet-asset-listing deployments/dev/10)
-    address constant IWSPYX = 0xCb4Ee509849AC1101b16556c658d6c48e5862fFA;
-    /// @dev Mainnet wSPYx (canonical wrapper) — the sink key the feed must be built on; guards
-    ///      against listing the new iwSPYx on a feed still keyed to the abandoned 0xc88F wrapper
-    address constant WSPYX_MAINNET = 0xE7E553Cd128F0011777323A0b44a7b96EA1CB540;
+contract SupportPaxgCollateral is AddSummerLendCollateral {
+    /// @dev iPAXG ShadowOFT on Optimism (cash-mainnet-asset-listing deployments/dev/10)
+    address constant IPAXG = 0x56904d70E597e1D2D40853c61B6aA95622c70B0e;
+    /// @dev Mainnet PAXG — the sink key the feed must be built on
+    address constant PAXG_MAINNET = 0x45804880De22913dAFE09f4980848ECE6EcbAf78;
 
     uint16 constant COLLATERAL_FACTOR_BPS = 73_00;
     uint32 constant MAX_LIQUIDATION_BONUS_BPS = 10_750; // collateral paid out per unit of debt: 100% + 7.5%
@@ -58,33 +56,33 @@ contract SupportWspyxCollateral is AddSummerLendCollateral {
         string memory cashLendJson = vm.readFile(string.concat(vm.projectRoot(), "/deployments/", getEnv(), "/", vm.toString(block.chainid), "/cash-lend.json"));
         LendGateway gateway = LendGateway(stdJson.readAddress(cashLendJson, ".lendGateway"));
 
-        // The current "iwSPYx / USD" OracleSinkPriceFeed, kept fresh by RefreshSummerLendOracles
-        address iwspyxUsdFeed = stdJson.readAddress(vm.readFile(jsonPath), ".details.iwSPYx.oracle");
-        // Fail closed if the json still points at a feed keyed to the abandoned 0xc88F wrapper
-        require(OracleSinkPriceFeed(iwspyxUsdFeed).token() == WSPYX_MAINNET, "feed keyed to wrong wrapper; deploy DeployWspyxOracleSinkFeed and update .details.iwSPYx.oracle");
-        _requireLivePrice(iwspyxUsdFeed, "iwSPYx / USD");
+        // The current "iPAXG / USD" OracleSinkPriceFeed, kept fresh by RefreshSummerLendOracles
+        address ipaxgUsdFeed = stdJson.readAddress(vm.readFile(jsonPath), ".details.iPAXG.oracle");
+        // Fail closed if the json points at a feed keyed to the wrong token
+        require(OracleSinkPriceFeed(ipaxgUsdFeed).token() == PAXG_MAINNET, "feed keyed to wrong token; deploy DeployPaxgOracleSinkFeed and set .details.iPAXG.oracle");
+        _requireLivePrice(ipaxgUsdFeed, "iPAXG / USD");
 
         vm.startBroadcast(vm.envUint("PRIVATE_KEY"));
 
         // 1. Aave v4: collateral-only reserve on the OracleSink feed
-        _list(IWSPYX, iwspyxUsdFeed, COLLATERAL_FACTOR_BPS, MAX_LIQUIDATION_BONUS_BPS);
-        uint256 reserveId = _reserveIdOf(IWSPYX);
+        _list(IPAXG, ipaxgUsdFeed, COLLATERAL_FACTOR_BPS, MAX_LIQUIDATION_BONUS_BPS);
+        uint256 reserveId = _reserveIdOf(IPAXG);
 
         // 2. LendGateway: mirror the reserve into the gateway registry (no-op when unchanged)
-        gateway.setReserveId(IWSPYX, reserveId);
+        gateway.setReserveId(IPAXG, reserveId);
 
         // 3. DebtManager: 73% LTV / 78% LT / 7.5% LB on the 100e18 scale
         IDebtManager.CollateralTokenConfig memory config = IDebtManager.CollateralTokenConfig({ ltv: DM_LTV, liquidationThreshold: DM_LIQUIDATION_THRESHOLD, liquidationBonus: DM_LIQUIDATION_BONUS });
-        if (debtManager.isCollateralToken(IWSPYX)) debtManager.setCollateralTokenConfig(IWSPYX, config);
-        else debtManager.supportCollateralToken(IWSPYX, config);
+        if (debtManager.isCollateralToken(IPAXG)) debtManager.setCollateralTokenConfig(IPAXG, config);
+        else debtManager.supportCollateralToken(IPAXG, config);
 
         vm.stopBroadcast();
 
         _recordReserveIds(vm.readFile(jsonPath));
 
-        console.log("iwSPYx reserveId:", reserveId);
+        console.log("iPAXG reserveId:", reserveId);
         console.log("gateway reserve registered:", address(gateway));
-        IDebtManager.CollateralTokenConfig memory recorded = debtManager.collateralTokenConfig(IWSPYX);
+        IDebtManager.CollateralTokenConfig memory recorded = debtManager.collateralTokenConfig(IPAXG);
         console.log("DebtManager ltv/lt/lb (1e18 %):", recorded.ltv / 1e18, recorded.liquidationThreshold / 1e18);
         console.log("  liquidation bonus (1e16 %):", recorded.liquidationBonus / 1e16);
     }


### PR DESCRIPTION
- Re-keys the dev iwSPYx lend chain to the canonical-wrapper listing: sink key `0xc88F...` -> `0xE7E553...B540`, iwSPYx `0xc833...3869` -> `0xCb4Ee5...2fFA` (fresh ShadowOFT from the re-listing; params untouched at 73/78/7.5).
- Adds `DeployPaxgOracleSinkFeed` (direct full-USD sink feed, no composition leg, 2-day staleness matching PAXG's sink window) and `SupportPaxgCollateral` (iPAXG `0x56904d...0B0e`, same dual aave-v4 + LendGateway + DebtManager shape as wSPYx).
- Adds an iPAXG leg to `RefreshSummerLendOracles`'s dev block so future rotations cover it.
- Both `Support*Collateral` scripts now fail closed if `.details.<symbol>.oracle` in aave-v4-test.json points at a feed keyed to the wrong token (guards against listing the new iwSPYx on the abandoned-wrapper feed).

Note for the dev run: the old iwSPYx reserve (assetId 20, token `0xc833...`) stays orphaned on the TEST instance — pause it manually if it matters.

Linear: COR-1203, COR-1204 (under COR-1194).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/etherfi-protocol/codesmith/cash-v3/pr/254"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788382257&installation_model_id=18424&pr_number=254&repository=etherfi-protocol%2Fcash-v3&return_to=https%3A%2F%2Fgithub.com%2Fetherfi-protocol%2Fcash-v3%2Fpull%2F254&signature=6dab33525834599af6e29679a34475afd56d6f7c8ec7ac6d253c261b6b89e64d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes collateral listing, oracle keys, and LTV/liquidation parameters on dev lend infrastructure; wrong addresses or stale JSON could mis-price or block listing until feeds are redeployed.
> 
> **Overview**
> **Re-keys dev iwSPYx** lend wiring to the canonical mainnet wSPYx wrapper (`0xE7E553…`) and the re-listed Optimism ShadowOFT (`0xCb4Ee5…`), with matching updates in `DeployWspyxOracleSinkFeed`, `RefreshSummerLendOracles`, and `aave-v4-test.json` (iwSPYx oracle / `spyUsdLeg` addresses).
> 
> **Adds iPAXG** support: `DeployPaxgOracleSinkFeed` deploys a direct OracleSink **PAXG/USD** feed (no SPY-style composition leg, **2-day** sink staleness), `SupportPaxgCollateral` lists iPAXG on Aave v4 TEST, `LendGateway`, and `DebtManager` at **73% / 78% / 7.5%** (same shape as iwSPYx), and `RefreshSummerLendOracles` refreshes iPAXG in the dev block. The deployment JSON gains **`assetIds` / `reserveIds`** maps and **`details.iPAXG`**.
> 
> **Safety:** `SupportWspyxCollateral` and `SupportPaxgCollateral` now **`require`** the oracle in JSON is an `OracleSinkPriceFeed` keyed to the expected mainnet token before listing—blocking collateral on feeds tied to the abandoned wSPYx wrapper or a mismatched PAXG key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 914fd8c9c301b8b80a68f286532eaf535ca9358c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->