### PR TITLE
feat: dev Stargate withdraw config + topup rail for iwSPYx and iPAXG

### DIFF
--- a/scripts/AddCollateralOftsTopUpEthereum.s.sol
+++ b/scripts/AddCollateralOftsTopUpEthereum.s.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { stdJson } from "forge-std/StdJson.sol";
+import { console } from "forge-std/console.sol";
+
+import { TopUpFactory } from "../src/top-up/TopUpFactory.sol";
+import { Utils } from "./utils/Utils.sol";
+
+/**
+ * @title AddCollateralOftsTopUpEthereum
+ * @author ether.fi
+ * @notice Registers wSPYx and PAXG for top-up bridging from Ethereum to Optimism (the Cash chain)
+ *         via etherfi's OFT adapters, so the top-up relayer can bridge a user's mainnet deposit
+ *         into the wrapped asset on Optimism. Mirrors the weETH/LINK `oftBridgeAdapter` top-up config.
+ * @dev `TopUpFactory.setTokenConfig` routes a deposited token through a bridge adapter to a recipient
+ *      on the destination chain. For these tokens the adapter is the EtherFiOFTBridgeAdapter, whose
+ *      `additionalData` is `abi.encode(address oftAdapter, uint32 destEid)`. `setTokenConfig` is
+ *      `onlyRoleRegistryOwner`, so the broadcaster must be the dev RoleRegistry owner. Idempotent.
+ *      Run on Ethereum mainnet:
+ *
+ *        ENV=dev forge script scripts/AddCollateralOftsTopUpEthereum.s.sol \
+ *          --rpc-url $MAINNET_RPC --account dev-owner --sender <dev-owner-address> --broadcast
+ */
+contract AddCollateralOftsTopUpEthereum is Utils {
+    /// @notice Canonical wSPYx on Ethereum mainnet (the deposited token users top up with).
+    address constant WSPYX_MAINNET = 0xE7E553Cd128F0011777323A0b44a7b96EA1CB540;
+
+    /// @notice etherfi wSPYx OFT adapter on Ethereum dev (lock-on-deposit). Locks wSPYx and sends the
+    ///         LayerZero message that mints the wrapped asset on Optimism.
+    address constant WSPYX_OFT_ADAPTER = 0x24f64E0a6C366B32e973C23d4DEdB4527E0C422A;
+
+    /// @notice PAXG on Ethereum mainnet (the deposited token users top up with).
+    address constant PAXG_MAINNET = 0x45804880De22913dAFE09f4980848ECE6EcbAf78;
+
+    /// @notice etherfi PAXG OFT adapter on Ethereum dev (lock-on-deposit). Locks PAXG and sends the
+    ///         LayerZero message that mints the wrapped asset on Optimism.
+    address constant PAXG_OFT_ADAPTER = 0x770d31FF00F6795D42349040D5BD74AAebE60FF4;
+
+    /// @notice TopUpDest on Optimism dev (receives bridged tokens and credits user safes).
+    address constant TOP_UP_DEST_OPTIMISM = 0x06fe42Cf3C63412f1955758ce2798709476a38fd;
+
+    /// @notice Cash chain (Optimism) destination.
+    uint256 constant OPTIMISM_CHAIN_ID = 10;
+    uint32 constant OPTIMISM_EID = 30_111;
+
+    // DECISION (top-up slippage): max slippage the OFT bridge will tolerate, in bps. Matches the
+    // weETH/LINK oftBridgeAdapter config. TopUpFactory caps this at 200 bps.
+    uint96 constant MAX_SLIPPAGE_BPS = 50; // 0.5%
+
+    function run() public {
+        require(block.chainid == 1, "run on Ethereum (chainId 1)");
+        // The hardcoded constants are dev OFT/TopUpDest addresses, and the env-read TopUpFactory
+        // below must resolve to the dev deployment. getEnv() defaults to "mainnet", and chainId
+        // alone cannot tell dev from prod (both live on chain 1), so fail loudly unless ENV=dev.
+        require(isEqualString(getEnv(), "dev"), "dev only");
+
+        string memory deployments = readTopUpSourceDeployment();
+        TopUpFactory topUpFactory = TopUpFactory(payable(stdJson.readAddress(deployments, ".addresses.TopUpSourceFactory")));
+        address oftBridgeAdapter = stdJson.readAddress(deployments, ".addresses.EtherFiOFTBridgeAdapter");
+
+        address[] memory tokens = new address[](2);
+        tokens[0] = WSPYX_MAINNET;
+        tokens[1] = PAXG_MAINNET;
+        uint256[] memory chainIds = new uint256[](2);
+        chainIds[0] = OPTIMISM_CHAIN_ID;
+        chainIds[1] = OPTIMISM_CHAIN_ID;
+        TopUpFactory.TokenConfig[] memory configs = new TopUpFactory.TokenConfig[](2);
+        configs[0] = TopUpFactory.TokenConfig({ bridgeAdapter: oftBridgeAdapter, recipientOnDestChain: TOP_UP_DEST_OPTIMISM, maxSlippageInBps: MAX_SLIPPAGE_BPS, additionalData: abi.encode(WSPYX_OFT_ADAPTER, OPTIMISM_EID) });
+        configs[1] = TopUpFactory.TokenConfig({ bridgeAdapter: oftBridgeAdapter, recipientOnDestChain: TOP_UP_DEST_OPTIMISM, maxSlippageInBps: MAX_SLIPPAGE_BPS, additionalData: abi.encode(PAXG_OFT_ADAPTER, OPTIMISM_EID) });
+
+        // Signer comes from the CLI (--account keystore, --ledger, etc.), never an env var or arg.
+        vm.startBroadcast();
+        topUpFactory.setTokenConfig(tokens, chainIds, configs);
+        vm.stopBroadcast();
+
+        console.log("Registered wSPYx + PAXG top-up (Ethereum -> Optimism) on TopUpFactory");
+        console.log("  TopUpFactory:            ", address(topUpFactory));
+        console.log("  wSPYx (mainnet):         ", WSPYX_MAINNET);
+        console.log("  wSPYx OFT adapter:       ", WSPYX_OFT_ADAPTER);
+        console.log("  PAXG (mainnet):          ", PAXG_MAINNET);
+        console.log("  PAXG OFT adapter:        ", PAXG_OFT_ADAPTER);
+        console.log("  recipient (OP TopUpDest):", TOP_UP_DEST_OPTIMISM);
+        console.log("  dest chainId / EID:      ", OPTIMISM_CHAIN_ID, OPTIMISM_EID);
+    }
+}

--- a/scripts/ConfigureCollateralOftsDevStargate.s.sol
+++ b/scripts/ConfigureCollateralOftsDevStargate.s.sol
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { stdJson } from "forge-std/StdJson.sol";
+import { console } from "forge-std/console.sol";
+
+import { StargateModule } from "../src/modules/stargate/StargateModule.sol";
+import { ICashModule } from "../src/interfaces/ICashModule.sol";
+import { IRoleRegistry } from "../src/interfaces/IRoleRegistry.sol";
+import { Utils } from "./utils/Utils.sol";
+
+/// @title ConfigureCollateralOftsDevStargate
+/// @notice Wires the dev iwSPYx and iPAXG ShadowOFTs for cross-chain withdrawal from Optimism
+///         via a direct EOA broadcast: registers both as OFT assets on StargateModule and
+///         whitelists them as withdrawable on CashModule.
+///
+/// Usage:
+///   source .env && ENV=dev forge script scripts/ConfigureCollateralOftsDevStargate.s.sol \
+///     --rpc-url $OPTIMISM_RPC --broadcast --account deployer
+contract ConfigureCollateralOftsDevStargate is Utils {
+    // Dev iTOKEN ShadowOFTs on Optimism
+    address constant IWSPYX = 0xCb4Ee509849AC1101b16556c658d6c48e5862fFA;
+    address constant IPAXG = 0x56904d70E597e1D2D40853c61B6aA95622c70B0e;
+
+    StargateModule stargateModule;
+    ICashModule cashModule;
+    IRoleRegistry roleRegistry;
+
+    function run() public {
+        require(block.chainid == 10, "Must run on Optimism (10)");
+        require(isEqualString(getEnv(), "dev"), "ENV must be dev");
+
+        string memory deployments = readDeploymentFile();
+        stargateModule = StargateModule(payable(stdJson.readAddress(deployments, ".addresses.StargateModule")));
+        cashModule = ICashModule(stdJson.readAddress(deployments, ".addresses.CashModule"));
+        roleRegistry = IRoleRegistry(stdJson.readAddress(deployments, ".addresses.RoleRegistry"));
+
+        console.log("StargateModule:", address(stargateModule));
+        console.log("CashModule:", address(cashModule));
+        console.log("RoleRegistry:", address(roleRegistry));
+
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        address deployer = vm.addr(deployerPrivateKey);
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        _ensureRole(cashModule.CASH_MODULE_CONTROLLER_ROLE(), deployer);
+        _ensureRole(stargateModule.STARGATE_MODULE_ADMIN_ROLE(), deployer);
+
+        _configureStargateAssets();
+        _configureCashWithdrawable();
+
+        vm.stopBroadcast();
+    }
+
+    /// @dev Grants `role` to `account` if missing and the deployer owns the RoleRegistry.
+    function _ensureRole(bytes32 role, address account) internal {
+        if (roleRegistry.hasRole(role, account)) return;
+        require(roleRegistry.owner() == account, "deployer lacks role and does not own RoleRegistry");
+        roleRegistry.grantRole(role, account);
+    }
+
+    /// @dev Registers both iTOKENs as OFT assets on StargateModule (pool == the OFT itself).
+    ///      Skips entries that already match to keep re-runs cheap.
+    function _configureStargateAssets() internal {
+        address[] memory allAssets = new address[](2);
+        allAssets[0] = IWSPYX;
+        allAssets[1] = IPAXG;
+
+        uint256 count;
+        address[] memory pending = new address[](2);
+        for (uint256 i = 0; i < allAssets.length; i++) {
+            StargateModule.AssetConfig memory existing = stargateModule.getAssetConfig(allAssets[i]);
+            if (!(existing.isOFT && existing.pool == allAssets[i])) {
+                pending[count++] = allAssets[i];
+            }
+        }
+
+        if (count == 0) {
+            console.log("StargateModule asset config already up to date, skipping");
+            return;
+        }
+
+        address[] memory assets = new address[](count);
+        StargateModule.AssetConfig[] memory assetConfigs = new StargateModule.AssetConfig[](count);
+        for (uint256 i = 0; i < count; i++) {
+            assets[i] = pending[i];
+            assetConfigs[i] = StargateModule.AssetConfig({ isOFT: true, pool: pending[i] });
+        }
+
+        stargateModule.setAssetConfig(assets, assetConfigs);
+        console.log("StargateModule asset config set for", count, "asset(s)");
+    }
+
+    /// @dev Whitelists both iTOKENs as withdrawable on CashModule. The underlying whitelist
+    ///      is already idempotent (no-op if already whitelisted), so this is safe to re-run.
+    function _configureCashWithdrawable() internal {
+        address[] memory withdrawableAssets = new address[](2);
+        withdrawableAssets[0] = IWSPYX;
+        withdrawableAssets[1] = IPAXG;
+
+        bool[] memory shouldWhitelist = new bool[](2);
+        shouldWhitelist[0] = true;
+        shouldWhitelist[1] = true;
+
+        cashModule.configureWithdrawAssets(withdrawableAssets, shouldWhitelist);
+    }
+}


### PR DESCRIPTION
- `ConfigureCollateralOftsDevStargate` (OP, dev EOA): registers iwSPYx `0xCb4Ee5...2fFA` and iPAXG `0x56904d...0B0e` on StargateModule as OFT assets (`{isOFT: true, pool: <iTOKEN>}` — same shape as the wHYPE/beHYPE config) and whitelists both via `configureWithdrawAssets`. Idempotent; grants the two gate roles inline when the deployer owns the dev RoleRegistry.
- `AddCollateralOftsTopUpEthereum` (ETH, dev EOA): `TopUpFactory.setTokenConfig` for canonical wSPYx `0xE7E553...B540` and PAXG through `EtherFiOFTBridgeAdapter` to the OP TopUpDest, `additionalData = abi.encode(oftAdapter, 30111)`, 50bps slippage — clone of the unmerged LINK script from https://github.com/etherfi-protocol/cash-v3/commit/95b2584.

Both validated on anvil forks of ETH+OP: Stargate asset configs read back correctly (setAssetConfig's `IStargate(pool).token() == asset` check passes for ShadowOFTs), topup configs read back byte-exact.

Linear: COR-1203, COR-1204 (under COR-1194).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/etherfi-protocol/codesmith/cash-v3/pr/255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788382307&installation_model_id=18424&pr_number=255&repository=etherfi-protocol%2Fcash-v3&return_to=https%3A%2F%2Fgithub.com%2Fetherfi-protocol%2Fcash-v3%2Fpull%2F255&signature=21934758ed98a40c96c256a0a2a52f81538c6a35821915e8eac7e61ec108f8a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to new operational Forge scripts with dev-only guards; they do not modify production contract source.
> 
> **Overview**
> Adds **two dev-only Forge scripts** to wire **iwSPYx** and **iPAXG** collateral through Cash’s existing top-up and Stargate paths—no on-chain contract changes.
> 
> **`ConfigureCollateralOftsDevStargate`** (Optimism, `ENV=dev`): registers the dev ShadowOFTs on **`StargateModule`** as OFT assets (`isOFT: true`, pool = token) and whitelists them for withdrawal via **`CashModule.configureWithdrawAssets`**. It can grant **`CASH_MODULE_CONTROLLER_ROLE`** and **`STARGATE_MODULE_ADMIN_ROLE`** when the deployer owns **`RoleRegistry`**, and skips Stargate updates when config already matches.
> 
> **`AddCollateralOftsTopUpEthereum`** (Ethereum mainnet, `ENV=dev`): calls **`TopUpFactory.setTokenConfig`** for mainnet **wSPYx** and **PAXG** through **`EtherFiOFTBridgeAdapter`** to the Optimism **`TopUpDest`**, with OFT adapter + EID in **`additionalData`** and **50 bps** slippage (same pattern as weETH/LINK). Chain and env guards block accidental prod use.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ccd9cdd138f13717590ce8dfaaf507efc8fb5b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->