### PR TITLE
feat: reserve the prod TradingSafeFactory address across EVM chains

### DIFF
--- a/scripts/trading-account/ReserveTradingSafeFactoryAddress.s.sol
+++ b/scripts/trading-account/ReserveTradingSafeFactoryAddress.s.sol
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { Script } from "forge-std/Script.sol";
+import { console2 } from "forge-std/console2.sol";
+
+import { UUPSProxy } from "../../src/UUPSProxy.sol";
+import { RoleRegistry } from "../../src/role-registry/RoleRegistry.sol";
+import { EtherFiPlaceholder } from "../../src/utils/EtherFiPlaceholder.sol";
+import { TradingAccountCreate3, TradingAccountProdConfig as C } from "./TradingAccountProdConfig.sol";
+
+/// @title ReserveTradingSafeFactoryAddress
+/// @notice Reserves the production `TradingSafeFactory` CREATE3 address on every chain the protocol may
+///         expand to, so the factory keeps a single cross-chain address the way `TopUpSourceFactory` does.
+///
+/// Reuses `SALT_TRADING_SAFE_FACTORY_PROXY`, so the reserved address matches the live Ethereum factory.
+/// Everything is idempotent: chains that already hold the reservation (or the real factory) are no-ops.
+///
+/// Usage:
+///   PRIVATE_KEY=0x... forge script scripts/trading-account/ReserveTradingSafeFactoryAddress.s.sol \
+///     --rpc-url <RPC> --broadcast
+///   forge script scripts/trading-account/ReserveTradingSafeFactoryAddress.s.sol --sig 'verify()' --rpc-url <RPC>
+contract ReserveTradingSafeFactoryAddress is Script, TradingAccountCreate3 {
+    /// @dev Salts shared with `scripts/ReserveAddresses.s.sol`, which reserved the top-up factory slot.
+    ///      Reusing them keeps the placeholder and RoleRegistry impl addresses identical across chains.
+    bytes32 private constant SALT_RESERVED_ROLE_REGISTRY_PROXY = 0x6cae761c5315d96c88fdeb2bdf7f689cb66abc92a4e823b7954d41f88321bd0e;
+    bytes32 private constant SALT_RESERVED_ROLE_REGISTRY_IMPL = keccak256("ReserveAddresses.RoleRegistryImpl");
+    bytes32 private constant SALT_RESERVED_PLACEHOLDER_IMPL = keccak256("ReserveAddresses.EtherFiPlaceholderImpl");
+
+    bytes32 private constant OZ_INIT_SLOT = 0xf0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a00;
+    bytes32 private constant ROLE_REGISTRY_SLOT = 0xa5586bb7fe6c4d1a576fc53fefe6d5915940638d338769f6905020734977f500;
+
+    /// @dev HyperEVM's reserved RoleRegistry predates the shared reservation and is owned by a separate
+    ///      multisig; `C.OPERATING_SAFE` is not an upgrader there.
+    uint256 private constant HYPEREVM_CHAIN_ID = 999;
+    address private constant HYPEREVM_ROLE_REGISTRY_OWNER = 0xf27128a5b064e8d97EDaa60D24bFa2FD1eeC26eB;
+
+    function run() external {
+        _requireSupportedChain();
+        require(C.NICKS_FACTORY.code.length > 0, "Nick's factory not deployed on this chain");
+
+        address reservation = _predict(C.SALT_TRADING_SAFE_FACTORY_PROXY);
+        console2.log("=== Reserve TradingSafeFactory address ===");
+        console2.log("Chain ID:           ", block.chainid);
+        console2.log("TradingSafeFactory: ", reservation);
+
+        if (reservation.code.length > 0) {
+            console2.log("[SKIP] address already occupied on this chain");
+            _verify();
+            return;
+        }
+
+        vm.startBroadcast(vm.envUint("PRIVATE_KEY"));
+
+        address roleRegistry = _ensureReservedRoleRegistry();
+        _requireRegistryControlsUpgrades(roleRegistry);
+
+        address placeholderImpl = _deployCreate3(type(EtherFiPlaceholder).creationCode, SALT_RESERVED_PLACEHOLDER_IMPL);
+        address deployed = _deployProxy(C.SALT_TRADING_SAFE_FACTORY_PROXY, placeholderImpl, abi.encodeCall(EtherFiPlaceholder.initialize, (roleRegistry)));
+        require(deployed == reservation, "TradingSafeFactory prediction mismatch");
+
+        vm.stopBroadcast();
+
+        console2.log("  RoleRegistry:     ", roleRegistry);
+        console2.log("  Placeholder impl: ", placeholderImpl);
+
+        _verify();
+    }
+
+    /// @notice Read-only post-deployment verification. Reverts on any failed check so CI can use the exit code.
+    function verify() external view {
+        _requireSupportedChain();
+        _verify();
+    }
+
+    /// @dev Deploys the shared reservation RoleRegistry if this chain does not have it yet. Only Arbitrum
+    ///      still lacks it; every other target chain received it from `scripts/ReserveAddresses.s.sol`.
+    function _ensureReservedRoleRegistry() private returns (address roleRegistry) {
+        roleRegistry = _predict(SALT_RESERVED_ROLE_REGISTRY_PROXY);
+        if (roleRegistry.code.length > 0) return roleRegistry;
+
+        // address(0) data provider matches ReserveAddresses.s.sol, so the impl address stays identical
+        // across chains. A real data provider requires a fresh impl at upgrade time.
+        address impl = _deployCreate3(abi.encodePacked(type(RoleRegistry).creationCode, abi.encode(address(0))), SALT_RESERVED_ROLE_REGISTRY_IMPL);
+        address deployed = _deployProxy(SALT_RESERVED_ROLE_REGISTRY_PROXY, impl, abi.encodeCall(RoleRegistry.initialize, (C.OPERATING_SAFE)));
+        require(deployed == roleRegistry, "RoleRegistry prediction mismatch");
+    }
+
+    /// @dev `UpgradeableProxy._authorizeUpgrade` calls `roleRegistry.onlyUpgrader`, which returns nothing, so
+    ///      Solidity emits no extcodesize check. Against a code-less registry that call silently succeeds and
+    ///      anyone could upgrade the reservation, so the registry must be verified before the proxy is deployed.
+    function _requireRegistryControlsUpgrades(address roleRegistry) private view {
+        require(roleRegistry.code.length > 0, "reserved RoleRegistry has no code");
+        require(uint256(vm.load(roleRegistry, OZ_INIT_SLOT)) > 0, "reserved RoleRegistry not initialized");
+
+        address expectedOwner = _expectedRoleRegistryOwner();
+        require(RoleRegistry(roleRegistry).owner() == expectedOwner, "reserved RoleRegistry has unexpected owner");
+        RoleRegistry(roleRegistry).onlyUpgrader(expectedOwner);
+    }
+
+    function _verify() private view {
+        address reservation = _predict(C.SALT_TRADING_SAFE_FACTORY_PROXY);
+        address placeholderImpl = _predict(SALT_RESERVED_PLACEHOLDER_IMPL);
+
+        require(reservation.code.length > 0, "TradingSafeFactory address not reserved");
+        require(uint256(vm.load(reservation, OZ_INIT_SLOT)) > 0, "reservation not initialized");
+
+        address impl = address(uint160(uint256(vm.load(reservation, C.EIP1967_IMPL_SLOT))));
+        require(impl.code.length > 0, "reservation impl has no code");
+
+        address roleRegistry = address(uint160(uint256(vm.load(reservation, ROLE_REGISTRY_SLOT))));
+        require(roleRegistry.code.length > 0, "reservation roleRegistry has no code");
+
+        if (impl == placeholderImpl) {
+            require(roleRegistry == _predict(SALT_RESERVED_ROLE_REGISTRY_PROXY), "reservation points at unexpected RoleRegistry");
+            _requireRegistryControlsUpgrades(roleRegistry);
+            console2.log("[OK] placeholder reservation held, upgradeable by", _expectedRoleRegistryOwner());
+        } else {
+            // Chains where the real factory shipped keep their own RoleRegistry, so only assert the
+            // address is a live, upgrade-controlled proxy rather than pinning the placeholder impl.
+            require(RoleRegistry(roleRegistry).owner() != address(0), "reservation roleRegistry has no owner");
+            console2.log("[OK] real deployment held at reserved address, impl", impl);
+        }
+    }
+
+    function _expectedRoleRegistryOwner() private view returns (address) {
+        return block.chainid == HYPEREVM_CHAIN_ID ? HYPEREVM_ROLE_REGISTRY_OWNER : C.OPERATING_SAFE;
+    }
+
+    function _deployProxy(bytes32 salt, address implementation, bytes memory initData) private returns (address) {
+        return _deployCreate3(abi.encodePacked(type(UUPSProxy).creationCode, abi.encode(implementation, initData)), salt);
+    }
+
+    /// @dev Matches the chains that already hold the `TopUpSourceFactory` reservation. Guards against
+    ///      burning the salt on a chain that was never reviewed.
+    function _requireSupportedChain() private view {
+        uint256 id = block.chainid;
+        bool supported = id == 1 // Ethereum
+            || id == 10 // Optimism
+            || id == 56 // BNB Chain
+            || id == 137 // Polygon
+            || id == 146 // Sonic
+            || id == 999 // HyperEVM
+            || id == 4217 // Tempo
+            || id == 5000 // Mantle
+            || id == 8453 // Base
+            || id == 9745 // Plasma
+            || id == 42_161 // Arbitrum
+            || id == 43_114 // Avalanche
+            || id == 59_144 // Linea
+            || id == 534_352; // Scroll
+        require(supported, "chain not in the reservation set");
+    }
+}


### PR DESCRIPTION
## Summary

Locks in the production `TradingSafeFactory` address so it stays identical on every chain the trading stack may ship to next, the same way `TopUpSourceFactory` is pinned to `0xF4e147Db314947fC1275a8CbB6Cde48c510cd8CF` everywhere.

Adds `scripts/trading-account/ReserveTradingSafeFactoryAddress.s.sol`, which deploys an `EtherFiPlaceholder` behind a `UUPSProxy` at the **existing** prod salt `keccak256("TradingAccount.Prod.v1.TradingSafeFactoryProxy")`. That means every chain lands on `0xE54e00b0e72F8FC8Cb7e124C378bAd2E7371d2b8` — the same address as the live Ethereum factory — rather than a new reservation-only address.

No `src/` changes; this is script-only.

### How it mirrors the top-up reservation

It reuses the salts from `scripts/ReserveAddresses.s.sol`, so the placeholder impl (`0x0168d60bbE352C3Fb9a897b262aFEBc5Ce77CEad`) and RoleRegistry (`0x5C1E3D653fcbC54Ae25c2AD9d59548D2082C687B`) are the shared ones already onchain, with the ops safe `0xA6cf33124cb342D1c604cAC87986B965F428AAC4` as owner and `address(0)` as data provider.

### Current onchain state (verified while writing this)

`0xE54e00b0…` is occupied **only on Ethereum**; the slot is free on all 13 other target chains and on every other chain I probed, so there is no collision risk.

| Chain | Reserved RoleRegistry | Placeholder impl | Factory slot | What the script does |
|---|---|---|---|---|
| Ethereum (1) | present | absent | **real factory** | skips, verifies existing deployment |
| Optimism (10), Polygon (137), Sonic (146), Tempo (4217), Mantle (5000), Plasma (9745), Avalanche (43114), Linea (59144) | present | present | free | reservation proxy only (2 txs) |
| BNB (56), HyperEVM (999), Base (8453), Scroll (534352) | present | absent | free | placeholder impl + reservation (4 txs) |
| Arbitrum (42161) | **absent** | absent | free | RoleRegistry impl + proxy, placeholder impl, reservation (8 txs) |

## Safety detail worth reviewing

`UpgradeableProxy._authorizeUpgrade` calls `roleRegistry.onlyUpgrader(msg.sender)`, which returns nothing — so Solidity emits no `extcodesize` check and the call **silently succeeds against a code-less address**. Pointing a reservation at a registry that does not exist on that chain would leave the address upgradeable by anyone, i.e. hijackable. The script therefore requires the registry to have code, be initialized, be owned by the expected owner, and to actually authorize that owner as an upgrader, all *before* the reservation proxy is deployed. This is why Arbitrum gets the registry deployed first instead of just reserving the slot.

Two deliberate exceptions, both encoded as explicit constants rather than loosened checks:
- **HyperEVM** (999): its reserved RoleRegistry predates the shared reservation and is owned by `0xf27128a5b064e8d97EDaa60D24bFa2FD1eeC26eB`; I confirmed onchain that the ops safe is *not* an upgrader there, so the expected owner is chain-specific.
- A chain allowlist of exactly the 14 chains above, so the salt can't be burned on an unreviewed chain.

## Known follow-up (not addressed here)

`TradingSafeFactory.initialize` is `initializer`, and the placeholder already consumes initializer version 1. Upgrading a reserved placeholder to the real factory will therefore revert on `initialize`, and the beacon is created inside that call, so it can't be skipped. Redeeming any reservation needs a `reinitializer` variant or a one-off migration impl. This is a pre-existing property of the reservation pattern — it applies equally to the 7 top-up chains reserved by `ReserveAddresses.s.sol` — so I left it alone rather than changing `TradingSafeFactory` in an address-reservation PR. Worth deciding before the first real cross-chain deploy.

## Test plan

- [x] `forge build` clean for the whole repo; `forge fmt --check` clean
- [x] Simulated against live forks for each distinct case: Polygon (2 txs), Arbitrum (8 txs, deploys the missing registry), BNB and HyperEVM (4 txs), Ethereum (skips and verifies the real factory)
- [x] Confirmed the chain guard rejects an out-of-set chain (Unichain 130 reverts with `chain not in the reservation set`)
- [x] Verified the reused salt reproduces `0xE54e00b0…`, matching the deployed Ethereum factory
- [ ] Broadcast per chain and record addresses in the deployment manifests (separate step, needs the deployer key)

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/etherfi-protocol/codesmith/cash-v3/pr/260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788454048&installation_model_id=18424&pr_number=260&repository=etherfi-protocol%2Fcash-v3&return_to=https%3A%2F%2Fgithub.com%2Fetherfi-protocol%2Fcash-v3%2Fpull%2F260&signature=4d7c3eaaa925809b1c19b55359c3d767b97dcd95446bad0372f2d5a657816fe2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->