### PR TITLE
chore: repoint dev Summer Lend oracles off Pyth onto Chainlink proxies

### DIFF
--- a/deployments/dev/10/aave-v4-test.json
+++ b/deployments/dev/10/aave-v4-test.json
@@ -22,23 +22,23 @@
     },
     "ETHFI": {
       "assetId": 2,
-      "oracle": "0x3688ccB12F2eD98c7EC6587AfE25Ee1352754F39"
+      "oracle": "0x5f3AB9C6827C327b7D0F472Eb9B48954bF8fB3CA"
     },
     "WHYPE": {
       "assetId": 3,
-      "oracle": "0x043CfC32dC6477479Bb3240147064345cb377009"
+      "oracle": "0x5A0Cd4c7b56349030D8180358592A783F45cEE7a"
     },
     "beHYPE": {
       "assetId": 4,
-      "oracle": "0x826A756D05F706E3B17142D5dF649342EEda281a"
+      "oracle": "0xb4C086BD0C5Aa7ad39317B05378f392F72A07694"
     },
     "EURC": {
       "assetId": 5,
-      "oracle": "0x53aeD288F362e23171E1dd8c4D7e670B7a2Bd199"
+      "oracle": "0x5E169BFAacB0CA0d500459da652D33d962CD9cbA"
     },
     "sETHFI": {
       "assetId": 6,
-      "oracle": "0x14864EEFB48F78833c4c12b5Dd001857B99d42D3"
+      "oracle": "0x23fB1FcDeBa86AbAD98f05cD5e43471506771EFa"
     },
     "liquidETH": {
       "assetId": 7,
@@ -86,7 +86,7 @@
     },
     "frxUSD": {
       "assetId": 18,
-      "oracle": "0x439755986dB80135F7Aa4d300c113Faa88aDe304"
+      "oracle": "0x29D41f740b21dd28E1627DF2cCd307E978A7A454"
     },
     "iwSPYx": {
       "oracle": "0x5ce12709a8881309580e6768d0111CD7526c6888",


### PR DESCRIPTION
Records the new dev Summer Lend price sources in `aave-v4-test.json` after repointing the Aave v4 test instance off the retired Pyth per-pair oracles onto the official Chainlink proxies — the same ones the PriceProviderV2s use since the 3CP-619 repoint.

| Reserve | New feed | Composition |
|---|---|---|
| ETHFI | `0x5f3AB9C6827C327b7D0F472Eb9B48954bF8fB3CA` | ChainlinkPriceFeed over ETHFI/USD `0x9A3C9759…` |
| WHYPE | `0x5A0Cd4c7b56349030D8180358592A783F45cEE7a` | ChainlinkPriceFeed over HYPE/USD `0x961f6a07…` |
| beHYPE | `0xb4C086BD0C5Aa7ad39317B05378f392F72A07694` | beHYPE/HYPE rate `0x8792DD89…` × wHYPE/USD feed |
| EURC | `0x5E169BFAacB0CA0d500459da652D33d962CD9cbA` | ChainlinkPriceFeed over EURC/USD `0xDb2A51a5…` |
| sETHFI | `0x23fB1FcDeBa86AbAD98f05cD5e43471506771EFa` | Veda accountant × new ETHFI/USD feed |
| frxUSD | `0x29D41f740b21dd28E1627DF2cCd307E978A7A454` | ChainlinkPriceFeed over FRXUSD/USD `0x14a2Aa41…`, stable |

Broadcast on OP dev via `RepointSummerLendOraclesDev` (spoke `updateReservePriceSource`, <2% price-move asserts green); all six feeds are Etherscan-verified. Feeds use a 2-day staleness bound (the proxies run ~24h heartbeats).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/etherfi-protocol/codesmith/cash-v3/pr/269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788625902&installation_model_id=18424&pr_number=269&repository=etherfi-protocol%2Fcash-v3&return_to=https%3A%2F%2Fgithub.com%2Fetherfi-protocol%2Fcash-v3%2Fpull%2F269&signature=648095e02f7932533a20a246857153e6b615d367ab610c4b18c662fd183573da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wrong oracle addresses in the manifest can mislead scripts and operators and, if replayed on-chain, would affect collateral pricing for those reserves.
> 
> **Overview**
> Updates **`deployments/dev/10/aave-v4-test.json`** so six Summer Lend reserves point at the new Chainlink-based price feeds instead of the retired Pyth per-pair oracles: **ETHFI**, **WHYPE**, **beHYPE**, **EURC**, **sETHFI**, and **frxUSD**. Only the `details.<symbol>.oracle` values change; other reserves and instance addresses are untouched.
> 
> This keeps the dev manifest aligned with on-chain `updateReservePriceSource` work (same proxy feeds used elsewhere after the PriceProviderV2 repoint).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37db91a0b9ddfbd12e5650354f489561de232ab2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->