### PR TITLE
chore: fix oracles for dev lend

### DIFF
--- a/deployments/dev/10/aave-v4-test.json
+++ b/deployments/dev/10/aave-v4-test.json
@@ -22,23 +22,23 @@
     },
     "ETHFI": {
       "assetId": 2,
-      "oracle": "0x3688ccB12F2eD98c7EC6587AfE25Ee1352754F39"
+      "oracle": "0x5f3AB9C6827C327b7D0F472Eb9B48954bF8fB3CA"
     },
     "WHYPE": {
       "assetId": 3,
-      "oracle": "0x043CfC32dC6477479Bb3240147064345cb377009"
+      "oracle": "0x5A0Cd4c7b56349030D8180358592A783F45cEE7a"
     },
     "beHYPE": {
       "assetId": 4,
-      "oracle": "0x826A756D05F706E3B17142D5dF649342EEda281a"
+      "oracle": "0xb4C086BD0C5Aa7ad39317B05378f392F72A07694"
     },
     "EURC": {
       "assetId": 5,
-      "oracle": "0x53aeD288F362e23171E1dd8c4D7e670B7a2Bd199"
+      "oracle": "0x5E169BFAacB0CA0d500459da652D33d962CD9cbA"
     },
     "sETHFI": {
       "assetId": 6,
-      "oracle": "0x14864EEFB48F78833c4c12b5Dd001857B99d42D3"
+      "oracle": "0x23fB1FcDeBa86AbAD98f05cD5e43471506771EFa"
     },
     "liquidETH": {
       "assetId": 7,
@@ -86,7 +86,7 @@
     },
     "frxUSD": {
       "assetId": 18,
-      "oracle": "0x439755986dB80135F7Aa4d300c113Faa88aDe304"
+      "oracle": "0x29D41f740b21dd28E1627DF2cCd307E978A7A454"
     },
     "iwSPYx": {
       "oracle": "0x5ce12709a8881309580e6768d0111CD7526c6888",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dev-only deployment JSON; no application or contract code changes, though wrong addresses could misconfigure local/dev lend testing until redeployed on-chain.
> 
> **Overview**
> Updates **seven** price-feed oracle contract addresses in the dev Optimism (`chain 10`) Aave v4 test deployment manifest (`deployments/dev/10/aave-v4-test.json`).
> 
> The changed assets are **ETHFI**, **WHYPE**, **beHYPE**, **EURC**, **sETHFI**, and **frxUSD**; **asset IDs** and all other oracle entries are unchanged. This aligns the recorded dev lend oracles with the corrected on-chain feed deployments used by the Summer Lend / Aave v4 dev tooling that reads this file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe01d0048d1a37d695b396b8bf45a18f77a709b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/etherfi-protocol/codesmith/cash-v3/pr/270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788629814&installation_model_id=18424&pr_number=270&repository=etherfi-protocol%2Fcash-v3&return_to=https%3A%2F%2Fgithub.com%2Fetherfi-protocol%2Fcash-v3%2Fpull%2F270&signature=31d3d25b8f4f1638c91ff557692752b1f17ab92808427417b34bedadd04a32af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->