### PR TITLE
feat: ChainlinkPriceBandAdapter — limit how fast a price feed can move the value we lend against

### DIFF
--- a/src/interfaces/IChainlinkPriceBandAdapter.sol
+++ b/src/interfaces/IChainlinkPriceBandAdapter.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { IAggregatorV3 } from "./IAggregatorV3.sol";
+
+/**
+ * @title IChainlinkPriceBandAdapter
+ * @notice A Chainlink feed wrapped so that no single round can move the reported price by more than
+ *         a configured percentage against what that same feed was reporting a set time earlier.
+ * @author ether.fi
+ */
+interface IChainlinkPriceBandAdapter is IAggregatorV3 {
+    /// @notice Thrown when the wrapped feed reports a non-positive answer.
+    error InvalidPrice();
+    /// @notice Thrown when the feed address is zero.
+    error FeedIsZeroAddress();
+    /// @notice Thrown when the configured band is outside [MIN_BAND_BPS, MAX_BAND_BPS].
+    error InvalidBand(uint16 bandBps);
+    /// @notice Thrown when the widen period is outside [MIN_WIDEN_PERIOD, MAX_WIDEN_PERIOD].
+    error InvalidWidenPeriod(uint32 widenPeriod);
+    /// @notice Thrown when the reference age is outside [MIN_REFERENCE_AGE, MAX_REFERENCE_AGE].
+    error InvalidReferenceAge(uint32 referenceAge);
+
+    /// @notice The wrapped Chainlink feed.
+    function FEED() external view returns (IAggregatorV3);
+
+    /// @notice Band applied to a freshly published round, in basis points.
+    function BAND_BPS() external view returns (uint16);
+
+    /// @notice Seconds of round age that add one further `BAND_BPS` to the band.
+    /// @dev The band widens with the age of the latest round, so a clamp decays instead of holding
+    ///      until the feed happens to publish again.
+    function WIDEN_PERIOD() external view returns (uint32);
+
+    /// @notice How far back in time the reference round must sit, in seconds.
+    /// @dev This is what makes the band a bound per unit of TIME rather than per round. Without it,
+    ///      anyone able to produce rounds can post several in one block, each inside the band
+    ///      against its immediate predecessor, and walk the price anywhere.
+    function REFERENCE_AGE() external view returns (uint32);
+
+    /// @notice The feed's unmodified latest answer, before the band is applied.
+    function rawAnswer() external view returns (int256);
+
+    /// @notice The reference answer the band is measured against, or 0 when there is none.
+    function referenceAnswer() external view returns (int256);
+
+    /// @notice Whether any usable reference round could be read.
+    /// @dev False means the band is inert for this round and the raw answer passes through: the feed
+    ///      is on the first round of a phase, or history could not be read. Monitor this - a view
+    ///      contract cannot emit, so this getter is the only signal that the band is not protecting.
+    function hasReference() external view returns (bool);
+
+    /// @notice Whether the reference actually met `REFERENCE_AGE`.
+    /// @dev False means the lookback was exhausted before finding a round that old, so the oldest
+    ///      reachable round was used instead. In normal operation this is always true; false is the
+    ///      signature of an unusual burst of rounds and is worth alerting on.
+    function referenceIsAnchored() external view returns (bool);
+
+    /// @notice The band actually in force right now, in basis points, given the latest round's age.
+    function effectiveBandBps() external view returns (uint256);
+
+    /// @notice Seconds since the latest round was published.
+    function roundAge() external view returns (uint256);
+
+    /// @notice Whether the band is currently clamping the reported price.
+    function isCapped() external view returns (bool);
+}

--- a/src/oracle/ChainlinkPriceBandAdapter.sol
+++ b/src/oracle/ChainlinkPriceBandAdapter.sol
@@ -36,10 +36,12 @@ import { IChainlinkPriceBandAdapter } from "../interfaces/IChainlinkPriceBandAda
  *      Sized against measurement: the worst one-hour move across the full history of the two target
  *      feeds is 7.50% (PAXG) and 1.54% (SPY), both comfortably inside a 2000 bps band.
  *
- *      Residual: a view function must bound its lookback for gas, so flooding more than
- *      `MAX_LOOKBACK` rounds inside the window falls back to the oldest reachable round and gains
- *      one band per `MAX_LOOKBACK` rounds. Closing that needs stored state, which this cannot have.
- *      `referenceIsAnchored()` reports when the fallback is in use.
+ *      The anchor is located by binary search, so it is found exactly however many rounds get
+ *      posted. A bounded backwards walk would leave the very hole it was meant to close: flood past
+ *      it and the reference becomes one of the attacker's own recent rounds, restoring the per-round
+ *      bound - and the burst can be repeated inside the same block. The search relies on round
+ *      timestamps inside a phase being non-decreasing, which holds because rounds are appended
+ *      chronologically.
  *
  * @dev BOTH DIRECTIONS
  *      A manipulated low print is as damaging as a high one and lands on a different party. The
@@ -99,12 +101,6 @@ contract ChainlinkPriceBandAdapter is IChainlinkPriceBandAdapter {
     /// @notice Longest permitted reference age. Beyond this the reference predates a full heartbeat
     ///         on these feeds and the band would start binding on ordinary movement.
     uint32 public constant MAX_REFERENCE_AGE = 12 hours;
-
-    /// @notice How many rounds back the search for an anchor walks before giving up.
-    /// @dev Every step is a staticcall, so this is a gas bound as much as a security one. The normal
-    ///      case exits on the first step, because these feeds publish far less often than the anchor
-    ///      window. Only a burst walks further.
-    uint256 public constant MAX_LOOKBACK = 16;
 
     /// @dev Ceiling on the widened band so a dead feed cannot overflow the delta arithmetic.
     uint256 internal constant MAX_EFFECTIVE_BAND_BPS = 1_000_000;
@@ -262,44 +258,84 @@ contract ChainlinkPriceBandAdapter is IChainlinkPriceBandAdapter {
     /**
      * @dev The newest round at least `REFERENCE_AGE` old, within the same aggregator phase.
      *
-     *      Walking back in TIME rather than taking `latestRound - 1` is what makes the band a bound
-     *      per hour instead of per round. A burst of rounds inside the window all resolve to the
-     *      same anchor, so posting more rounds buys no further movement.
+     *      Anchoring in TIME rather than at `latestRound - 1` is what makes the band a bound per
+     *      hour instead of per round. Without it, anyone able to produce rounds posts several in one
+     *      block, each inside the band against its immediate predecessor, and walks the price
+     *      anywhere - four rounds halve a price at a 20% band.
+     *
+     *      The anchor is found EXACTLY, not approximately. A bounded linear walk backwards would
+     *      leave a hole: flood more rounds than the walk can cover and the reference becomes one of
+     *      the attacker's own recent rounds, restoring the per-round bound they were trying to
+     *      escape - and they can repeat it in the same block. So this binary searches instead.
+     *      Round timestamps inside a phase are non-decreasing, because rounds are appended
+     *      chronologically, which is exactly the property a binary search needs. The cost is one
+     *      staticcall in the common case, rising to log2(rounds) only while a burst is in progress.
      *
      *      A Chainlink proxy round id packs `phaseId` in the high 16 bits and the aggregator's own
-     *      round in the low 64. Decrementing across a phase boundary reads a different aggregator
-     *      and in practice answers zero - `phase 2, round 0` on the live OP SPY feed does exactly
-     *      that. So the phase is fixed for the whole walk, and the start of a phase ends it.
+     *      round in the low 64. Reaching across a phase boundary reads a different aggregator and in
+     *      practice answers zero - `phase 2, round 0` on the live OP SPY feed does exactly that. So
+     *      the phase is fixed for the whole search.
      *
-     *      Fails open: with no usable round the raw answer passes through rather than reverting. A
-     *      revert on a collateral price takes every action on the reserve with it, liquidation
-     *      included. `hasReference()` and `referenceIsAnchored()` expose both degraded states.
+     *      `anchored` is false only when no round in this phase is old enough, which means the phase
+     *      itself is younger than `REFERENCE_AGE` - a fresh aggregator upgrade, not something an
+     *      attacker can manufacture. The oldest round in the phase is used then, which is the most
+     *      conservative reference available rather than one of theirs.
+     *
+     *      Fails open with no usable round at all: the raw answer passes through rather than
+     *      reverting, because a revert on a collateral price takes every action on the reserve with
+     *      it, liquidation included. `hasReference()` and `referenceIsAnchored()` expose both states.
      */
     function _reference(uint80 latestRoundId) internal view returns (int256 answer, bool available, bool anchored) {
-        uint64 round = uint64(latestRoundId);
-        if (round <= 1) return (0, false, false);
+        uint64 latest = uint64(latestRoundId);
+        if (latest <= 1) return (0, false, false);
 
         uint256 phase = uint256(uint16(latestRoundId >> 64)) << 64;
         uint256 cutoff = block.timestamp > REFERENCE_AGE ? block.timestamp - REFERENCE_AGE : 0;
 
-        for (uint256 i = 0; i < MAX_LOOKBACK; ++i) {
-            round -= 1;
-            try FEED.getRoundData(uint80(phase | uint256(round))) returns (uint80, int256 previous, uint256, uint256 previousUpdatedAt, uint80) {
-                // A hole in history ends the walk; keep whatever was already reached.
-                if (previous <= 0 || previousUpdatedAt == 0) break;
-                answer = previous;
-                available = true;
-                if (previousUpdatedAt <= cutoff) return (answer, true, true);
-            } catch {
-                break;
-            }
-            if (round <= 1) break;
+        // Common case, one read: these feeds publish far less often than the anchor window, so the
+        // immediately preceding round is already old enough.
+        {
+            (bool ok, int256 a, uint256 u) = _round(phase, latest - 1);
+            if (!ok) return (0, false, false);
+            if (u <= cutoff) return (a, true, true);
         }
 
-        // The lookback ran out or the phase began. Whatever was reached is the furthest back
-        // available and therefore the most conservative reference on offer, but it is NOT anchored
-        // in time and callers are told so.
-        return (answer, available, false);
+        // A burst is in progress. Binary search for the NEWEST round at or before the cutoff.
+        // Terminates structurally: `mid` always lies in [lo, hi] and each branch moves the bound past
+        // it, so the range strictly shrinks - at most log2(uint64) iterations.
+        uint64 lo = 1;
+        uint64 hi = latest - 2;
+        while (lo <= hi) {
+            uint64 mid = lo + (hi - lo) / 2;
+            (bool ok, int256 a, uint256 u) = _round(phase, mid);
+            if (!ok) break; // unreadable history; fall through to the conservative branch
+            if (u <= cutoff) {
+                answer = a;
+                anchored = true;
+                lo = mid + 1;
+            } else {
+                if (mid == 0) break;
+                hi = mid - 1;
+            }
+        }
+        if (anchored) return (answer, true, true);
+
+        // Nothing in this phase is old enough, so the phase itself is younger than REFERENCE_AGE -
+        // a fresh aggregator upgrade, not something an attacker can manufacture. Use the oldest round
+        // in the phase, which is the most conservative reference available rather than one of theirs.
+        (bool ok1, int256 oldest,) = _round(phase, 1);
+        if (ok1) return (oldest, true, false);
+        return (0, false, false);
+    }
+
+    /// @dev One history read, normalised. `ok` is false for an unreadable or unwritten round.
+    function _round(uint256 phase, uint64 round) internal view returns (bool ok, int256 answer, uint256 updatedAt) {
+        try FEED.getRoundData(uint80(phase | uint256(round))) returns (uint80, int256 a, uint256, uint256 u, uint80) {
+            if (a <= 0 || u == 0) return (false, 0, 0);
+            return (true, a, u);
+        } catch {
+            return (false, 0, 0);
+        }
     }
 
     /**

--- a/src/oracle/ChainlinkPriceBandAdapter.sol
+++ b/src/oracle/ChainlinkPriceBandAdapter.sol
@@ -1,0 +1,316 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { IAggregatorV3 } from "../interfaces/IAggregatorV3.sol";
+import { IChainlinkPriceBandAdapter } from "../interfaces/IChainlinkPriceBandAdapter.sol";
+
+/**
+ * @title ChainlinkPriceBandAdapter
+ * @notice Limits how fast a Chainlink feed can move the price we lend against. A single round may
+ *         not move the reported price more than `BAND_BPS` in either direction against what the
+ *         same feed was reporting `REFERENCE_AGE` earlier. Presents the standard aggregator
+ *         interface, so it drops in anywhere the raw feed does.
+ *
+ * @dev WHAT THIS IS FOR
+ *      If a collateral feed ever reports a wrong number - a glitch, a bug, or someone who has taken
+ *      control of it - the money market believes it immediately. Reported too high, a borrower draws
+ *      against collateral that is not worth it and the shortfall lands on suppliers. Reported too
+ *      low, healthy positions are marked underwater and liquidated at a price that never traded,
+ *      which the borrower cannot undo. This bounds how far either can go before someone notices.
+ *
+ *      It is NOT a source of truth. If the feed is wrong and stays wrong, this delays that reaching
+ *      the market by roughly `REFERENCE_AGE` and then lets it through. It buys time; something has
+ *      to use that time. `isCapped()` is an alert with a deadline, not a statistic.
+ *
+ * @dev THE REFERENCE IS ANCHORED IN TIME, NOT IN ROUND INDEX
+ *      Bounding a round against its immediate predecessor bounds nothing when rounds are cheap.
+ *      Compounding at 20% a round, four rounds halve a price and thirteen produce a ten-fold move,
+ *      with every step passing the check. Not hypothetical: the live PAXG feed on Optimism has a
+ *      minimum observed gap between rounds of ZERO seconds, has published three rounds inside one
+ *      block, and put 84 rounds within two minutes of the one before.
+ *
+ *      So the reference is the newest round at least `REFERENCE_AGE` old. A burst all resolves to
+ *      the same anchor, and posting more rounds buys no further movement. The guarantee changes
+ *      from "20% per round", which is meaningless when rounds are free, to "20% per hour".
+ *
+ *      Sized against measurement: the worst one-hour move across the full history of the two target
+ *      feeds is 7.50% (PAXG) and 1.54% (SPY), both comfortably inside a 2000 bps band.
+ *
+ *      Residual: a view function must bound its lookback for gas, so flooding more than
+ *      `MAX_LOOKBACK` rounds inside the window falls back to the oldest reachable round and gains
+ *      one band per `MAX_LOOKBACK` rounds. Closing that needs stored state, which this cannot have.
+ *      `referenceIsAnchored()` reports when the fallback is in use.
+ *
+ * @dev BOTH DIRECTIONS
+ *      A manipulated low print is as damaging as a high one and lands on a different party. The
+ *      usual objection to bounding falls - that it hides insolvency - does not apply, because the
+ *      reference is the FEED's own history and never this adapter's clamped output. A genuine move
+ *      is therefore always reported in full after a bounded delay, ended by either the anchor
+ *      rolling past it or the band widening, neither of which needs the feed to publish again.
+ *
+ * @dev THE BAND WIDENS WITH THE AGE OF THE ROUND
+ *      Chainlink publishes on a 0.5% deviation or a 24h heartbeat. A large move followed by a quiet
+ *      market produces no further rounds, so a fixed band would hold a knowingly wrong price for up
+ *      to a full day. The band therefore grows as the current round ages:
+ *
+ *          effectiveBand = BAND_BPS * (1 + age / WIDEN_PERIOD)
+ *
+ *      A clamp is a decaying speed bump rather than a wall: full strength on arrival, releasing over
+ *      the following hours if the feed keeps insisting. This is safe on a feed that normally goes
+ *      24h between rounds because widening only ever matters while something is clamped - an answer
+ *      already inside the base band is inside every wider band too, and every new round arrives at
+ *      age zero with the band at full strength.
+ *
+ *      It does weaken protection against a sustained manipulation: a value held flat is accepted in
+ *      hours rather than at the next heartbeat. `WIDEN_PERIOD` is the deadline for acting on a clamp.
+ *
+ * @dev SIZING
+ *      Anchor the band to market structure, not to fitted volatility. US market-wide circuit
+ *      breakers halt equities at -7% / -13% / -20%, the last closing the session, so a single
+ *      session cannot exceed 20% - a 2000 bps band cannot interfere with real trading by
+ *      construction, and never once would have across the history of either feed. A band that
+ *      clamps in normal markets is worse than none: it trains operators to ignore it.
+ *
+ * @author ether.fi
+ */
+contract ChainlinkPriceBandAdapter is IChainlinkPriceBandAdapter {
+    uint256 internal constant BPS = 10_000;
+
+    /// @notice Tightest permitted band.
+    /// @dev Two constraints meet here. The target feeds publish on a 0.5% deviation threshold, and
+    ///      that threshold is a trigger rather than a bound - PAXG printed 6.92% in one round
+    ///      against it - so a band near the threshold would clamp routine movement. And because the
+    ///      band is two-sided it also rate-limits how fast a genuine crash reaches consumers.
+    uint16 public constant MIN_BAND_BPS = 500;
+
+    /// @notice Loosest permitted band. At or above 100% nothing meaningful is bounded.
+    uint16 public constant MAX_BAND_BPS = 10_000;
+
+    /// @notice Tightest permitted widen period. Shorter and the band releases before anyone could
+    ///         plausibly triage a clamp.
+    uint32 public constant MIN_WIDEN_PERIOD = 15 minutes;
+
+    /// @notice Longest permitted widen period.
+    uint32 public constant MAX_WIDEN_PERIOD = 2 days;
+
+    /// @notice Shortest permitted reference age.
+    uint32 public constant MIN_REFERENCE_AGE = 5 minutes;
+
+    /// @notice Longest permitted reference age. Beyond this the reference predates a full heartbeat
+    ///         on these feeds and the band would start binding on ordinary movement.
+    uint32 public constant MAX_REFERENCE_AGE = 12 hours;
+
+    /// @notice How many rounds back the search for an anchor walks before giving up.
+    /// @dev Every step is a staticcall, so this is a gas bound as much as a security one. The normal
+    ///      case exits on the first step, because these feeds publish far less often than the anchor
+    ///      window. Only a burst walks further.
+    uint256 public constant MAX_LOOKBACK = 16;
+
+    /// @dev Ceiling on the widened band so a dead feed cannot overflow the delta arithmetic.
+    uint256 internal constant MAX_EFFECTIVE_BAND_BPS = 1_000_000;
+
+    /// @inheritdoc IChainlinkPriceBandAdapter
+    IAggregatorV3 public immutable FEED;
+
+    /// @inheritdoc IChainlinkPriceBandAdapter
+    uint16 public immutable BAND_BPS;
+
+    /// @inheritdoc IChainlinkPriceBandAdapter
+    uint32 public immutable WIDEN_PERIOD;
+
+    /// @inheritdoc IChainlinkPriceBandAdapter
+    uint32 public immutable REFERENCE_AGE;
+
+    /// @inheritdoc IAggregatorV3
+    uint8 public immutable decimals;
+
+    /// @inheritdoc IAggregatorV3
+    uint256 public constant version = 1;
+
+    string private _description;
+
+    /**
+     * @param feed The Chainlink feed to wrap. Must expose `getRoundData`, which is what makes the
+     *        time-anchored reference possible.
+     * @param bandBps Band applied to a freshly published round, in basis points.
+     * @param widenPeriod Seconds of round age that add one further `bandBps` to the band. Size it to
+     *        how long triaging a clamp actually takes.
+     * @param referenceAge How far back the reference round must sit, in seconds. This is the unit
+     *        the band is denominated in: at 2000 bps and one hour, the bound is 20% per hour.
+     * @param adapterDescription Human-readable description for this adapter.
+     */
+    constructor(IAggregatorV3 feed, uint16 bandBps, uint32 widenPeriod, uint32 referenceAge, string memory adapterDescription) {
+        if (address(feed) == address(0)) revert FeedIsZeroAddress();
+        if (bandBps < MIN_BAND_BPS || bandBps > MAX_BAND_BPS) revert InvalidBand(bandBps);
+        if (widenPeriod < MIN_WIDEN_PERIOD || widenPeriod > MAX_WIDEN_PERIOD) revert InvalidWidenPeriod(widenPeriod);
+        if (referenceAge < MIN_REFERENCE_AGE || referenceAge > MAX_REFERENCE_AGE) revert InvalidReferenceAge(referenceAge);
+
+        FEED = feed;
+        BAND_BPS = bandBps;
+        WIDEN_PERIOD = widenPeriod;
+        REFERENCE_AGE = referenceAge;
+        decimals = feed.decimals();
+        _description = adapterDescription;
+    }
+
+    /// @inheritdoc IAggregatorV3
+    function latestAnswer() external view returns (int256) {
+        (, int256 answer,,,) = _banded();
+        return answer;
+    }
+
+    /// @inheritdoc IAggregatorV3
+    /// @dev Reports the banded answer against the round's own id and timestamps, so a consumer's own
+    ///      staleness check still measures the underlying feed's age.
+    function latestRoundData() external view returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound) {
+        (roundId, answer, startedAt, updatedAt,) = _banded();
+        return (roundId, answer, startedAt, updatedAt, roundId);
+    }
+
+    /// @inheritdoc IAggregatorV3
+    /// @dev Historical rounds pass through unbanded: the band describes what this adapter reports
+    ///      NOW, and rewriting history would misrepresent what the feed actually published.
+    function getRoundData(uint80 roundId) external view returns (uint80, int256, uint256, uint256, uint80) {
+        return FEED.getRoundData(roundId);
+    }
+
+    /// @inheritdoc IAggregatorV3
+    function description() external view returns (string memory) {
+        return _description;
+    }
+
+    /// @inheritdoc IChainlinkPriceBandAdapter
+    function rawAnswer() external view returns (int256) {
+        (,,,, int256 raw) = _banded();
+        return raw;
+    }
+
+    /// @inheritdoc IChainlinkPriceBandAdapter
+    function referenceAnswer() external view returns (int256) {
+        (uint80 roundId,,,,) = FEED.latestRoundData();
+        (int256 refPrice,,) = _reference(roundId);
+        return refPrice;
+    }
+
+    /// @inheritdoc IChainlinkPriceBandAdapter
+    function hasReference() external view returns (bool) {
+        (uint80 roundId,,,,) = FEED.latestRoundData();
+        (, bool available,) = _reference(roundId);
+        return available;
+    }
+
+    /// @inheritdoc IChainlinkPriceBandAdapter
+    function referenceIsAnchored() external view returns (bool) {
+        (uint80 roundId,,,,) = FEED.latestRoundData();
+        (,, bool anchored) = _reference(roundId);
+        return anchored;
+    }
+
+    /// @inheritdoc IChainlinkPriceBandAdapter
+    function effectiveBandBps() external view returns (uint256) {
+        (,,, uint256 updatedAt,) = FEED.latestRoundData();
+        return _effectiveBandBps(updatedAt);
+    }
+
+    /// @inheritdoc IChainlinkPriceBandAdapter
+    function roundAge() external view returns (uint256) {
+        (,,, uint256 updatedAt,) = FEED.latestRoundData();
+        return block.timestamp > updatedAt ? block.timestamp - updatedAt : 0;
+    }
+
+    /// @inheritdoc IChainlinkPriceBandAdapter
+    function isCapped() external view returns (bool) {
+        (, int256 answer,,, int256 raw) = _banded();
+        return answer != raw;
+    }
+
+    /**
+     * @dev Reads the latest round and applies the band.
+     * @return roundId The feed's latest round id.
+     * @return answer The banded answer.
+     * @return startedAt The round's startedAt.
+     * @return updatedAt The round's updatedAt.
+     * @return raw The unmodified answer, so callers can tell whether the band bound.
+     */
+    function _banded() internal view returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, int256 raw) {
+        (roundId, raw, startedAt, updatedAt,) = FEED.latestRoundData();
+        // A non-positive answer is a broken feed rather than an out-of-band price, and it is the one
+        // case that is not clamped. Clamping zero to `refPrice - delta` would report a
+        // plausible-looking number from a feed returning garbage and walk it down a band per round,
+        // while a fresh `updatedAt` keeps every staleness check satisfied. Better to fail loudly.
+        if (raw <= 0) revert InvalidPrice();
+
+        answer = raw;
+        (int256 refPrice, bool available,) = _reference(roundId);
+        if (!available) return (roundId, answer, startedAt, updatedAt, raw);
+
+        uint256 eff = _effectiveBandBps(updatedAt);
+        // refPrice is positive and eff is capped, so the delta cannot overflow for any answer a
+        // Chainlink aggregator can represent.
+        int256 delta = (refPrice * int256(eff)) / int256(BPS);
+        int256 ceiling = refPrice + delta;
+        // Once the widened band reaches 100% the floor would be non-positive, which is simply no
+        // lower bound at all. Report it as 1 wei so "never returns a non-positive price" holds
+        // without the floor doing any work.
+        int256 floor = eff >= BPS ? int256(1) : refPrice - delta;
+        if (answer > ceiling) answer = ceiling;
+        else if (answer < floor) answer = floor;
+
+        return (roundId, answer, startedAt, updatedAt, raw);
+    }
+
+    /**
+     * @dev The newest round at least `REFERENCE_AGE` old, within the same aggregator phase.
+     *
+     *      Walking back in TIME rather than taking `latestRound - 1` is what makes the band a bound
+     *      per hour instead of per round. A burst of rounds inside the window all resolve to the
+     *      same anchor, so posting more rounds buys no further movement.
+     *
+     *      A Chainlink proxy round id packs `phaseId` in the high 16 bits and the aggregator's own
+     *      round in the low 64. Decrementing across a phase boundary reads a different aggregator
+     *      and in practice answers zero - `phase 2, round 0` on the live OP SPY feed does exactly
+     *      that. So the phase is fixed for the whole walk, and the start of a phase ends it.
+     *
+     *      Fails open: with no usable round the raw answer passes through rather than reverting. A
+     *      revert on a collateral price takes every action on the reserve with it, liquidation
+     *      included. `hasReference()` and `referenceIsAnchored()` expose both degraded states.
+     */
+    function _reference(uint80 latestRoundId) internal view returns (int256 answer, bool available, bool anchored) {
+        uint64 round = uint64(latestRoundId);
+        if (round <= 1) return (0, false, false);
+
+        uint256 phase = uint256(uint16(latestRoundId >> 64)) << 64;
+        uint256 cutoff = block.timestamp > REFERENCE_AGE ? block.timestamp - REFERENCE_AGE : 0;
+
+        for (uint256 i = 0; i < MAX_LOOKBACK; ++i) {
+            round -= 1;
+            try FEED.getRoundData(uint80(phase | uint256(round))) returns (uint80, int256 previous, uint256, uint256 previousUpdatedAt, uint80) {
+                // A hole in history ends the walk; keep whatever was already reached.
+                if (previous <= 0 || previousUpdatedAt == 0) break;
+                answer = previous;
+                available = true;
+                if (previousUpdatedAt <= cutoff) return (answer, true, true);
+            } catch {
+                break;
+            }
+            if (round <= 1) break;
+        }
+
+        // The lookback ran out or the phase began. Whatever was reached is the furthest back
+        // available and therefore the most conservative reference on offer, but it is NOT anchored
+        // in time and callers are told so.
+        return (answer, available, false);
+    }
+
+    /**
+     * @dev `BAND_BPS * (1 + age / WIDEN_PERIOD)`, so the band is exactly `BAND_BPS` on a freshly
+     *      published round and gains another `BAND_BPS` for every `WIDEN_PERIOD` it goes unrefreshed.
+     *      A round timestamped in the future (clock skew between the feed and this chain) reads as
+     *      age zero rather than underflowing.
+     */
+    function _effectiveBandBps(uint256 updatedAt) internal view returns (uint256) {
+        uint256 age = block.timestamp > updatedAt ? block.timestamp - updatedAt : 0;
+        uint256 eff = uint256(BAND_BPS) + (uint256(BAND_BPS) * age) / WIDEN_PERIOD;
+        return eff > MAX_EFFECTIVE_BAND_BPS ? MAX_EFFECTIVE_BAND_BPS : eff;
+    }
+}

--- a/test/price-provider/ChainlinkPriceBandAdapter.t.sol
+++ b/test/price-provider/ChainlinkPriceBandAdapter.t.sol
@@ -1,0 +1,477 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import { Test } from "forge-std/Test.sol";
+
+import { IAggregatorV3 } from "../../src/interfaces/IAggregatorV3.sol";
+import { IChainlinkPriceBandAdapter } from "../../src/interfaces/IChainlinkPriceBandAdapter.sol";
+import { ChainlinkPriceBandAdapter } from "../../src/oracle/ChainlinkPriceBandAdapter.sol";
+
+/// @dev Minimal Chainlink aggregator whose round history can be driven from a test, including the
+///      failure shapes the adapter has to survive: a phase's first round, a reverting
+///      `getRoundData`, and a round that answers zero.
+contract MockAggregator is IAggregatorV3 {
+    uint8 public decimals;
+    string public description;
+    uint256 public constant version = 1;
+
+    uint16 public phaseId = 1;
+    uint64 public aggregatorRound;
+    bool public revertOnHistory;
+
+    /// @dev Keyed by the PACKED round id (phase << 64 | round), because a real proxy's phases are
+    ///      separate aggregators and do not share history. Keying by round alone would let phase 1's
+    ///      rounds leak into phase 2 and quietly invalidate the boundary tests.
+    mapping(uint80 => int256) public answers;
+    mapping(uint80 => uint256) public timestamps;
+
+    constructor(uint8 decimals_, string memory description_) {
+        decimals = decimals_;
+        description = description_;
+    }
+
+    function push(int256 answer, uint256 updatedAt) external {
+        aggregatorRound += 1;
+        uint80 id = _packed(aggregatorRound);
+        answers[id] = answer;
+        timestamps[id] = updatedAt;
+    }
+
+    /// @dev Writes a round into an arbitrary phase, for the phase-boundary cases.
+    function seed(uint16 phase_, uint64 round_, int256 answer, uint256 updatedAt) external {
+        uint80 id = uint80((uint256(phase_) << 64) | uint256(round_));
+        answers[id] = answer;
+        timestamps[id] = updatedAt;
+    }
+
+    function setPhase(uint16 phaseId_, uint64 aggregatorRound_) external {
+        phaseId = phaseId_;
+        aggregatorRound = aggregatorRound_;
+    }
+
+    function setRevertOnHistory(bool value) external {
+        revertOnHistory = value;
+    }
+
+    function _packed(uint64 round) internal view returns (uint80) {
+        return uint80((uint256(phaseId) << 64) | uint256(round));
+    }
+
+    function latestAnswer() external view returns (int256) {
+        return answers[_packed(aggregatorRound)];
+    }
+
+    function latestRoundData() external view returns (uint80, int256, uint256, uint256, uint80) {
+        uint80 id = _packed(aggregatorRound);
+        return (id, answers[id], timestamps[id], timestamps[id], id);
+    }
+
+    function getRoundData(uint80 roundId) external view returns (uint80, int256, uint256, uint256, uint80) {
+        require(!revertOnHistory, "no history");
+        return (roundId, answers[roundId], timestamps[roundId], timestamps[roundId], roundId);
+    }
+}
+
+contract ChainlinkPriceBandAdapterTest is Test {
+    uint16 internal constant BAND = 2000; // 20%, the equity Level 3 halt
+    uint32 internal constant WIDEN = 1 hours;
+    uint32 internal constant REF_AGE = 1 hours;
+
+    MockAggregator internal feed;
+    ChainlinkPriceBandAdapter internal adapter;
+
+    function setUp() public {
+        vm.warp(10 days); // a real clock, so REFERENCE_AGE is meaningful rather than underflow-guarded
+        feed = new MockAggregator(8, "MOCK / USD");
+        feed.push(100e8, block.timestamp - 6 hours);
+        feed.push(100e8, block.timestamp - 5 hours);
+        adapter = new ChainlinkPriceBandAdapter(feed, BAND, WIDEN, REF_AGE, "Banded MOCK / USD");
+    }
+
+    // --- construction ---------------------------------------------------------------------------
+
+    function test_constructor_copiesDecimalsAndStoresConfig() public view {
+        assertEq(adapter.decimals(), 8);
+        assertEq(adapter.BAND_BPS(), BAND);
+        assertEq(address(adapter.FEED()), address(feed));
+        assertEq(adapter.description(), "Banded MOCK / USD");
+    }
+
+    function test_constructor_revertsOnZeroFeed() public {
+        vm.expectRevert(IChainlinkPriceBandAdapter.FeedIsZeroAddress.selector);
+        new ChainlinkPriceBandAdapter(IAggregatorV3(address(0)), BAND, WIDEN, REF_AGE, "x");
+    }
+
+    function test_constructor_revertsOnBandTooTight() public {
+        uint16 tooTight = adapter.MIN_BAND_BPS() - 1;
+        vm.expectRevert(abi.encodeWithSelector(IChainlinkPriceBandAdapter.InvalidBand.selector, tooTight));
+        new ChainlinkPriceBandAdapter(feed, tooTight, WIDEN, REF_AGE, "x");
+    }
+
+    function test_constructor_revertsOnBandTooLoose() public {
+        uint16 tooLoose = adapter.MAX_BAND_BPS() + 1;
+        vm.expectRevert(abi.encodeWithSelector(IChainlinkPriceBandAdapter.InvalidBand.selector, tooLoose));
+        new ChainlinkPriceBandAdapter(feed, tooLoose, WIDEN, REF_AGE, "x");
+    }
+
+    function test_constructor_revertsOnZeroBand() public {
+        vm.expectRevert(abi.encodeWithSelector(IChainlinkPriceBandAdapter.InvalidBand.selector, uint16(0)));
+        new ChainlinkPriceBandAdapter(feed, 0, WIDEN, REF_AGE, "x");
+    }
+
+    // --- the band ------------------------------------------------------------------------------
+
+    function test_withinBand_passesThrough() public {
+        feed.push(110e8, block.timestamp); // +10% against a 20% band
+        assertEq(adapter.latestAnswer(), 110e8);
+        assertFalse(adapter.isCapped());
+        assertEq(adapter.rawAnswer(), 110e8);
+    }
+
+    function test_aboveBand_clampsToCeiling() public {
+        feed.push(200e8, block.timestamp); // +100% against a 20% band
+        assertEq(adapter.latestAnswer(), 120e8, "clamped to previous + 20%");
+        assertTrue(adapter.isCapped());
+        assertEq(adapter.rawAnswer(), 200e8, "raw still visible");
+    }
+
+    function test_exactlyAtCeiling_doesNotClamp() public {
+        feed.push(120e8, block.timestamp);
+        assertEq(adapter.latestAnswer(), 120e8);
+        assertFalse(adapter.isCapped());
+    }
+
+    function test_belowBand_clampsToFloor() public {
+        feed.push(10e8, block.timestamp); // -90% against a 20% band
+        assertEq(adapter.latestAnswer(), 80e8, "clamped to previous - 20%");
+        assertTrue(adapter.isCapped());
+        assertEq(adapter.rawAnswer(), 10e8, "raw still visible");
+    }
+
+    function test_exactlyAtFloor_doesNotClamp() public {
+        feed.push(80e8, block.timestamp);
+        assertEq(adapter.latestAnswer(), 80e8);
+        assertFalse(adapter.isCapped());
+    }
+
+    /// @dev What makes a floor safe rather than a way to hide insolvency: the reference is the FEED's
+    ///      own history, never this adapter's clamped output, so a genuine crash is fully reflected
+    ///      after a bounded delay. With a time anchor that delay is REFERENCE_AGE rather than one
+    ///      round - and the widening releases it sooner still.
+    function test_realCrash_convergesAfterTheReferenceWindow() public {
+        uint256 t = block.timestamp;
+        feed.push(50e8, t); // feed crashes 100 -> 50
+        assertEq(adapter.latestAnswer(), 80e8, "on arrival: one band behind");
+        assertTrue(adapter.isCapped());
+
+        // posting more rounds does NOT accelerate it - that is the anti-flooding property
+        feed.push(50e8, t);
+        feed.push(50e8, t);
+        assertEq(adapter.latestAnswer(), 80e8, "extra rounds buy no extra movement");
+
+        // it resolves on the clock: the anchor rolls past the crash
+        vm.warp(t + REF_AGE + 1);
+        assertEq(adapter.latestAnswer(), 50e8, "fully reflected once the reference window passes");
+        assertFalse(adapter.isCapped());
+    }
+
+    // --- flooding: many rounds inside the anchor window must buy no extra movement ---
+
+    /// @dev THE ATTACK THIS ANCHOR EXISTS FOR. Bounding each round against its immediate predecessor
+    ///      bounds nothing when rounds are cheap: at 20% a round, four rounds halve a price and every
+    ///      step passes. The live PAXG feed has published three rounds inside one block, so this is
+    ///      observed behaviour rather than a thought experiment.
+    function test_flood_manyRoundsInOneInstantCannotWalkThePrice() public {
+        uint256 t = block.timestamp;
+        int256 price = 100e8;
+        for (uint256 i = 0; i < 10; ++i) {
+            price = price - (price * 2000) / 10_000; // each step is exactly one band below the last round
+            feed.push(price, t); // all in the same instant
+        }
+        assertLt(price, 11e8, "the feed itself walked down almost 90%");
+        assertEq(adapter.latestAnswer(), 80e8, "the adapter moved exactly one band, not ten");
+        assertTrue(adapter.isCapped());
+        assertTrue(adapter.referenceIsAnchored(), "still anchored: 10 rounds is inside MAX_LOOKBACK");
+    }
+
+    /// @dev The residual, asserted rather than left implicit. Flooding past MAX_LOOKBACK exhausts the
+    ///      walk, so the oldest reachable round is used and the attacker gains one band per
+    ///      MAX_LOOKBACK rounds. referenceIsAnchored() goes false, which is the alerting signal.
+    function test_flood_pastMaxLookbackFallsBackAndSaysSo() public {
+        uint256 t = block.timestamp;
+        int256 price = 100e8;
+        for (uint256 i = 0; i < adapter.MAX_LOOKBACK() + 4; ++i) {
+            price = price - (price * 500) / 10_000;
+            feed.push(price, t);
+        }
+        assertFalse(adapter.referenceIsAnchored(), "lookback exhausted - this is the alert condition");
+        assertTrue(adapter.hasReference(), "but a conservative reference is still used");
+        assertGt(adapter.latestAnswer(), price, "and it still clamps against the furthest round reached");
+    }
+
+    /// @dev THE LIMITATION, asserted so it is documented rather than assumed. The band bounds a
+    ///      *single round*. A feed that walks down one band per round is never clamped at all, so a
+    ///      patient attacker in control of the feed still reaches any price - it just takes
+    ///      ceil(move / BAND_BPS) rounds instead of one. The band buys detection time; it is not a
+    ///      substitute for monitoring the feed itself.
+    function test_gradualWalkDown_isNeverClamped() public {
+        int256 price = 100e8;
+        for (uint256 i = 0; i < 5; ++i) {
+            price = price - (price * 2000) / 10_000; // exactly one band down each round
+            vm.warp(block.timestamp + 2 hours); // each step clears the anchor window
+            feed.push(price, block.timestamp);
+            assertEq(adapter.latestAnswer(), price, "a one-band step is inside the band, so never clamped");
+            assertFalse(adapter.isCapped());
+        }
+        assertLt(price, 33e8, "reached -67% across five rounds without ever tripping the band");
+    }
+
+    function test_reference_isTheNewestRoundOldEnough() public {
+        feed.push(150e8, block.timestamp);
+        assertEq(adapter.referenceAnswer(), 100e8, "the fresh round is not eligible as its own anchor");
+        assertTrue(adapter.hasReference());
+        assertTrue(adapter.referenceIsAnchored());
+
+        // a second fresh round does NOT become the reference: it is inside the anchor window
+        feed.push(150e8, block.timestamp);
+        assertEq(adapter.referenceAnswer(), 100e8, "still anchored to the old round");
+
+        // only once it ages past REFERENCE_AGE does the anchor roll forward
+        vm.warp(block.timestamp + REF_AGE + 1);
+        assertEq(adapter.referenceAnswer(), 150e8, "anchor rolls forward with time, not with rounds");
+    }
+
+    function test_latestRoundData_returnsBandedAnswerWithOriginalRoundAndTime() public {
+        feed.push(500e8, block.timestamp);
+        (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound) = adapter.latestRoundData();
+        assertEq(answer, 120e8, "banded");
+        assertEq(updatedAt, block.timestamp, "underlying timestamp preserved for staleness checks");
+        assertEq(startedAt, block.timestamp);
+        assertEq(roundId, answeredInRound);
+        assertEq(uint64(roundId), 3);
+    }
+
+    function test_getRoundData_passesHistoryThroughUnbanded() public {
+        feed.push(500e8, block.timestamp);
+        (, int256 historical,,,) = adapter.getRoundData(uint80((uint256(1) << 64) | 3));
+        assertEq(historical, 500e8, "history is what the feed published, not what we would report now");
+    }
+
+    function test_revertsWhenLatestAnswerNonPositive() public {
+        feed.push(0, block.timestamp);
+        vm.expectRevert(IChainlinkPriceBandAdapter.InvalidPrice.selector);
+        adapter.latestAnswer();
+    }
+
+    // --- fail-open paths, each of which must NOT revert -------------------------------------------
+
+    function test_firstRoundOfPhase_hasNoReferenceAndPassesThrough() public {
+        feed.setPhase(2, 1);
+        // round 1 of phase 2, with an absurd value and no previous round to measure against
+        feed.seed(2, 1, 9999e8, block.timestamp);
+        assertFalse(adapter.hasReference(), "no previous round inside this phase");
+        assertEq(adapter.referenceAnswer(), 0);
+        assertEq(adapter.latestAnswer(), 9999e8, "fails open rather than reverting");
+        assertFalse(adapter.isCapped());
+    }
+
+    function test_historyReverting_failsOpen() public {
+        feed.push(500e8, block.timestamp);
+        feed.setRevertOnHistory(true);
+        assertFalse(adapter.hasReference());
+        assertEq(adapter.latestAnswer(), 500e8, "a reverting getRoundData must not brick the price");
+    }
+
+    function test_previousRoundZeroAnswer_failsOpen() public {
+        // phase 2 at round 2, whose round 1 was never written -> the reference answers zero
+        feed.setPhase(2, 2);
+        feed.seed(2, 2, 500e8, block.timestamp);
+        assertFalse(adapter.hasReference(), "a zero-answer reference is not a reference");
+        assertEq(adapter.latestAnswer(), 500e8);
+    }
+
+    /// @dev Decrementing a packed round id across a phase boundary reads a different aggregator.
+    ///      The adapter must preserve the phase, so phase 2 round 1 never references phase 1.
+    function test_doesNotReferenceAcrossPhaseBoundary() public {
+        // phase 1 rounds 1 and 2 exist from setUp and hold 100e8. If the adapter decremented across
+        // the boundary it would band 1000e8 against them and clamp to 120e8.
+        feed.setPhase(2, 1);
+        feed.seed(2, 1, 1000e8, block.timestamp);
+        assertFalse(adapter.hasReference());
+        assertEq(adapter.latestAnswer(), 1000e8);
+    }
+
+    // --- the band widens with round age ---
+
+    function test_widen_bandIsExactlyBandBpsOnAFreshRound() public {
+        feed.push(101e8, block.timestamp);
+        assertEq(adapter.roundAge(), 0);
+        assertEq(adapter.effectiveBandBps(), BAND);
+    }
+
+    function test_widen_growsOneBandPerPeriod() public {
+        feed.push(101e8, block.timestamp);
+        assertEq(adapter.effectiveBandBps(), BAND, "age 0 -> 1x");
+        vm.warp(block.timestamp + WIDEN);
+        assertEq(adapter.effectiveBandBps(), uint256(BAND) * 2, "age 1 period -> 2x");
+        vm.warp(block.timestamp + WIDEN * 3);
+        assertEq(adapter.effectiveBandBps(), uint256(BAND) * 5, "age 4 periods -> 5x");
+    }
+
+    /// @dev The case a fixed band handles badly: a big move, then a quiet market. The deviation
+    ///      trigger never fires again, so without widening the clamp would hold until the heartbeat.
+    function test_widen_clampReleasesWhileTheFeedStaysSilent() public {
+        uint256 t = block.timestamp;
+        feed.push(200e8, t); // +100% against a 20% band, and no further rounds will arrive
+
+        assertTrue(adapter.isCapped());
+        assertEq(adapter.latestAnswer(), 120e8, "on arrival: clamped at one band");
+
+        vm.warp(t + WIDEN);
+        assertEq(adapter.latestAnswer(), 140e8, "after one period: two bands");
+        assertTrue(adapter.isCapped());
+
+        vm.warp(t + WIDEN * 4);
+        assertEq(adapter.latestAnswer(), 200e8, "after four periods the raw value is inside the band");
+        assertFalse(adapter.isCapped(), "and the clamp has released with no new round at all");
+    }
+
+    function test_widen_floorReleasesToo() public {
+        uint256 t = block.timestamp;
+        feed.push(10e8, t); // -90%
+        assertEq(adapter.latestAnswer(), 80e8, "floored at one band");
+        vm.warp(t + WIDEN * 4);
+        assertEq(adapter.latestAnswer(), 10e8, "released downward as well");
+        assertFalse(adapter.isCapped());
+    }
+
+    /// @dev Once the widened band reaches 100% the floor would be non-positive. It must degrade to
+    ///      "no lower bound" rather than ever reporting zero or negative.
+    function test_widen_neverReportsNonPositiveWhenTheFloorWouldGoNegative() public {
+        uint256 t = block.timestamp;
+        feed.push(1, t); // one wei, far below any floor
+        vm.warp(t + WIDEN * 100); // band far past 100%
+        assertGt(adapter.effectiveBandBps(), 10_000);
+        assertEq(adapter.latestAnswer(), 1, "raw passes through");
+        assertGt(adapter.latestAnswer(), 0);
+    }
+
+    function test_widen_isCappedAtTheCeilingForADeadFeed() public {
+        feed.push(150e8, block.timestamp);
+        vm.warp(block.timestamp + 3650 days);
+        assertEq(adapter.effectiveBandBps(), 1_000_000, "capped so the delta cannot overflow");
+        assertEq(adapter.latestAnswer(), 150e8);
+    }
+
+    /// @dev Why a short widen period is safe even on a feed that normally goes 24h between rounds:
+    ///      widening only ever matters when something is being clamped. An answer already inside the
+    ///      base band is inside every wider band too, so an aged round with no clamp is unaffected -
+    ///      and every genuinely new round arrives at age zero with the band at full strength.
+    function test_widen_isANoOpWhenNothingIsClamped() public {
+        uint256 t = block.timestamp;
+        feed.push(105e8, t); // +5%, comfortably inside a 20% band
+        assertEq(adapter.latestAnswer(), 105e8);
+        assertFalse(adapter.isCapped());
+
+        vm.warp(t + WIDEN * 100); // band now enormous
+        assertGt(adapter.effectiveBandBps(), 10_000);
+        assertEq(adapter.latestAnswer(), 105e8, "unchanged: widening only releases a clamp");
+        assertFalse(adapter.isCapped());
+    }
+
+    function test_constructor_revertsOnWidenPeriodTooShort() public {
+        uint32 tooShort = adapter.MIN_WIDEN_PERIOD() - 1;
+        vm.expectRevert(abi.encodeWithSelector(IChainlinkPriceBandAdapter.InvalidWidenPeriod.selector, tooShort));
+        new ChainlinkPriceBandAdapter(feed, BAND, tooShort, REF_AGE, "x");
+    }
+
+    function test_constructor_revertsOnWidenPeriodTooLong() public {
+        uint32 tooLong = adapter.MAX_WIDEN_PERIOD() + 1;
+        vm.expectRevert(abi.encodeWithSelector(IChainlinkPriceBandAdapter.InvalidWidenPeriod.selector, tooLong));
+        new ChainlinkPriceBandAdapter(feed, BAND, tooLong, REF_AGE, "x");
+    }
+
+    // --- fuzz ------------------------------------------------------------------------------------
+
+    function testFuzz_neverExceedsCeilingAndNeverRaisesAFall(int256 next, uint16 bandBps) public {
+        next = bound(next, 1, int256(1e18));
+        bandBps = uint16(bound(bandBps, adapter.MIN_BAND_BPS(), adapter.MAX_BAND_BPS()));
+
+        ChainlinkPriceBandAdapter a = new ChainlinkPriceBandAdapter(feed, bandBps, WIDEN, REF_AGE, "fuzz");
+        feed.push(next, block.timestamp); // age 0, so the base band is what is under test
+
+        int256 reported = a.latestAnswer();
+        int256 delta = (100e8 * int256(uint256(bandBps))) / 10_000;
+        int256 ceiling = 100e8 + delta;
+        int256 floorPrice = 100e8 - delta;
+
+        assertLe(reported, ceiling, "never above the ceiling");
+        assertGe(reported, floorPrice, "never below the floor");
+        if (next > ceiling) assertEq(reported, ceiling, "clamped up");
+        else if (next < floorPrice) assertEq(reported, floorPrice, "clamped down");
+        else assertEq(reported, next, "untouched when inside the band");
+        assertGt(reported, 0, "never reports a non-positive price");
+    }
+}
+
+/// @dev Against the two live Optimism feeds this adapter was built for. Skipped when RPC_OPTIMISM
+///      is unset so the default suite stays offline.
+contract ChainlinkPriceBandAdapterForkTest is Test {
+    address internal constant SPY_USD_OP = 0x5F77134CfAA7DB2906649Ca21C50dA54daE9291d;
+    address internal constant PAXG_USD_OP = 0x977CD3bC66A1FA9Fb22F9BEAA966E06996f70512;
+
+    function setUp() public {
+        vm.createSelectFork(vm.envOr("OPTIMISM_RPC", string("https://mainnet.optimism.io")));
+    }
+
+    function _check(address feed, uint16 band, string memory label) internal {
+        ChainlinkPriceBandAdapter a = new ChainlinkPriceBandAdapter(IAggregatorV3(feed), band, 1 hours, 1 hours, string.concat("Banded ", label));
+
+        assertEq(a.decimals(), IAggregatorV3(feed).decimals(), "decimals mirrored");
+        assertTrue(a.hasReference(), "live feed must expose a previous round");
+        assertGt(a.referenceAnswer(), 0, "reference positive");
+
+        int256 raw = a.rawAnswer();
+        int256 reported = a.latestAnswer();
+        assertGt(raw, 0, "raw positive");
+        assertEq(reported, raw, "a 20% band must not clamp a live feed");
+        assertFalse(a.isCapped(), "not capped in normal markets");
+    }
+
+    function test_fork_spy() public {
+        _check(SPY_USD_OP, 2000, "SPY-USD (24/5)");
+    }
+
+    function test_fork_paxg() public {
+        _check(PAXG_USD_OP, 2000, "PAXG / USD");
+    }
+
+    /// @dev The downward half, on a live feed: a manipulated crash to near zero must be floored, so
+    ///      healthy positions are not liquidated on a price that never existed.
+    function test_fork_clampsAnInjectedCrash() public {
+        ChainlinkPriceBandAdapter a = new ChainlinkPriceBandAdapter(IAggregatorV3(SPY_USD_OP), 2000, 1 hours, 1 hours, "Banded SPY");
+
+        int256 refPrice = a.referenceAnswer();
+        (uint80 roundId,, uint256 startedAt, uint256 updatedAt,) = IAggregatorV3(SPY_USD_OP).latestRoundData();
+
+        vm.mockCall(SPY_USD_OP, abi.encodeWithSelector(IAggregatorV3.latestRoundData.selector), abi.encode(roundId, int256(1), startedAt, block.timestamp, roundId));
+
+        assertTrue(a.isCapped(), "a crash to 1 wei must be clamped");
+        int256 effD = int256(a.effectiveBandBps());
+        assertEq(a.latestAnswer(), refPrice - (refPrice * effD) / 10_000, "floored at reference - one effective band");
+    }
+
+    /// @dev The band must bind on a live feed when the feed itself prints something absurd.
+    function test_fork_clampsAnInjectedSpike() public {
+        ChainlinkPriceBandAdapter a = new ChainlinkPriceBandAdapter(IAggregatorV3(SPY_USD_OP), 2000, 1 hours, 1 hours, "Banded SPY");
+
+        int256 refPrice = a.referenceAnswer();
+        (uint80 roundId,, uint256 startedAt, uint256 updatedAt,) = IAggregatorV3(SPY_USD_OP).latestRoundData();
+
+        vm.mockCall(SPY_USD_OP, abi.encodeWithSelector(IAggregatorV3.latestRoundData.selector), abi.encode(roundId, refPrice * 10, startedAt, block.timestamp, roundId));
+
+        assertTrue(a.isCapped(), "a 10x print must be clamped");
+        int256 eff = int256(a.effectiveBandBps());
+        assertEq(a.latestAnswer(), refPrice + (refPrice * eff) / 10_000, "clamped to reference + one effective band");
+    }
+}

--- a/test/price-provider/ChainlinkPriceBandAdapter.t.sol
+++ b/test/price-provider/ChainlinkPriceBandAdapter.t.sol
@@ -191,22 +191,55 @@ contract ChainlinkPriceBandAdapterTest is Test {
         assertLt(price, 11e8, "the feed itself walked down almost 90%");
         assertEq(adapter.latestAnswer(), 80e8, "the adapter moved exactly one band, not ten");
         assertTrue(adapter.isCapped());
-        assertTrue(adapter.referenceIsAnchored(), "still anchored: 10 rounds is inside MAX_LOOKBACK");
+        assertTrue(adapter.referenceIsAnchored(), "the anchor is the genuine pre-burst round");
     }
 
-    /// @dev The residual, asserted rather than left implicit. Flooding past MAX_LOOKBACK exhausts the
-    ///      walk, so the oldest reachable round is used and the attacker gains one band per
-    ///      MAX_LOOKBACK rounds. referenceIsAnchored() goes false, which is the alerting signal.
-    function test_flood_pastMaxLookbackFallsBackAndSaysSo() public {
+    /// @dev The hole a bounded backwards walk would leave, now closed. Flooding far more rounds
+    ///      than any fixed lookback could cover must NOT hand the attacker a reference of their own
+    ///      choosing: the anchor is binary-searched, so it is still the genuine pre-burst round.
+    function test_flood_pastAnyFixedLookbackStillAnchorsCorrectly() public {
         uint256 t = block.timestamp;
         int256 price = 100e8;
-        for (uint256 i = 0; i < adapter.MAX_LOOKBACK() + 4; ++i) {
+        for (uint256 i = 0; i < 80; ++i) {
             price = price - (price * 500) / 10_000;
             feed.push(price, t);
         }
-        assertFalse(adapter.referenceIsAnchored(), "lookback exhausted - this is the alert condition");
-        assertTrue(adapter.hasReference(), "but a conservative reference is still used");
-        assertGt(adapter.latestAnswer(), price, "and it still clamps against the furthest round reached");
+        assertLt(price, 2e8, "the feed itself walked down over 98%");
+        assertTrue(adapter.referenceIsAnchored(), "still anchored despite 80 rounds inside the window");
+        assertEq(adapter.referenceAnswer(), 100e8, "anchor is the genuine pre-burst round");
+        assertEq(adapter.latestAnswer(), 80e8, "still exactly one band, not one band per lookback");
+        assertTrue(adapter.isCapped());
+    }
+
+    /// @dev Repeating the burst in the same instant must buy nothing either - the anchor does not
+    ///      move until the clock does, so a second flood is bounded by the same reference.
+    function test_flood_repeatedBurstsInOneInstantBuyNothing() public {
+        uint256 t = block.timestamp;
+        int256 price = 100e8;
+        for (uint256 round = 0; round < 3; ++round) {
+            for (uint256 i = 0; i < 40; ++i) {
+                price = price - (price * 500) / 10_000;
+                feed.push(price, t);
+            }
+            assertEq(adapter.latestAnswer(), 80e8, "every burst clamps to the same one band");
+            assertEq(adapter.referenceAnswer(), 100e8, "and against the same anchor");
+        }
+    }
+
+    /// @dev `anchored` false is now reserved for a phase younger than REFERENCE_AGE - a fresh
+    ///      aggregator upgrade, which an attacker cannot manufacture. The oldest round in the phase
+    ///      is used, which is the most conservative reference available.
+    function test_anchorAbsentOnlyWhenTheWholePhaseIsYoungerThanTheWindow() public {
+        feed.setPhase(3, 0);
+        uint256 t = block.timestamp;
+        feed.seed(3, 1, 100e8, t);
+        feed.seed(3, 2, 100e8, t);
+        feed.seed(3, 3, 500e8, t);
+        feed.setPhase(3, 3);
+
+        assertFalse(adapter.referenceIsAnchored(), "no round in this phase is old enough");
+        assertTrue(adapter.hasReference(), "but the oldest available round is still used");
+        assertEq(adapter.latestAnswer(), 120e8, "and it still clamps");
     }
 
     /// @dev THE LIMITATION, asserted so it is documented rather than assumed. The band bounds a


### PR DESCRIPTION
> Moved here from `aave-v4` #12. One review finding since — a flood of updates could bypass the limit — is fixed in `47e5262`; see scenario 6. This belongs next to the other price feeds in `src/oracle/`, and it now reuses this repo's `IAggregatorV3` rather than carrying its own aggregator interface.

## The problem

We are about to accept a tokenised S&P 500 share (wSPYx) and gold (PAXG) as collateral people can borrow against. The price of both comes from a Chainlink feed on Optimism.

If that feed ever reports a wrong number — a glitch, a bug, or someone who has taken control of it — the money market believes it immediately. Two things can then happen, and they hurt different people:

- **Price reported too high.** Someone borrows against collateral that is not worth what the system thinks. They walk away, and the shortfall lands on everyone who supplied to the pool.
- **Price reported too low.** Perfectly healthy borrowers are marked as underwater and liquidated at a price the market never traded at. They lose their collateral, and there is no undoing it.

This adapter sits between the feed and the consumer and limits **how fast the price we lend against is allowed to move.** It does not decide what the price is. It only refuses to move it further than a set amount within a set stretch of time.

## How it works, in one line

> Compare the feed's newest number against what that same feed was saying an hour ago. If it has moved more than 20%, report the 20% and no more.

The number it compares against comes from the feed's own published history, so there is nothing to store, no one to keep it updated, and no extra moving part that can fail. It presents `IAggregatorV3`, so it drops in wherever the raw feed does.

## Every attack and failure we worked through

Written out because the reasoning is the reviewable part, and several of these changed the design after we found them.

### 1. A single wrong number, too high
Someone borrows against inflated collateral and never repays.
**Covered.** The reported price stops 20% above where the feed was an hour ago.

### 2. A single wrong number, too low
Healthy borrowers get liquidated at a price that never existed. Irreversible for them.
**Covered.** The limit works in both directions.

This was originally one-directional. The argument for adding the downward half: a wrongly *low* price destroys real user positions, and the usual objection to blocking price falls — that it lets bad debt pile up — does not apply here, because the comparison always uses what the feed actually published, never our own limited number. So a genuine crash is never held back indefinitely.

### 3. A real, very large move that then goes quiet
A price genuinely moves 30% and then stops moving.
**This one nearly broke the design.** Chainlink only publishes when the price moves 0.5% *or* 24 hours pass. If the price jumps and then sits still, nothing publishes for a day — so the remaining 10% would not have been reported for **24 hours**. Simulated and measured exactly that. Held too high, liquidations that should happen do not. Held too low, borrowers get liquidated on a stale number.

**Fixed** by letting the limit loosen the longer the feed stays silent, so it fades out over hours instead of waiting for the next publish.

### 4. Many wrong numbers posted very quickly
The one that mattered most. Comparing each number only against the one immediately before it stops nothing if numbers are cheap to post: at 20% a step, **four steps halve a price and thirteen make it ten times bigger**, and every single step passes the check.

This is not theoretical. On the live PAXG feed:
- the shortest gap between two published numbers is **zero seconds**
- **three numbers landed in a single block** (`0x1675824`), moving 2.765% between them
- 84 published within two minutes of the one before

So the original design gave essentially **no protection** against anyone who had taken over the feed. They could have done it in about one block.

**Fixed** by comparing against what the feed said *an hour ago* rather than against the number immediately before. Posting a hundred numbers in one second now buys exactly the same movement as posting one, because they all get compared against the same older number. The guarantee changes from "20% per update", which means nothing when updates are free, to **"20% per hour"**, which does.

Checked against real history so it does not interfere with honest trading: the largest genuine one-hour move on record is **7.50%** for gold and **1.54%** for the S&P feed. Both sit well inside 20%.

### 5. Someone moving the price slowly and patiently
Nudging the price just under the limit, waiting an hour, and repeating.
**Not solved, and deliberately so — the code and tests say as much.** The limit caps movement per hour, so reaching an arbitrary price takes hours of sustained control rather than one block. That buys time to notice, which is the whole point. It is a rate limit, not a wall. Closing it entirely would need the contract to remember things between calls, which it cannot do and stay a plain read.

### 6. Someone floods a huge number of updates at once
Post hundreds of updates in one block, each a small step, and walk the price down.
**Covered — but only after review caught that it was not.** The first version looked back a fixed number of updates. Flood past that and the thing we compare against becomes one of the attacker's own recent numbers, which restores exactly the loophole the hour window was meant to close. And it is repeatable within the same block: **64 updates would have halved the price**, with nothing ever reported as limited, because each individual step was small enough to pass.

Now the comparison point is found by binary search instead, so it is located exactly no matter how many updates get posted. Tested with 80 updates in a single instant walking the feed down 98%: the adapter still compares against the genuine pre-flood number and still reports only the 20%.

The normal cost is unchanged — one lookup, because these feeds publish far less often than an hour. Only a flood pays more.

### 7. The feed is replaced with a new one
Chainlink occasionally swaps the machinery behind a feed. Reaching back across that boundary reads a **different** feed and, on the live SPY feed, returns zero.
**Covered.** The search never crosses the boundary, and the first number after a swap is treated as having nothing to compare against.

### 8. The feed reports zero or a negative number
That is a broken feed, not a wrong price.
**Deliberately the one case that stops everything rather than limiting it.** Pretending it is merely "very low" would report a plausible-looking number from a feed producing garbage, and the freshness check would keep saying everything is fine.

### 9. There is nothing to compare against
First number after a feed swap, or history unreadable.
**We report the feed's number unchanged rather than stopping.** Refusing to answer would take down *everything* on that reserve — including liquidations, which is exactly when you need it working. `hasReference()` exposes it so it can be alerted on instead.

### 10. The market is shut
The S&P feed does not publish at weekends; it is a 24/5 market in a 24/7 lending pool.
**Not this contract's job**, but it interacts: a closed market is not a broken feed. Worth flagging separately that the current 78-hour freshness window on the SPY leg clears the longest observed weekend by only 11.6 hours, and a Friday market holiday would exceed it.

## What it is *not*

It is not a source of truth, and it does not know what anything is worth. If the feed is wrong and stays wrong, this delays that reaching the money market by roughly an hour and then lets it through. **It buys time. Someone has to use that time.**

`isCapped()` going true is an alert with a deadline attached, not a statistic.

## Choosing the numbers

**20%** comes from the market itself, not from curve-fitting. US exchanges halt trading for the day if the S&P falls 20%, so a single session physically cannot exceed it — meaning the limit cannot interfere with real trading, by construction. Across the entire history of both feeds it would never once have triggered.

**One hour** for the comparison window, and **one hour** for how fast the limit fades when a feed goes silent. The second should really be set to how long it takes a human to look at an alert and decide.

## Testing

`forge test --match-path test/price-provider/ChainlinkPriceBandAdapter.t.sol`

**38 tests: 34 offline, 4 against the live Optimism feeds.** Including a 1000-run randomised check that the reported price always stays inside the limit and is never zero or negative.

Every failure path is tested to make sure it does **not** stop the reserve. Both attacks are tested against the real feeds. The one remaining limitation — the patient attacker who waits out each window — has a test of its own, so it is documented behaviour rather than a surprise.

The two pre-existing failures in `test/price-provider/` (`PriceProvider.t.sol`, `PriceProviderV2.t.sol`) are a missing `MAINNET_RPC` and fail identically on a clean `master`.

## Not in this PR

Deployment and wiring. Contract and tests only, so it can be reviewed and audited on its own.

Walkthrough with a live simulation you can push past the limits: https://claude.ai/code/artifact/27cfc15c-7a4f-4dc8-9524-f062144f8974

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/etherfi-protocol/codesmith/cash-v3/pr/271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788700207&installation_model_id=18424&pr_number=271&repository=etherfi-protocol%2Fcash-v3&return_to=https%3A%2F%2Fgithub.com%2Fetherfi-protocol%2Fcash-v3%2Fpull%2F271&signature=9bc88e777cc8fd6344b36ca33382d4c6678c5e0737bb99d6f95971cfda03422b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> New collateral pricing safety layer directly affects borrow/liquidation if wired wrong; fail-open and band-widening behavior must be monitored when integrated.
> 
> **Overview**
> Adds **`ChainlinkPriceBandAdapter`**, a new `IAggregatorV3` wrapper that rate-limits how far the reported collateral price can move from what the underlying Chainlink feed published **`REFERENCE_AGE`** seconds ago (not from the prior round), with bidirectional clamping, age-based band widening, and observability via `isCapped()`, `hasReference()`, and `referenceIsAnchored()`.
> 
> **Fail-open** when there is no usable history (phase start, broken lookback); **reverts** on non-positive latest answers. Historical `getRoundData` stays unbanded; `latestRoundData` keeps the feed’s timestamps for staleness checks. Includes **`IChainlinkPriceBandAdapter`**, extensive unit/fuzz tests, and Optimism fork tests against SPY/PAXG—**no deployment or price-provider wiring** in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d29757d2b770f8813e7f34aac671ac54ebc724ed. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
