### PR TITLE
chore(deployments): sync lend oracle manifests to live OP state

### DIFF
--- a/deployments/dev/10/aave-v4-test.json
+++ b/deployments/dev/10/aave-v4-test.json
@@ -17,6 +17,7 @@
     "eUSD": 11,
     "frxUSD": 18,
     "iPAXG": 24,
+    "iwQQQx": 25,
     "iwSPYx": 23,
     "iwTBLLx": 26,
     "liquidBTC": 8,
@@ -29,86 +30,146 @@
     "weEUR": 13
   },
   "details": {
-    "weETH": {
-      "assetId": 0,
-      "oracle": "0x96A0bd28762FfFcAd61814480AdcF25852407575"
-    },
-    "USDC": {
-      "assetId": 1,
-      "oracle": "0x4AF1F64c2d3Af036f01E9312F5efbb03e6Fbb069"
-    },
     "ETHFI": {
       "assetId": 2,
-      "oracle": "0x5f3AB9C6827C327b7D0F472Eb9B48954bF8fB3CA"
-    },
-    "WHYPE": {
-      "assetId": 3,
-      "oracle": "0x5A0Cd4c7b56349030D8180358592A783F45cEE7a"
-    },
-    "beHYPE": {
-      "assetId": 4,
-      "oracle": "0xb4C086BD0C5Aa7ad39317B05378f392F72A07694"
+      "oracle": "0x1fcD5397C65CE3aB3314416cc64c66128123b56a",
+      "reserveId": 2,
+      "underlying": "0xe0080d2F853ecDdbd81A643dC10DA075Df26fD3f"
     },
     "EURC": {
       "assetId": 5,
-      "oracle": "0x5E169BFAacB0CA0d500459da652D33d962CD9cbA"
-    },
-    "sETHFI": {
-      "assetId": 6,
-      "oracle": "0x23fB1FcDeBa86AbAD98f05cD5e43471506771EFa"
-    },
-    "liquidETH": {
-      "assetId": 7,
-      "oracle": "0x679f9A5b3bce48EA1C23d212687CB42f68d69b09"
-    },
-    "liquidBTC": {
-      "assetId": 8,
-      "oracle": "0x7D699793abf8d0D7B564Fa7D691d8319402a865a"
-    },
-    "liquidUSD": {
-      "assetId": 9,
-      "oracle": "0x741e22029ff8e0f1dab6EaAf3534a78D378f3326"
-    },
-    "eBTC": {
-      "assetId": 10,
-      "oracle": "0x767c781d95102dAf6aF4d39A280A2D628569F12c"
-    },
-    "eUSD": {
-      "assetId": 11,
-      "oracle": "0x9ED5A183a8B6e1A57e7cB59414b163ba3cbEBA41"
-    },
-    "liquidRESERVE": {
-      "assetId": 19,
-      "oracle": "0x40b9592D149fA7e6f5BA1A5Cc323ef285C99d903"
-    },
-    "weEUR": {
-      "assetId": 13,
-      "oracle": "0xD83883E629880768cB34e0081C0307A0B1bb398e"
-    },
-    "liquidRWA": {
-      "assetId": 14,
-      "oracle": "0xB17c7d6d0EeF182CB3427934a585E13f3107fE95"
-    },
-    "USDT": {
-      "assetId": 15,
-      "oracle": "0xa5c7cBf2B6E4C709C53cE08d2335106022D6dc6e"
-    },
-    "WETH": {
-      "assetId": 16,
-      "oracle": "0xE38195823A53B9597cD82ABcB2c608CEa9A31540"
+      "oracle": "0xDf1150433D0d7eb7913dc8D60687D3977C3C5FA9",
+      "reserveId": 5,
+      "underlying": "0xDCB612005417Dc906fF72c87DF732e5a90D49e11"
     },
     "OP": {
       "assetId": 17,
-      "oracle": "0xcAd11E8565B9Af9559F1C8AACdE3C523eC53DC1e"
+      "oracle": "0x8774f71894A10056f7C7AC5E6863FF092BA7a3B5",
+      "reserveId": 17,
+      "underlying": "0x4200000000000000000000000000000000000042"
+    },
+    "USDC": {
+      "assetId": 1,
+      "oracle": "0x5B057985496A6ff09bf62C9Ba867Ae5dDEAFA4E0",
+      "reserveId": 1,
+      "underlying": "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85"
+    },
+    "USDT": {
+      "assetId": 15,
+      "oracle": "0x7579977643ee68946DB95d9Cb5fF582674619025",
+      "reserveId": 15,
+      "underlying": "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58"
+    },
+    "WETH": {
+      "assetId": 16,
+      "oracle": "0x4060F7d705A32DfC7B96f352e62589c25007e16B",
+      "reserveId": 16,
+      "underlying": "0x4200000000000000000000000000000000000006"
+    },
+    "WHYPE": {
+      "assetId": 3,
+      "oracle": "0xA9D5227D0063904Cb20d0fC9a2e71dd4cb19F8cD",
+      "reserveId": 3,
+      "underlying": "0xd83E3d560bA6F05094d9D8B3EB8aaEA571D1864E"
+    },
+    "beHYPE": {
+      "assetId": 4,
+      "oracle": "0x0547C7F5E4923895C5516D57aaE108fDb943933F",
+      "reserveId": 4,
+      "underlying": "0xA519AfBc91986c0e7501d7e34968FEE51CD901aC"
+    },
+    "eBTC": {
+      "assetId": 10,
+      "oracle": "0x24a0f20d45d044640Ab1cdcBCD23195AB2b4a810",
+      "reserveId": 10,
+      "underlying": "0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"
+    },
+    "eUSD": {
+      "assetId": 11,
+      "oracle": "0xD7b9c2d4ed89298433aA8CE035D9F593068ED34f",
+      "reserveId": 11,
+      "underlying": "0x939778D83b46B456224A33Fb59630B11DEC56663"
     },
     "frxUSD": {
       "assetId": 18,
-      "oracle": "0x29D41f740b21dd28E1627DF2cCd307E978A7A454"
+      "oracle": "0x41D2200dbad68710C74E5a8E515D883b6177acf7",
+      "reserveId": 18,
+      "underlying": "0x80Eede496655FB9047dd39d9f418d5483ED600df"
+    },
+    "iPAXG": {
+      "assetId": 24,
+      "oracle": "0xaC28d7fe39d16aa0d35CDCc8cE939125cB3f091b",
+      "reserveId": 24,
+      "underlying": "0x41a7f2bb9789199654c206f09392674c1Af6676c"
+    },
+    "iwQQQx": {
+      "assetId": 25,
+      "leg": "0x2cD17B00f5E2C0613323C2fdB9709d54d958AFEb",
+      "oracle": "0x7106e8D7f272BAa57dbB99372FBBC7FDD06D29DC",
+      "reserveId": 26,
+      "underlying": "0x3c99d3a81b27583B2E26dbd387C10411f2763516"
     },
     "iwSPYx": {
-      "oracle": "0x5ce12709a8881309580e6768d0111CD7526c6888",
-      "spyUsdLeg": "0x3184C90dAFbC13Eff2D402B84d341B2f71720140",
-      "assetId": 20
+      "assetId": 23,
+      "leg": "0xf41eBb842D8e2e2ea818BC6f27497fEF97FAe68F",
+      "oracle": "0x8b44f7Acf288ea79795223dDfd5F872f51d33fb9",
+      "reserveId": 23,
+      "underlying": "0xc1e636Aae7d6B46229FC2C362d562610519e8D7c"
+    },
+    "iwTBLLx": {
+      "assetId": 26,
+      "leg": "0xeb1A9eBBe265E3f0Bd69d0eF27536cD1DC77Bc73",
+      "oracle": "0x81D0305B9DC94f8f177Bbf6DbEB0278D7afF22Df",
+      "reserveId": 25,
+      "underlying": "0x5F8b2D2b97aD4d63188f44965778F6004D5bc387"
+    },
+    "liquidBTC": {
+      "assetId": 8,
+      "oracle": "0x16e73C673C09bD02098535D98DbD825E63f086D2",
+      "reserveId": 8,
+      "underlying": "0x5f46d540b6eD704C3c8789105F30E075AA900726"
+    },
+    "liquidETH": {
+      "assetId": 7,
+      "oracle": "0xb23A64323F7D8C31d28F8d5a7592b8914d881d0f",
+      "reserveId": 7,
+      "underlying": "0xf0bb20865277aBd641a307eCe5Ee04E79073416C"
+    },
+    "liquidRESERVE": {
+      "assetId": 19,
+      "oracle": "0x6b5C6155A07A5E3af6591d48571FC1BdFEc929BC",
+      "reserveId": 19,
+      "underlying": "0xca5921DF65E2e1b0B98Ae91c0187BA80D4124898"
+    },
+    "liquidRWA": {
+      "assetId": 14,
+      "oracle": "0x6Bf29C9bec671EE7787352EBc42c2151a7BC2854",
+      "reserveId": 14,
+      "underlying": "0x17bC8Ffd82b8a36e737Ca1141C025089589B915e"
+    },
+    "liquidUSD": {
+      "assetId": 9,
+      "oracle": "0x672e7e070E49FaC6e26b3FEC912C328d15859CF6",
+      "reserveId": 9,
+      "underlying": "0x08c6F91e2B681FaF5e17227F2a44C307b3C1364C"
+    },
+    "sETHFI": {
+      "assetId": 6,
+      "oracle": "0x5924194Cf0d39b8eAE66aFe52ef80A027F3DC39f",
+      "reserveId": 6,
+      "underlying": "0x86B5780b606940Eb59A062aA85a07959518c0161"
+    },
+    "weETH": {
+      "assetId": 0,
+      "oracle": "0x6D6afbc1579EB8e17C170Fc60a67161bc9F44874",
+      "reserveId": 0,
+      "underlying": "0x5A7fACB970D094B6C7FF1df0eA68D99E6e73CBFF"
+    },
+    "weEUR": {
+      "assetId": 13,
+      "oracle": "0xFA239571dDa672A935Fb7962513b37b1CfF280cb",
+      "reserveId": 13,
+      "underlying": "0xcC476B1a49bcDf5192561e87b6Fb8ea78aa28C13"
     }
   },
   "hub": "0x03641abDa8BF0d9196CE44EbEd9f85ccCe3c5e1f",
@@ -127,6 +188,7 @@
     "eUSD": 11,
     "frxUSD": 18,
     "iPAXG": 24,
+    "iwQQQx": 26,
     "iwSPYx": 23,
     "iwTBLLx": 25,
     "liquidBTC": 8,
@@ -137,6 +199,35 @@
     "sETHFI": 6,
     "weETH": 0,
     "weEUR": 13
+  },
+  "shadowedReserves": {
+    "iPAXG#22": {
+      "assetId": 22,
+      "oracle": "0x7DC0EAff1ECaED8A8A5aDC07dEe1997fF4617800",
+      "reserveId": 22,
+      "underlying": "0x56904d70E597e1D2D40853c61B6aA95622c70B0e"
+    },
+    "iwSPYx#20": {
+      "assetId": 20,
+      "leg": "0x3184C90dAFbC13Eff2D402B84d341B2f71720140",
+      "oracle": "0x5ce12709a8881309580e6768d0111CD7526c6888",
+      "reserveId": 20,
+      "underlying": "0xc83305D859EAc5E34B6aa00b4a45bDC13b2F3869"
+    },
+    "iwSPYx#21": {
+      "assetId": 21,
+      "leg": "0xcA5bB551C8919B500C576d93042aA385E8F8a08A",
+      "oracle": "0xF81b2D32401fcd8E2d9649F15f809c72a5D574f5",
+      "reserveId": 21,
+      "underlying": "0xCb4Ee509849AC1101b16556c658d6c48e5862fFA"
+    },
+    "liquidRESERVE#12": {
+      "assetId": 12,
+      "leg": "0x8239C48ff262AffCBA90Cb36206539Bfecb8EA9a",
+      "oracle": "0xEaba9eb473b3D044B9D88A746e642c1DD67EAdB0",
+      "reserveId": 12,
+      "underlying": "0xE5d3854736e0D513aAE2D8D708Ad94d14Fd56A6a"
+    }
   },
   "spoke": "0x7e99c7846df8527FFE510a2CA0215874052102ed",
   "spokeImpl": "0xd5a5efaA08f2DF808f2EA2dBFA82cfC0B0AfaF75",

--- a/deployments/mainnet/10/summer-lend-feeds.json
+++ b/deployments/mainnet/10/summer-lend-feeds.json
@@ -1,64 +1,64 @@
 {
   "details": {
     "BTC": {
-      "oracle": "0xd85031243f5c9CeFf5a976f509de65D0E12aec59"
+      "oracle": "0x00cb3f2A553E0b641877e9C4E7eBbf64c277f492"
     },
     "ETH": {
-      "oracle": "0xCFe45EF2B9E138E5A2e1C25592441D5c556B3ca3"
+      "oracle": "0x4060F7d705A32DfC7B96f352e62589c25007e16B"
     },
     "ETHFI": {
-      "oracle": "0x89AB0BeEF8f88933f4724a2D0C4a149c644a8a80"
+      "oracle": "0x1fcD5397C65CE3aB3314416cc64c66128123b56a"
     },
     "EURC": {
-      "oracle": "0xcBF18F68e2aBd480231241fa97BD41aE556433A0"
+      "oracle": "0xDf1150433D0d7eb7913dc8D60687D3977C3C5FA9"
     },
     "OP": {
-      "oracle": "0x6D53a69EBC75cFeDf319F77569a4F732f75AED79"
+      "oracle": "0x8774f71894A10056f7C7AC5E6863FF092BA7a3B5"
     },
     "PAXG": {
-      "oracle": "0x7DC0EAff1ECaED8A8A5aDC07dEe1997fF4617800"
+      "oracle": "0xaC28d7fe39d16aa0d35CDCc8cE939125cB3f091b"
     },
     "QQQ": {
-      "oracle": "0x459E1D5e587eB81bA25C6AA1e817e40bd36fb2F4"
+      "oracle": "0x2cD17B00f5E2C0613323C2fdB9709d54d958AFEb"
     },
     "SPY": {
-      "oracle": "0x045ACc54e73f93c5b9B4F20Fa01931cB23234C38"
+      "oracle": "0xf41eBb842D8e2e2ea818BC6f27497fEF97FAe68F"
     },
     "TBLL": {
-      "oracle": "0x1A74F66b6CF21b582C316398925b24D3D04C8C7D"
+      "oracle": "0xeb1A9eBBe265E3f0Bd69d0eF27536cD1DC77Bc73"
     },
     "USDC": {
-      "oracle": "0xE55eacdC1EC9dA0f33B9CEa7D136a47CC6008C69"
+      "oracle": "0x5B057985496A6ff09bf62C9Ba867Ae5dDEAFA4E0"
     },
     "USDT": {
-      "oracle": "0x6a6B2529c1BC14f0A062D7903B4894B477BfFc92"
+      "oracle": "0x7579977643ee68946DB95d9Cb5fF582674619025"
     },
     "beHYPE": {
-      "oracle": "0xefeDBa79436767AAfcF7902C66383d4735DacA50"
+      "oracle": "0x0547C7F5E4923895C5516D57aaE108fDb943933F"
     },
     "eBTC": {
-      "oracle": "0xFa80bA4b7aC946F3b45DC8ED537b1BEbD8eC860f"
+      "oracle": "0x24a0f20d45d044640Ab1cdcBCD23195AB2b4a810"
     },
     "eUSD": {
-      "oracle": "0xD617E1D59aA992D985c07ADC48c36aD2a00E751b"
+      "oracle": "0xD7b9c2d4ed89298433aA8CE035D9F593068ED34f"
     },
     "frxUSD": {
-      "oracle": "0x859c126dad6952a798ecdc5c06f7063B8a9FCC31"
+      "oracle": "0x41D2200dbad68710C74E5a8E515D883b6177acf7"
     },
     "iwQQQx": {
-      "oracle": "0xb5f61BDfCa60c02d13377d4386288FE143b9d6bE"
+      "oracle": "0x7106e8D7f272BAa57dbB99372FBBC7FDD06D29DC"
     },
     "iwSPYx": {
-      "oracle": "0x253F4Fb7082e314430972A2B783aD7514D20d64c"
+      "oracle": "0x8b44f7Acf288ea79795223dDfd5F872f51d33fb9"
     },
     "iwTBLLx": {
-      "oracle": "0x1cee92F999D536320aFb740b2ea5318C45d9C93B"
+      "oracle": "0x81D0305B9DC94f8f177Bbf6DbEB0278D7afF22Df"
     },
     "liquidBTC": {
-      "oracle": "0xD60ec8fCba09c7642099eA89A9D58721B00277C7"
+      "oracle": "0x16e73C673C09bD02098535D98DbD825E63f086D2"
     },
     "liquidETH": {
-      "oracle": "0x48420d702a3190235B5A5D123ca82f876752add1"
+      "oracle": "0xb23A64323F7D8C31d28F8d5a7592b8914d881d0f"
     },
     "liquidRESERVE": {
       "oracle": "0x6b5C6155A07A5E3af6591d48571FC1BdFEc929BC"
@@ -67,19 +67,19 @@
       "oracle": "0x6Bf29C9bec671EE7787352EBc42c2151a7BC2854"
     },
     "liquidUSD": {
-      "oracle": "0x17DdE04d8Ff1024D3076944658ED9B6bd5F51451"
+      "oracle": "0x672e7e070E49FaC6e26b3FEC912C328d15859CF6"
     },
     "sETHFI": {
-      "oracle": "0xaF8749C3DC1Fc0592f21c2593204C45D3bE0d322"
+      "oracle": "0x5924194Cf0d39b8eAE66aFe52ef80A027F3DC39f"
     },
     "wHYPE": {
-      "oracle": "0x7405E1C9a5AdC2A1730f38186f5845EC54Cd1B22"
+      "oracle": "0xA9D5227D0063904Cb20d0fC9a2e71dd4cb19F8cD"
     },
     "weETH": {
-      "oracle": "0x81ED135fc10FF855202E582d8cfd50E8A5533fd9"
+      "oracle": "0x6D6afbc1579EB8e17C170Fc60a67161bc9F44874"
     },
     "weEUR": {
-      "oracle": "0x7605dbe2948C99a559B9a065881916Ef043dA567"
+      "oracle": "0xFA239571dDa672A935Fb7962513b37b1CfF280cb"
     }
   }
 }


### PR DESCRIPTION
Regenerates both Aave v4 price-source manifests on OP Mainnet from live chain state. Deployment records only — no contract or script changes in this PR.

## Why

**`deployments/mainnet/10/summer-lend-feeds.json` was stale in all 27 entries.** It records the pre-CAPO, pre-3CP-644 feed set, so not a single address in it was what prod actually reads today. This was already flagged in `scripts/aave-v4/README-3CP-644.md` and `scripts/wspyx-paxg/README.md`.

**`deployments/dev/10/aave-v4-test.json`** predated the later dev refreshes and was missing the three stock reserves entirely. `scripts/lend/README.md` told you to fix its `details` map by hand.

## What changed

`summer-lend-feeds.json` — every entry now reflects the live prod source. The four leg-only keys (`BTC`, `SPY`, `QQQ`, `TBLL`), which no reserve points at directly, are resolved out of the live source graph via `underlyingUsdFeed()` and `BASE_TO_USD_AGGREGATOR()` rather than carried forward.

`aave-v4-test.json` — records the dev instance after its reserves were repointed at prod's feeds: 20 repointed, 3 already there, 4 dev-only tokens prod does not list keep their own feeds. Matching was by underlying token, not symbol, because dev lists superseded tokens sharing a symbol with a live one.

## Schema is preserved

Existing readers keep working. The symbol → id maps keep their last-wins convention, and `details` stays symbol-keyed. Additions only:

- `details` entries gain `reserveId`, `assetId`, `underlying` alongside `oracle`, plus `leg` where the source exposes a composed USD leg — so a symbol listed more than once is no longer ambiguous about which token it describes.
- The four reserves shadowed by the last-wins rule are recorded under `shadowedReserves` (keyed `<symbol>#<reserveId>`) instead of being silently dropped.

## Verification

Read back from chain after the dev repoint:

- All **23/23** shared dev reserves match prod exactly, 0 mismatches.
- All **27/27** dev reserves price without reverting. eBTC previously reverted `StalePrice()` — both the feed and `getReservePrice(10)` — and now prices at $78,900.36.
- 19 of the 20 repointed feeds returned byte-identical prices to the dev feeds they replaced; the 20th was the broken eBTC. The graphs differed in composition, not price.

Prod's Aave instance was never written to; it was read-only throughout.

## Note

The generating scripts (`PointDevOraclesAtProd.s.sol`, `SyncLendFeedManifests.s.sol`) are intentionally **not** in this PR, per request to commit the JSONs only. Until they land, these files are still hand-maintained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Oracle address manifests drive future lend deployments and dev/prod parity; incorrect entries would misconfigure pricing, though this PR only updates off-chain records and does not write prod contracts.
> 
> **Overview**
> Refreshes **OP Mainnet deployment JSON** so recorded price-feed addresses match what is on chain today, with **no contract or script changes** in this PR.
> 
> **`deployments/mainnet/10/summer-lend-feeds.json`** — all **27** `details.<symbol>.oracle` entries are repointed from the stale pre-CAPO / pre-3CP-644 set to the live prod sources (including leg-resolved addresses for `BTC`, `ETH`, `QQQ`, `SPY`, and `TBLL` where reserves do not point at those keys directly).
> 
> **`deployments/dev/10/aave-v4-test.json`** — brings the dev Aave v4 test manifest in line with prod-aligned feeds: adds **`iwQQQx`**, enriches each active reserve with **`reserveId`**, **`assetId`**, **`underlying`**, and **`leg`** where applicable, updates oracle addresses across reserves, and introduces **`shadowedReserves`** so superseded same-symbol reserves (e.g. older `iwSPYx` / `iPAXG` / `liquidRESERVE`) are not lost under the symbol-keyed `details` map.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d82430be0a30b3c9cc3500b6f892e50402db27f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/etherfi-protocol/codesmith/cash-v3/pr/294"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790684682&installation_model_id=18424&pr_number=294&repository=etherfi-protocol%2Fcash-v3&return_to=https%3A%2F%2Fgithub.com%2Fetherfi-protocol%2Fcash-v3%2Fpull%2F294&signature=a14db93d10ebb4337d13f394a944e875e35922c342da39ebc52929228d0ea8f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->