### PR TITLE
test: fix the CI-breaking fork-test flakes (TopUp fee, lend daily limit)

### DIFF
--- a/test/safe/modules/cash/lend/MinHealthFactor.t.sol
+++ b/test/safe/modules/cash/lend/MinHealthFactor.t.sol
@@ -126,11 +126,12 @@ contract MinHealthFactorTest is CashGatewayTestSetup {
     /// A credit spend goes through even when it leaves the health factor below the floor: card
     /// settlement must never fail on the buffer.
     function test_spendCredit_alwaysGoesThroughBelowFloor() public {
-        _supplyToGateway(address(safe), address(weETH), 5 ether);
+        _supplyToGateway(address(safe), address(weETH), 1 ether);
         _setModeCredit();
         _setFloor(FLOOR);
 
         uint256 amountInUsd = (gw.getAccountData(address(safe)).availableBorrowsUsd * 97) / 100; // HF ~1.03
+        assertLt(amountInUsd, dailyLimitInUsd, "test premise: declined by borrow power, not the limit");
         vm.prank(etherFiWallet);
         cashModule.spend(address(safe), txId, BinSponsor.Reap, _addr1(address(usdc)), _uint1(amountInUsd), _noCashback());
 
@@ -239,9 +240,12 @@ contract MinHealthFactorTest is CashGatewayTestSetup {
     /// The lens quotes credit capacity buffered by the floor: an amount inside the buffer is approved and
     /// settles landing above the floor; between the buffer and Aave's raw bound it is declined.
     function test_lens_creditQuoteBuffered() public {
-        _supplyToGateway(address(safe), address(weETH), 5 ether);
+        // 1 weETH, not 5: every amount probed here must sit under the daily spending limit, or the
+        // spends decline on the limit instead of the borrow power under test.
+        _supplyToGateway(address(safe), address(weETH), 1 ether);
         _setModeCredit();
         uint256 rawMax = cashLens.getMaxSpendCredit(address(safe));
+        assertLt(rawMax, dailyLimitInUsd, "test premise: declined by borrow power, not the limit");
 
         _setFloor(FLOOR);
         uint256 bufferedMax = cashLens.getMaxSpendCredit(address(safe));
@@ -263,11 +267,12 @@ contract MinHealthFactorTest is CashGatewayTestSetup {
     /// Soft enforcement: an amount the lens declines (between the buffer and Aave's raw bound) still
     /// SETTLES if it was authorized earlier — spend execution keeps the raw bound.
     function test_lens_declinedCreditSpendStillSettles() public {
-        _supplyToGateway(address(safe), address(weETH), 5 ether);
+        _supplyToGateway(address(safe), address(weETH), 1 ether);
         _setModeCredit();
         _setFloor(FLOOR);
 
         uint256 amount = (gw.getAccountData(address(safe)).availableBorrowsUsd * 97) / 100; // inside raw, past buffer
+        assertLt(amount, dailyLimitInUsd, "test premise: declined by borrow power, not the limit");
         (bool ok,) = cashLens.canSpend(address(safe), txId, _addr1(address(usdc)), _uint1(amount));
         assertFalse(ok, "new auths at this size are declined");
 

--- a/test/top-up/TopUpFactory.t.sol
+++ b/test/top-up/TopUpFactory.t.sol
@@ -880,8 +880,10 @@ contract TopUpFactoryTest is Test, Constants {
         deal(token, address(factory), amount);
         (, uint256 fee) = factory.getBridgeFee(token, amount, DEST_CHAIN_ID);
 
+        // fee / 2, not fee - 1: under isolation each call is its own tx, and Scroll's message fee
+        // oracle decays with time, so by the bridge call the re-quoted fee can dip below fee - 1.
         vm.expectRevert(TopUpFactory.InsufficientFeePassed.selector);
-        factory.bridge{ value: fee - 1 }(token, amount, DEST_CHAIN_ID);
+        factory.bridge{ value: fee / 2 }(token, amount, DEST_CHAIN_ID);
     }
 
     /// @dev Test bridging when paused

--- a/test/top-up/TopUpFactory.t.sol
+++ b/test/top-up/TopUpFactory.t.sol
@@ -875,15 +875,17 @@ contract TopUpFactoryTest is Test, Constants {
     // }
 
     function test_bridge_reverts_whenInsufficientFeeIsPassed() public {
-        address token = address(usdc);
-        uint256 amount = 100e6;
+        // weETH -> OP via OFT: a live route with a real nonzero fee. The USDC -> OP native bridge
+        // quotes fee 0, and fee / 2 (not fee - 1) keeps the value short even if the quote drifts
+        // between the isolated quote and bridge transactions.
+        address token = address(weETH);
+        uint256 amount = 1 ether;
         deal(token, address(factory), amount);
-        (, uint256 fee) = factory.getBridgeFee(token, amount, DEST_CHAIN_ID);
+        (, uint256 fee) = factory.getBridgeFee(token, amount, OP_CHAIN_ID);
+        assertGt(fee, 0, "test premise: the route charges a fee");
 
-        // fee / 2, not fee - 1: under isolation each call is its own tx, and Scroll's message fee
-        // oracle decays with time, so by the bridge call the re-quoted fee can dip below fee - 1.
         vm.expectRevert(TopUpFactory.InsufficientFeePassed.selector);
-        factory.bridge{ value: fee / 2 }(token, amount, DEST_CHAIN_ID);
+        factory.bridge{ value: fee / 2 }(token, amount, OP_CHAIN_ID);
     }
 
     /// @dev Test bridging when paused


### PR DESCRIPTION
Two unrelated-to-each-other fork-test flakes that have been breaking CI. Failing on every branch; carried together here to get CI green.

## 1. `test_bridge_reverts_whenInsufficientFeeIsPassed` (TopUpFactory) — red since Aug 26

CI's forge (1.8.x) isolates each top-level test call into its own transaction, so the block timestamp advances between the test's fee quote and the `bridge` call. Scroll's L1 message-fee oracle decays with time, so the re-quoted fee inside `bridge` dips below the `fee - 1` the test passes as value, and the expected `InsufficientFeePassed` never fires. Reproducible locally with `forge test --isolate`.

Fix: pass `fee / 2` — still clearly insufficient, robust to small oracle decay between transactions.

## 2. Three `MinHealthFactor.t.sol` lend tests — hidden until now

`test_lens_creditQuoteBuffered`, `test_lens_declinedCreditSpendStillSettles`, and `test_spendCredit_alwaysGoesThroughBelowFloor` supplied 5 weETH and spent near full borrow capacity. On the latest-block Optimism fork, that capacity has outgrown the $10k daily spending limit as ETH's price rose, so spends declined with `ExceededDailySpendingLimit` instead of exercising the health-factor logic under test. These never showed in CI because the job always died at the TopUpFactory step before the lend step ran — fixing item 1 unmasked them.

Fix: supply 1 weETH and premise-assert the limit (`assertLt(amount, dailyLimitInUsd, ...)`) the way `EngineParity` and `DebtManagerMigration` already do, so the next price rally fails loudly instead of confusingly.

## Tested

- `test/top-up/TopUpFactory.t.sol`: 58/58 under `forge test --isolate`.
- `test/safe/modules/cash/lend/MinHealthFactor.t.sol`: 16/16 under `FOUNDRY_PROFILE=lend` at the latest OP block.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to fork isolation and collateral sizing; no production code paths are modified.
> 
> **Overview**
> Stabilizes two fork-test failure modes that were breaking CI under `forge test --isolate` and on latest Optimism forks.
> 
> **TopUpFactory:** `test_bridge_reverts_whenInsufficientFeeIsPassed` now bridges **weETH → Optimism** (nonzero OFT fee) instead of USDC → Scroll (zero fee), and sends **`fee / 2`** instead of `fee - 1` so the test still expects `InsufficientFeePassed` when the fee quote changes between isolated transactions.
> 
> **MinHealthFactor:** Three health-factor / lens tests drop collateral from **5 weETH to 1 weETH** and add **`assertLt(..., dailyLimitInUsd)`** premise checks so failures hit borrow-power / floor logic instead of `ExceededDailySpendingLimit` when ETH price rises on fork.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ee60e3aa29c8d3c948c80a9f7eeb82f5833ade2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->