### PR TITLE
ci: drop the lend fork tests from CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,11 +60,3 @@ jobs:
         env:
           TS_NODE_COMPILER_OPTIONS: '{"module":"commonjs"}'
         id: test
-
-      # The lend (Aave v4) tests deploy a real Aave v4 instance on an Optimism fork, so they run under the
-      # lend profile against the fork rather than the default profile.
-      - name: Run lend tests
-        run: FOUNDRY_PROFILE=lend forge test -vvv --match-path 'test/safe/modules/cash/lend/**'
-        env:
-          TS_NODE_COMPILER_OPTIONS: '{"module":"commonjs"}'
-        id: test-lend


### PR DESCRIPTION
Removes the "Run lend tests" step from the Test workflow.

The lend (Aave v4) suite forks Optimism on every PR push and was causing spikes on the shared Alchemy key. It was added to prove the dev Aave v4 instance works, which it now does. The tests stay in the repo under `FOUNDRY_PROFILE=lend` for local runs.

Note: the default `forge test` step still forks `TEST_RPC`, so this cuts the fork load rather than removing it.

Test plan: workflow YAML validated locally; CI on this PR shows the step gone.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/etherfi-protocol/codesmith/cash-v3/pr/298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790948825&installation_model_id=18424&pr_number=298&repository=etherfi-protocol%2Fcash-v3&return_to=https%3A%2F%2Fgithub.com%2Fetherfi-protocol%2Fcash-v3%2Fpull%2F298&signature=3a470950138d42c363f3324c01770174c550bd563b62492e3201a0f761b89de5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change; it reduces fork/RPC load and does not alter contract or test source behavior.
> 
> **Overview**
> **Removes the dedicated `Run lend tests` job step** from `.github/workflows/test.yml`, so PR CI no longer runs `FOUNDRY_PROFILE=lend forge test` against `test/safe/modules/cash/lend/**`.
> 
> That step was an extra Optimism-forked Aave v4 suite on top of the default `forge test` step. **Lend tests remain in the repo** and can still be executed locally with the `lend` Foundry profile; they are just no longer gated in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 322076499c5d5c4be5abfea442099434ef2b6127. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->