### PR TITLE
Audit fixes: Certora Item 17 report (role re-gating)

### DIFF
--- a/src/across/AcrossSwapModule.sol
+++ b/src/across/AcrossSwapModule.sol
@@ -125,8 +125,6 @@ contract AcrossSwapModule is ModuleBase, ModuleCheckBalance, ModuleLendGatewaySa
     event MulticallHandlerSet(address oldMulticallHandler, address newMulticallHandler);
     event PeripherySet(address oldPeriphery, address newPeriphery);
 
-    /// @notice Reverts when a non-admin tries to set per-chain constants.
-    error OnlyAdmin();
     /// @notice Reverts when `requestSwap` is called on a safe with an active swap.
     error OrderAlreadyActive();
     /// @notice Reverts when `executeSwap` / `cancelSwap` finds no stored swap.

--- a/src/cashback-dispatcher/CashbackDispatcher.sol
+++ b/src/cashback-dispatcher/CashbackDispatcher.sol
@@ -284,12 +284,12 @@ contract CashbackDispatcher is UpgradeableProxy {
 
     /**
      * @notice Updates the Price Provider address
-     * @dev Only callable by addresses with ADMIN_TIMELOCK_ROLE
+     * @dev Only callable by the RoleRegistry owner (the upgrade timelock)
      * @param _priceProvider New Price Provider address
      * @custom:throws InvalidValue When the provided address is zero
      * @custom:throws CashbackTokenPriceNotConfigured When the new provider has no price for the cashback token
      */
-    function setPriceProvider(address _priceProvider) external onlyAdminTimelock {
+    function setPriceProvider(address _priceProvider) external onlyRoleRegistryOwner {
         if (_priceProvider == address(0)) revert InvalidValue();
 
         address[] memory cashbackTokens = getCashbackTokens();

--- a/src/data-provider/EtherFiDataProvider.sol
+++ b/src/data-provider/EtherFiDataProvider.sol
@@ -85,8 +85,6 @@ contract EtherFiDataProvider is UpgradeableProxy {
     error InvalidCashModule();
     /// @notice Thrown when an invalid Cash lens address is provided
     error InvalidCashLens();
-    /// @notice Thrown when a non-admin address attempts to perform an admin-only operation
-    error OnlyAdmin();
     /// @notice Throws when trying to reinit the modules
     error ModulesAlreadySetup();
 
@@ -195,11 +193,10 @@ contract EtherFiDataProvider is UpgradeableProxy {
 
     /**
      * @notice Updates the address of the Cash Lens
-     * @dev Only callable by addresses with ADMIN_ROLE
+     * @dev Only callable by the RoleRegistry owner (the upgrade timelock)
      * @param cashLens New cash lens address to set
      */
-    function setCashLens(address cashLens) external {
-        _onlyAdmin();
+    function setCashLens(address cashLens) external onlyRoleRegistryOwner {
         _setCashLens(cashLens);
     }
 
@@ -227,31 +224,28 @@ contract EtherFiDataProvider is UpgradeableProxy {
 
     /**
      * @notice Updates the address of the Price Provider
-     * @dev Only callable by addresses with ADMIN_TIMELOCK_ROLE
+     * @dev Only callable by the RoleRegistry owner (the upgrade timelock)
      * @param _priceProvider New price provider address to set
      */
-    function setPriceProvider(address _priceProvider) external {
-        _onlyAdminTimelock();
+    function setPriceProvider(address _priceProvider) external onlyRoleRegistryOwner {
         _setPriceProvider(_priceProvider);
     }
 
     /**
      * @notice Updates the hook address
-     * @dev Only callable by addresses with ADMIN_TIMELOCK_ROLE
+     * @dev Only callable by the RoleRegistry owner (the upgrade timelock)
      * @param hook New hook address to set
      */
-    function setHookAddress(address hook) external {
-        _onlyAdminTimelock();
+    function setHookAddress(address hook) external onlyRoleRegistryOwner {
         _setHookAddress(hook);
     }
 
     /**
      * @notice Updates the etherFiSafeFactory instance address
-     * @dev Only callable by addresses with ADMIN_TIMELOCK_ROLE
+     * @dev Only callable by the RoleRegistry owner (the upgrade timelock)
      * @param factory New factory address to set
      */
-    function setEtherFiSafeFactory(address factory) external {
-        _onlyAdminTimelock();
+    function setEtherFiSafeFactory(address factory) external onlyRoleRegistryOwner {
         _setEtherFiSafeFactory(factory);
     }
 
@@ -303,11 +297,10 @@ contract EtherFiDataProvider is UpgradeableProxy {
 
     /**
      * @notice Updates the address of the Cash Module
-     * @dev Only callable by addresses with ADMIN_TIMELOCK_ROLE
+     * @dev Only callable by the RoleRegistry owner (the upgrade timelock)
      * @param cashModule New cash module address to set
      */
-    function setCashModule(address cashModule) external {
-        _onlyAdminTimelock();
+    function setCashModule(address cashModule) external onlyRoleRegistryOwner {
         _setCashModule(cashModule);
     }
 

--- a/src/enso/EnsoSwapModule.sol
+++ b/src/enso/EnsoSwapModule.sol
@@ -105,8 +105,6 @@ contract EnsoSwapModule is ModuleBase, ModuleCheckBalance, ModuleLendGatewaySand
     event SwapCancelled(address indexed safe, bytes32 indexed swapId);
     event EnsoRouterSet(address oldEnsoRouter, address newEnsoRouter);
 
-    /// @notice Reverts when a non-admin tries to set the Enso Router.
-    error OnlyAdmin();
     /// @notice Reverts when `requestSwap` is called on a safe with an active swap.
     error OrderAlreadyActive();
     /// @notice Reverts when `executeSwap` / `cancelSwap` finds no stored swap.

--- a/src/interfaces/ICashModule.sol
+++ b/src/interfaces/ICashModule.sol
@@ -534,7 +534,7 @@ interface ICashModule {
      * @dev Only callable by accounts with ADMIN_ROLE
      * @param assets Array of asset addresses to configure
      * @param shouldWhitelist Array of boolean suggesting whether to whitelist the assets
-     * @custom:throws OnlyCashModuleController if the caller does not have ADMIN_ROLE role
+     * @custom:throws OnlyAdmin if the caller does not have ADMIN_ROLE
      * @custom:throws InvalidInput If the arrays are empty
      * @custom:throws ArrayLengthMismatch If the arrays have different lengths
      * @custom:throws InvalidAddress If any address is the zero address
@@ -544,18 +544,18 @@ interface ICashModule {
 
     /**
      * @notice Sets the settlement dispatcher address for a bin sponsor
-     * @dev Only callable by accounts with ADMIN_TIMELOCK_ROLE
+     * @dev Only callable by the RoleRegistry owner (the upgrade timelock)
      * @param binSponsor Bin sponsor for which the settlement dispatcher is updated
      * @param dispatcher Address of the new settlement dispatcher for the bin sponsor
-     * @custom:throws InvalidInput if caller doesn't have the controller role
+     * @custom:throws OnlyRoleRegistryOwner if the caller is not the RoleRegistry owner
      */
     function setSettlementDispatcher(BinSponsor binSponsor, address dispatcher) external;
 
     /**
      * @notice Sets the Aave gateway address for the initial Lend deployment
-     * @dev Only callable by accounts with ADMIN_TIMELOCK_ROLE while no gateway is configured
+     * @dev Only callable by the RoleRegistry owner (the upgrade timelock), while no gateway is configured
      * @param gateway Address of the gateway contract
-     * @custom:throws OnlyCashModuleController if caller doesn't have the controller role
+     * @custom:throws OnlyRoleRegistryOwner if the caller is not the RoleRegistry owner
      * @custom:throws InvalidInput if gateway = address(0)
      * @custom:throws GatewayAlreadySet if the gateway has already been configured
      */
@@ -579,7 +579,7 @@ interface ICashModule {
      * @param withdrawalDelay Delay in seconds before a withdrawal can be finalized
      * @param spendLimitDelay Delay in seconds before spending limit changes take effect
      * @param modeDelay Delay in seconds before a mode change takes effect
-     * @custom:throws OnlyCashModuleController if caller doesn't have the controller role
+     * @custom:throws OnlyAdmin if the caller does not have ADMIN_ROLE
      */
     function setDelays(uint64 withdrawalDelay, uint64 spendLimitDelay, uint64 modeDelay) external;
 
@@ -768,7 +768,7 @@ interface ICashModule {
      * @notice Sets the new CashModuleSetters implementation address
      * @dev Only callable by the RoleRegistry owner (the upgrade timelock)
      * @param newCashModuleSetters Address of the new CashModuleSetters implementation
-     * @custom:throws OnlyCashModuleController if caller doesn't have the controller role
+     * @custom:throws OnlyRoleRegistryOwner if the caller is not the RoleRegistry owner
      * @custom:throws InvalidInput if newCashModuleSetters = address(0)
      */
     function setCashModuleSettersAddress(address newCashModuleSetters) external;

--- a/src/modules/cash/CashModuleSetters.sol
+++ b/src/modules/cash/CashModuleSetters.sol
@@ -37,13 +37,12 @@ contract CashModuleSetters is CashModuleStorageContract {
 
     /**
      * @notice Sets the settlement dispatcher address for a bin sponsor
-     * @dev Only callable by accounts with ADMIN_TIMELOCK_ROLE
+     * @dev Only callable by the RoleRegistry owner (the upgrade timelock)
      * @param binSponsor Bin sponsor for which the settlement dispatcher is updated
      * @param dispatcher Address of the new settlement dispatcher for the bin sponsor
      * @custom:throws InvalidInput if caller doesn't have the controller role
      */
-    function setSettlementDispatcher(BinSponsor binSponsor, address dispatcher) external {
-        roleRegistry().onlyAdminTimelock(msg.sender);
+    function setSettlementDispatcher(BinSponsor binSponsor, address dispatcher) external onlyRoleRegistryOwner {
         if (dispatcher == address(0)) revert InvalidInput();
 
         CashModuleStorage storage $ = _getCashModuleStorage();
@@ -65,14 +64,13 @@ contract CashModuleSetters is CashModuleStorageContract {
 
     /**
      * @notice Sets the Aave gateway address for the initial Lend deployment
-     * @dev Only callable by accounts with ADMIN_TIMELOCK_ROLE while no gateway is configured
+     * @dev Only callable by the RoleRegistry owner (the upgrade timelock)
      * @param gateway Address of the gateway contract
-     * @custom:throws OnlyCashModuleController if caller doesn't have the controller role
+     * @custom:throws OnlyRoleRegistryOwner if the caller is not the RoleRegistry owner
      * @custom:throws InvalidInput if gateway has no contract code (also rejects address(0))
      * @custom:throws GatewayAlreadySet if the gateway has already been configured
      */
-    function setLendGateway(address gateway) external {
-        roleRegistry().onlyAdminTimelock(msg.sender);
+    function setLendGateway(address gateway) external onlyRoleRegistryOwner {
         // One-time bootstrap that can't be repointed, so guard against a mistyped EOA or undeployed address.
         if (gateway.code.length == 0) revert InvalidInput();
 
@@ -102,7 +100,7 @@ contract CashModuleSetters is CashModuleStorageContract {
      * @dev Only callable by accounts with ADMIN_ROLE
      * @param assets Array of asset addresses to configure
      * @param shouldWhitelist Array of boolean suggesting whether to whitelist the assets
-     * @custom:throws OnlyCashModuleController if the caller does not have ADMIN_ROLE role
+     * @custom:throws OnlyAdmin if the caller does not have ADMIN_ROLE
      * @custom:throws InvalidInput If the arrays are empty
      * @custom:throws ArrayLengthMismatch If the arrays have different lengths
      * @custom:throws InvalidAddress If any address is the zero address
@@ -150,7 +148,7 @@ contract CashModuleSetters is CashModuleStorageContract {
      * @param withdrawalDelay Delay in seconds before a withdrawal can be finalized
      * @param spendLimitDelay Delay in seconds before spending limit changes take effect
      * @param modeDelay Delay in seconds before a mode change takes effect
-     * @custom:throws OnlyCashModuleController if caller doesn't have the controller role
+     * @custom:throws OnlyAdmin if the caller does not have ADMIN_ROLE
      */
 
     function setDelays(uint64 withdrawalDelay, uint64 spendLimitDelay, uint64 modeDelay) external {

--- a/src/modules/cash/CashModuleStorageContract.sol
+++ b/src/modules/cash/CashModuleStorageContract.sol
@@ -112,9 +112,6 @@ contract CashModuleStorageContract is UpgradeableProxy, ModuleBase {
     /// @notice Error thrown when a recipient address is set to zero
     error RecipientCannotBeAddressZero();
 
-    /// @notice Error thrown when a function restricted to the Cash Module Controller is called by another address
-    error OnlyCashModuleController();
-
     /// @notice Error thrown when attempting to process a withdrawal before the delay period has elapsed
     error CannotWithdrawYet();
 

--- a/src/modules/etherfi/EtherFiLiquidModule.sol
+++ b/src/modules/etherfi/EtherFiLiquidModule.sol
@@ -546,14 +546,14 @@ contract EtherFiLiquidModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardT
      * @notice Adds new liquid assets and their corresponding tellers to the module
      * @param liquidAssets Array of liquid asset addresses to add
      * @param tellers Array of teller addresses corresponding to the liquid assets
-     * @dev Only callable by accounts with the ADMIN_ROLE role
-     * @custom:throws Unauthorized If caller doesn't have the admin role
+     * @dev Only callable by addresses with ADMIN_TIMELOCK_ROLE
+     * @custom:throws OnlyAdminTimelock if the caller does not have ADMIN_TIMELOCK_ROLE
      * @custom:throws ArrayLengthMismatch If the lengths of arrays mismatch
      * @custom:throws InvalidInput If any provided address is zero or the array is empty
      * @custom:throws InvalidConfiguration If a teller's vault doesn't match the expected liquid asset
      */
     function addLiquidAssets(address[] calldata liquidAssets, address[] calldata tellers) external {
-        etherFiDataProvider.roleRegistry().onlyAdmin(msg.sender);
+        etherFiDataProvider.roleRegistry().onlyAdminTimelock(msg.sender);
 
         uint256 len = liquidAssets.length;
         if (len != tellers.length) revert ArrayLengthMismatch();
@@ -577,7 +577,7 @@ contract EtherFiLiquidModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardT
      * @notice Removes liquid assets from the module
      * @param liquidAssets Array of liquid asset addresses to remove
      * @dev Only callable by accounts with the ADMIN_ROLE role
-     * @custom:throws Unauthorized If caller doesn't have the admin role
+     * @custom:throws OnlyAdmin if the caller does not have ADMIN_ROLE
      * @custom:throws InvalidInput If the array is empty
      */
     function removeLiquidAsset(address[] calldata liquidAssets) external {

--- a/src/modules/hype/BeHYPEStakeModule.sol
+++ b/src/modules/hype/BeHYPEStakeModule.sol
@@ -53,8 +53,6 @@ contract BeHYPEStakeModule is ModuleBase, ModuleCheckBalance, ModuleLendGatewayS
     error InsufficientFee();
     /// @notice Thrown when refunding excess fee back to the caller fails
     error RefundFailed();
-    /// @notice Thrown when caller lacks the required module admin role
-    error Unauthorized();
 
     /**
      * @notice Contract constructor
@@ -97,7 +95,7 @@ contract BeHYPEStakeModule is ModuleBase, ModuleCheckBalance, ModuleLendGatewayS
      * @notice Sets the gas limit used when refunding excess fees
      * @dev Setting the gas limit to zero resets it back to the default value
      * @param refundGasLimit The gas limit to use when refunding excess fees
-     * @custom:throws Unauthorized If the caller lacks the module admin role
+     * @custom:throws OnlyAdmin if the caller does not have ADMIN_ROLE
      */
     function setRefundGasLimit(uint32 refundGasLimit) external {
         IRoleRegistry roleRegistry = IRoleRegistry(etherFiDataProvider.roleRegistry());

--- a/src/modules/midas/MidasModule.sol
+++ b/src/modules/midas/MidasModule.sol
@@ -273,13 +273,13 @@ contract MidasModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardTransient
      * @param midasTokens Array of Midas token addresses to add
      * @param depositVaults Array of deposit vault addresses corresponding to the Midas tokens
      * @param redemptionVaults Array of redemption vault addresses corresponding to the Midas tokens
-     * @dev Only callable by accounts with the ADMIN_ROLE role
-     * @custom:throws Unauthorized If caller doesn't have the admin role
+     * @dev Only callable by addresses with ADMIN_TIMELOCK_ROLE
+     * @custom:throws OnlyAdminTimelock if the caller does not have ADMIN_TIMELOCK_ROLE
      * @custom:throws ArrayLengthMismatch If the lengths of arrays mismatch
      * @custom:throws InvalidInput If any provided address is zero or the array is empty
      */
     function addMidasVaults(address[] calldata midasTokens, address[] calldata depositVaults, address[] calldata redemptionVaults) external {
-        etherFiDataProvider.roleRegistry().onlyAdmin(msg.sender);
+        etherFiDataProvider.roleRegistry().onlyAdminTimelock(msg.sender);
 
         uint256 len = midasTokens.length;
         if (len != depositVaults.length || len != redemptionVaults.length) revert ArrayLengthMismatch();
@@ -306,7 +306,7 @@ contract MidasModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardTransient
      * @notice Removes Midas vaults from the module
      * @param midasTokens Array of Midas token addresses to remove
      * @dev Only callable by accounts with the ADMIN_ROLE role
-     * @custom:throws Unauthorized If caller doesn't have the admin role
+     * @custom:throws OnlyAdmin if the caller does not have ADMIN_ROLE
      * @custom:throws InvalidInput If the array is empty
      */
     function removeMidasVaults(address[] calldata midasTokens) external {

--- a/src/modules/stargate/StargateModule.sol
+++ b/src/modules/stargate/StargateModule.sol
@@ -168,7 +168,7 @@ contract StargateModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardTransi
      * @dev Only callable by addresses with ADMIN_TIMELOCK_ROLE
      * @param assets Array of asset addresses to configure
      * @param assetConfigs Array of corresponding asset configurations
-     * @custom:throws Unauthorized if caller doesn't have admin role
+     * @custom:throws OnlyAdminTimelock if the caller does not have ADMIN_TIMELOCK_ROLE
      * @custom:throws ArrayLengthMismatch if arrays have different lengths
      * @custom:throws InvalidInput if any asset address is zero
      * @custom:throws InvalidStargatePool if pool doesn't match the token

--- a/src/modules/wormhole/WormholeModule.sol
+++ b/src/modules/wormhole/WormholeModule.sol
@@ -156,7 +156,7 @@ contract WormholeModule is ModuleBase, ModuleCheckBalance, ReentrancyGuardTransi
      * @notice Sets the asset configuration for a given asset
      * @param assets Array of asset addresses to configure
      * @param assetConfigs Array of corresponding asset configurations
-     * @custom:throws Unauthorized If the caller is not the ADMIN role
+     * @custom:throws OnlyAdminTimelock if the caller does not have ADMIN_TIMELOCK_ROLE
      */
     function setAssetConfig(address[] memory assets, AssetConfig[] memory assetConfigs) external {
         IRoleRegistry roleRegistry = IRoleRegistry(etherFiDataProvider.roleRegistry());

--- a/src/oracle/PriceProvider.sol
+++ b/src/oracle/PriceProvider.sol
@@ -176,12 +176,12 @@ contract PriceProvider is UpgradeableProxy {
 
     /**
      * @notice Updates the price oracle configurations for multiple tokens
-     * @dev Only callable by addresses with ADMIN_TIMELOCK_ROLE
+     * @dev Only callable by addresses with ADMIN_ROLE
      * @param _tokens Array of token addresses to configure
      * @param _configs Array of configurations corresponding to each token
      * @custom:throws ArrayLengthMismatch If arrays have different lengths
      */
-    function setTokenConfig(address[] calldata _tokens, Config[] calldata _configs) external onlyAdminTimelock {
+    function setTokenConfig(address[] calldata _tokens, Config[] calldata _configs) external onlyAdmin {
         _setTokenConfig(_tokens, _configs);
     }
 

--- a/src/oracle/PriceProviderV2.sol
+++ b/src/oracle/PriceProviderV2.sol
@@ -203,20 +203,20 @@ contract PriceProviderV2 is UpgradeableProxy {
 
     /**
      * @notice Updates the price oracle configurations for multiple tokens
-     * @dev Only callable by addresses with ADMIN_TIMELOCK_ROLE
+     * @dev Only callable by addresses with ADMIN_ROLE
      * @param _tokens Array of token addresses to configure
      * @param _configs Array of configurations corresponding to each token
      */
-    function setTokenConfig(address[] calldata _tokens, Config[] calldata _configs) external onlyAdminTimelock {
+    function setTokenConfig(address[] calldata _tokens, Config[] calldata _configs) external onlyAdmin {
         _setTokenConfig(_tokens, _configs);
     }
 
     /**
      * @notice Removes the price oracle configuration for a token
-     * @dev Only callable by addresses with ADMIN_TIMELOCK_ROLE
+     * @dev Only callable by addresses with ADMIN_ROLE
      * @param _token Address of the token to remove the config for
      */
-    function removeTokenConfig(address _token) external onlyAdminTimelock {
+    function removeTokenConfig(address _token) external onlyAdmin {
         PriceProviderV2Storage storage $ = _getPriceProviderV2Storage();
         if ($.isBaseAsset[_token]) revert BaseAssetCannotBeRemoved();
         if ($.tokenConfig[_token].oracle == address(0)) revert TokenConfigNotSet();
@@ -226,10 +226,10 @@ contract PriceProviderV2 is UpgradeableProxy {
 
     /**
      * @notice Sets a base asset to true or false
-     * @dev Only callable by addresses with ADMIN_TIMELOCK_ROLE
+     * @dev Only callable by addresses with ADMIN_ROLE
      * @param _baseAsset Address of the base asset
      */
-    function setBaseAsset(address _baseAsset, bool _isBaseAsset) external onlyAdminTimelock {
+    function setBaseAsset(address _baseAsset, bool _isBaseAsset) external onlyAdmin {
         PriceProviderV2Storage storage $ = _getPriceProviderV2Storage();
         $.isBaseAsset[_baseAsset] = _isBaseAsset;
         emit BaseAssetSet(_baseAsset, _isBaseAsset);

--- a/src/stock-withdraw/StockWithdrawModule.sol
+++ b/src/stock-withdraw/StockWithdrawModule.sol
@@ -197,8 +197,6 @@ contract StockWithdrawModule is ModuleBase, UpgradeableProxy, IBridgeModule {
      */
     event ProviderFeeSet(uint16 oldFeeBps, uint16 newFeeBps, address oldFeeReceiver, address newFeeReceiver);
 
-    /// @notice Reverts when a non-admin calls an admin function.
-    error OnlyAdmin();
     /// @notice Reverts when the iToken is not on the supported list.
     error TokenNotSupported();
     /// @notice Reverts when a supported iToken is not its own OFT (ShadowOFT invariant).
@@ -332,12 +330,12 @@ contract StockWithdrawModule is ModuleBase, UpgradeableProxy, IBridgeModule {
      *         in-flight order, and `minReturn` still protects the user on the destination.
      * @param _providerFeeBps Fee in basis points; zero disables the fee.
      * @param _feeReceiver Recipient of the fee; may be zero only when the fee is zero.
-     * @custom:throws OnlyAdmin If the caller lacks `ADMIN_ROLE`.
+     * @custom:throws OnlyAdminTimelock if the caller does not have ADMIN_TIMELOCK_ROLE
      * @custom:throws ProviderFeeTooHigh If the fee exceeds `MAX_PROVIDER_FEE_BPS`.
      * @custom:throws InvalidInput If the receiver is zero while the fee is non-zero.
      */
     function setProviderFee(uint16 _providerFeeBps, address _feeReceiver) external {
-        _onlyAdmin();
+        _onlyAdminTimelock();
         _setProviderFee(_providerFeeBps, _feeReceiver);
     }
 
@@ -777,7 +775,7 @@ contract StockWithdrawModule is ModuleBase, UpgradeableProxy, IBridgeModule {
         }
     }
 
-    /// @dev Reverts unless the caller holds `ADMIN_ROLE`.
+    /// @dev Reverts unless the caller holds `ADMIN_TIMELOCK_ROLE`.
     function _onlyAdmin() internal view {
         IRoleRegistry(etherFiDataProvider.roleRegistry()).onlyAdmin(msg.sender);
     }

--- a/src/top-up/TopUpFactory.sol
+++ b/src/top-up/TopUpFactory.sol
@@ -136,8 +136,6 @@ contract TopUpFactory is BeaconFactory, Constants, ITopUpFactory {
     /// @param shares Amount of `wrapper` the TopUp was credited.
     event WrapStock(address indexed topUp, address indexed wrapper, address indexed underlying, uint256 assets, uint256 shares);
 
-    /// @notice Error thrown when a non-admin tries to deploy a topUp contract
-    error OnlyAdmin();
     /// @notice Error thrown when trying to pull funds from an address not registered as deployedAddresses
     error InvalidTopUpAddress();
     /// @notice Error thrown when zero address is provided for a token
@@ -343,7 +341,7 @@ contract TopUpFactory is BeaconFactory, Constants, ITopUpFactory {
     /**
      * @notice Takes each `tokens[i]` off the topup lane for `chainIds[i]`: clears its bridge
      *         configuration for that destination and drops it from the supported set.
-     * @dev Admin-only, and the inverse of `setTokenConfig`, which is otherwise a one-way door —
+     * @dev Only callable by addresses with ADMIN_TIMELOCK_ROLE
      *      it only ever adds to `supportedTokens`, and rejects a zeroed config, so before this
      *      there was no way to retire an asset from the lane at all.
      *
@@ -448,7 +446,7 @@ contract TopUpFactory is BeaconFactory, Constants, ITopUpFactory {
      * @notice Sets the recovery wallet address for emergency fund recovery
      * @dev Only callable by admin role
      * @param _recoveryWallet The new recovery wallet address
-     * @custom:throws OnlyAdmin if caller doesn't have admin role
+     * @custom:throws OnlyAdminTimelock if the caller does not have ADMIN_TIMELOCK_ROLE
      * @custom:throws RecoveryWalletCannotBeZeroAddress if provided address is zero
      */
     function setRecoveryWallet(address _recoveryWallet) external onlyAdminTimelock {
@@ -485,7 +483,7 @@ contract TopUpFactory is BeaconFactory, Constants, ITopUpFactory {
     /**
      * @notice Registers, for each `tokens[i]`, the ERC-4626 vault a redirect must deposit it
      *         into instead of transferring it — or clears that with the zero address.
-     * @dev Admin-only. This is the whole of the stock-wrapping feature's configuration: the
+     * @dev Only callable by addresses with ADMIN_TIMELOCK_ROLE
      *      tokenized equities a TradingSafe can hold are `WrappedBackedToken` vaults (wTSLAx),
      *      while what a user sends to a TopUp address is the raw Backed xStock underneath
      *      (TSLAx), which is trading-supported in no form of its own and would otherwise be

--- a/src/trading-safe/TradingLens.sol
+++ b/src/trading-safe/TradingLens.sol
@@ -56,9 +56,6 @@ contract TradingLens is UpgradeableProxy, Constants {
     /// @param token The token contract address.
     event SupportedTokenRemoved(address indexed token);
 
-    /// @notice Reverts when the caller doesn't hold `ADMIN_ROLE`.
-    error OnlyAdmin();
-
     /// @notice Reverts when a zero-address token is passed to `addSupportedToken`.
     error InvalidToken();
 

--- a/src/trading-safe/TradingSafeFactory.sol
+++ b/src/trading-safe/TradingSafeFactory.sol
@@ -234,12 +234,12 @@ contract TradingSafeFactory is BeaconFactory, ITradingSafeFactory {
 
     /**
      * @notice Sets the `TradingLens` registry backing `isSupportedToken`.
-     * @dev Admin-only. The lens owns the supported-trading-token set; the factory exposes it
+     * @dev Only callable by the RoleRegistry owner (the upgrade timelock)
      *      so cross-chain callers (the TopUp source factory) can gate redirects on it.
      * @param _tradingLens Address of the `TradingLens` on this chain.
      * @custom:throws TradingLensCannotBeZeroAddress If `_tradingLens == address(0)`.
      */
-    function setTradingLens(address _tradingLens) external onlyAdmin {
+    function setTradingLens(address _tradingLens) external onlyRoleRegistryOwner {
         if (_tradingLens == address(0)) revert TradingLensCannotBeZeroAddress();
         TradingSafeFactoryStorage storage $ = _getTradingSafeFactoryStorage();
         emit TradingLensSet($.tradingLens, _tradingLens);

--- a/test/data-provider/EtherFiDataProvider.t.sol
+++ b/test/data-provider/EtherFiDataProvider.t.sol
@@ -8,6 +8,7 @@ import { UUPSProxy } from "../../src/UUPSProxy.sol";
 import { EtherFiDataProvider } from "../../src/data-provider/EtherFiDataProvider.sol";
 import { ArrayDeDupLib } from "../../src/libraries/ArrayDeDupLib.sol";
 import { RoleRegistry } from "../../src/role-registry/RoleRegistry.sol";
+import { UpgradeableProxy } from "../../src/utils/UpgradeableProxy.sol";
 
 contract EtherFiDataProviderTest is Test {
     EtherFiDataProvider public provider;
@@ -460,7 +461,7 @@ contract EtherFiDataProviderTest is Test {
     function test_setCashModule_updatesAddress() public {
         address newCashModule = address(0x600);
 
-        vm.prank(admin);
+        vm.prank(owner);
         vm.expectEmit(true, true, true, true);
         emit EtherFiDataProvider.CashModuleConfigured(cashModule, newCashModule);
         provider.setCashModule(newCashModule);
@@ -472,12 +473,12 @@ contract EtherFiDataProviderTest is Test {
         address newCashModule = address(0x600);
 
         vm.prank(nonAdmin);
-        vm.expectRevert(RoleRegistry.OnlyAdminTimelock.selector);
+        vm.expectRevert(UpgradeableProxy.OnlyRoleRegistryOwner.selector);
         provider.setCashModule(newCashModule);
     }
 
     function test_setCashModule_reverts_whenZeroAddress() public {
-        vm.prank(admin);
+        vm.prank(owner);
         vm.expectRevert(EtherFiDataProvider.InvalidCashModule.selector);
         provider.setCashModule(address(0));
     }
@@ -487,7 +488,7 @@ contract EtherFiDataProviderTest is Test {
     function test_setHookAddress_updatesAddress() public {
         address newHook = address(0x500);
 
-        vm.prank(admin);
+        vm.prank(owner);
         provider.setHookAddress(newHook);
 
         assertEq(provider.getHookAddress(), newHook);
@@ -496,7 +497,7 @@ contract EtherFiDataProviderTest is Test {
     function test_setHookAddress_emitsEvent() public {
         address newHook = address(0x500);
 
-        vm.prank(admin);
+        vm.prank(owner);
         vm.expectEmit(true, true, true, true);
         emit EtherFiDataProvider.HookAddressUpdated(hookAddress, newHook);
         provider.setHookAddress(newHook);
@@ -506,12 +507,12 @@ contract EtherFiDataProviderTest is Test {
         address newHook = address(0x500);
 
         vm.prank(nonAdmin);
-        vm.expectRevert(RoleRegistry.OnlyAdminTimelock.selector);
+        vm.expectRevert(UpgradeableProxy.OnlyRoleRegistryOwner.selector);
         provider.setHookAddress(newHook);
     }
 
     function test_setHookAddress_reverts_whenZeroAddress() public {
-        vm.prank(admin);
+        vm.prank(owner);
         vm.expectRevert(EtherFiDataProvider.InvalidInput.selector);
         provider.setHookAddress(address(0));
     }
@@ -635,7 +636,7 @@ contract EtherFiDataProviderTest is Test {
 
     function test_setRecoveryDelayPeriod_reverts_whenCalledByNonAdmin() public {
         vm.prank(nonAdmin);
-        vm.expectRevert(EtherFiDataProvider.OnlyAdmin.selector);
+        vm.expectRevert(RoleRegistry.OnlyAdmin.selector);
         provider.setRecoveryDelayPeriod(newRecoveryPeriod);
     }
 

--- a/test/price-provider/PriceProvider.t.sol
+++ b/test/price-provider/PriceProvider.t.sol
@@ -137,6 +137,7 @@ contract PriceProviderTest is Test {
         )));
 
         roleRegistry.grantRole(keccak256("ADMIN_TIMELOCK_ROLE"), owner);
+        roleRegistry.grantRole(keccak256("ADMIN_ROLE"), owner);
 
         vm.stopPrank();
     }
@@ -202,7 +203,7 @@ contract PriceProviderTest is Test {
         address notOwner = makeAddr("notOwner");
 
         vm.startPrank(notOwner);
-        vm.expectRevert(RoleRegistry.OnlyAdminTimelock.selector);
+        vm.expectRevert(RoleRegistry.OnlyAdmin.selector);
         priceProvider.setTokenConfig(tokens, tokensConfig);
         vm.stopPrank();
     }

--- a/test/price-provider/PriceProviderV2.t.sol
+++ b/test/price-provider/PriceProviderV2.t.sol
@@ -137,6 +137,7 @@ contract PriceProviderV2Test is Test {
         )));
 
         roleRegistry.grantRole(keccak256("ADMIN_TIMELOCK_ROLE"), owner);
+        roleRegistry.grantRole(keccak256("ADMIN_ROLE"), owner);
 
         vm.stopPrank();
     }
@@ -563,7 +564,7 @@ contract PriceProviderV2Test is Test {
 
         address notOwner = makeAddr("notOwner");
         vm.prank(notOwner);
-        vm.expectRevert(RoleRegistry.OnlyAdminTimelock.selector);
+        vm.expectRevert(RoleRegistry.OnlyAdmin.selector);
         priceProvider.setTokenConfig(tokens, configs);
     }
 
@@ -888,7 +889,7 @@ contract PriceProviderV2Test is Test {
     function test_removeTokenConfig_reverts_unauthorized() public {
         address notOwner = makeAddr("notOwner");
         vm.prank(notOwner);
-        vm.expectRevert(RoleRegistry.OnlyAdminTimelock.selector);
+        vm.expectRevert(RoleRegistry.OnlyAdmin.selector);
         priceProvider.removeTokenConfig(eth);
     }
 
@@ -1071,7 +1072,7 @@ contract PriceProviderV2Test is Test {
     function test_setBaseAsset_reverts_unauthorized() public {
         address notOwner = makeAddr("notOwner");
         vm.prank(notOwner);
-        vm.expectRevert(RoleRegistry.OnlyAdminTimelock.selector);
+        vm.expectRevert(RoleRegistry.OnlyAdmin.selector);
         priceProvider.setBaseAsset(eth, false);
     }
 

--- a/test/safe/modules/cash/SetLendGateway.t.sol
+++ b/test/safe/modules/cash/SetLendGateway.t.sol
@@ -13,6 +13,7 @@ import { CashModuleCore } from "../../../../src/modules/cash/CashModuleCore.sol"
 import { CashModuleSetters } from "../../../../src/modules/cash/CashModuleSetters.sol";
 import { CashEventEmitter, CashModuleTestSetup } from "./CashModuleTestSetup.t.sol";
 import { RoleRegistry } from "../../../../src/role-registry/RoleRegistry.sol";
+import { UpgradeableProxy } from "../../../../src/utils/UpgradeableProxy.sol";
 
 contract CashModuleSetLendGatewayTest is CashModuleTestSetup {
     using MessageHashUtils for bytes32;
@@ -99,7 +100,7 @@ contract CashModuleSetLendGatewayTest is CashModuleTestSetup {
         MockLendGateway newGateway = new MockLendGateway();
 
         vm.prank(notOwner);
-        vm.expectRevert(RoleRegistry.OnlyAdminTimelock.selector);
+        vm.expectRevert(UpgradeableProxy.OnlyRoleRegistryOwner.selector);
         cashModule.setLendGateway(address(newGateway));
 
         vm.prank(owner);

--- a/test/safe/modules/cash/SetSettlementDispatcher.t.sol
+++ b/test/safe/modules/cash/SetSettlementDispatcher.t.sol
@@ -6,6 +6,7 @@ import { Test } from "forge-std/Test.sol";
 import { ICashModule, Mode, BinSponsor, Cashback } from "../../../../src/interfaces/ICashModule.sol";
 import { CashEventEmitter, CashModuleTestSetup } from "./CashModuleTestSetup.t.sol";
 import { RoleRegistry } from "../../../../src/role-registry/RoleRegistry.sol";
+import { UpgradeableProxy } from "../../../../src/utils/UpgradeableProxy.sol";
 
 contract CashModuleSetSettlementDispatcherTest is CashModuleTestSetup {
     function setUp() public override {
@@ -54,7 +55,7 @@ contract CashModuleSetSettlementDispatcherTest is CashModuleTestSetup {
         
         // Attempt to set new settlement dispatcher with non-controller account
         vm.prank(nonController);
-        vm.expectRevert(RoleRegistry.OnlyAdminTimelock.selector);
+        vm.expectRevert(UpgradeableProxy.OnlyRoleRegistryOwner.selector);
         cashModule.setSettlementDispatcher(BinSponsor.Rain, newDispatcher);
     }
     

--- a/test/safe/modules/cash/cashback-dispatcher/CashbackDispatcher.t.sol
+++ b/test/safe/modules/cash/cashback-dispatcher/CashbackDispatcher.t.sol
@@ -265,7 +265,7 @@ contract CashbackDispatcherTest is CashModuleTestSetup {
 
     function test_setPriceProvider_reverts_whenCallerNotOwner() public {
         vm.startPrank(notOwner);
-        vm.expectRevert(RoleRegistry.OnlyAdminTimelock.selector);
+        vm.expectRevert(UpgradeableProxy.OnlyRoleRegistryOwner.selector);
         cashbackDispatcher.setPriceProvider(address(priceProvider));
         vm.stopPrank();
     }

--- a/test/safe/modules/midas/MidasModule.t.sol
+++ b/test/safe/modules/midas/MidasModule.t.sol
@@ -468,7 +468,7 @@ contract MidasModuleTest is SafeTestSetup {
         address[] memory redemptionVaults = new address[](1);
         redemptionVaults[0] = makeAddr("redemptionVault");
 
-        vm.expectRevert(RoleRegistry.OnlyAdmin.selector);
+        vm.expectRevert(RoleRegistry.OnlyAdminTimelock.selector);
         vm.prank(owner1);
         midasModule.addMidasVaults(midasTokens, depositVaults, redemptionVaults);
     }

--- a/test/stock-withdraw/StockWithdrawModule.t.sol
+++ b/test/stock-withdraw/StockWithdrawModule.t.sol
@@ -719,7 +719,7 @@ contract StockWithdrawModuleTest is SafeTestSetup {
         bool[] memory supported = new bool[](1);
         supported[0] = true;
 
-        vm.expectRevert(StockWithdrawModule.OnlyAdmin.selector);
+        vm.expectRevert(RoleRegistry.OnlyAdmin.selector);
         module.configureTokens(iTokens, supported);
 
         // a token whose OFT.token() != itself must be rejected
@@ -768,7 +768,7 @@ contract StockWithdrawModuleTest is SafeTestSetup {
     }
 
     function test_setLzGasLimits_adminOnlyValidatesAndStores() public {
-        vm.expectRevert(StockWithdrawModule.OnlyAdmin.selector);
+        vm.expectRevert(RoleRegistry.OnlyAdmin.selector);
         module.setLzGasLimits(80_000, 500_000);
 
         vm.startPrank(moduleAdmin);
@@ -788,7 +788,7 @@ contract StockWithdrawModuleTest is SafeTestSetup {
     // ---- provider fee ----
 
     function test_setProviderFee_adminOnlyCapAndValidation() public {
-        vm.expectRevert(StockWithdrawModule.OnlyAdmin.selector);
+        vm.expectRevert(RoleRegistry.OnlyAdminTimelock.selector);
         module.setProviderFee(100, feeReceiver);
 
         vm.startPrank(moduleAdmin);

--- a/test/trading-safe/TradingLens.t.sol
+++ b/test/trading-safe/TradingLens.t.sol
@@ -102,7 +102,7 @@ contract TradingLensTest is Test {
     }
 
     function test_addSupportedToken_revertsWhen_notAdmin() public {
-        vm.expectRevert(TradingLens.OnlyAdmin.selector);
+        vm.expectRevert(RoleRegistry.OnlyAdmin.selector);
         vm.prank(stranger);
         lens.addSupportedToken(address(tokenA));
     }
@@ -135,7 +135,7 @@ contract TradingLensTest is Test {
         vm.prank(admin);
         lens.addSupportedToken(address(tokenA));
 
-        vm.expectRevert(TradingLens.OnlyAdmin.selector);
+        vm.expectRevert(RoleRegistry.OnlyAdmin.selector);
         vm.prank(stranger);
         lens.removeSupportedToken(address(tokenA));
     }


### PR DESCRIPTION
# Audit fixes: Certora Item 17 internal report

Addresses the Certora review of the role re-gating PR (audited at `18f224a1`). One code change per finding, nothing else.

| Finding | Disposition | Change |
|---|---|---|
| L-01 — operating timelock can install delegatecall code via `TopUpFactory.setTokenConfig` (bridgeAdapter) | **Acknowledged** | none — the timelock tier is trusted for bridge config; adapter selection stays behind the 8h delay |
| I-01 — fast admin can replace live Midas vault destinations | **Fixed** | `MidasModule.addMidasVaults` → `ADMIN_TIMELOCK_ROLE` |
| I-02 — fast collateral-risk changes can affect legacy Safe health | **Acknowledged** | none — risk-parameter agility is deliberate |
| I-03 — fast admin can replace a live teller for a pending liquid-asset bridge | **Fixed** | `EtherFiLiquidModule.addLiquidAssets` → `ADMIN_TIMELOCK_ROLE` |
| I-04 — oracle configuration loses a faster incident-response path | **Fixed** | feed config back on the fast admin: `PriceProvider.setTokenConfig`, `PriceProviderV2.setTokenConfig` / `removeTokenConfig` / `setBaseAsset` → `ADMIN_ROLE`. The provider *pointer* (`EtherFiDataProvider.setPriceProvider`) is not fast — it moves to owner per I-07 |
| I-05 — fast admin can redirect provider-fee revenue (live `feeReceiver`) | **Fixed** | `StockWithdrawModule.setProviderFee` → `ADMIN_TIMELOCK_ROLE` |
| I-06 — one timelock role controls both module-withdrawal allowlists | **Acknowledged** | none — both lists intentionally sit on the same timelock tier |
| I-07 — fast/operational roles can replace core protocol dependencies | **Fixed** | nine pointer setters → `onlyRoleRegistryOwner`: `EtherFiDataProvider.{setCashModule, setCashLens, setPriceProvider, setHookAddress, setEtherFiSafeFactory}`, `CashModuleSetters.{setSettlementDispatcher, setLendGateway}`, `CashbackDispatcher.setPriceProvider`, `TradingSafeFactory.setTradingLens` |
| I-08 — stale NatSpec + unreachable `OnlyAdmin`-style error declarations | **Fixed** | removed the dead error declarations at the listed locations (Across, Enso, DataProvider, CashModuleStorageContract, StockWithdrawModule, TopUpFactory, TradingLens, BeHYPE) and normalized every gated function's `@dev` / `@custom:throws` to the actual RoleRegistry error, including the interfaces |

Test updates are limited to matching the new gates (revert selectors, and the PriceProvider/DataProvider setups acting as the right principal). The gate-map Notion doc will be updated after this PR is reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/etherfi-protocol/codesmith/cash-v3/pr/299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790952273&installation_model_id=18424&pr_number=299&repository=etherfi-protocol%2Fcash-v3&return_to=https%3A%2F%2Fgithub.com%2Fetherfi-protocol%2Fcash-v3%2Fpull%2F299&signature=4258dd1b17cec8a77c1f65268883d5d81750d4fcd230a2e02c4e1b52e54e0e48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes who can repoint cash/oracle/settlement dependencies and mutate live vault, teller, and fee config—security-critical governance surface—even though the intent is to tighten fast-admin paths.
> 
> **Overview**
> Addresses **Certora Item 17** follow-ups on access control after the role re-gating work: who may change live protocol dependencies, vault/teller routing, fees, and oracle feeds.
> 
> **Stricter gates (slower / upgrade-tier principals):** Core dependency **pointer** updates now require **`onlyRoleRegistryOwner`** (RoleRegistry owner / upgrade timelock)—including `EtherFiDataProvider` cash lens, cash module, price provider, hook, and safe factory; `CashModuleSetters` settlement dispatchers and one-time lend gateway bootstrap; `CashbackDispatcher.setPriceProvider`; and `TradingSafeFactory.setTradingLens`. **Live routing config** moves to **`ADMIN_TIMELOCK_ROLE`**: `MidasModule.addMidasVaults`, `EtherFiLiquidModule.addLiquidAssets`, and `StockWithdrawModule.setProviderFee`.
> 
> **Faster oracle ops:** `PriceProvider` / `PriceProviderV2` token config, removal, and base-asset flags revert to **`ADMIN_ROLE`** so feed changes are not stuck behind the operating timelock (the global price-provider **pointer** stays on the registry owner).
> 
> **Docs and ABI cleanup:** Removes unused local `OnlyAdmin`-style errors and `OnlyCashModuleController` where gates already go through `RoleRegistry`; aligns NatSpec and `ICashModule` `@custom:throws` with the real revert types. Tests expect the updated selectors and callers (e.g. registry owner vs admin).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2aed606ac4ad33cf5ec47e400c4812e25f85bc6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->