### PR TITLE
test: re-enable OP mainnet bytecode verification after the taxi and lend deployments

### DIFF
--- a/test/upgrade-bytecode-verification/VerifyOPMainnet.t.sol
+++ b/test/upgrade-bytecode-verification/VerifyOPMainnet.t.sol
@@ -255,29 +255,21 @@ contract VerifyOPMainnetBytecode is ContractCodeChecker, Utils {
     // ---- Settlement dispatchers ----
 
     function test_verifyBytecode_SettlementDispatcherReap() public {
-        // Taxi mode changes this implementation bytecode. Re-enable after the taxi deployment.
-        vm.skip(true);
         address local = address(new SettlementDispatcherV2(BinSponsor.Reap, dataProviderProxy));
         _verify("SettlementDispatcherReap", settlementReapImpl, local);
     }
 
     function test_verifyBytecode_SettlementDispatcherRain() public {
-        // Taxi mode changes this implementation bytecode. Re-enable after the taxi deployment.
-        vm.skip(true);
         address local = address(new SettlementDispatcherV2(BinSponsor.Rain, dataProviderProxy));
         _verify("SettlementDispatcherRain", settlementRainImpl, local);
     }
 
     function test_verifyBytecode_SettlementDispatcherPix() public {
-        // Taxi mode changes this implementation bytecode. Re-enable after the taxi deployment.
-        vm.skip(true);
         address local = address(new SettlementDispatcherV2(BinSponsor.PIX, dataProviderProxy));
         _verify("SettlementDispatcherPix", settlementPixImpl, local);
     }
 
     function test_verifyBytecode_SettlementDispatcherCardOrder() public {
-        // Taxi mode changes this implementation bytecode. Re-enable after the taxi deployment.
-        vm.skip(true);
         address local = address(new SettlementDispatcherV2(BinSponsor.CardOrder, dataProviderProxy));
         _verify("SettlementDispatcherCardOrder", settlementCardOrderImpl, local);
     }
@@ -336,8 +328,6 @@ contract VerifyOPMainnetBytecode is ContractCodeChecker, Utils {
     }
 
     function test_verifyBytecode_StargateModule() public {
-        // Taxi mode changes this module bytecode. Re-enable after the taxi deployment.
-        vm.skip(true);
         address[] memory assets = new address[](2);
         assets[0] = cc.usdc;
         assets[1] = cc.weETH;

--- a/test/upgrade-bytecode-verification/VerifyOPMainnet.t.sol
+++ b/test/upgrade-bytecode-verification/VerifyOPMainnet.t.sol
@@ -163,10 +163,6 @@ contract VerifyOPMainnetBytecode is ContractCodeChecker, Utils {
     }
 
     function test_verifyBytecode_EtherFiSafe() public {
-        // RecoveryManager (compiled into EtherFiSafe) now rejects setRecoveryThreshold(0), so its
-        // bytecode no longer matches the deployed pre-fix OP implementation. Re-enable after the
-        // next safe-implementation deployment.
-        vm.skip(true);
         address local = address(new EtherFiSafe(dataProviderProxy));
         _verify("EtherFiSafe", safeImpl, local);
     }
@@ -181,9 +177,6 @@ contract VerifyOPMainnetBytecode is ContractCodeChecker, Utils {
     }
 
     function test_verifyBytecode_EtherFiHook() public {
-        // EtherFiHook skips the health hook for gateway safes in Lend, so its bytecode no longer
-        // matches the deployed pre-Lend OP implementation. Re-enable after the Lend deployment.
-        vm.skip(true);
         address local = address(new EtherFiHook(dataProviderProxy));
         _verify("EtherFiHook", hookImpl, local);
     }
@@ -191,33 +184,21 @@ contract VerifyOPMainnetBytecode is ContractCodeChecker, Utils {
     // ---- Cash module ----
 
     function test_verifyBytecode_CashModuleCore() public {
-        // CashModule drops the preLiquidate/postLiquidate callbacks for Lend, so its bytecode no longer
-        // matches the deployed pre-Lend version. Re-enable after the Lend deployment.
-        vm.skip(true);
         address local = address(new CashModuleCore(dataProviderProxy));
         _verify("CashModuleCore", cashModuleCoreImpl, local);
     }
 
     function test_verifyBytecode_CashModuleSetters() public {
-        // CashModuleSetters gains gateway wiring plus the lend opt-out (setLendGateway/toggleLend) for Lend, so
-        // its bytecode no longer matches the deployed pre-Lend OP implementation. Re-enable after the Lend deployment.
-        vm.skip(true);
         address local = address(new CashModuleSetters(dataProviderProxy));
         _verify("CashModuleSetters", cashModuleSettersImpl, local);
     }
 
     function test_verifyBytecode_CashLens() public {
-        // CashLens is rewritten for Lend (reads the Aave gateway through CashModule), so its
-        // bytecode no longer matches the deployed pre-Lend version. Re-enable after the Lend deployment.
-        vm.skip(true);
         address local = address(new CashLens(cashModuleProxy, dataProviderProxy));
         _verify("CashLens", cashLensImpl, local);
     }
 
     function test_verifyBytecode_CashEventEmitter() public {
-        // CashEventEmitter gains the gateway update and Repay events for Lend, so its bytecode no longer
-        // matches the deployed pre-Lend OP implementation. Re-enable after the Lend deployment.
-        vm.skip(true);
         address local = address(new CashEventEmitter(cashModuleProxy));
         _verify("CashEventEmitter", cashEventEmitterImpl, local);
     }
@@ -230,17 +211,11 @@ contract VerifyOPMainnetBytecode is ContractCodeChecker, Utils {
     // ---- Debt manager ----
 
     function test_verifyBytecode_DebtManagerCore() public {
-        // DebtManager's liquidation path is removed for Lend, so its bytecode no longer matches the
-        // deployed pre-Lend version. Re-enable after the Lend deployment.
-        vm.skip(true);
         address local = address(new DebtManagerCore(dataProviderProxy));
         _verify("DebtManagerCore", debtManagerCoreImpl, local);
     }
 
     function test_verifyBytecode_DebtManagerAdmin() public {
-        // The shared DebtManager storage contract gains the ETHER_FI_WALLET_ROLE getter for Lend, so
-        // the bytecode no longer matches the deployed pre-Lend version. Re-enable after the Lend deployment.
-        vm.skip(true);
         address local = address(new DebtManagerAdmin(dataProviderProxy));
         _verify("DebtManagerAdmin", debtManagerAdminImpl, local);
     }
@@ -277,9 +252,6 @@ contract VerifyOPMainnetBytecode is ContractCodeChecker, Utils {
     // ---- Top up ----
 
     function test_verifyBytecode_TopUpDest() public {
-        // TopUpDest supplies topups into the lend gateway for Lend, so its bytecode no longer
-        // matches the deployed pre-Lend OP implementation. Re-enable after the Lend deployment.
-        vm.skip(true);
         address local = address(new TopUpDest(dataProviderProxy, cc.weth));
         _verify("TopUpDest", topUpDestImpl, local);
     }
@@ -287,17 +259,11 @@ contract VerifyOPMainnetBytecode is ContractCodeChecker, Utils {
     // ---- Modules (non-proxy, deployed via CREATE3) ----
 
     function test_verifyBytecode_OpenOceanSwapModule() public {
-        // OpenOceanSwapModule gains the Aave sandwich for Lend, so its bytecode no longer matches the deployed
-        // pre-Lend OP implementation. Re-enable after the Lend deployment.
-        vm.skip(true);
         address local = address(new OpenOceanSwapModule(cc.swapRouterOpenOcean, dataProviderProxy));
         _verify("OpenOceanSwapModule", openOceanSwapModule, local);
     }
 
     function test_verifyBytecode_EtherFiLiquidModule() public {
-        // The liquid modules gain the Aave sandwich for Lend, so their bytecode no longer matches the deployed
-        // pre-Lend OP implementations. Re-enable after the Lend deployment.
-        vm.skip(true);
         address[] memory assets = new address[](4);
         assets[0] = cc.liquidEth;
         assets[1] = cc.liquidBtc;
@@ -315,8 +281,6 @@ contract VerifyOPMainnetBytecode is ContractCodeChecker, Utils {
     }
 
     function test_verifyBytecode_EtherFiLiquidModuleWithReferrer() public {
-        // Skipped for the same Lend bytecode change as EtherFiLiquidModule above.
-        vm.skip(true);
         address[] memory assets = new address[](1);
         assets[0] = cc.sethfi;
 
@@ -341,25 +305,16 @@ contract VerifyOPMainnetBytecode is ContractCodeChecker, Utils {
     }
 
     function test_verifyBytecode_FraxModule() public {
-        // FraxModule gains the Aave sandwich for Lend, so its bytecode no longer matches the deployed
-        // pre-Lend OP implementation. Re-enable after the Lend deployment.
-        vm.skip(true);
         address local = address(new FraxModule(dataProviderProxy, cc.fraxusd, cc.fraxCustodian, cc.fraxRemoteHop));
         _verify("FraxModule", fraxModule, local);
     }
 
     function test_verifyBytecode_EtherFiStakeModule() public {
-        // EtherFiStakeModule gains the Aave sandwich for Lend, so its bytecode no longer matches the deployed
-        // pre-Lend OP implementation. Re-enable after the Lend deployment.
-        vm.skip(true);
         address local = address(new EtherFiStakeModule(dataProviderProxy, cc.syncPool, cc.weth, cc.weETH));
         _verify("EtherFiStakeModule", etherFiStakeModule, local);
     }
 
     function test_verifyBytecode_LiquidUSDLiquifierModule() public {
-        // The liquifier gains the dual-engine gateway repay for Lend, so its bytecode no longer matches the
-        // deployed pre-Lend OP implementation. Re-enable after the Lend deployment.
-        vm.skip(true);
         address liquifierImpl = _getImpl(liquidUsdLiquifierProxy);
         address local = address(new LiquidUSDLiquifierOPModule(debtManagerProxy, dataProviderProxy));
         _verify("LiquidUSDLiquifierModule", liquifierImpl, local);


### PR DESCRIPTION
## Summary
- Removes 20 of the 21 vm.skip guards in VerifyOPMainnet.t.sol. Each was added when a PR changed bytecode ahead of its deployment; all of those deployments have since executed.
- Taxi (#291): StargateModule and the four SettlementDispatcherV2 proxies. Live since OP Safe nonces 97 and 99 (3CP-663).
- Lend: EtherFiHook, CashModuleCore, CashModuleSetters, CashLens, CashEventEmitter, DebtManagerCore, DebtManagerAdmin, TopUpDest, OpenOceanSwapModule, EtherFiLiquidModule, EtherFiLiquidModuleWithReferrer, FraxModule, EtherFiStakeModule, LiquidUSDLiquifierModule. Live since the Lend go-live (3CP-614).
- Safe: EtherFiSafe (RecoveryManager threshold fix). Live since the safe implementation upgrade (3CP-666).
- EtherFiSafeFactory stays skipped: the factory has not been redeployed since the placeholder reinitialize hook was removed, and the test still fails with a post-trim length mismatch.

Closes COR-1498

## Test plan
- [x] forge test --match-path test/upgrade-bytecode-verification/VerifyOPMainnet.t.sol against live Optimism: 23 passed, 0 failed, 1 skipped (EtherFiSafeFactory)
- [x] forge fmt --check and forge lint on the changed file

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that tightens CI against OP mainnet; no production contract or deployment logic is modified.
> 
> **Overview**
> Re-enables **20** Optimism mainnet bytecode verification tests in `VerifyOPMainnet.t.sol` by removing `vm.skip(true)` and the associated “re-enable after deployment” comments. Those skips were added while repo bytecode diverged from on-chain implementations ahead of **Taxi**, **Lend**, and **EtherFiSafe** upgrades; those deployments are now live, so `_verify` runs again for hook, cash, debt, settlement dispatchers, top-up, and module contracts.
> 
> **EtherFiSafeFactory** remains skipped: on-chain factory bytecode still does not match the repo after the placeholder reinitialize hook was removed, until the next factory deployment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d1bfe4cb1f6911b033907b256c680d7c5bd734e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->